### PR TITLE
Restore `.name` attr

### DIFF
--- a/custom_components/ramses_cc/broker.py
+++ b/custom_components/ramses_cc/broker.py
@@ -587,8 +587,8 @@ class RamsesBroker:
         :param device: The device to update in the registry
         :type device: RamsesRFEntity
         """
-        if hasattr(device, "_name") and device._name:
-            name = device._name
+        if hasattr(device, "name") and device.name:
+            name = device.name
         elif isinstance(device, System):
             name = f"Controller {device.id}"
         elif device._SLUG:


### PR DESCRIPTION
Fix issue #318 part 2
See https://developers.home-assistant.io/docs/device_registry_index/