### PR TITLE
Fix duplicate param entity creation error happening on some occasions

### DIFF
--- a/custom_components/ramses_cc/broker.py
+++ b/custom_components/ramses_cc/broker.py
@@ -375,15 +375,7 @@ class RamsesBroker:
               not be called manually. Parameter entities are created only once per
               device per Home Assistant session.
         """
-        # Check if we've already created parameter entities for this device
         device_id = device.id
-        if device_id in self._parameter_entities_created:
-            _LOGGER.debug(
-                "Parameter entities already created for %s, skipping",
-                device_id,
-            )
-            return
-
         from .number import create_parameter_entities
 
         entities = create_parameter_entities(self, device)
@@ -401,8 +393,6 @@ class RamsesBroker:
                 SIGNAL_NEW_DEVICES.format("number"),
                 entities,
             )
-            # Mark this device as having parameter entities created
-            self._parameter_entities_created.add(device_id)
         else:
             _LOGGER.debug("No parameter entities created for %s", device_id)
 


### PR DESCRIPTION
This PR should fix some new errors I found.

I noticed some errors happening on some restarts. Didn't see them before, probably because I got different timing and race conditions now.

part of the problematic logs:
```
2025-10-29 14:14:56.137 INFO (MainThread) [custom_components.ramses_cc.number] Created parameter entity: number.32_153289_param_95 for 32_153289 (param_id=95)
2025-10-29 14:14:56.137 DEBUG (MainThread) [custom_components.ramses_cc.number] Processed 16 parameter entities for 32_153289 using async_get_or_create
2025-10-29 14:14:56.137 DEBUG (MainThread) [custom_components.ramses_cc.broker] create_parameter_entities returned 16 entities for 32:153289
2025-10-29 14:14:56.137 INFO (MainThread) [custom_components.ramses_cc.broker] Adding 16 parameter entities for 32:153289
2025-10-29 14:14:56.137 DEBUG (MainThread) [custom_components.ramses_cc.number] Processing 16 items
2025-10-29 14:14:56.137 DEBUG (MainThread) [custom_components.ramses_cc.number] Adding 16 entities directly
2025-10-29 14:14:56.138 ERROR (MainThread) [homeassistant.components.number] Platform ramses_cc does not generate unique IDs. ID 32_153289_param_01 is already used by number.32_153289_param_01 - ignoring number.32_153289_param_01
2025-10-29 14:14:56.138 ERROR (MainThread) [homeassistant.components.number] Platform ramses_cc does not generate unique IDs. ID 32_153289_param_31 is already used by number.32_153289_param_31 - ignoring number.32_153289_param_31
```
Now all duplicate prevention is moved to `number.py`.