### PR TITLE
Filter cached packets against known_list

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -176,7 +176,7 @@ def merge_schemas(config_schema: _SchemaT, cached_schema: _SchemaT) -> _SchemaT 
         _LOGGER.info("Using a merged schema")
         return merged_schema
 
-    _LOGGER.info("Cached schema is a subset of config schema")
+    _LOGGER.info("Cached schema is a subset of config schema. Skipping cashed.")
     return None
 
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -176,7 +176,7 @@ def merge_schemas(config_schema: _SchemaT, cached_schema: _SchemaT) -> _SchemaT 
         _LOGGER.info("Using a merged schema")
         return merged_schema
 
-    _LOGGER.info("Cached schema is a subset of config schema. Skipping cashed.")
+    _LOGGER.info("Cached schema is a subset of config schema. Skipping cached.")
     return None
 
 

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -148,7 +148,7 @@
                 "data_description": {
                     "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
                     "known_list": "A mapping of known device IDs and optionally their traits.",
-                    "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common."
+                    "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. After activating, clear the discovered system schemas cache before restarting."
                 }
             },
             "advanced_features": {
@@ -166,7 +166,7 @@
                 "description": "Optional packet log to aid troubleshooting and help development.",
                 "data": {
                     "file_name": "Packet log file name",
-                    "rotate_bytes": "Maximum size of each packet log",
+                    "rotate_bytes": "Maximum size of each packet log. Leave empty for daily logs",
                     "rotate_backups": "Number of packet logs to keep"
                 },
                 "data_description": {
@@ -175,7 +175,7 @@
             },
             "clear_cache": {
                 "title": "Clear cache",
-                "description": "Choose items below to immediately clear the cache and reload the integration after significant changes to your system schema or configuration.",
+                "description": "Select items below to immediately clear their cache and reload the integration after significant changes to your system schema or configuration.",
                 "data": {
                     "clear_schema": "Clear discovered system schema(s)",
                     "clear_packets": "Clear system state (recent packets)"

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -15,7 +15,7 @@
                 "menu_options": {
                     "choose_serial_port": "Seriële poort",
                     "config": "Gateway-configuratie",
-                    "schema": "Systeemschema en erkende devices",
+                    "schema": "Systeemschema en erkende apparaten",
                     "advanced_features": "Geavanceerde instellingen",
                     "packet_log": "Packet-log",
                     "clear_cache": "Wis cache"
@@ -60,7 +60,7 @@
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
-                    "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld,. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor."
+                    "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld,. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor. Wis wel 1x de systeem-cache nadat je deze optie activeert."
                 }
             },
             "advanced_features": {
@@ -78,7 +78,7 @@
                 "description": "Optioneel packet-logbestand voor probleemoplossing en doorontwikkeling van de ramses_rf integratie.",
                 "data": {
                     "file_name": "Bestandsnaam packet-log",
-                    "rotate_bytes": "Maximumgrootte per packet-log",
+                    "rotate_bytes": "Maximumgrootte per packet-log. Laat leeg voor dagelijks log",
                     "rotate_backups": "Aantal te bewaren packet-logs"
                 },
                 "data_description": {
@@ -175,7 +175,7 @@
             },
             "clear_cache": {
                 "title": "Cache beheren",
-                "description": "De geselecteerde caches worden direct gewist als je op [VERZENDEN] klikt. Herlaad daarna de integratie na grote aanpassingen in het systeemschema of de configuratie. Beide schuifjes naar links = niets wissen",
+                "description": "De geselecteerde caches worden direct gewist als je op [Verzenden] klikt. Herlaad daarna de integratie na grote aanpassingen in het systeemschema of de configuratie. Beide schuifjes naar links = niets wissen",
                 "data": {
                     "clear_schema": "Wis ontdekte systeemschema('s)",
                     "clear_packets": "Wis systeemtoestand (recente berichten)"


### PR DESCRIPTION
Fix issue #296 #202 error when turning on force_known_list config option.
Only happens when e.g. there is an orphan that is not also in the known_list, or a cached packet log from an unknown device.
PR skips those and adds dump of config in debug mode.
User should still delete & rebuild caches before restart:
<img width="690" height="510" alt="ramses config delete system cache" src="https://github.com/user-attachments/assets/448eb9c3-0125-4401-893e-0f622842b807" />
