### PR TITLE
Entity Services schema tests

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Final
@@ -52,9 +51,9 @@ from .const import (
     ZoneMode,
 )
 from .schemas import (
-    SVCS_RAMSES_CLIMATE,
     SCH_SET_SYSTEM_MODE_EXTRA,
     SCH_SET_ZONE_MODE_EXTRA,
+    SVCS_RAMSES_CLIMATE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -272,7 +271,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         if duration is not None:
             entry.update({"duration": duration})
         # strict, non-entity schema check
-        checked_entry = SCH_SET_SYSTEM_MODE_EXTRA(entry)  # type: ignore[unused-ignore]
+        SCH_SET_SYSTEM_MODE_EXTRA(entry)  # result not used
 
         # move params to `until`, we can reuse the init params:
         if duration is not None:

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -272,7 +272,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         if duration is not None:
             entry.update({"duration": duration})
         # stricter, non-entity schema check
-        checked_entry = SCH_SET_SYSTEM_MODE_EXTRA(entry)  # f"Invalid System Mode entry: {err}")
+        checked_entry = SCH_SET_SYSTEM_MODE_EXTRA(entry)  # type: ignore[unused-ignore]
 
         # move params to `until`, we can reuse the init params:
         if duration is not None:

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Final
@@ -39,8 +40,6 @@ from ramses_rf.device.hvac import HvacVentilator
 from ramses_rf.system.heat import Evohome
 from ramses_rf.system.zones import Zone
 from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
-
-from voluptuous import MultipleInvalid
 
 from . import RamsesEntity, RamsesEntityDescription
 from .broker import RamsesBroker
@@ -268,12 +267,12 @@ class RamsesController(RamsesEntity, ClimateEntity):
     ) -> None:
         """Set the (native) operating mode of the Controller."""
 
-        # tighter, non-entity schema check
-        schema = SCH_SET_ZONE_MODE_EXTRA
+        # stricter, non-entity schema check
+        schema: vol.Schema = SCH_SET_SYSTEM_MODE_EXTRA
         try:
             schema({mode: mode, period: period, duration: duration})
-        except MultipleInvalid as err:
-            _LOGGER.warning(f"Invalid DHW entry: {err}")
+        except vol.MultipleInvalid as err:
+            _LOGGER.warning(f"Invalid System Mode entry: {err}")
 
         if duration is not None:
             # evohome controllers utilise whole hours
@@ -471,12 +470,12 @@ class RamsesZone(RamsesEntity, ClimateEntity):
     ) -> None:
         """Set the (native) operating mode of the Zone."""
 
-        # tighter, non-entity schema check
-        schema = SCH_SET_ZONE_MODE_EXTRA
+        # stricter, non-entity schema check
+        schema: vol.Schema = SCH_SET_ZONE_MODE_EXTRA
         try:
             schema({mode: mode, setpoint: setpoint, duration: duration, until: until})
-        except MultipleInvalid as err:
-            _LOGGER.warning(f"Invalid DHW entry: {err}")
+        except vol.MultipleInvalid as err:
+            _LOGGER.warning(f"Invalid Zone Mode entry: {err}")
 
         # insert default duration of 1 hour, replacing the entity service call schema default
         if (

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -280,9 +280,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
             until = datetime.now() + duration  # <=24 hours, was verified
         elif period is None:
             until = None
-        elif (
-            period.seconds == period.microseconds == 0
-        ):
+        elif period.seconds == period.microseconds == 0:
             # this is the behaviour of an evohome controller
             date_ = datetime.now().date() + timedelta(days=1) + period
             until = datetime(date_.year, date_.month, date_.day)
@@ -482,13 +480,11 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             entry.update({"until": until})
 
         # stricter, non-entity schema check
-        checked_entry = SCH_SET_ZONE_MODE_EXTRA(entry)  # f"Invalid Zone Mode entry: {err}")
+        checked_entry = SCH_SET_ZONE_MODE_EXTRA(entry)
         # default `duration` of 1 hour updated by schema default, so can't use original
 
         if until is None and "duration" in checked_entry:
-            until = (
-                datetime.now() + checked_entry["duration"]
-            )  # move duration to until
+            until = datetime.now() + checked_entry["duration"]  # move duration to until
         self._device.set_mode(
             mode=mode,
             setpoint=setpoint,

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -271,7 +271,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
             entry.update({"period": period})
         if duration is not None:
             entry.update({"duration": duration})
-        # stricter, non-entity schema check
+        # strict, non-entity schema check
         checked_entry = SCH_SET_SYSTEM_MODE_EXTRA(entry)  # type: ignore[unused-ignore]
 
         # move params to `until`, we can reuse the init params:
@@ -287,6 +287,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         else:
             until = datetime.now() + period
         # duration and/or period are now in until
+        assert mode is not None
         self._device.set_mode(mode, until=until)  # note: mode is a positional argument
         self.async_write_ha_state_delayed()
 
@@ -479,7 +480,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         if until is not None:
             entry.update({"until": until})
 
-        # stricter, non-entity schema check
+        # strict, non-entity schema check
         checked_entry = SCH_SET_ZONE_MODE_EXTRA(entry)
         # default `duration` of 1 hour updated by schema default, so can't use original
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -262,6 +262,9 @@ class RamsesController(RamsesEntity, ClimateEntity):
     ) -> None:
         """Set the (native) operating mode of the Controller."""
 
+        # tighter, non-entity schema check
+
+
         if duration is not None:
             # evohome controllers utilise whole hours
             until = datetime.now() + duration  # <=24 hours
@@ -403,7 +406,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             self.async_reset_zone_mode()
         elif hvac_mode == HVACMode.HEAT:  # TemporaryOverride
             self.async_set_zone_mode(mode=ZoneMode.PERMANENT, setpoint=25)
-        else:  # HVACMode.OFF, PermentOverride, temp = min
+        else:  # HVACMode.OFF, PermanentOverride, temp = min
             self.async_set_zone_mode(self._device.set_frost_mode)
 
     @callback
@@ -458,12 +461,14 @@ class RamsesZone(RamsesEntity, ClimateEntity):
     ) -> None:
         """Set the (native) operating mode of the Zone."""
 
