### PR TITLE
Bump dependencies

### DIFF
--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -12,8 +12,8 @@
     "requirements": [
       "aiousbwatcher>=1.1.1",
       "pyserial-asyncio-fast>=0.14",
-      "ramses-rf==0.51.7"
+      "ramses-rf==0.51.8"
     ],
     "single_config_entry": true,
-    "version": "0.51.7"
+    "version": "0.51.8"
   }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 # Requirements to dev the source code
-# - last checked/updated: 2025-09-22 (c.f. HA 2025.9.3)
+# - last checked/updated: 2025-10-05 (c.f. HA 2025.10.0)
 #
 
 # requirements (dependencies) are in manifest.json
@@ -7,7 +7,7 @@
 
   aiousbwatcher         >= 1.1.1                 # as per: manifest.json latest: 1.1.1
   pyserial-asyncio-fast >= 0.14                  # as per: manifest.json latest: 0.16
-  ramses_rf             == 0.51.6                # as per: manifest.json latest:
+  ramses_rf             == 0.51.8                # as per: manifest.json latest:
 
 
 
@@ -15,7 +15,7 @@
 # - pip list | grep -E 'pre-commit|ruff|mypy|types-|voluptuous'
 
 # used for development (linting)
-    pre-commit >= 4.0.1                          # latest: 4.3.0
+    pre-commit >= 4.2.0                          # latest: 4.3.0
     ruff >= 0.13.0                               # latest: 0.13.0 See also: pre-commit-config.yaml
 
 # used for development (typing)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 # Requirements to test the source code
-# - last checked/updated: 2025-08-17 (c.f. HA 2025.8.1)
+# - last checked/updated: 2025-10-05 (c.f. HA 2025.10.0)
 #
 
 # may need to use this version of ramses_rf...
@@ -14,4 +14,4 @@
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest
 
-  pytest_homeassistant_custom_component >= 0.13.285
+  pytest_homeassistant_custom_component >= 0.13.286


### PR DESCRIPTION
For 0.51.8, pre-commit >= 4.2.0, pytest_homeassistant_custom_component >= 0.13.286