### PR TITLE
implement  empty async_turn_off, async_turn_on to avoid NotImplemente…

### DIFF
--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -238,6 +238,24 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
 
         self._commands[command[0]] = packet_string
 
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the remote device.
+
+        :param kwargs: Additional arguments for the turn_off operation
+        :type kwargs: Any
+        """
+        _LOGGER.debug("Turning off REM device %s", self._device.id)
+        pass
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the remote device.
+
+        :param kwargs: Additional arguments for the turn_on operation
+        :type kwargs: Any
+        """
+        _LOGGER.debug("Turning on REM device %s", self._device.id)
+        pass
+
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesRemoteEntityDescription(RamsesEntityDescription, RemoteEntityDescription):


### PR DESCRIPTION
when turning a REM on or OFF in the device UI the following error occured:
2025-10-05 16:48:00.109 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [139968408719008] Unexpected exception
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 264, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2835, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2878, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 850, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
        hass, entity, func, data, call.context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 922, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1682, in async_turn_off
    await self.hass.async_add_executor_job(ft.partial(self.turn_off, **kwargs))
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1678, in turn_off
    raise NotImplementedError
NotImplementedError