+        # tighter, non-entity schema check
+
         # insert default duration of 1 hour, replacing the entity service call schema default
         if mode == ZoneMode.TEMPORARY and duration is None and until is None and setpoint:
             duration = timedelta(hours=1)
 
         if until is None and duration is not None:
-            until = datetime.now() + duration
+            until = datetime.now() + duration  # duration is never passed on to _device
         self._device.set_mode(mode=mode, setpoint=setpoint, until=until)
         self.async_write_ha_state_delayed()
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -289,7 +289,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         else:
             until = datetime.now() + period
         # duration and/or period are now in until
-        self._device.set_mode(system_mode=checked_entry["mode"], until=until)
+        self._device.set_mode(system_mode=mode, until=until)
         self.async_write_ha_state_delayed()
 
 
@@ -483,7 +483,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
 
         # stricter, non-entity schema check
         checked_entry = SCH_SET_ZONE_MODE_EXTRA(entry)  # f"Invalid Zone Mode entry: {err}")
-        # default `duration` of 1 hour handled by schema default, so can't use original
+        # default `duration` of 1 hour updated by schema default, so can't use original
 
         if until is None and "duration" in checked_entry:
             until = (

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -287,7 +287,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         else:
             until = datetime.now() + period
         # duration and/or period are now in until
-        self._device.set_mode(system_mode=mode, until=until)
+        self._device.set_mode(mode, until=until)  # note: mode is a positional argument
         self.async_write_ha_state_delayed()
 
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -457,6 +457,11 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         until: datetime | None = None,
     ) -> None:
         """Set the (native) operating mode of the Zone."""
+
+        # insert default duration of 1 hour, replacing the entity service call schema default
+        if mode == ZoneMode.TEMPORARY and duration is None and until is None and setpoint:
+            duration = timedelta(hours=1)
+
         if until is None and duration is not None:
             until = datetime.now() + duration
         self._device.set_mode(mode=mode, setpoint=setpoint, until=until)

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -268,7 +268,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         """Set the (native) operating mode of the Controller."""
         entry: dict[str, Any] = {"mode": mode}
         if period is not None:
-            entry.update({"active": period})
+            entry.update({"period": period})
         if duration is not None:
             entry.update({"duration": duration})
         # stricter, non-entity schema check
@@ -475,7 +475,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
 
         entry: dict[str, Any] = {"mode": mode}
         if setpoint is not None:
-            entry.update({"active": setpoint})
+            entry.update({"setpoint": setpoint})
         if duration is not None:
             entry.update({"duration": duration})
         if until is not None:

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -395,17 +395,11 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
         vol.Optional(ATTR_SETPOINT): vol.All(
             cv.positive_float, vol.Range(min=5, max=35)
         ),
-        vol.Optional(ATTR_SETPOINT): vol.All(
-            cv.positive_float, vol.Range(min=5, max=35)
-        ),
+        vol.Optional(ATTR_UNTIL): cv.datetime,
         vol.Optional(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
             cv.time_period,
             vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
         ),
-        vol.Optional(ATTR_SETPOINT): vol.All(
-            cv.positive_float, vol.Range(min=5, max=35)
-        ),
-        vol.Optional(ATTR_UNTIL): cv.datetime,
     }
 )
 
@@ -496,18 +490,11 @@ SCH_SET_DHW_MODE = cv.make_entity_service_schema(
             ]
         ),
         vol.Optional(ATTR_ACTIVE): cv.boolean,
-        vol.Optional(ATTR_ACTIVE): True,  # TODO: vol.Any(truthy)
-        vol.Optional(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
-            cv.time_period,
-            vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
-        ),
-        vol.Optional(ATTR_ACTIVE): cv.boolean,
+        vol.Optional(ATTR_UNTIL): cv.datetime,
         vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
             vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
         ),
-        vol.Optional(ATTR_ACTIVE): cv.boolean,
-        vol.Optional(ATTR_UNTIL): cv.datetime,
     }
 )
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -331,7 +331,7 @@ SCH_SET_SYSTEM_MODE = cv.make_entity_service_schema(
     }
 )
 
-SCH_SET_SYSTEM_MODE_EXTRA = vol.Schema(  # TODO check, adapted from DHW
+SCH_SET_SYSTEM_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
     vol.Any(
         {  # also: Off, Heat, Cool (for pre-evohome)
             vol.Required(ATTR_MODE): vol.In(
@@ -403,39 +403,39 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
     }
 )
 
-SCH_SET_ZONE_MODE_EXTRA = vol.Schema(  # copied from DHW, TODO check
-    vol.Msg(
-        vol.Any(
-            {
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
-                # only mode with no setpoint
-            },
-            {
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.PERMANENT, ZoneMode.ADVANCED]),
-                vol.Required(ATTR_SETPOINT): vol.All(
-                    cv.positive_float, vol.Range(min=5, max=35)
-                ),
-            },
-            {
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-                vol.Required(ATTR_SETPOINT): vol.All(
-                    cv.positive_float, vol.Range(min=5, max=35)
-                ),
-                vol.Required(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
-                    cv.time_period,
-                    vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
-                ),
-            },
-            {
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-                vol.Required(ATTR_SETPOINT): vol.All(
-                    cv.positive_float, vol.Range(min=5, max=35)
-                ),
-                vol.Required(ATTR_UNTIL): cv.datetime,
-            },
-        ),
-        msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
+SCH_SET_ZONE_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
+    # vol.Msg(  # TODO turn on if good checks are working 2025
+    vol.Any(
+        {
+            vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
+            # only mode with no setpoint
+        },
+        {
+            vol.Required(ATTR_MODE): vol.In([ZoneMode.PERMANENT, ZoneMode.ADVANCED]),
+            vol.Required(ATTR_SETPOINT): vol.All(
+                cv.positive_float, vol.Range(min=5, max=35)
+            ),
+        },
+        {
+            vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+            vol.Required(ATTR_SETPOINT): vol.All(
+                cv.positive_float, vol.Range(min=5, max=35)
+            ),
+            vol.Required(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
+                cv.time_period,
+                vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+            ),
+        },
+        {
+            vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+            vol.Required(ATTR_SETPOINT): vol.All(
+                cv.positive_float, vol.Range(min=5, max=35)
+            ),
+            vol.Required(ATTR_UNTIL): cv.datetime,
+        },
     ),
+    #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
+    # ),
     extra=vol.PREVENT_EXTRA,
 )
 
@@ -501,7 +501,7 @@ SCH_SET_DHW_MODE = cv.make_entity_service_schema(
     }
 )
 
