### PR TITLE
feat: Add support for 2411 fan parameters

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -3,6 +3,7 @@
 Requires a Honeywell HGI80 (or compatible) gateway.
 """
 
+# ruff: noqa: I001  # Allow non-standard import order
 from __future__ import annotations
 
 import logging
@@ -33,15 +34,24 @@ from .const import (
     CONF_SEND_PACKET,
     DOMAIN,
     SIGNAL_UPDATE,
+    ATTR_DEVICE_ID,
 )
 from .schemas import (
     SCH_BIND_DEVICE,
     SCH_DOMAIN_CONFIG,
+    SCH_GET_ALL_FAN_PARAMS,
+    SCH_GET_FAN_PARAM,
+    SCH_SET_FAN_PARAM,
     SCH_NO_SVC_PARAMS,
     SCH_SEND_PACKET,
+    SCH_UPDATE_PARAMETERS,
     SVC_BIND_DEVICE,
     SVC_FORCE_UPDATE,
+    SVC_GET_ALL_FAN_PARAMS,
+    SVC_GET_FAN_PARAM,
     SVC_SEND_PACKET,
+    SVC_SET_FAN_PARAM,
+    SVC_UPDATE_PARAMETERS,
 )
 
 if TYPE_CHECKING:
@@ -55,12 +65,13 @@ CONFIG_SCHEMA = vol.All(
     cv.deprecated(DOMAIN, raise_if_present=False),
     vol.Schema({DOMAIN: SCH_DOMAIN_CONFIG}, extra=vol.ALLOW_EXTRA),
 )
-
-PLATFORMS: Final[Platform] = (
+# seems not being used ...
+PLATFORMS: Final[tuple[Platform, ...]] = (
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
-    Platform.SENSOR,
+    Platform.NUMBER,
     Platform.REMOTE,
+    Platform.SENSOR,
     Platform.WATER_HEATER,
 )
 
@@ -86,43 +97,57 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Create a ramses_rf (RAMSES_II)-based system."""
 
+    _LOGGER.debug("=== RAMSES_CC SETUP ENTRY START ===")
     _LOGGER.debug("Setting up entry %s...", entry.entry_id)
 
-    broker = RamsesBroker(hass, entry)  # KeyError: 'serial_port'
+    # Check if this entry is already set up
+    if entry.entry_id in hass.data[DOMAIN]:
+        _LOGGER.debug("Entry %s is already set up", entry.entry_id)
+        return True
+
+    broker = RamsesBroker(hass, entry)
 
     try:
+        # Store the broker in hass.data before setting it up
+        hass.data[DOMAIN][entry.entry_id] = broker
         await broker.async_setup()
     except exc.TransportSourceInvalid as err:  # not TransportSerialError
         _LOGGER.error("Unrecoverable problem with the serial port: %s", err)
+        hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
         return False
     except exc.TransportError as err:
         msg = f"There is a problem with the serial port: {err} (check config)"
         _LOGGER.warning(
             "Failed to set up entry %s (will retry): %s", entry.entry_id, msg
         )
-        raise ConfigEntryNotReady(msg) from err  # TODO: when to give up?
+        hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
+        raise ConfigEntryNotReady(msg) from err
 
-    # Setup is complete and config is valid, so start polling
-    hass.data[DOMAIN][entry.entry_id] = broker
+    # Start the broker after successful setup
     await broker.async_start()
 
+    _LOGGER.debug("Registering domain services and events")
     async_register_domain_services(hass, entry, broker)
     async_register_domain_events(hass, entry, broker)
+    _LOGGER.debug("Finished registering domain services and events")
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
 
     _LOGGER.debug("Successfully set up entry %s", entry.entry_id)
+
     return True
 
 
 async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
-    hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+    _LOGGER.debug("Config entry %s updated, reloading integration...", entry.entry_id)
+
+    # Just reload the entry, which will handle unloading and setting up again
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-
     broker: RamsesBroker = hass.data[DOMAIN][entry.entry_id]
     if not await broker.async_unload_platforms():
         return False
@@ -192,6 +217,35 @@ def async_register_domain_services(
     async def async_send_packet(call: ServiceCall) -> None:
         await broker.async_send_packet(call)
 
+    @verify_domain_control(hass, DOMAIN)
+    async def async_get_fan_param(call: ServiceCall) -> None:
+        await broker.async_get_fan_param(call)
+
+    @verify_domain_control(hass, DOMAIN)
+    async def async_set_fan_param(call: ServiceCall) -> None:
+        await broker.async_set_fan_param(call)
+
+    @verify_domain_control(hass, DOMAIN)
+    async def async_update_parameters(call: ServiceCall) -> None:
+        """Handle update_parameters service calls."""
+        device_id = call.data[ATTR_DEVICE_ID]
+        _LOGGER.debug("Updating all parameters for device %s", device_id)
+        await broker.async_update_all_parameters(device_id)
+
+    @verify_domain_control(hass, DOMAIN)
+    async def async_get_all_fan_params(call: ServiceCall) -> None:
+        """Handle get_all_fan_params service calls."""
+        device_id = call.data[ATTR_DEVICE_ID]
+        from_id = call.data.get("from_id")
+        fan_id = call.data.get("fan_id", device_id)
+        _LOGGER.debug(
+            "Getting all parameters for device %s (from: %s, fan_id: %s)",
+            device_id,
+            from_id or "HGI",
+            fan_id,
+        )
+        await broker.async_get_all_fan_params(device_id, from_id=from_id, fan_id=fan_id)
+
     hass.services.async_register(
         DOMAIN, SVC_BIND_DEVICE, async_bind_device, schema=SCH_BIND_DEVICE
     )
@@ -199,6 +253,29 @@ def async_register_domain_services(
         DOMAIN, SVC_FORCE_UPDATE, async_force_update, schema=SCH_NO_SVC_PARAMS
     )
 
+    hass.services.async_register(
+        DOMAIN, SVC_GET_FAN_PARAM, async_get_fan_param, schema=SCH_GET_FAN_PARAM
+    )
+
+    hass.services.async_register(
+        DOMAIN, SVC_SET_FAN_PARAM, async_set_fan_param, schema=SCH_SET_FAN_PARAM
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SVC_UPDATE_PARAMETERS,
+        async_update_parameters,
+        schema=SCH_UPDATE_PARAMETERS,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SVC_GET_ALL_FAN_PARAMS,
+        async_get_all_fan_params,
+        schema=SCH_GET_ALL_FAN_PARAMS,
+    )
+
+    # Advanced features
     if entry.options.get(CONF_ADVANCED_FEATURES, {}).get(CONF_SEND_PACKET):
         hass.services.async_register(
             DOMAIN, SVC_SEND_PACKET, async_send_packet, schema=SCH_SEND_PACKET
@@ -227,7 +304,14 @@ class RamsesEntity(Entity):
         self._device = device
         self.entity_description = entity_description
 
-        self._attr_unique_id = device.id
+        # For parameter entities, include the parameter ID in the unique_id
+        if hasattr(entity_description, "parameter_id"):
+            self._attr_unique_id = (
+                f"{device.id}-param-{entity_description.parameter_id}"
+            )
+        else:
+            self._attr_unique_id = device.id
+
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device.id)})
 
     @property
@@ -247,9 +331,19 @@ class RamsesEntity(Entity):
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         self._broker._entities[self.unique_id] = self
+
+        # Listen for general update signal (for backward compatibility)
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, SIGNAL_UPDATE, self.async_write_ha_state
+            )
+        )
+
+        # Also listen for device-specific update signal
+        device_signal = f"{SIGNAL_UPDATE}_{self._device.id}"
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, device_signal, self.async_write_ha_state
             )
         )
 

--- a/custom_components/ramses_cc/broker.py
+++ b/custom_components/ramses_cc/broker.py
@@ -14,7 +14,7 @@ import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -33,9 +33,11 @@ from ramses_rf.schemas import SZ_SCHEMA
 from ramses_rf.system import Evohome, System, Zone
 from ramses_tx.address import pkt_addrs
 from ramses_tx.command import Command
