### PR TITLE
Bump release, reqs

### DIFF
--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -12,8 +12,8 @@
     "requirements": [
       "aiousbwatcher>=1.1.1",
       "pyserial-asyncio-fast>=0.14",
-      "ramses-rf==0.52.1"
+      "ramses-rf==0.52.3"
     ],
     "single_config_entry": true,
-    "version": "0.52.1"
+    "version": "0.52.3"
   }

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
 
   aiousbwatcher         >= 1.1.1                 # as per: manifest.json latest: 1.1.1
   pyserial-asyncio-fast >= 0.14                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.52.1                # as per: manifest.json latest:
+  ramses-rf             == 0.52.3                # as per: manifest.json latest:
 
 # libraries required for development (lint/type/test)...
 # - pip list | grep -E 'pre-commit|ruff|mypy|types-|voluptuous'
@@ -17,5 +17,5 @@
     ruff >= 0.13.0                               # latest: 0.13.0 See also: pre-commit-config.yaml
 
 # used for development (typing)
-    mypy >= 1.15.0                               # latest: 1.18.2
+    mypy >= 1.18.0                               # latest: 1.18.2
     voluptuous >= 0.15.2                         # latest: 0.15.2 =HA

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -14,4 +14,4 @@
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest
 
-  pytest_homeassistant_custom_component >= 0.13.286
+  pytest_homeassistant_custom_component >= 0.13.289


### PR DESCRIPTION
- version + ramses-rf==0.52.3
- mypy >= 1.18.0
- pytest_homeassistant_custom_component >= 0.13.289