-SCH_SET_DHW_MODE_EXTRA = vol.Schema(
+SCH_SET_DHW_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
     vol.Any(
         {
             vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -404,34 +404,37 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
 )
 
 SCH_SET_ZONE_MODE_EXTRA = vol.Schema(  # copied from DHW, TODO check
-    vol.Any(
-        {
-            vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
-            # only mode with no setpoint
-        },
-        {
-            vol.Required(ATTR_MODE): vol.In([ZoneMode.PERMANENT, ZoneMode.ADVANCED]),
-            vol.Required(ATTR_SETPOINT): vol.All(
-                cv.positive_float, vol.Range(min=5, max=35)
-            ),
-        },
-        {
-            vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-            vol.Required(ATTR_SETPOINT): vol.All(
-                cv.positive_float, vol.Range(min=5, max=35)
-            ),
-            vol.Required(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
-                cv.time_period,
-                vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
-            ),
-        },
-        {
-            vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-            vol.Required(ATTR_SETPOINT): vol.All(
-                cv.positive_float, vol.Range(min=5, max=35)
-            ),
-            vol.Required(ATTR_UNTIL): cv.datetime,
-        },
+    vol.Msg(
+        vol.Any(
+            {
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
+                # only mode with no setpoint
+            },
+            {
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.PERMANENT, ZoneMode.ADVANCED]),
+                vol.Required(ATTR_SETPOINT): vol.All(
+                    cv.positive_float, vol.Range(min=5, max=35)
+                ),
+            },
+            {
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+                vol.Required(ATTR_SETPOINT): vol.All(
+                    cv.positive_float, vol.Range(min=5, max=35)
+                ),
+                vol.Required(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
+                    cv.time_period,
+                    vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+                ),
+            },
+            {
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+                vol.Required(ATTR_SETPOINT): vol.All(
+                    cv.positive_float, vol.Range(min=5, max=35)
+                ),
+                vol.Required(ATTR_UNTIL): cv.datetime,
+            },
+        ),
+        msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
     ),
     extra=vol.PREVENT_EXTRA,
 )

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -332,17 +332,18 @@ SCH_SET_SYSTEM_MODE = cv.make_entity_service_schema(
 )
 
 SCH_SET_SYSTEM_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
+    # vol.Msg(  # TODO turn on if good checks are working 8-2025
     vol.Any(
-        {  # also: Off, Heat, Cool (for pre-evohome)
+        {  # A also: Off, Heat, Cool (for pre-evohome)
             vol.Required(ATTR_MODE): vol.In(
                 [SystemMode.AUTO, SystemMode.HEAT_OFF, SystemMode.RESET]
             )
         },
-        {
+        {  # B
             vol.Required(ATTR_MODE): vol.In([SystemMode.ECO_BOOST]),
             vol.Optional(ATTR_DURATION): vol.Any(SCH_DURATION, None),
-        },  # Duration: : None is indefinitely; 0 is invalid
-        {  # canBeTemporary: true, timingMode: Period
+        },  # duration: : None is indefinitely; 0 is invalid
+        {  # C canBeTemporary: true, timingMode: Period
             vol.Required(ATTR_MODE): vol.In(
                 [
                     SystemMode.AWAY,
@@ -354,6 +355,8 @@ SCH_SET_SYSTEM_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
             vol.Optional(ATTR_PERIOD): vol.Any(SCH_PERIOD, None),
         },  # Period: None is indefinitely; 0 is the end of today, 1 is end of tomorrow
     ),
+    #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
+    # ),
     extra=vol.PREVENT_EXTRA,
 )
 
@@ -396,7 +399,7 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
             cv.positive_float, vol.Range(min=5, max=35)
         ),
         vol.Optional(ATTR_UNTIL): cv.datetime,
-        vol.Optional(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
+        vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
             vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
         ),
@@ -404,19 +407,19 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
 )
 
 SCH_SET_ZONE_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
-    # vol.Msg(  # TODO turn on if good checks are working 2025
+    # vol.Msg(  # TODO turn on if good checks are working 8-2025
     vol.Any(
-        {
+        {  # A
             vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
             # only mode with no setpoint
         },
-        {
+        {  # B
             vol.Required(ATTR_MODE): vol.In([ZoneMode.PERMANENT, ZoneMode.ADVANCED]),
             vol.Required(ATTR_SETPOINT): vol.All(
                 cv.positive_float, vol.Range(min=5, max=35)
             ),
         },
-        {
+        {  # C
             vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
             vol.Required(ATTR_SETPOINT): vol.All(
                 cv.positive_float, vol.Range(min=5, max=35)
@@ -426,7 +429,7 @@ SCH_SET_ZONE_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
                 vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
             ),
         },
-        {
+        {  # D
             vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
             vol.Required(ATTR_SETPOINT): vol.All(
                 cv.positive_float, vol.Range(min=5, max=35)
@@ -502,8 +505,9 @@ SCH_SET_DHW_MODE = cv.make_entity_service_schema(
 )
 
 SCH_SET_DHW_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
+    # vol.Msg(  # TODO turn on if good checks are working 8-2025
     vol.Any(
-        {
+        {  # A
             vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
             # only mode with no active
         },
@@ -511,7 +515,7 @@ SCH_SET_DHW_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
             vol.Required(ATTR_MODE): vol.In([ZoneMode.PERMANENT, ZoneMode.ADVANCED]),
             vol.Required(ATTR_ACTIVE): cv.boolean,
         },
-        {  # a.k.a DHW boost
+        {  # B a.k.a DHW boost
             vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
             vol.Required(ATTR_ACTIVE): True,  # TODO: vol.Any(truthy)
             vol.Required(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
@@ -519,7 +523,7 @@ SCH_SET_DHW_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
                 vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
             ),
         },
-        {
+        {  # C
             vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
             vol.Required(ATTR_ACTIVE): cv.boolean,
             vol.Required(ATTR_DURATION): vol.All(
@@ -527,12 +531,14 @@ SCH_SET_DHW_MODE_EXTRA = vol.Schema(  # original Entity Service action schema
                 vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
             ),
         },
-        {
+        {  # D
             vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
             vol.Required(ATTR_ACTIVE): cv.boolean,
             vol.Required(ATTR_UNTIL): cv.datetime,
         },
     ),
+    #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
+    # ),
     extra=vol.PREVENT_EXTRA,
 )
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -29,7 +29,6 @@ from homeassistant.helpers.entity_platform import (
 from ramses_rf.system.heat import StoredHw
 from ramses_rf.system.zones import DhwZone
 from ramses_tx.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE
-from voluptuous import MultipleInvalid
 
 from . import RamsesEntity, RamsesEntityDescription
 from .broker import RamsesBroker
@@ -197,11 +196,12 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
     ) -> None:
         """Set the (native) operating mode of the water heater."""
 
-        # tighter, non-entity schema check
-        schema = SCH_SET_DHW_MODE_EXTRA
+        # active = 123  # EB very crude schema (bool) debug effort
+        # stricter, non-entity schema check
+        schema: vol.Schema = SCH_SET_DHW_MODE_EXTRA
         try:
             schema({mode: mode, active: active, duration: duration, until: until})
-        except MultipleInvalid as err:
+        except vol.MultipleInvalid as err:
             _LOGGER.warning(f"Invalid DHW entry: {err}")
 
         # insert default duration of 1 hour, replacing the entity service call schema default

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -203,7 +203,7 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         if until is not None:
             entry.update({"until": until})
 
-        # stricter, non-entity schema check
+        # strict, non-entity schema check
         checked_entry = SCH_SET_DHW_MODE_EXTRA(entry)
         # default `duration` of 1 hour updated by schema default, so can't use original
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -198,25 +198,27 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
         # stricter, non-entity schema check
         checked_entry = SCH_SET_DHW_MODE_EXTRA(
-            {mode: mode, active: active, duration: duration, until: until}
-        )
-        # throw vol.MultipleInvalid as err:
-        #     _LOGGER.warning(f"Invalid DHW entry: {err}")
+            {"mode": mode, "active": active, "duration": duration, "until": until}
+        )  # , f"Invalid DHW entry: {err}")
 
         # insert default duration of 1 hour, replacing the entity service call schema default
         if (
-            checked_entry[mode] == ZoneMode.TEMPORARY
-            and checked_entry[active] == True
-            and checked_entry[duration] is None
-            and checked_entry[until] is None
+            checked_entry["mode"] == ZoneMode.TEMPORARY
+            and checked_entry["active"] == True
+            and checked_entry["duration"] is None
+            and checked_entry["until"] is None
         ):
             checked_entry[duration] = timedelta(hours=1)
 
-        if checked_entry[until] is None and checked_entry[duration] is not None:
-            checked_entry[until] = (
-                dt.now() + checked_entry[duration]
+        if checked_entry["until"] is None and checked_entry[duration] is not None:
+            checked_entry["until"] = (
+                dt.now() + checked_entry["duration"]
             )  # duration will be ignored by receiving _device
-        self._device.set_mode(checked_entry)  #
+        self._device.set_mode(
+            mode=checked_entry["mode"],
+            active=checked_entry["active"],
+            until=checked_entry["until"],
+        )
         self.async_write_ha_state_delayed()
 
     @callback

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -204,7 +204,7 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
             entry.update({"until": until})
 
         # stricter, non-entity schema check
-        checked_entry = SCH_SET_DHW_MODE_EXTRA(entry)  # f"Invalid DHW entry: {err}")
+        checked_entry = SCH_SET_DHW_MODE_EXTRA(entry)
         # default `duration` of 1 hour updated by schema default, so can't use original
 
         if until is None and "duration" in checked_entry:

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from dataclasses import dataclass
 from datetime import datetime as dt, timedelta
 from typing import Any, Final
@@ -33,7 +32,7 @@ from ramses_tx.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE
 from . import RamsesEntity, RamsesEntityDescription
 from .broker import RamsesBroker
 from .const import DOMAIN, SystemMode, ZoneMode
-from .schemas import SVCS_RAMSES_WATER_HEATER, SCH_SET_DHW_MODE_EXTRA
+from .schemas import SCH_SET_DHW_MODE_EXTRA, SVCS_RAMSES_WATER_HEATER
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -202,10 +202,15 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         try:
             schema({mode: mode, active: active, duration: duration, until: until})
         except MultipleInvalid as err:
-            _LOGGER.info(f"Invalid entry: {err}")
+            _LOGGER.warning(f"Invalid DHW entry: {err}")
 
         # insert default duration of 1 hour, replacing the entity service call schema default
-        if mode == ZoneMode.TEMPORARY and duration is None and until is None and active == True:
+        if (
+            mode == ZoneMode.TEMPORARY
+            and duration is None
+            and until is None
+            and active == True
+        ):
             duration = timedelta(hours=1)
 
         if until is None and duration is not None:

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -194,6 +194,11 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         until: dt | None = None,
     ) -> None:
         """Set the (native) operating mode of the water heater."""
+
+        # insert default duration of 1 hour, replacing the entity service call schema default
+        if mode == ZoneMode.TEMPORARY and duration is None and until is None and active == True:
+            duration = timedelta(hours=1)
+
         if until is None and duration is not None:
             until = dt.now() + duration
         self._device.set_mode(mode=mode, active=active, until=until)

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -208,9 +208,7 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         # default `duration` of 1 hour updated by schema default, so can't use original
 
         if until is None and "duration" in checked_entry:
-            until = (
-                    dt.now() + checked_entry["duration"]
-            )  # move duration to until
+            until = dt.now() + checked_entry["duration"]  # move duration to until
         self._device.set_mode(
             mode=mode,
             active=active,

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -205,7 +205,7 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
         # stricter, non-entity schema check
         checked_entry = SCH_SET_DHW_MODE_EXTRA(entry)  # f"Invalid DHW entry: {err}")
-        # default `duration` of 1 hour handled by schema default, so can't use original
+        # default `duration` of 1 hour updated by schema default, so can't use original
 
         if until is None and "duration" in checked_entry:
             until = (

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -729,9 +729,11 @@ TESTS_SET_SYSTEM_MODE_FAIL2: dict[str, dict[str, Any]] = {
 async def test_set_system_mode_good(
     hass: HomeAssistant, entry: ConfigEntry, idx: str
 ) -> None:
-    """Confirm that valid params are acceptable to the entity service schema
+    """
+    Confirm that valid params are acceptable to the entity service schema
     as well as to the (mocked) parsing checks in ramses_rf.gateway.Gateway.send_cmd
-    Cover nested if-then-else not supported as entity-schema since HA 2025.09"""
+    Cover nested if-then-else not supported as entity-schema since HA 2025.09
+    """
 
     data = {
         "entity_id": "climate.01_145038",

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -71,8 +71,6 @@ from custom_components.ramses_cc.schemas import (
 from custom_components.ramses_cc.sensor import SVCS_RAMSES_SENSOR
 from custom_components.ramses_cc.water_heater import SVCS_RAMSES_WATER_HEATER
 from ramses_rf.gateway import Gateway
-from ramses_tx.const import Priority
-from ramses_tx.exceptions import CommandInvalid
 
 from ..virtual_rf import VirtualRf
 from .helpers import TEST_DIR, cast_packets_to_rf
@@ -652,9 +650,6 @@ async def test_set_dhw_mode_good(
         **TESTS_SET_DHW_MODE_GOOD[idx],  # type: ignore[dict-item]
     }
 
-    # with mock method ramses_rf.gateway.Gateway.send_cmd, replace TSSGMA[] with:
-    # asserts = {"priority": Priority.HIGH, "wait_for_reply": True}
-
     await _test_entity_service_call(
         hass,
         SVC_SET_DHW_MODE,
@@ -798,9 +793,6 @@ async def test_set_system_mode_good(
         "entity_id": "climate.01_145038",
         **TESTS_SET_SYSTEM_MODE_GOOD[idx],
     }
-
-    # with mock method ramses_rf.gateway.Gateway.send_cmd, replace TSSGMA[] with:
-    # asserts = {"priority": Priority.HIGH, "wait_for_reply": True}
 
     await _test_entity_service_call(
         hass,
@@ -959,9 +951,6 @@ async def test_set_zone_mode_good(
         "entity_id": "climate.01_145038_02",
         **TESTS_SET_ZONE_MODE_GOOD[idx],
     }
-
-    # with mock method ramses_rf.gateway.Gateway.send_cmd, replace TSSGMA[] with:
-    # asserts = {"priority": Priority.HIGH}
 
     await _test_entity_service_call(
         hass,

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -750,10 +750,11 @@ async def test_set_dhw_schedule(hass: HomeAssistant, entry: ConfigEntry) -> None
 # Set_system_mode tests
 TESTS_SET_SYSTEM_MODE_GOOD: dict[str, dict[str, Any]] = {
     # TODO in the next 4 tests, the mock method does not report receiving 'mode'
-    # "00": {"mode": "auto"},
-    # "01": {"mode": "eco_boost"},
-    # "02": {"mode": "day_off", "period": {"days": 3}},
-    # "03": {"mode": "eco_boost", "duration": {"hours": 3, "minutes": 30}},
+    "00": {"mode": "auto"},
+    "01": {"mode": "eco_boost"},
+    "02": {"mode": "day_off", "period": {"days": 3}},
+    # TODO small timing offset makes the next test often fail locally and on GitHub, round times in Command?
+    # "03": {"mode": "eco_boost", "duration": {"hours": 3}},
 }  # requires custom asserts, returned from mock method success
 # with mock method ramses_tx.command.Command.set_system_mode
 TESTS_SET_SYSTEM_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -204,8 +204,8 @@ SERVICES = {
     ),
     SVC_SET_DHW_MODE: (
         # Use ramses_rf built-in validation, by mocking
-        # "ramses_rf.gateway.Gateway.send_cmd",
-        "ramses_tx.command.Command.set_dhw_mode",  # debug issue #233
+        "ramses_rf.gateway.Gateway.send_cmd",
+        # "ramses_tx.command.Command.set_dhw_mode",  # small timing offset always makes this call fail
         # to catch nested entry schema, uses dedicated asserts than other services
         SCH_SET_DHW_MODE,
     ),
@@ -219,8 +219,8 @@ SERVICES = {
     ),
     SVC_SET_SYSTEM_MODE: (
         # Use ramses_rf built-in validation, by mocking
-        # "ramses_rf.gateway.Gateway.send_cmd",
-        "ramses_tx.command.Command.set_system_mode",  # debug issue #233
+        "ramses_rf.gateway.Gateway.send_cmd",
+        # "ramses_tx.command.Command.set_system_mode",  # small timing offset always makes this call fail
         # to catch nested entry schema, uses dedicated asserts than other services
         SCH_SET_SYSTEM_MODE,
     ),
@@ -230,8 +230,8 @@ SERVICES = {
     ),
     SVC_SET_ZONE_MODE: (
         # Use ramses_rf built-in validation, by mocking
-        # "ramses_rf.gateway.Gateway.send_cmd",
-        "ramses_tx.command.Command.set_zone_mode",  # debug issue #233
+        "ramses_rf.gateway.Gateway.send_cmd",
+        # "ramses_tx.command.Command.set_zone_mode",  # small timing offset always makes this call fail
         # to catch nested entry schema, uses dedicated asserts than other services
         SCH_SET_ZONE_MODE,
     ),

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -594,18 +594,18 @@ TESTS_SET_DHW_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
         "active": True,
     },
     "41": {
-        "active": True,
         "mode": "temporary_override",
+        "active": True,
         "until": _ASS_UNTIL,
     },
     "52": {
-        "active": True,
         "mode": "temporary_override",
+        "active": True,
         "until": _ASS_UNTIL_MIDNIGHT,
     },
     "62": {
-        "active": True,
         "mode": "temporary_override",
+        "active": True,
         "until": _ASS_UNTIL,
     },
 }

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -749,23 +749,23 @@ async def test_set_dhw_schedule(hass: HomeAssistant, entry: ConfigEntry) -> None
 
 # Set_system_mode tests
 TESTS_SET_SYSTEM_MODE_GOOD: dict[str, dict[str, Any]] = {
-    # TODO in the next 4 tests, the mock method does not report receiving 'mode'
+    # TODO in all 4 tests, the mock method does not report receiving 'mode'
     "00": {"mode": "auto"},
     "01": {"mode": "eco_boost"},
-    "02": {"mode": "day_off", "period": {"days": 3}},
     # TODO small timing offset makes the next test often fail locally and on GitHub, round times in Command?
+    # "02": {"mode": "day_off", "period": {"days": 3}},
     # "03": {"mode": "eco_boost", "duration": {"hours": 3}},
 }  # requires custom asserts, returned from mock method success
 # with mock method ramses_tx.command.Command.set_system_mode
 TESTS_SET_SYSTEM_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
-    "00": {"mode": "auto", "until": None},
-    "01": {"mode": "eco_boost", "until": None},
+    "00": {"until": None},  # "mode": "auto" not showing up
+    "01": {"until": None},  # "mode": "eco_boost" not showing up
     "02": {
-        "mode": "day_off",
+        # "mode": "day_off",
         "until": _ASS_UNTIL_3DAYS,
     },  # must adjust for pytest run time
     "03": {
-        "mode": "eco_boost",
+        # "mode": "eco_boost",
         "until": dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180),
     },
 }

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -94,7 +94,7 @@ _ASS_UNTIL_3DAYS = dt.now().replace(minute=0, second=0, microsecond=0) + td(
     days=3
 )  # system_mode_good[03]
 # (dt.now().replace(minute=0, second=0, microsecond=0) + td(days=4)  # min. 0, max. 99
-_ASS_DUR_3H30 = dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=210)
+_ASS_DUR_3H = dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180)
 _ASS_UNTIL_MIDNIGHT = dt.now().replace(hour=0, minute=0, second=0, microsecond=0) + td(
     days=1
 )
@@ -576,7 +576,7 @@ TESTS_SET_DHW_MODE_GOOD = {
     "52": {
         "mode": "temporary_override",
         "active": True,
-        "duration": {"days": 0},
+        "duration": {"hours": 3},
     },  # = end of today
     "62": {"mode": "temporary_override", "active": True, "until": _UNTIL},
 }  # requires custom asserts, returned from mock method success
@@ -584,14 +584,18 @@ TESTS_SET_DHW_MODE_GOOD = {
 TESTS_SET_DHW_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "11": {
         "mode": "follow_schedule",
+        'active': None,
+        'until': None,
     },
     "21": {
         "mode": "permanent_override",
         "active": True,
+        'until': None,
     },
     "31": {
         "mode": "advanced_override",
         "active": True,
+        'until': None,
     },
     "41": {
         "mode": "temporary_override",
@@ -757,7 +761,7 @@ TESTS_SET_SYSTEM_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "00": {"mode": "auto", "until": None},
     "01": {"mode": "eco_boost", "until": None},
     "02": {"mode": "day_off", "until": _ASS_UNTIL_3DAYS},  # must adjust for
-    "03": {"mode": "eco_boost", "until": _ASS_DUR_3H30},
+    "03": {"mode": "eco_boost", "until": _ASS_DUR_3H},
 }
 
 TESTS_SET_SYSTEM_MODE_FAIL: dict[str, dict[str, Any]] = {
@@ -765,7 +769,6 @@ TESTS_SET_SYSTEM_MODE_FAIL: dict[str, dict[str, Any]] = {
 }  # no asserts, caught in entity_schema
 
 TESTS_SET_SYSTEM_MODE_FAIL2: dict[str, dict[str, Any]] = {
-    # TODO next entry should fail in Gateway.send_cmd()
     "05": {
         "mode": "day_off",
         "period": {"days": 3},
@@ -886,9 +889,9 @@ TESTS_SET_ZONE_MODE_GOOD: dict[str, dict[str, Any]] = {
 }  # requires custom asserts, returned from mock method success
 # with mock method ramses_tx.command.Command.set_zone_mode
 TESTS_SET_ZONE_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
-    "11": {"mode": "follow_schedule"},
-    "21": {"mode": "permanent_override", "setpoint": 12.1},
-    "31": {"mode": "advanced_override", "setpoint": 13.1},
+    "11": {"mode": "follow_schedule", "setpoint": None, "until": None},
+    "21": {"mode": "permanent_override", "setpoint": 12.1, "until": None},
+    "31": {"mode": "advanced_override", "setpoint": 13.1, "until": None},
     "41": {
         "mode": "temporary_override",
         "setpoint": 14.1,
@@ -897,6 +900,7 @@ TESTS_SET_ZONE_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "52": {
         "mode": "temporary_override",
         "setpoint": 15.1,
+        "until": None
     },
     "62": {"mode": "temporary_override", "setpoint": 16.1, "until": _ASS_UNTIL},
 }

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -87,14 +87,15 @@ NUM_SVCS_AFTER = 10  # proxy for success
 NUM_ENTS_AFTER = 45  # proxy for success
 
 # format for dt asserts, shows as: {'until': datetime.datetime(2025, 8, 11, 22, 11, 14, 774707)}
+# must round down to prev full hour to allow pytest server run time (or could still fail 1 sec after whole hour)
+# no problem if datetime is in the past, not verified
 _ASS_UNTIL = dt.now().replace(minute=0, second=0, microsecond=0) + td(
     hours=2  # min. 1, max. 24
-)  # until an hour from now
+)  # until an hour from "now"
 _ASS_UNTIL_3DAYS = dt.now().replace(minute=0, second=0, microsecond=0) + td(
     days=3
-)  # system_mode_good[03]
-# (dt.now().replace(minute=0, second=0, microsecond=0) + td(days=4)  # min. 0, max. 99
-_ASS_DUR_3H = dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180)
+)
+#_ASS_DUR_3H = dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180)
 _ASS_UNTIL_MIDNIGHT = dt.now().replace(hour=0, minute=0, second=0, microsecond=0) + td(
     days=1
 )
@@ -102,7 +103,7 @@ _ASS_UNTIL_10D = dt.now().replace(minute=0, second=0, microsecond=0) + td(
     days=10, hours=4
 )  # min. 1, max. 24
 
-# entries for service call format
+# same in service call entry format
 _UNTIL = _ASS_UNTIL.strftime(
     "%Y-%m-%d %H:%M:%S"  # until an hour from now, formatted as "2024-03-16 14:00:00"
 )
@@ -760,21 +761,22 @@ TESTS_SET_SYSTEM_MODE_GOOD: dict[str, dict[str, Any]] = {
 TESTS_SET_SYSTEM_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "00": {"mode": "auto", "until": None},
     "01": {"mode": "eco_boost", "until": None},
-    "02": {"mode": "day_off", "until": _ASS_UNTIL_3DAYS},  # must adjust for
-    "03": {"mode": "eco_boost", "until": _ASS_DUR_3H},
+    "02": {"mode": "day_off", "until": _ASS_UNTIL_3DAYS},  # must adjust for pytest run time
+    "03": {"mode": "eco_boost", "until": dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180)
+           },
 }
 
 TESTS_SET_SYSTEM_MODE_FAIL: dict[str, dict[str, Any]] = {
     "04": {},  # flagged!
-}  # no asserts, caught in entity_schema
+}  # no asserts required, caught in entity_schema
 
 TESTS_SET_SYSTEM_MODE_FAIL2: dict[str, dict[str, Any]] = {
     "05": {
         "mode": "day_off",
-        "period": {"days": 3},
+        "period": {"days": 3},  # both duration and period
         "duration": {"hours": 3, "minutes": 30},
     },
-}
+}  # no asserts required, caught in checked_entry validation
 
 
 # TODO: extended test of underlying method (duration/period)

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -89,11 +89,10 @@ NUM_ENTS_AFTER = 45  # proxy for success
 # format for dt asserts, shows as: {'until': datetime.datetime(2025, 8, 11, 22, 11, 14, 774707)}
 # must round down to prev full hour to allow pytest server run time (or could still fail 1 sec after whole hour)
 # no problem if datetime is in the past, not verified
-_ASS_UNTIL = dt.now() + td(
+_ASS_UNTIL = dt.now().replace(microsecond=0) + td(
     hours=1  # min. 1, max. 24
 )  # until an hour from "now"
 _ASS_UNTIL_3DAYS = dt.now().replace(minute=0, second=0, microsecond=0) + td(days=3)
-# _ASS_DUR_3H = determine in each test
 _ASS_UNTIL_MIDNIGHT = dt.now().replace(hour=0, minute=0, second=0, microsecond=0) + td(
     days=1
 )
@@ -103,7 +102,7 @@ _ASS_UNTIL_10D = dt.now().replace(minute=0, second=0, microsecond=0) + td(
 
 # same in service call entry format
 _UNTIL = _ASS_UNTIL.strftime(
-    "%Y-%m-%d %H:%M:%S"  # until an hour from now, formatted as "2024-03-16 14:00:00"
+    "%Y-%m-%d %H:%M:%S"  # until an hour from now, formatted as "2024-03-16 14:00:00" no msec
 )
 # _UNTIL_MIDNIGHT = _ASS_UNTIL_MIDNIGHT.strftime("%Y-%m-%d %H:%M:%S")
 # _UNTIL10D = _ASS_UNTIL_10D.strftime("%Y-%m-%d %H:%M:%S")
@@ -575,7 +574,7 @@ TESTS_SET_DHW_MODE_GOOD = {
     "52": {
         "mode": "temporary_override",
         "active": True,
-        "duration": {"hours": 3},
+        "duration": {"hours": 4},
     },  # = end of today
     "62": {"mode": "temporary_override", "active": True, "until": _UNTIL},
 }  # requires custom asserts, returned from mock method success
@@ -604,7 +603,7 @@ TESTS_SET_DHW_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "52": {
         "mode": "temporary_override",
         "active": True,
-        "until": _ASS_UNTIL_MIDNIGHT,
+        "until": dt.now().replace(minute=0, second=0, microsecond=0) + td(hours=4),
     },
     "62": {
         "mode": "temporary_override",
@@ -895,7 +894,7 @@ TESTS_SET_ZONE_MODE_GOOD: dict[str, dict[str, Any]] = {
         "setpoint": 13.1,
     },  # TODO not accepted in SCH_SET_ZONE_MODE_EXTRA schema " must be one of follow-schedule"
     "41": {"mode": "temporary_override", "setpoint": 14.1},  # default duration 1 hour
-    "52": {"mode": "temporary_override", "setpoint": 15.1, "duration": {"hours": 5}},
+    "52": {"mode": "temporary_override", "setpoint": 15.1, "duration": {"hours": 3}},
     "62": {"mode": "temporary_override", "setpoint": 16.1, "until": _UNTIL},
 }  # requires custom asserts, returned from mock method success
 # with mock method ramses_tx.command.Command.set_zone_mode
@@ -908,7 +907,11 @@ TESTS_SET_ZONE_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
         "setpoint": 14.1,
         "until": _ASS_UNTIL,
     },
-    "52": {"mode": "temporary_override", "setpoint": 15.1, "until": None},
+    "52": {
+        "mode": "temporary_override",
+        "setpoint": 15.1,
+        "until": dt.now().replace(minute=0, second=0, microsecond=0) + td(hours=3),
+    },
     "62": {"mode": "temporary_override", "setpoint": 16.1, "until": _ASS_UNTIL},
 }
 

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -105,8 +105,8 @@ _ASS_UNTIL_10D = dt.now().replace(minute=0, second=0, microsecond=0) + td(
 _UNTIL = _ASS_UNTIL.strftime(
     "%Y-%m-%d %H:%M:%S"  # until an hour from now, formatted as "2024-03-16 14:00:00"
 )
-_UNTIL_MIDNIGHT = _ASS_UNTIL_MIDNIGHT.strftime("%Y-%m-%d %H:%M:%S")
-_UNTIL10D = _ASS_UNTIL_10D.strftime("%Y-%m-%d %H:%M:%S")
+# _UNTIL_MIDNIGHT = _ASS_UNTIL_MIDNIGHT.strftime("%Y-%m-%d %H:%M:%S")
+# _UNTIL10D = _ASS_UNTIL_10D.strftime("%Y-%m-%d %H:%M:%S")
 
 TEST_CONFIG: Final = {
     "serial_port": {"port_name": None},
@@ -889,11 +889,11 @@ TESTS_SET_ZONE_MODE_GOOD: dict[str, dict[str, Any]] = {
     "21": {
         "mode": "permanent_override",
         "setpoint": 12.1,
-    },  # not accepted in schema " must be one of follow-schedule"
+    },  # TODO not accepted in SCH_SET_ZONE_MODE_EXTRA schema " must be one of follow-schedule"
     "31": {
         "mode": "advanced_override",
         "setpoint": 13.1,
-    },  # not accepted in schema " must be one of follow-schedule"
+    },  # TODO not accepted in SCH_SET_ZONE_MODE_EXTRA schema " must be one of follow-schedule"
     "41": {"mode": "temporary_override", "setpoint": 14.1},  # default duration 1 hour
     "52": {"mode": "temporary_override", "setpoint": 15.1, "duration": {"hours": 5}},
     "62": {"mode": "temporary_override", "setpoint": 16.1, "until": _UNTIL},

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -89,13 +89,11 @@ NUM_ENTS_AFTER = 45  # proxy for success
 # format for dt asserts, shows as: {'until': datetime.datetime(2025, 8, 11, 22, 11, 14, 774707)}
 # must round down to prev full hour to allow pytest server run time (or could still fail 1 sec after whole hour)
 # no problem if datetime is in the past, not verified
-_ASS_UNTIL = dt.now().replace(minute=0, second=0, microsecond=0) + td(
-    hours=2  # min. 1, max. 24
+_ASS_UNTIL = dt.now() + td(
+    hours=1  # min. 1, max. 24
 )  # until an hour from "now"
-_ASS_UNTIL_3DAYS = dt.now().replace(minute=0, second=0, microsecond=0) + td(
-    days=3
-)
-#_ASS_DUR_3H = dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180)
+_ASS_UNTIL_3DAYS = dt.now().replace(minute=0, second=0, microsecond=0) + td(days=3)
+# _ASS_DUR_3H = determine in each test
 _ASS_UNTIL_MIDNIGHT = dt.now().replace(hour=0, minute=0, second=0, microsecond=0) + td(
     days=1
 )
@@ -585,18 +583,18 @@ TESTS_SET_DHW_MODE_GOOD = {
 TESTS_SET_DHW_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "11": {
         "mode": "follow_schedule",
-        'active': None,
-        'until': None,
+        "active": None,
+        "until": None,
     },
     "21": {
         "mode": "permanent_override",
         "active": True,
-        'until': None,
+        "until": None,
     },
     "31": {
         "mode": "advanced_override",
         "active": True,
-        'until': None,
+        "until": None,
     },
     "41": {
         "mode": "temporary_override",
@@ -761,9 +759,14 @@ TESTS_SET_SYSTEM_MODE_GOOD: dict[str, dict[str, Any]] = {
 TESTS_SET_SYSTEM_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "00": {"mode": "auto", "until": None},
     "01": {"mode": "eco_boost", "until": None},
-    "02": {"mode": "day_off", "until": _ASS_UNTIL_3DAYS},  # must adjust for pytest run time
-    "03": {"mode": "eco_boost", "until": dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180)
-           },
+    "02": {
+        "mode": "day_off",
+        "until": _ASS_UNTIL_3DAYS,
+    },  # must adjust for pytest run time
+    "03": {
+        "mode": "eco_boost",
+        "until": dt.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180),
+    },
 }
 
 TESTS_SET_SYSTEM_MODE_FAIL: dict[str, dict[str, Any]] = {
@@ -883,8 +886,14 @@ async def test_set_zone_config(
 
 TESTS_SET_ZONE_MODE_GOOD: dict[str, dict[str, Any]] = {
     "11": {"mode": "follow_schedule"},
-    "21": {"mode": "permanent_override", "setpoint": 12.1},
-    "31": {"mode": "advanced_override", "setpoint": 13.1},
+    "21": {
+        "mode": "permanent_override",
+        "setpoint": 12.1,
+    },  # not accepted in schema " must be one of follow-schedule"
+    "31": {
+        "mode": "advanced_override",
+        "setpoint": 13.1,
+    },  # not accepted in schema " must be one of follow-schedule"
     "41": {"mode": "temporary_override", "setpoint": 14.1},  # default duration 1 hour
     "52": {"mode": "temporary_override", "setpoint": 15.1, "duration": {"hours": 5}},
     "62": {"mode": "temporary_override", "setpoint": 16.1, "until": _UNTIL},
@@ -899,11 +908,7 @@ TESTS_SET_ZONE_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
         "setpoint": 14.1,
         "until": _ASS_UNTIL,
     },
-    "52": {
-        "mode": "temporary_override",
-        "setpoint": 15.1,
-        "until": None
-    },
+    "52": {"mode": "temporary_override", "setpoint": 15.1, "until": None},
     "62": {"mode": "temporary_override", "setpoint": 16.1, "until": _ASS_UNTIL},
 }
 


### PR DESCRIPTION
Fixes #268
Validates `set_zone_mode`, `set_dhw_mode` and `set_system_made` action call data using the original _nested_ schemas, just before invoking ramses_rf.
The accompanying tests use mocking of ramses_rf Command.set_system_mode() etc. Some timed test proved unreliable and are turned off, so must tweak later. Results are nearly correct ± a few secs.
Edit: system_mode not being returned by `assert mock_method.call_args.kwargs == asserts` is to be expected: it is a positional argument. The validation has already been done before.