-from ramses_tx.const import Code
+from ramses_tx.const import Code, DevType
 from ramses_tx.exceptions import PacketAddrSetInvalid
+from ramses_tx.ramses import _2411_PARAMS_SCHEMA
 from ramses_tx.schemas import (
+    SZ_BOUND_TO,
     SZ_KNOWN_LIST,
     SZ_PACKET_LOG,
     SZ_SERIAL_PORT,
@@ -59,7 +61,6 @@ from .schemas import merge_schemas, schema_is_minimal
 
 if TYPE_CHECKING:
     from . import RamsesEntity
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,6 +98,9 @@ class RamsesBroker:
         self._dhws: list[Zone] = []
 
         self._sem = Semaphore(value=1)
+
+        # Initialize platforms dictionary to store platform references
+        self.platforms: dict[str, Any] = {}
 
         self.learn_device_id: str | None = None  # TODO: can we do without this?
 
@@ -205,21 +209,37 @@ class RamsesBroker:
         add_new_devices: Callable[[RamsesRFEntity], None],
     ) -> None:
         """Register a platform for device addition."""
+        platform_str = platform.domain if hasattr(platform, "domain") else platform
+        _LOGGER.debug("[broker]Registering platform %s", platform_str)
+
+        # Store the platform reference for entity lookup
+        if platform_str not in self.platforms:
+            self.platforms[platform_str] = []
+        self.platforms[platform_str].append(platform)
+
         self.entry.async_on_unload(
             async_dispatcher_connect(
-                self.hass, SIGNAL_NEW_DEVICES.format(platform.domain), add_new_devices
+                self.hass, SIGNAL_NEW_DEVICES.format(platform_str), add_new_devices
             )
         )
 
-    async def _async_setup_platform(self, platform: str) -> None:
-        """Set up a platform."""
+    async def _async_setup_platform(self, platform: str) -> bool:
+        """Set up a platform and return True if successful."""
         if platform not in self._platform_setup_tasks:
             self._platform_setup_tasks[platform] = self.hass.async_create_task(
                 self.hass.config_entries.async_forward_entry_setups(
                     self.entry, [platform]
                 )
             )
-        await self._platform_setup_tasks[platform]
+        try:
+            await self._platform_setup_tasks[platform]
+            _LOGGER.debug("Platform setup completed for %s", platform)
+            return True
+        except Exception as ex:
+            _LOGGER.error(
+                "Error setting up %s platform: %s", platform, str(ex), exc_info=True
+            )
+            return False
 
     async def async_unload_platforms(self) -> bool:
         """Unload platforms."""
@@ -228,11 +248,201 @@ class RamsesBroker:
             for platform, task in self._platform_setup_tasks.items()
             if not task.cancel()
         ]
-        return all(await asyncio.gather(*tasks))
+        result = all(await asyncio.gather(*tasks))
+        _LOGGER.debug("Platform unload completed with result: %s", result)
+        return result
+
+    async def _get_all_fan_params(
+        self, device: Device, from_id: str | None = None
+    ) -> None:
+        """Request values for all supported 2411 parameters of a device.
+
+        Uses the async_get_fan_param servicecall to request each parameter value.
+        Uses the specified from_id, bound REM/DIS device, or HGI as the source for the request.
+
+        Args:
+            device: The device to request parameters for
+            from_id: Optional source device ID to use for the request. If not provided,
+                   will use the bound REM/DIS device or HGI.
+        """
+        if not hasattr(device, "supports_2411") or not device.supports_2411:
+            _LOGGER.debug("Device %s does not support 2411 parameters", device.id)
+            return
+
+        _LOGGER.debug("Requesting all parameter values for device %s", device.id)
+
+        # If from_id is not provided, try to get it from bound REM/DIS device or HGI
+        if from_id is None:
+            if hasattr(device, "get_bound_rem") and (from_id := device.get_bound_rem()):
+                _LOGGER.debug("Using bound device %s for parameter requests", from_id)
+            elif self.client and self.client.hgi and (from_id := self.client.hgi.id):
+                _LOGGER.debug("Using HGI device %s for parameter requests", from_id)
+
+            if not from_id:
+                _LOGGER.error(
+                    "Cannot request parameters: No HGI or bound REM/DIS device available for %s",
+                    device.id,
+                )
+                return
+
+        # Request parameters one at a time with a small delay between them
+        for param_id in _2411_PARAMS_SCHEMA:
+            try:
+                _LOGGER.debug("Requesting value for parameter %s", param_id)
+                # Create parameter dictionary with proper types
+                params = {
+                    "device_id": str(device.id),
+                    "param_id": str(param_id),
+                    "from_id": str(from_id)
+                    if from_id
+                    else None,  # Either HGI or bound REM/DIS device
+                    "fan_id": str(
+                        device.id
+                    ),  # Always use the device's own ID as fan_id
+                }
+                # Call directly with the params dict
+                await self.async_get_fan_param(params)
+                await asyncio.sleep(0.1)  # Small delay between requests
+            except Exception as ex:
+                _LOGGER.warning(
+                    "Failed to request parameter %s: %s",
+                    param_id,
+                    str(ex),
+                    exc_info=True,
+                )
+
+    async def _async_create_parameter_entities(self, device: Device) -> None:
+        """Create parameter entities for a device that supports 2411 parameters."""
+        from .number import (
+            async_create_parameter_entities,
+        )  # import here to avoid circular import
+
+        entities = await async_create_parameter_entities(self, device)
+        if entities:
+            _LOGGER.info(
+                "Adding %d parameter entities for %s", len(entities), device.id
+            )
+            async_dispatcher_send(
+                self.hass, SIGNAL_NEW_DEVICES.format(Platform.NUMBER), entities
+            )
+
+    async def _setup_fan_bound_devices(self, device: Device) -> None:
+        """Set up bound devices for a FAN device.
+
+        It checks if the device is a FAN.
+        It adds a bound REM or DIS device to the FAN's tracking.
+        We need this when setting a 2411 parameter value, or the
+        FAN will not respond to it.
+        For now it only supports 1 bound device. To add more (CO2 ?) we need to
+        adapt the schema to accept a list of bound devices and adapt this method
+        to handle more than 1 bound device.
+        Hvac already has a _bound_devices dict prepared.
+        """
+        # Only proceed if this is a FAN device
+        if not isinstance(device, HvacVentilator):
+            return
+
+        # Get device configuration from known_list
+        device_config = self.options.get(SZ_KNOWN_LIST, {}).get(device.id, {})
+        if SZ_BOUND_TO in device_config:
+            _LOGGER.debug("Device config: %s", device_config)
+            _LOGGER.debug("Device type: %s", device.type)
+            _LOGGER.debug("Device class: %s", device.__class__)
+
+            bound_device_id = device_config[SZ_BOUND_TO]
+            _LOGGER.info(
+                "Binding FAN %s and REM/DIS device %s", device.id, bound_device_id
+            )
+
+            # Find the bound device and get its type
+            bound_device = next(
+                (d for d in self.client.devices if d.id == bound_device_id),
+                None,
+            )
+
+            if bound_device:
+                # Determine the device type based on the class
+                if isinstance(bound_device, HvacRemoteBase):
+                    device_type = DevType.REM
+                elif (
+                    hasattr(bound_device, "_SLUG") and bound_device._SLUG == DevType.DIS
+                ):
+                    device_type = DevType.DIS
+                else:
+                    _LOGGER.warning(
+                        "Cannot bind device %s of type %s to FAN %s: must be REM or DIS",
+                        bound_device_id,
+                        getattr(bound_device, "_SLUG", "unknown"),
+                        device.id,
+                    )
+                    return
+
+                # Add the bound device to the FAN's tracking
+                device.add_bound_device(bound_device_id, device_type)
+                _LOGGER.info(
+                    "Bound FAN %s to %s device %s",
+                    device.id,
+                    device_type,
+                    bound_device_id,
+                )
+            else:
+                _LOGGER.warning(
+                    "Bound device %s not found for FAN %s", bound_device_id, device.id
+                )
+
+    async def _async_setup_device(self, device: Device) -> None:
+        """Set up a device and its entities.
+
+        Called from async_update() when a device is first discovered.
+        It checks if the device is a FAN.
+        It sets up the device and its entities, and also checks for bound REM/DIS devices.
+        """
+        _LOGGER.debug("Setting up device: %s", device)
+
+        # For FAN devices, set up bound devices and parameter handling
+        if hasattr(device, "_SLUG") and device._SLUG == "FAN":
+            await self._setup_fan_bound_devices(device)
+
+            # Set up the initialization callback - will be called on first message
+            if hasattr(device, "set_initialized_callback"):
+
+                async def on_first_message() -> None:
+                    _LOGGER.debug(
+                        "First message received from FAN %s, creating parameter entities",
+                        device.id,
+                    )
+                    # Create parameter entities after first message is received
+                    await self._async_create_parameter_entities(device)
+                    # Request all parameters after creating entities
+                    await self._get_all_fan_params(device)
+
+                device.set_initialized_callback(
+                    lambda: self.hass.async_create_task(on_first_message())
+                )
+
+            # Set up parameter update callback
+            if hasattr(device, "set_param_update_callback"):
+                device.set_param_update_callback(
+                    lambda param_id, value: self.hass.bus.async_fire(
+                        "ramses_cc.fan_param_updated",
+                        {"device_id": device.id, "param_id": param_id, "value": value},
+                    )
+                )
+
+            # Check if device is already initialized (e.g., from cached messages)
+            # This handles the case where we restart but the device already has state
+            if hasattr(device, "supports_2411") and device.supports_2411:
+                if getattr(device, "_initialized", False):
+                    _LOGGER.debug(
+                        "Device %s already initialized, creating parameter entities and requesting parameters",
+                        device.id,
+                    )
+                    await self._async_create_parameter_entities(device)
+                    await self._get_all_fan_params(device)
 
     def _update_device(self, device: RamsesRFEntity) -> None:
