### PR TITLE
`broker`: add a delay when req. all params

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -270,9 +270,7 @@ def async_register_domain_services(
 
     @verify_domain_control(DOMAIN)
     async def async_update_fan_params(call: ServiceCall) -> None:
-        await broker._async_run_fan_param_sequence(
-            call.data if hasattr(call, "data") else call
-        )
+        await broker._async_run_fan_param_sequence(call)
 
     hass.services.async_register(
         DOMAIN, SVC_BIND_DEVICE, async_bind_device, schema=SCH_BIND_DEVICE

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -453,8 +453,8 @@ class RamsesNumberParam(RamsesNumberBase):
         1. Calls the parent class's async_added_to_hass method
         2. Sets up an event listener for parameter updates
 
-        Note: Initial parameter values are requested by the broker's
-        async_get_all_fan_params method in a controlled manner to prevent
+        Note: Parameter values are requested by the broker's
+        get_all_fan_params method in a controlled manner to prevent
         flooding the RF protocol.
 
         :return: None

--- a/tests/tests_new/test_bound_device.py
+++ b/tests/tests_new/test_bound_device.py
@@ -274,7 +274,7 @@ class TestBoundDeviceFunctionality:
         # Mock the device lookup to return our mock device
         with patch.object(self.broker, "_get_device", return_value=mock_bound_device):
             # Act - Call the method under test
-            await self.broker.async_get_all_fan_params(call)
+            await self.broker._async_run_fan_param_sequence(call)
 
             # Assert - Verify bound device was used for all parameter requests
             # Note: We can't easily test the exact number without importing the schema,

--- a/tests/tests_new/test_fan_param.py
+++ b/tests/tests_new/test_fan_param.py
@@ -36,7 +36,7 @@ class TestFanParameterGet:
     """Test cases for the get_fan_param service.
 
     This test class verifies the behaviour of the async_get_fan_param and
-    async_get_all_fan_params methods in the RamsesBroker class, including
+    _async_run_fan_param_sequence methods in the RamsesBroker class, including
     error handling and edge cases for parameter reading operations.
     """
 
@@ -930,7 +930,7 @@ class TestFanParameterSet:
 class TestFanParameterUpdate:
     """Test cases for the update_fan_params service.
 
-    This test class verifies the behaviour of the async_get_all_fan_params method
+    This test class verifies the behaviour of the _async_run_fan_param_sequence method
     in the RamsesBroker class, which sends parameter read requests for all parameters
     defined in the 2411 parameter schema to the specified FAN device.
     """
@@ -990,7 +990,7 @@ class TestFanParameterUpdate:
         call = ServiceCall(hass, "ramses_cc", "update_fan_params", service_data)
 
         # Act - Call the method under test
-        await self.broker.async_get_all_fan_params(call)
+        await self.broker._async_run_fan_param_sequence(call)
 
         # Verify all parameters in the schema were requested
         # Note: We can't easily test the exact number without importing the schema,
@@ -1018,7 +1018,7 @@ class TestFanParameterUpdate:
         call = ServiceCall(hass, "ramses_cc", "update_fan_params", service_data)
 
         # Act - Call the method under test
-        await self.broker.async_get_all_fan_params(call)
+        await self.broker._async_run_fan_param_sequence(call)
 
         # Verify commands were constructed with HGI as source
         # Check that at least one call was made with the correct parameters
@@ -1049,7 +1049,7 @@ class TestFanParameterUpdate:
         caplog.set_level(logging.ERROR)
 
         # Act - Call the method under test
-        await self.broker.async_get_all_fan_params(call)
+        await self.broker._async_run_fan_param_sequence(call)
 
         # Verify error was logged
         assert any(
@@ -1093,7 +1093,7 @@ class TestFanParameterUpdate:
             caplog.set_level(logging.WARNING)  # Capture warnings and above
 
             # Act - Call the method under test
-            await broker.async_get_all_fan_params(call)
+            await broker._async_run_fan_param_sequence(call)
 
             # Verify the warning was logged
             warning_message = "Cannot get parameter: No valid source device available"
@@ -1129,7 +1129,7 @@ class TestFanParameterUpdate:
         call = ServiceCall(hass, "ramses_cc", "update_fan_params", service_data)
 
         # Act - Call the method under test
-        await self.broker.async_get_all_fan_params(call)
+        await self.broker._async_run_fan_param_sequence(call)
 
         # Verify commands were constructed with fan_id as target
         calls = self.mock_get_fan_param.call_args_list
@@ -1171,7 +1171,7 @@ class TestFanParameterUpdate:
         caplog.set_level(logging.ERROR)
 
         # Act - Call the method under test
-        await self.broker.async_get_all_fan_params(call)
+        await self.broker._async_run_fan_param_sequence(call)
 
         # Verify the error was logged
         assert any(


### PR DESCRIPTION
I found the system freeze on a dev system, probably caused by too many messages flooding the system and causing time-outs.
Added a delay of .5sec between RQ in request_all_params and removed a duplicate RQ from added_to_hass.

Didn't notice this happening before. Could be related to my other project that i'm building on top of _cc.