### PR TITLE
bump `pytest_homeassistant_custom_component`

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -14,4 +14,4 @@
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest
 
-  pytest_homeassistant_custom_component >= 0.13.271
+  pytest_homeassistant_custom_component >= 0.13.285


### PR DESCRIPTION
 bump to >= 0.13.285 (HA 2025.10.0), only applied to dev.testing