### PR TITLE
Add Feature: a ramses_cc.add_command action to add commands outside the config flow

### DIFF
--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -128,21 +128,9 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         data:
           command: boost
           timeout: 3
-          packet_string: "RQ --- 29:162275 30:123456 --:------ 22F1 003 000030"  # optional
         target:
           entity_id: remote.device_id
         """
-
-        # Extract packet_string from kwargs if provided
-        packet_string = kwargs.pop("packet_string", None)
-
-        _LOGGER.debug(
-            "async_learn_command called with: command=%s, timeout=%s, packet_string=%s, kwargs=%s",
-            command,
-            timeout,
-            packet_string,
-            kwargs,
-        )
 
         # HACK to make ramses_cc call work as per HA service call
         command = [command] if isinstance(command, str) else list(command)
@@ -153,11 +141,6 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
 
         if command[0] in self._commands:
             await self.async_delete_command(command)
-
-        # If packet_string is provided, add it directly without listening
-        if packet_string:
-            self._commands[command[0]] = packet_string
-            return
 
         @callback
         def event_filter(event: Event) -> bool:

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -611,6 +611,15 @@ SCH_LEARN_COMMAND = cv.make_entity_service_schema(
         vol.Required(ATTR_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
             cv.positive_int, vol.Range(min=MIN_TIMEOUT, max=MAX_TIMEOUT)
         ),
+    },
+)
+
+# New service: add_command (inject a packet without RF learning loop)
+SVC_ADD_COMMAND: Final = "add_command"
+SCH_ADD_COMMAND = cv.make_entity_service_schema(
+    {
+        vol.Required(ATTR_COMMAND): cv.string,
+        vol.Required("packet_string"): cv.string,
     }
 )
 
@@ -646,6 +655,7 @@ SCH_DELETE_COMMAND = cv.make_entity_service_schema(
 
 SVCS_RAMSES_REMOTE = {
     SVC_DELETE_COMMAND: SCH_DELETE_COMMAND,
+    SVC_ADD_COMMAND: SCH_ADD_COMMAND,
     SVC_LEARN_COMMAND: SCH_LEARN_COMMAND,
     SVC_SEND_COMMAND: SCH_SEND_COMMAND,
 }

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -81,7 +81,7 @@ _CALL_LATER_DELAY: Final = 0  # from: custom_components.ramses_cc.broker.py
 
 NUM_DEVS_BEFORE = 3  # HGI, faked THM, faked REM
 NUM_DEVS_AFTER = 15  # proxy for success of cast_packets_to_rf()
-NUM_SVCS_AFTER = 10  # proxy for success
+NUM_SVCS_AFTER = 11  # proxy for success (includes add_command service)
 NUM_ENTS_AFTER = 47  # proxy for success
 NUM_ENTS_AFTER_ALT = (
     NUM_ENTS_AFTER - 9

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -81,7 +81,7 @@ _CALL_LATER_DELAY: Final = 0  # from: custom_components.ramses_cc.broker.py
 
 NUM_DEVS_BEFORE = 3  # HGI, faked THM, faked REM
 NUM_DEVS_AFTER = 15  # proxy for success of cast_packets_to_rf()
-NUM_SVCS_AFTER = 11  # proxy for success (includes add_command service)
+NUM_SVCS_AFTER = 11  # proxy for success
 NUM_ENTS_AFTER = 47  # proxy for success
 NUM_ENTS_AFTER_ALT = (
     NUM_ENTS_AFTER - 9


### PR DESCRIPTION
There are Ramses commands that allow a remote to set the ventilation unit to any percentage between 44% and 89.5%, with a defined resolution. For the Orcon ventilation unit, I identified the relevant command to be `31E0`.

While it's straightforward to calculate the required command for a specific percentage using a Python script and transmit it via the remote, the current implementation of ramses_cc does not support this functionality directly.

Although I believe the ideal solution would be to send arbitrary command strings to the remote in real time, I haven't implemented this yet—mainly because I haven't found a way to do this yet. Instead, I devised a workaround by introducing a new action in ramses_cc called `add_command`. Here's how it can be used:

```yaml
service: ramses.add_command
target:
  entity_id: remote.29_162275
data:
  command: setpoint  
  packet_string: " I --- 29:162275 32:146231 --:------ 31E0 008 000046000100AA00"
```

Once registered, the command can be triggered as follows:

```yaml
action: ramses_cc.send_command
target:
  entity_id: remote.29_162275
data:
  command: setpoint
  num_repeats: 3     # optional (default 3)
  delay_secs: 0.05   # optional (default 0.05)
```

I made the following changes in the code for this:

- Added SVC_ADD_COMMAND and SCH_ADD_COMMAND schemas in schemas.py
- Implemented async_add_command method in remote.py for direct command injection
- Removed unused imports and applied consistent code formatting

Note: All ramses_cc actions are also exposed under the remote namespace (e.g., `remote.learn_command`). However, the new `add_command` action is not yet available under that alias.