-        if hasattr(device, "name") and device.name:
-            name = device.name
+        if hasattr(device, "_name") and device._name:
+            name = device._name
         elif isinstance(device, System):
             name = f"Controller {device.id}"
         elif device._SLUG:
@@ -308,6 +518,9 @@ class RamsesBroker:
         for device in self._devices + self._systems + self._zones + self._dhws:
             self._update_device(device)
 
+        for device in new_devices + new_systems + new_zones + new_dhws:
+            await self._async_setup_device(device)
+
         new_entities = new_devices + new_systems + new_zones + new_dhws
         # these two are the only opportunity to use async_forward_entry_setups with
         # multiple platforms (i.e. not just one)...
@@ -320,10 +533,10 @@ class RamsesBroker:
         await async_add_entities(
             Platform.REMOTE, [d for d in new_devices if isinstance(d, HvacRemoteBase)]
         )
-
         await async_add_entities(Platform.CLIMATE, new_systems)
         await async_add_entities(Platform.CLIMATE, new_zones)
         await async_add_entities(Platform.WATER_HEATER, new_dhws)
+        await async_add_entities(Platform.NUMBER, new_entities)
 
         if new_entities:
             await self.async_save_client_state()
@@ -331,7 +544,6 @@ class RamsesBroker:
         # Trigger state updates of all entities
         async_dispatcher_send(self.hass, SIGNAL_UPDATE)
 
-    # The service handlers are class methods to facilitate mocking...
     async def async_bind_device(self, call: ServiceCall) -> None:
         """Handle the bind_device service call."""
 
@@ -383,3 +595,305 @@ class RamsesBroker:
 
         await self.client.async_send_cmd(cmd)
         async_call_later(self.hass, _CALL_LATER_DELAY, self.async_update)
