### PR TITLE
Make `bound_rem` available in javascript cards thru `this._hass.states[s…`

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -567,10 +567,6 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
             data["bound_rem"] = bound_rem  # already a string ID
         return data
 
-    def _handle_state_change(self) -> None:
-        """Handle state changes and immediately update HA."""
-        self.async_write_ha_state()
-
     @property
     def current_humidity(self) -> int | None:
         """Return the current humidity."""


### PR DESCRIPTION
There are a few ways to get data from _cc to a javascript card in a safe way. This is one of them.
It adds a 'bound_rem' to the state dict in climate entity.
With it we can get the REM_id and send commands from a js card without specifying the source. So a user only needs to enter it once for a FAN in the config flow. Actually, only needs to define the FAN id and the card can construct all required commands without entering them all in the config_flow.
Another way I tried is to use websocket_api. That also works fine: create a function in a separate file, register it and get the return value when calling it from .js. That may be handy if you want to make more functions available in the future, and they could also have some more logic than only returning a value... 
For now I choose the first option cause there is less overhead.

If you want I can give you a PR with an example of the websocket option. No need to merge this one if you want to take a look at that as well... 
ps. Servicecalls only fire and forget, don't give any return value.
ps2 you can find the card (wip)  [here](https://github.com/wimpie70/orcon-fan-card)