### PR TITLE
Pin `aiodns`

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -8,7 +8,7 @@
   aiousbwatcher         >= 1.1.1                 # as per: manifest.json latest: 1.1.1
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
   ramses-rf             == 0.52.4                # as per: manifest.json latest:
-  pycares               == 4.11.0                # pinned for compatibility of ha_cc
+  pycares               == 4.9.0                 # pinned for compatibility of ha_cc
                                                  # (pycares 5.x not yet compatible with aiodns)
 
 # libraries required for development (lint/type/test)...


### PR DESCRIPTION
fix dependency via `pytest_homeassistant_custom_component`, copied from HA core
as found by @PWhite-Eng 