+
+    def _find_entity(self, device_id: str, param_id: str) -> Any | None:
+        """Find an entity by device ID and parameter ID.
+
+        Args:
+            device_id: The device ID (with either colons or underscores)
+            param_id: The parameter ID
+
+        Returns:
+            The entity if found, None otherwise
+        """
+        # Normalize device ID to use underscores for entity ID
+        safe_device_id = device_id.replace(":", "_")
+        target_entity_id = f"number.{safe_device_id}_param_{param_id}"
+
+        # First try to find the entity in the entity registry
+        ent_reg = er.async_get(self.hass)
+
+        # Try with the exact entity ID first
+        entity_entry = ent_reg.async_get(target_entity_id)
+        if entity_entry:
+            _LOGGER.debug(f"Found entity {target_entity_id} in entity registry")
+            # Get the actual entity from the platform
+            platforms = self.platforms.get("number", [])
+            _LOGGER.debug(f"Checking platforms: {platforms}")
+            for platform in platforms:
+                if (
+                    hasattr(platform, "entities")
+                    and target_entity_id in platform.entities
+                ):
+                    return platform.entities[target_entity_id]
+                else:
+                    _LOGGER.debug(
+                        f"Entity {target_entity_id} not found in platform.entities"
+                    )
+
+        _LOGGER.debug(f"Entity {target_entity_id} not found in any known location")
+        return None
+
+    def _set_entity_pending(self, entity: Any, param_id: str) -> None:
+        """Set an entity to pending state.
+
+        Args:
+            entity: The entity to update
+            param_id: The parameter ID for logging
+        """
+        if not entity:
+            return
+
+        try:
+            entity._is_pending = True
+            entity.async_write_ha_state()
+            _LOGGER.debug("Set pending state for parameter %s", param_id)
+        except Exception as ex:
+            _LOGGER.warning(
+                "Failed to set pending state for parameter %s: %s", param_id, str(ex)
+            )
+
+    def _clear_entity_pending(self, entity: Any, param_id: str) -> None:
+        """Clear pending state for an entity.
+
+        Args:
+            entity: The entity to update
+            param_id: The parameter ID for logging
+        """
+        if not entity:
+            return
+
+        try:
+            if hasattr(entity, "_is_pending"):
+                entity._is_pending = False
+                entity.async_write_ha_state()
+                _LOGGER.debug("Cleared pending state for parameter %s", param_id)
+        except Exception as ex:
+            _LOGGER.warning(
+                "Failed to clear pending state for parameter %s: %s", param_id, str(ex)
+            )
+
+    async def _clear_pending_timeout(
+        self, entity: Any, param_id: str, timeout: int = 30
+    ) -> None:
+        """Clear pending state after a timeout if still set.
+
+        Args:
+            entity: The entity to update
+            param_id: The parameter ID for logging
+            timeout: Timeout in seconds
+        """
+        await asyncio.sleep(timeout)
+        self._clear_entity_pending(entity, param_id)
+
+    async def async_get_fan_param(self, call: dict[str, Any] | ServiceCall) -> None:
+        """Handle get_fan_param service call.
+
+        This sends a parameter read request to the specified fan device. The response
+        will be processed by the device's normal packet handling.
+
+        Args:
+            call: (ServiceCall | dict) call data containing:
+                - device_id: Target device ID (required)
+                - param_id: Parameter ID to read (required, 2 hex digits)
+                - from_id: Source device ID (optional, defaults to HGI)
+                - fan_id: Fan ID (optional, defaults to device_id)
+
+        Raises:
+            ValueError: If required parameters are missing or invalid
+        """
+        # Handle both ServiceCall and direct dict inputs
+        data: dict[str, Any] = call.data if hasattr(call, "data") else call
+
+        # Extract parameters
+        device_id: str | None = data.get("device_id")
+        param_id: str | None = data.get("param_id")
+        from_id: str | None = data.get("from_id")
+        fan_id: str | None = data.get("fan_id")
+
+        # Validate required parameters
+        if not device_id:
+            _LOGGER.error("Missing required parameter: device_id")
+            raise ValueError("required key not provided @ data['device_id']")
+
+        if not param_id:
+            _LOGGER.error("Missing required parameter: param_id")
+            raise ValueError("required key not provided @ data['param_id']")
+
+        # Validate parameter ID format (must be 2-digit hex)
+        try:
+            if len(param_id) != 2 or int(param_id, 16) < 0 or int(param_id, 16) > 0xFF:
+                raise ValueError
+        except (ValueError, TypeError):
+            error_msg = f"Invalid parameter ID: '{param_id}'. Must be a 2-digit hexadecimal value (00-FF)"
+            _LOGGER.error(error_msg)
+            raise ValueError(error_msg) from None
+
+        # Find the corresponding entity and set it to pending
+        entity = self._find_entity(fan_id or device_id, param_id)
+        self._set_entity_pending(entity, param_id)
+
+        if not from_id and self.client and self.client.hgi:
+            from_id = self.client.hgi.id
+
+        if not from_id:
+            raise ValueError("No source device ID specified and HGI not available")
+
+        cmd = Command.get_fan_param(fan_id or device_id, param_id, src_id=from_id)
+        _LOGGER.debug("Sending command: %s", cmd)
+
+        # Send the command directly using the gateway with a little delay to deminish message flooding
+        await self.client.async_send_cmd(cmd)
+        await asyncio.sleep(0.2)
+
+        # Clear pending state after 30 seconds if no response is received
+        if entity:
+            self.hass.async_create_task(self._clear_pending_timeout(entity, param_id))
+
+    async def async_get_all_fan_params(
+        self, device_id: str, from_id: str | None = None, fan_id: str | None = None
+    ) -> None:
+        """Request all fan parameters for a device.
+
+        This method sends a parameter read request for each parameter in the 2411 schema
+        to the specified fan device. The responses will be processed by the device's
+        normal packet handling.
+
+        Args:
+            device_id: The device ID to request parameters for
+            from_id: Optional source device ID (defaults to HGI or bound REM/DIS device)
+            fan_id: Optional fan device ID (defaults to device_id)
+
+        Raises:
+            ValueError: If device_id is not provided or device not found
+        """
+        if not device_id:
+            raise ValueError("device_id is required")
+
+        # Find the device
+        device = next((d for d in self._devices if d.id == device_id), None)
+        if not device:
+            raise ValueError(f"Device {device_id} not found")
+
+        # If no fan_id is provided, use the device_id
+        fan_id = fan_id or device_id
+
+        # Get the list of parameters to request
+        for param_id in _2411_PARAMS_SCHEMA:
+            try:
+                _LOGGER.debug("Requesting value for parameter %s", param_id)
+                # Create parameter dictionary
+                params: dict[str, Any] = {
+                    "device_id": device.id,
+                    "param_id": param_id,
+                    "from_id": from_id,  # Either HGI or bound REM/DIS device
+                    "fan_id": fan_id,  # Always use the device's own ID as fan_id
+                }
+                # Call directly with the params dict
+                await self.async_get_fan_param(params)
+                await asyncio.sleep(0.1)
+            except Exception as ex:
+                _LOGGER.warning(
+                    "Failed to request parameter %s: %s", param_id, ex, exc_info=True
+                )
+
+    async def async_set_fan_param(self, call: ServiceCall) -> None:
+        """Handle set_fan_param service call.
+
+        This sends a parameter write request to the specified fan device. The response
+        will be processed by the device's normal packet handling.
+
+        Args:
+            call: Service call data containing:
+                - device_id: Target device ID (required)
+                - param_id: Parameter ID to write (required, 2 hex digits)
+                - from_id: Source device ID (optional, defaults to HGI)
+                - fan_id: Fan ID (optional, defaults to device_id)
+
+        Raises:
+            ValueError: If required parameters are missing or invalid
+            ValueError: If parameter ID is not a valid 2-digit hex value
+        """
+        _LOGGER.debug("Processing set_fan_param service call with data: %s", call.data)
+        try:
+            # set parameters from service call with defaults
+            device_id = call.data.get("device_id")
+            param_id = str(
+                call.data.get("param_id", "")
+            ).upper()  # Normalize to uppercase
+            value = call.data.get("value")
+            from_id = call.data.get(
+                "from_id",
+                self.client.hgi.id if self.client and self.client.hgi else None,
+            )
+            fan_id = call.data.get("fan_id", device_id)
+
+            _LOGGER.debug(
+                "Parsed parameters - device_id: %s, param_id: %s, value: %s, from_id: %s, fan_id: %s",
+                device_id,
+                param_id,
+                value,
+                from_id,
+                fan_id,
+            )
+
+            # Validate required parameters
+            if not device_id:
+                _LOGGER.error("Missing required parameter: device_id")
+                raise ValueError("required key not provided @ data['device_id']")
+
+            if not param_id:
+                _LOGGER.error("Missing required parameter: param_id")
+                raise ValueError("required key not provided @ data['param_id']")
+
+            # Validate parameter ID format (must be 2-digit hex)
+            try:
+                if (
+                    len(param_id) != 2
+                    or int(param_id, 16) < 0
+                    or int(param_id, 16) > 0xFF
+                ):
+                    raise ValueError
+            except (ValueError, TypeError):
+                error_msg = f"Invalid parameter ID: '{param_id}'. Must be a 2-digit hexadecimal value (00-FF)"
+                _LOGGER.error(error_msg)
+                raise ValueError(error_msg) from None
+
+            # Find the corresponding entity and set it to pending
+            entity = self._find_entity(fan_id, param_id)
+            self._set_entity_pending(entity, param_id)
+
+            if not value:
+                _LOGGER.error("Missing required parameter: value")
+                raise ValueError("required key not provided @ data['value']")
+
+            if not from_id:
+                raise ValueError("No source device ID specified and HGI not available")
+
+            cmd = Command.set_fan_param(fan_id, param_id, value, src_id=from_id)
+            _LOGGER.debug("Sending command: %s", cmd)
+
+            # Send the command directly using the gateway with a little delay to deminish message flooding
+            await self.client.async_send_cmd(cmd)
+            await asyncio.sleep(0.2)
+
+            # Clear pending state after 30 seconds if no response is received
+            if entity:
+                self.hass.async_create_task(
+                    self._clear_pending_timeout(entity, param_id)
+                )
+
+        except Exception as ex:
+            # Clear pending state on error
+            if entity:
+                self._clear_entity_pending(entity, param_id)
+
+            _LOGGER.warning(
+                "Failed to send set_fan_param command to %s (param: %s, from: %s, value: %s): %s",
+                device_id,
+                param_id,
+                from_id,
+                value,
+                ex,
+                exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
+            )

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -571,6 +571,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
             store = Store(self.hass, STORAGE_VERSION, STORAGE_KEY)
             stored_data: dict[str, Any] = await store.async_load() or {}
+
             if SZ_CLIENT_STATE in stored_data:
                 if user_input["clear_schema"]:
                     stored_data[SZ_CLIENT_STATE].pop(SZ_SCHEMA)

--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -13,6 +13,7 @@ STORAGE_KEY: Final = DOMAIN
 # Dispatcher signals
 SIGNAL_NEW_DEVICES: Final = f"{DOMAIN}_new_devices_" + "{}"
 SIGNAL_UPDATE: Final = f"{DOMAIN}_update"
+SIGNAL_PARAM_SUPPORT_CHANGED: Final = f"{DOMAIN}_param_support_changed"
 
 # Config
 CONF_ADVANCED_FEATURES: Final = "advanced_features"
@@ -44,6 +45,7 @@ ATTR_DURATION: Final = "duration"
 ATTR_FAN_RATE: Final = "fan_rate"
 ATTR_FAULT_LOG: Final = "fault_log"
 ATTR_HEAT_DEMAND: Final = "heat_demand"
