### PR TITLE
UI i18n for `add_command` action

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -622,7 +622,9 @@ SCH_LEARN_COMMAND = cv.make_entity_service_schema(
     },
 )
 
-# New service: add_command (inject a packet without RF learning loop)
+# hvac services
+
+# add_command (inject a packet without RF learning loop)
 SVC_ADD_COMMAND: Final = "add_command"
 SCH_ADD_COMMAND = cv.make_entity_service_schema(
     {

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -675,6 +675,22 @@ send_command:
           mode: slider
 
 
+add_command:
+  # Add a command for a device. This service is used by code
+  target:
+    entity:
+      - integration: ramses_cc
+        domain: remote
+
+  fields:
+    command:
+      required: true
+      example: 'setpoint'
+    packet_string:
+      required: true
+      example: '" I --- 29:123456 32:654321 --:------ 31E0 008 000046000100AA00"'
+
+
 # changed entity_id (selector) to HA targets
 # since HA 2024.8 Update all references to "services" to "service actions"
 # see docs https://developers.home-assistant.io/docs/dev_101_services/

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -529,7 +529,7 @@
 
         "delete_command": {
             "name": "Delete a Remote command",
-            "description": "Deletes a RAMSES command from the database. This is a convenience wrapper for HA's own `delete_command` service call.",
+            "description": "Delete a RAMSES command from the database. This is a convenience wrapper for HA's own `delete_command` service call.",
             "fields": {
                 "entity_id": {
                     "name": "Entity_id",
@@ -544,7 +544,7 @@
 
         "learn_command": {
             "name": "Learn a Remote command",
-            "description": "Learns a RAMSES command and adds it to the database. This is a convenience wrapper for HA's own `learn_command` service call. The device should be bound to a fan/ventilation unit as a switch.",
+            "description": "Learn a RAMSES command and adds it to the database. This is a convenience wrapper for HA's own `learn_command` service call. The device should be bound to a fan/ventilation unit as a switch.",
             "fields": {
                 "entity_id": {
                     "name": "Entity_id",
@@ -557,6 +557,25 @@
                 "timeout": {
                     "name": "Timeout",
                     "description": "Timeout for the command to be learned (in seconds)."
+                }
+            }
+        },
+
+        "add_command": {
+            "name": "Add a Remote command",
+            "description": "Add a RAMSES command to the database until restart. Most often used by code, not manually.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "The entity_id of the remote, usually a HVAC device."
+                },
+                "command": {
+                    "name": "Command",
+                    "description": "Name of the command as string."
+                },
+                "packet_string": {
+                    "name": "Packet",
+                    "description": "Command packet as string."
                 }
             }
         },

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -561,6 +561,25 @@
             }
         },
 
+        "add_command": {
+            "name": "Voeg een Remote commando toe",
+            "description": "Voegt een RAMSES commando toe aan de database tot herstart. Vooral gebruikt in code, niet handmatig.",
+            "fields": {
+                "entity_id": {
+                    "name": "Entity_id",
+                    "description": "Entity_id van de afstandsbediening, meestal een HVAC-apparaat."
+                },
+                "command": {
+                    "name": "Commando",
+                    "description": "Naam van het commando als string."
+                },
+                "packet_string": {
+                    "name": "Packet",
+                    "description": "Commando-packet als string."
+                }
+            }
+        },
+
         "get_fan_param": {
             "name": "FAN Parameter opvragen",
             "description": "Vraag de huidige waarde op van een specifieke instelling (2411) van een FAN-apparaat.",


### PR DESCRIPTION
Add i18n en + nl, add service example values for `add_command` service action that was added in #289 as it is showing up in UI.