### PR TITLE
feat: Add optional development hook for local library loading

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -6,7 +6,9 @@ Requires a Honeywell HGI80 (or compatible) gateway.
 from __future__ import annotations
 
 import logging
+import os
 import re
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Final
 
@@ -64,6 +66,23 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# --- DEVELOPMENT HOOK ---
+# If a local copy of ramses_rf exists, use it instead of the system installed version.
+# This allows for testing changes without rebuilding the container.
+
+ENABLE_DEV_HOOK = False  # Set to true to enable the dev hook
+DEV_LIB_PATH = "/config/deps/ramses_rf/src"
+
+if ENABLE_DEV_HOOK and os.path.isdir(DEV_LIB_PATH):
+    # Insert at index 0 so it takes precedence over system libraries
+    sys.path.insert(0, DEV_LIB_PATH)
+
+    _LOGGER.warning(
+        "SECURITY WARNING: 'ramses_rf' is being loaded from a local development path: %s. "
+        "Do not use this in a production environment unless you understand the risks.",
+        DEV_LIB_PATH,
+    )
+# ------------------------
 
 CONFIG_SCHEMA = vol.All(
     cv.deprecated(DOMAIN, raise_if_present=False),


### PR DESCRIPTION
### Summary
This PR introduces a development hook in `__init__.py` that allows `ramses_cc` to load the `ramses_rf` library from a local directory (`/config/deps/ramses_rf/src`) instead of the system-installed package.

This feature is **disabled by default** via a constant flag (`ENABLE_DEV_HOOK = False)`.

### Motivation
Developing and testing changes to the underlying `ramses_rf` library within a Home Assistant environment (especially Container/OS) is currently difficult. It typically requires rebuilding containers or manually hacking site-packages, which is slow and error-prone.

This hook allows developers to:

1. Upload a modified library to a local folder (e.g., via Samba/VSCode).
2. Enable the hook.
3. Restart Home Assistant to immediately test library changes.

### Security Considerations
This feature allows Home Assistant to execute code from a user-writable directory (`/config/deps/`).

- **Risk:** If enabled, a malicious actor with access to the config folder could inject arbitrary code.
- **Mitigation 1 (Default State):** The feature is controlled by a hardcoded boolean `ENABLE_DEV_HOOK = False`. It must be manually edited by a developer to take effect. It is safe for general users who pull this update.
- **Mitigation 2 (Auditing):** When enabled and active, a `SECURITY WARNING` is logged to the Home Assistant logs during startup, explicitly stating that a local development library is being used.