+ATTR_PARAM_ID: Final = "parameter_id"
 ATTR_HUMIDITY: Final = "relative_humidity"
 ATTR_INDOOR_HUMIDITY: Final = "indoor_humidity"
 ATTR_LATEST_EVENT: Final = "latest_event"

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -1,0 +1,578 @@
+"""Support for RAMSES numbers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from types import UnionType
+
+from homeassistant.components.number import (
+    ENTITY_ID_FORMAT,
+    NumberEntity,
+    NumberEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import (
+    AddEntitiesCallback,
+    EntityPlatform,
+    async_get_current_platform,
+)
+
+from ramses_rf.device import Fakeable
+from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_tx import (
+    _2411_PARAMS_SCHEMA,
+    SZ_DATA_TYPE,
+    SZ_DATA_UNIT,
+    SZ_DESCRIPTION,
+    SZ_MAX_VALUE,
+    SZ_MIN_VALUE,
+    SZ_PRECISION,
+)
+
+# from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from . import RamsesEntity, RamsesEntityDescription
+from .broker import RamsesBroker
+from .const import DOMAIN
+from .schemas import SVCS_RAMSES_FAN_PARAM
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the number platform."""
+
+    broker: RamsesBroker = hass.data[DOMAIN][entry.entry_id]
+    platform: EntityPlatform = async_get_current_platform()
+    # register the FAN PARAM services to the platform
+    for k, v in SVCS_RAMSES_FAN_PARAM.items():
+        platform.async_register_entity_service(k, v, f"async_{k}")
+
+    @callback
+    def add_devices(devices: list[RamsesRFEntity]) -> None:
+        _LOGGER.debug("[Number] Adding %d devices", len(devices))
+        entities = [
+            description.ramses_cc_class(broker, device, description)
+            for device in devices
+            for description in NUMBER_DESCRIPTIONS
+            if isinstance(device, description.ramses_rf_class)
+            and hasattr(device, description.check_attr)
+        ]
+        async_add_entities(entities)
+
+    broker.async_register_platform(platform, add_devices)
+
+
+class RamsesNumber(RamsesEntity, NumberEntity):
+    """Representation of a generic number."""
+
+    entity_description: RamsesNumberEntityDescription
+    _attr_should_poll = False  # Disable polling, we'll update via events
+    _param_native_value: dict[str, float | None] = None  # type: ignore[assignment]
+
+    @property
+    def mode(self) -> str:
+        """Return the mode of the entity."""
+        if (
+            hasattr(self.entity_description, "ramses_rf_attr")
+            and self.entity_description.ramses_rf_attr == "75"
+        ):
+            return "slider"
+        return "auto"
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+
+        # Listen for parameter update events
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                "ramses_cc.fan_param_updated", self._async_param_updated
+            )
+        )
+
+        # Request initial value
+        await self._request_parameter_value()
+
+    @callback
+    def _async_param_updated(self, event) -> None:
+        """Handle parameter updates from the device.
+
+        This method is called when a fan parameter update event is received (for any 2411 entity).
+        It processes the event data and updates the entity state if the event is relevant to this entity.
+        """
+        data = event.data
+        our_param_id = getattr(self.entity_description, "ramses_rf_attr", "")
+        if not our_param_id:
+            return
+
+        # Only process if this is our parameter
+        if (
+            str(data.get("device_id", "")).lower() == str(self._device.id).lower()
+            and str(data.get("param_id", "")).lower() == str(our_param_id).lower()
+        ):
+            new_value = data.get("value")
+            if (
+                not hasattr(self, "_param_native_value")
+                or self._param_native_value is None
+            ):
+                self._param_native_value = {}
+
+            # Ensure we're using the same key type as in native_value property
+            param_id = str(
+                our_param_id
+            ).upper()  # Convert to uppercase string for consistency
+            self._param_native_value[param_id] = new_value
+            _LOGGER.debug(
+                "Parameter %s updated for device %s: %s (stored as: %s, full dict: %s)",
+                our_param_id,
+                self._device.id,
+                new_value,
+                self._param_native_value.get(param_id),
+                self._param_native_value,
+            )
+
+            # Clear pending state since we've received the update
+            if self._is_pending:
+                _LOGGER.debug("Clearing pending state for parameter %s", our_param_id)
+                self._is_pending = False
+                self._pending_value = None
+
+            self.async_write_ha_state()
+
+    def __init__(
+        self,
+        broker: RamsesBroker,
+        device: RamsesRFEntity,
+        entity_description: RamsesEntityDescription,
+    ) -> None:
+        """Initialize the number."""
+        _LOGGER.info("Found %r: %s", device, entity_description.key)
+        super().__init__(broker, device, entity_description)
+
+        # Initialize parameter values dictionary
+        self._param_native_value: dict[str, float | None] = {}
+
+        # Initialize pending state
+        self._is_pending = False
+        self._pending_value: float | None = None
+
+        self.entity_id = ENTITY_ID_FORMAT.format(
+            f"{device.id}_{entity_description.key}"
+        )
+        self._attr_unique_id = f"{device.id}-{entity_description.key}"
+
+        # Get the parameter ID from the entity description
+        param_id = getattr(entity_description, "ramses_rf_attr", "")
+
+        # Special case for parameters that are already in percentage - don't scale them
+        self._is_percentage = (
+            hasattr(entity_description, "unit_of_measurement")
+            and entity_description.unit_of_measurement == "%"
+            and param_id not in ("52", "95")
+        )  # Don't scale these parameters
+
+        # Set min/max/step values from entity description if available
+        if (
+            hasattr(entity_description, "min_value")
+            and entity_description.min_value is not None
+        ):
+            min_val = float(entity_description.min_value)
+            self._attr_native_min_value = (
+                min_val * 100 if self._is_percentage else min_val
+            )
+
+        if (
+            hasattr(entity_description, "max_value")
+            and entity_description.max_value is not None
+        ):
+            max_val = float(entity_description.max_value)
+            self._attr_native_max_value = (
+                max_val * 100 if self._is_percentage else max_val
+            )
+
+        # Special handling for temperature parameters (param 75) - force 0.1°C precision
+        if param_id == "75":
+            self._attr_native_step = 0.1
+            _LOGGER.debug(
+                "Forcing 0.1°C precision for parameter 75 (Comfort temperature)"
+            )
+        elif (
+            hasattr(entity_description, "precision")
+            and entity_description.precision is not None
+        ):
+            precision = float(entity_description.precision)
+            self._attr_native_step = precision * (100 if self._is_percentage else 1)
+
+        # Set unit of measurement if available
+        if (
+            hasattr(entity_description, "unit_of_measurement")
+            and entity_description.unit_of_measurement
+        ):
+            self._attr_native_unit_of_measurement = (
+                entity_description.unit_of_measurement
+            )
+
+        _LOGGER.debug(
+            "Initialized number entity %s with min=%s, max=%s, step=%s, unit=%s, is_percentage=%s, param_id=%s",
+            self.entity_id,
+            getattr(self, "_attr_native_min_value", "unset"),
+            getattr(self, "_attr_native_max_value", "unset"),
+            getattr(self, "_attr_native_step", "unset"),
+            getattr(self, "_attr_native_unit_of_measurement", "unset"),
+            self._is_percentage,
+            param_id,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return if the entity is available."""
+        """Return True if the entity is available."""
+        # TODO: Should use dtm of last packet received, rather than is not None
+        return (
+            isinstance(self._device, Fakeable) and self._device.is_faked
+        ) or self.state is not None  # TODO: but what if None _is_ its state?
+
+    async def _request_parameter_value(self) -> None:
+        """Request the current value of this parameter from the device.
+
+        This method implements rate limiting to prevent duplicate requests for the same parameter.
+        It will only make a new request if:
+        1. No request is currently pending for this parameter, AND
+        2. No request has been made for this parameter in the last 30 seconds
+
+        """
+        if (
+            not hasattr(self, "hass")
+            or not hasattr(self, "_device")
+            or not hasattr(self.entity_description, "ramses_rf_attr")
+        ):
+            _LOGGER.debug("_request_parameter_value: missing required attributes")
+            return
+
+        # Get the parameter ID from the entity description
+        param_id = self.entity_description.ramses_rf_attr
+        if not param_id:
+            _LOGGER.debug("_request_parameter_value: missing parameter ID")
+            return
+
+        # Check if we have a pending request for this parameter
+        request_key = f"_param_request_{param_id}"
+        last_request = getattr(self._device, request_key, None)
+
+        # Rate limiting: Only make a new request if the last one was more than 30 seconds ago
+        if last_request and (time.time() - last_request) < 30:
+            _LOGGER.debug(
+                "Skipping parameter %s request for %s: last request was %d seconds ago",
+                param_id,
+                self._device.id,
+                time.time() - last_request,
+            )
+            return
+
+        _LOGGER.debug("Requesting parameter %s from %s", param_id, self._device.id)
+
+        # Set pending state and update UI
+        self._is_pending = True
+        self.async_write_ha_state()
+
+        # Mark that we've made a request for this parameter
+        setattr(self._device, request_key, time.time())
+
+        # Request the parameter value from the device
+        self._device.get_fan_param(param_id)
+
+        # Schedule a check to clear the pending state if we don't get a response
+        async def clear_pending() -> None:
+            """Clear the pending state of the entity if no response is received."""
+            await asyncio.sleep(30)  # Wait 30 seconds for a response
+            if self._is_pending:
+                _LOGGER.debug(
+                    "No response received for parameter %s from %s, clearing pending state",
+                    param_id,
+                    self._device.id,
+                )
+                self._is_pending = False
+                self.async_write_ha_state()
+
+        self.hass.async_create_task(clear_pending())
+
+    @callback
+    def async_update(self) -> None:
+        """Update the entity state."""
+        self._attr_available = self.available
+        self._param_native_value = self.native_value
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the cached value."""
+        param_id = getattr(self.entity_description, "ramses_rf_attr", "")
+        if not param_id:
+            _LOGGER.error("Cannot get value: missing parameter ID")
+            return None
+
+        if not hasattr(self, "_param_native_value") or self._param_native_value is None:
+            _LOGGER.debug("No _param_native_value dict for parameter %s yet", param_id)
+            return None
+
+        # Convert param_id to uppercase string to match storage format
+        param_key = str(param_id).upper()
+        value = self._param_native_value.get(param_key)
+
+        if value is None:
+            _LOGGER.debug("No value available yet for parameter %s", param_id)
+            return None
+
+        try:
+            float_value = float(value)
+            return float_value * 100 if self._is_percentage else float_value
+        except (TypeError, ValueError) as err:
+            _LOGGER.debug(
+                "Could not convert parameter %s value '%s' to float: %s",
+                param_id,
+                value,
+                str(err),
+            )
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        if not hasattr(self, "_device") or not hasattr(
+            self.entity_description, "ramses_rf_attr"
+        ):
+            _LOGGER.error("Cannot set value: missing required attributes")
+            return
+
+        param_id = self.entity_description.ramses_rf_attr
+        if not param_id:
+            _LOGGER.error("Cannot set value: missing parameter ID")
+            return
+
+        _LOGGER.debug("Set native value for parameter %s to %s", param_id, value)
+
+        # Store the pending value and set pending state
+        self._pending_value = value
+        self._is_pending = True
+        self.async_write_ha_state()
+
+        try:
+            # Scale percentage values back to 0-1 range for the device
+            if self._is_percentage and value is not None:
+                value = value / 100.0
+                _LOGGER.debug(
+                    "%s: Scaled parameter %s value for device: %s",
+                    self.unique_id,
+                    param_id,
+                    value,
+                )
+
+            # Call the device's set_fan_param method
+            if hasattr(self._device, "set_fan_param"):
+                _LOGGER.debug(
+                    "%s: Setting parameter %s to %s", self.unique_id, param_id, value
+                )
+                await self._device.set_fan_param(param_id, value)
+                _LOGGER.debug(
+                    "%s: Successfully set parameter %s to %s",
+                    self.unique_id,
+                    param_id,
+                    value,
+                )
+
+                # Update the displayed value
+                self.async_write_ha_state()
+
+        except Exception as ex:
+            _LOGGER.error(
+                "%s: Error setting parameter %s to %s: %s",
+                self.unique_id,
+                param_id,
+                value,
+                ex,
+                exc_info=True,
+            )
+        finally:
+            # Clear pending state and update the UI
+            self._is_pending = False
+            self._pending_value = None
+            self.async_write_ha_state()
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon to use in the frontend, if any."""
+        # Show loading icon when update is in progress
+        if self._is_pending:
+            return "mdi:timer-sand"
+
+        # First check if there's a specific icon defined in the entity description
+        if (
+            hasattr(self.entity_description, "ramses_cc_icon_off")
+            and not self.native_value
+        ):
+            return self.entity_description.ramses_cc_icon_off
+
+        # Get parameter ID for special cases
+        param_id = getattr(self.entity_description, "ramses_rf_attr", "")
+
+        # Get unit of measurement for icon selection
+        unit = getattr(self, "_attr_native_unit_of_measurement", "")
+
+        # Select icon based on parameter ID and unit
+        if unit == "°C":
+            return "mdi:thermometer"
+        elif unit == "%" and param_id == "52":  # Sensor sensitivity
+            return "mdi:gauge"
+        elif unit == "%":
+            return "mdi:percent"
+        elif unit == "min":
+            return "mdi:timer"
+        elif param_id == "54":  # Moisture sensor overrun time
+            return "mdi:water-percent"
+        elif param_id == "95":  # Boost mode fan rate
+            return "mdi:fan-speed-3"
+
+        # Default icon if no specific match found
+        return "mdi:counter"
+
+
+@dataclass(frozen=True, kw_only=True)
+class RamsesNumberEntityDescription(RamsesEntityDescription, NumberEntityDescription):
+    """Class describing Ramses binary number entities."""
+
+    # integration-specific attributes
+    ramses_cc_class: type[RamsesNumber] = RamsesNumber
+    ramses_cc_icon_off: str | None = None  # no NumberEntityDescription.icon_off attr
+    ramses_rf_attr: str = ""
+    ramses_rf_class: type[RamsesRFEntity] | UnionType = RamsesRFEntity
+
+    # Parameters for 2411 parameter entities
+    check_attr: str | None = None
+    data_type: str | None = None
+    min_value: float | None = None
+    max_value: float | None = None
+    precision: float | None = None
+    parameter_id: str | None = None
+    parameter_desc: str | None = None
+    unit_of_measurement: str | None = None
+    mode: str = "auto"
+
+
+def get_number_descriptions(
+    device: RamsesRFEntity,
+) -> list[RamsesNumberEntityDescription]:
+    """Generate number entity descriptions for a device that supports 2411 parameters.
+
+    Args:
+        device: The device to generate descriptions for.
+
+    Returns:
+        A list of RamsesNumberEntityDescription objects for the device's parameters.
+    """
+    if not hasattr(device, "supports_2411") or not device.supports_2411:
+        return []
+
+    descriptions: list[RamsesNumberEntityDescription] = []
+
+    # Get parameter schema from the device
+    if not hasattr(device, "_2411_PARAMS_SCHEMA"):
+        return []
+    param_schema = device._2411_PARAMS_SCHEMA
+
+    # Create a description for each parameter
+    for param_id, param_info in param_schema.items():
+        # Get precision from schema or default to 1.0 for floats, 1 for ints
+        precision = param_info.get(
+            SZ_PRECISION, 1.0 if param_info.get(SZ_DATA_TYPE) == "float" else 1
+        )
+
+        # Special handling for temperature parameters (param 75) - force 0.1°C precision and slider mode
+        mode = "auto"
+        if (
+            param_id == "75"
+        ):  # comfort temp, keep it at 0.01 in 2411_params_schema since custom automations may depend on it
+            precision = 0.1
+            mode = "slider"  # Use slider mode for comfort temperature
+
+        desc = RamsesNumberEntityDescription(
+            key=f"param_{param_id}",
+            name=param_info.get(SZ_DESCRIPTION, f"Parameter {param_id}"),
+            ramses_rf_attr=param_id,
+            parameter_id=param_id,
+            parameter_desc=param_info.get(SZ_DESCRIPTION, ""),
+            min_value=param_info.get(SZ_MIN_VALUE, 0),
+            max_value=param_info.get(SZ_MAX_VALUE, 255),
+            precision=precision,
+            unit_of_measurement=param_info.get(SZ_DATA_UNIT, None),
+            mode=mode,  # Use slider mode for comfort temperature
+            ramses_cc_class=RamsesNumber,
+            ramses_rf_class=type(device),
+            data_type=param_info.get(SZ_DATA_TYPE, None),
+        )
+        descriptions.append(desc)
+
+    return descriptions
+
+
+async def async_create_parameter_entities(
+    broker: RamsesBroker, device: RamsesRFEntity
+) -> list[RamsesNumber]:
+    """Create parameter entities for a device.
+
+    Args:
+        broker: The RamsesBroker instance.
+        device: The device to create parameter entities for.
+
+    Returns:
+        A list of created RamsesNumber entities.
+    """
+    if not hasattr(device, "supports_2411") or not device.supports_2411:
+        _LOGGER.debug(
+            "Skipping parameter entities for %s - 2411 not supported", device.id
+        )
+        return []
+
+    _LOGGER.info(
+        "Creating parameter entities for %s (supports 2411 parameters)", device.id
+    )
+    descriptions = get_number_descriptions(device)
+    entities: list[RamsesNumber] = []
+
+    for description in descriptions:
+        if not hasattr(description, "ramses_rf_attr"):
+            continue
+        entity = description.ramses_cc_class(broker, device, description)
+        entities.append(entity)
+        _LOGGER.debug("Created parameter entity: %s for %s", description.key, device.id)
+
+    return entities
+
+
+NUMBER_DESCRIPTIONS: tuple[RamsesNumberEntityDescription, ...] = (
+    *[
+        RamsesNumberEntityDescription(
+            check_attr="supports_2411",
+            key=f"param_{param_id}",
+            entity_category=EntityCategory.CONFIG,
+            ramses_cc_class=RamsesNumber,
+            ramses_rf_attr=param_id,
+            ramses_rf_class=RamsesRFEntity,
+            data_type=param[SZ_DATA_TYPE],
+            min_value=float(param[SZ_MIN_VALUE]),
+            max_value=float(param[SZ_MAX_VALUE]),
+            precision=float(param[SZ_PRECISION]),
+            name=param[SZ_DESCRIPTION],
+            unit_of_measurement=param[SZ_DATA_UNIT],
+            mode="auto",
+        )
+        for param_id, param in _2411_PARAMS_SCHEMA.items()
+    ],
+    # Hardcoded item appended to the dynamic list can go below
+    # RamsesNumberEntityDescription(
+    # ),
+)

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1,5 +1,6 @@
 """Schemas for RAMSES integration."""
 
+# ruff: noqa: I001  # Allow non-standard import order
 from __future__ import annotations
 
 import logging
@@ -28,6 +29,7 @@ from ramses_rf.schemas import (
     SZ_ZONES,
 )
 from ramses_tx.const import COMMAND_REGEX
+from ramses_tx import SZ_BOUND_TO
 from ramses_tx.schemas import (
     SCH_ENGINE_DICT,
     SZ_PORT_CONFIG,
@@ -92,8 +94,14 @@ SCH_ADVANCED_FEATURES = vol.Schema(
     }
 )
 
+# Define the traits for FAN devices
+FAN_TRAITS = {
+    vol.Optional(SZ_BOUND_TO): vol.Match(r"^[0-9]{2}:[0-9]{6}$"),  # Device ID format
+    vol.Optional(CONF_COMMANDS): dict,
+}
+
 SCH_GLOBAL_TRAITS_DICT, SCH_TRAITS = sch_global_traits_dict_factory(
-    hvac_traits={vol.Optional(CONF_COMMANDS): dict}
+    hvac_traits=FAN_TRAITS
 )
 
 SCH_GATEWAY_CONFIG = SCH_GATEWAY_CONFIG.extend(
@@ -653,9 +661,62 @@ SCH_DELETE_COMMAND = cv.make_entity_service_schema(
     },
 )
 
+# Service schema for getting and setting fan parameters (using ramses_rf implementation)
+SVC_GET_FAN_PARAM: Final = "get_fan_param"
+SVC_GET_ALL_FAN_PARAMS: Final = "get_all_fan_params"
+SVC_SET_FAN_PARAM: Final = "set_fan_param"
+SVC_UPDATE_PARAMETERS: Final = "update_parameters"
+
+# Schema for_fan_param services
+# Note: Parameter validation is handled by ramses_rf
+_SCH_PARAM_ID = _SCH_DOM_IDX  # Reuse the same schema as domain index (2 hex digits)
+_SCH_VALUE = cv.string
+
+SCH_GET_ALL_FAN_PARAMS = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("fan_id"): _SCH_DEVICE_ID,
+    },
+    extra=vol.PREVENT_EXTRA,
+)
+
+SCH_GET_FAN_PARAM = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required("param_id"): _SCH_PARAM_ID,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("fan_id"): _SCH_DEVICE_ID,
+    }
+)
+
+SCH_SET_FAN_PARAM = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required("param_id"): _SCH_PARAM_ID,
+        vol.Required("value"): _SCH_VALUE,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("fan_id"): _SCH_DEVICE_ID,
+    }
+)
 SVCS_RAMSES_REMOTE = {
     SVC_DELETE_COMMAND: SCH_DELETE_COMMAND,
     SVC_ADD_COMMAND: SCH_ADD_COMMAND,
     SVC_LEARN_COMMAND: SCH_LEARN_COMMAND,
     SVC_SEND_COMMAND: SCH_SEND_COMMAND,
+    SVC_GET_FAN_PARAM: SCH_GET_FAN_PARAM,
+    SVC_SET_FAN_PARAM: SCH_SET_FAN_PARAM,
 }
+
+# Service schemas for number platform
+SVCS_RAMSES_FAN_PARAM = {
+    SVC_GET_FAN_PARAM: SCH_GET_FAN_PARAM,
+    SVC_GET_ALL_FAN_PARAMS: SCH_GET_ALL_FAN_PARAMS,
+    SVC_SET_FAN_PARAM: SCH_SET_FAN_PARAM,
+}
+
+SCH_UPDATE_PARAMETERS = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+    }
+)

--- a/custom_components/ramses_cc/tests/test_fan_parameters.py
+++ b/custom_components/ramses_cc/tests/test_fan_parameters.py
@@ -1,0 +1,154 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+# Import the fan_parameters module with type ignore since it might not exist yet
+from custom_components.ramses_cc import fan_parameters  # type: ignore[attr-defined]
+from custom_components.ramses_cc.broker import RamsesBroker
+
+# Create a type alias for the device class
+RamsesFanParametersDevice = fan_parameters.RamsesFanParametersDevice  # type: ignore[attr-defined, no-any-return]
+
+
+@pytest.fixture
+async def mock_broker() -> RamsesBroker:
+    """Mock broker instance."""
+    broker = MagicMock(spec=RamsesBroker)
+    broker.register_fan_param_handler = AsyncMock()
+    broker.unregister_fan_param_handler = AsyncMock()
+    broker.async_get_fan_param = AsyncMock()
+    return broker
+
+
+@pytest.fixture
+async def mock_device(mock_broker: RamsesBroker) -> RamsesFanParametersDevice:
+    """Mock fan device instance."""
+    return RamsesFanParametersDevice(
+        broker=mock_broker,
+        device_id="01:123456",
+        name="Test Fan",
+        fake_device_id="FA:KE01",
+        remote_device_id="32:999999",
+    )
+
+
+async def test_device_initialization(mock_device: RamsesFanParametersDevice) -> None:
+    """Test device initialization."""
+    assert mock_device.fan_device_id == "01:123456"
+    assert mock_device.name == "Test Fan Fan Parameters"
+    assert mock_device.fake_device_id == "FA:KE01"
+    assert mock_device.remote_device_id == "32:999999"
+    assert mock_device.device_id == "01:123456"
+
+
+async def test_parameter_update(mock_device: RamsesFanParametersDevice) -> None:
+    """Test parameter update handling."""
+    # Register callback
+    callback = AsyncMock()
+    unregister = mock_device.register_callback(callback)
+
+    # Update parameter
+    await mock_device._handle_parameter_update("4E", "1")
+
+    # Verify callback was called
+    callback.assert_called_once_with("4E", "1")
+
+    # Verify parameter value stored
+    assert mock_device._param_values["4E"] == "1"
+
+    # Test unregistering callback
+    unregister()
+    await mock_device._handle_parameter_update("4E", "2")
+    callback.assert_called_once()  # Should still be 1 call
+
+
+async def test_get_parameter_value(
+    mock_device: RamsesFanParametersDevice, mock_broker: RamsesBroker
+) -> None:
+    """Test getting parameter value."""
+    # Test getting parameter that exists
+    mock_device._param_values["4E"] = "1"
+    assert mock_device.get_parameter_value("4E") == "1"
+
+    # Test getting non-existent parameter
+    assert mock_device.get_parameter_value("4F") is None
+
+    # Test async get parameter
+    mock_broker.async_get_fan_param.return_value = None
+    await mock_device.async_get_parameter_value("4E")
+    mock_broker.async_get_fan_param.assert_called_once()
+
+
+async def test_device_registration(
+    mock_device: RamsesFanParametersDevice, mock_broker: RamsesBroker
+) -> None:
+    """Test device registration and unregistration."""
+    # Test registration
+    await mock_device.async_register()
+    mock_broker.register_fan_param_handler.assert_called_once()
+
+    # Test unregistration
+    await mock_device.async_unregister()
+    mock_broker.unregister_fan_param_handler.assert_called_once()
+
+
+async def test_cleanup(
+    mock_device: RamsesFanParametersDevice, mock_broker: RamsesBroker
+) -> None:
+    """Test device cleanup."""
+    # Add some entities and callbacks
+    mock_entity = MagicMock()
+    mock_entity.async_will_remove_from_hass = AsyncMock()
+    mock_device.entities.append(mock_entity)
+
+    callback = AsyncMock()
+    mock_device.register_callback(callback)
+
+    # Perform cleanup
+    await mock_device.async_will_remove_from_hass()
+
+    # Verify entity cleanup
+    mock_entity.async_will_remove_from_hass.assert_called_once()
+    assert len(mock_device.entities) == 0
+
+    # Verify callback cleanup
+    assert len(mock_device._update_callbacks) == 0
+
+    # Verify broker unregistration
+    mock_broker.unregister_fan_param_handler.assert_called_once()
+
+
+async def test_async_setup_entry(
+    hass: HomeAssistant, mock_broker: RamsesBroker
+) -> None:
+    """Test async setup entry."""
+    entry = MagicMock(spec=ConfigEntry)
+    entry.options = {"param_remote_id": {"01:123456": "32:999999"}}
+
+    with patch(
+        "custom_components.ramses_cc.fan_parameters.RamsesFanParametersDevice"
+    ) as mock_device_class:
+        mock_device = MagicMock()
+        mock_device_class.return_value = mock_device
+
+        # Import here to avoid circular import
+        from custom_components.ramses_cc import async_setup_entry
+
+        await async_setup_entry(hass, entry, AsyncMock())
+
+        # Verify device was created with correct parameters
+        mock_device_class.assert_called_once_with(
+            broker=mock_broker,
+            device_id="01:123456",
+            name="Test Fan",
+            fake_device_id=None,
+            remote_device_id="32:999999",
+        )
+
+        # Verify device was registered
+        mock_device.async_register.assert_called_once()
+
+        # Verify entities were added
+        mock_device.async_add_entities.assert_called_once()

--- a/custom_components/ramses_cc/tests/test_schemas.py
+++ b/custom_components/ramses_cc/tests/test_schemas.py
@@ -1,0 +1,151 @@
+import pytest
+from voluptuous import MultipleInvalid
+
+from custom_components.ramses_cc.schemas import (
+    _SCH_CMD_CODE,
+    _SCH_DEVICE_ID,
+    SCH_DOMAIN_CONFIG,
+    SCH_MINIMUM_TCS,
+)
+
+
+def test_device_id_schema() -> None:
+    """Test the device ID schema."""
+    valid_ids = [
+        "01:123456",
+        "32:999999",
+        "10:000000",
+    ]
+
+    invalid_ids = [
+        "01:12345",  # Too short
+        "01:1234567",  # Too long
+        "01:12345x",  # Invalid character
+        "1:123456",  # First part too short
+        "011:123456",  # First part too long
+    ]
+
+    for valid_id in valid_ids:
+        assert _SCH_DEVICE_ID(valid_id) == valid_id
+
+    for invalid_id in invalid_ids:
+        with pytest.raises(MultipleInvalid):
+            _SCH_DEVICE_ID(invalid_id)
+
+
+def test_command_code_schema() -> None:
+    """Test the command code schema."""
+    valid_codes = [
+        "0000",
+        "FFFF",
+        "1234",
+        "ABCD",
+    ]
+
+    invalid_codes = [
+        "000",  # Too short
+        "00000",  # Too long
+        "123X",  # Invalid character
+        "123",  # Too short
+        "12345",  # Too long
+    ]
+
+    for valid_code in valid_codes:
+        assert _SCH_CMD_CODE(valid_code) == valid_code
+
+    for invalid_code in invalid_codes:
+        with pytest.raises(MultipleInvalid):
+            _SCH_CMD_CODE(invalid_code)
+
+
+def test_domain_config_schema() -> None:
+    """Test the domain configuration schema."""
+    valid_config = {
+        "ramses_rf": {"port_config": {"serial_port": "/dev/ttyUSB0"}},
+        "scan_interval": 60,
+        "advanced_features": {
+            "send_packet": True,
+            "dev_mode": False,
+            "unknown_codes": True,
+        },
+        "known_list": {"01:123456": {"class": "FAN", "param_remote": "32:999999"}},
+    }
+
+    invalid_config = {
+        "ramses_rf": {"port_config": {"serial_port": "/dev/ttyUSB0"}},
+        "scan_interval": 2,  # Below minimum
+        "advanced_features": {
+            "send_packet": "not_a_bool",  # Invalid type
+            "dev_mode": False,
+            "unknown_codes": True,
+        },
+        "known_list": {
+            "01:123456": {
+                "class": "FAN",
+                "param_remote": "invalid_id",  # Invalid device ID
+            }
+        },
+    }
+
+    # Test valid config
+    try:
+        SCH_DOMAIN_CONFIG(valid_config)
+    except MultipleInvalid as e:
+        pytest.fail(f"Valid config should not raise errors: {e}")
+
+    # Test invalid config
+    with pytest.raises(MultipleInvalid):
+        SCH_DOMAIN_CONFIG(invalid_config)
+
+
+def test_minimum_tcs_schema() -> None:
+    """Test the minimum TCS schema."""
+    valid_tcs = {
+        "system": {"appliance_control": "10:123456"},
+        "zones": {"zone1": {"sensor": "01:123456"}},
+    }
+
+    invalid_tcs = {
+        "system": {
+            "appliance_control": "invalid_id"  # Invalid device ID
+        },
+        "zones": {
+            "zone1": {
+                "sensor": "01:12345"  # Invalid device ID
+            }
+        },
+    }
+
+    # Test valid TCS
+    try:
+        SCH_MINIMUM_TCS(valid_tcs)
+    except MultipleInvalid as e:
+        pytest.fail(f"Valid TCS should not raise errors: {e}")
+
+    # Test invalid TCS
+    with pytest.raises(MultipleInvalid):
+        SCH_MINIMUM_TCS(invalid_tcs)
+
+
+def test_param_remote_id_in_known_list():
+    """Test that param_remote_id is properly validated in known_list."""
+    valid_config = {
+        "known_list": {"01:123456": {"class": "FAN", "param_remote": "32:999999"}}
+    }
+
+    invalid_config = {
+        "known_list": {
+            "01:123456": {
+                "class": "FAN",
+                "param_remote": "invalid_id",  # Invalid device ID
+            }
+        }
+    }
+
+    try:
+        SCH_DOMAIN_CONFIG(valid_config)
+    except MultipleInvalid as e:
+        pytest.fail(f"Valid config with param_remote should not raise errors: {e}")
+
+    with pytest.raises(MultipleInvalid):
+        SCH_DOMAIN_CONFIG(invalid_config)


### PR DESCRIPTION
- Add RamsesNumber entity for handling fan parameters
- Implement parameter reading and writing in broker
- Add services: get_fan_param, set_fan_param, get_all_fan_params
- Add tests for fan parameter functionality
- Add 'bound' trait in config flow for FAN (a bound REM/DIS is needed to set a 2411 param)
- Update config flow to support fan parameter configuration

needs a bit more testing and some cleanup
requires ramses_rf counterpart