### PR TITLE
fix: resolve static analysis (mypy) errors found during dependency investigation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,7 @@ extensions = [
 pygments_style = "sphinx"  # enable syntax highlighting
 
 templates_path = ["_templates"]
-exclude_patterns = []
+exclude_patterns: list[str] = []
 
 # Language
 language = "en"

--- a/tests/tests_new/test_bound_device.py
+++ b/tests/tests_new/test_bound_device.py
@@ -7,6 +7,7 @@ TODO: add tests routing a service call via a (mocked) device
 """
 
 # import logging
+from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,7 +35,9 @@ class TestBoundDeviceFunctionality:
     """
 
     @pytest.fixture(autouse=True)
-    async def setup_bound_device_fixture(self, hass: HomeAssistant):
+    async def setup_bound_device_fixture(
+        self, hass: HomeAssistant
+    ) -> AsyncGenerator[None]:
         """Set up test environment for bound device operations.
 
         This fixture runs before each test method and sets up:

--- a/tests/tests_new/test_fan_param.py
+++ b/tests/tests_new/test_fan_param.py
@@ -48,9 +48,7 @@ class TestFanParameterGet:
     """
 
     @pytest.fixture(autouse=True)
-    async def setup_get_fixture(
-        self, hass: HomeAssistant
-    ) -> AsyncGenerator[None, None, None]:
+    async def setup_get_fixture(self, hass: HomeAssistant) -> AsyncGenerator[None]:
         """Set up test environment for GET operations.
 
         This fixture runs before each test method and sets up:
@@ -234,7 +232,7 @@ class TestFanParameterSet:
     """
 
     @pytest.fixture(autouse=True)
-    async def setup_set_fixture(self, hass: HomeAssistant):
+    async def setup_set_fixture(self, hass: HomeAssistant) -> AsyncGenerator[None]:
         """Set up test environment for SET operations.
 
         This fixture runs before each test method and sets up:
@@ -377,7 +375,7 @@ class TestFanParameterUpdate:
     """
 
     @pytest.fixture(autouse=True)
-    async def setup_update_fixture(self, hass: HomeAssistant):
+    async def setup_update_fixture(self, hass: HomeAssistant) -> AsyncGenerator[None]:
         """Set up test environment for UPDATE operations.
 
         This fixture runs before each test method and sets up:


### PR DESCRIPTION
While investigating the recent dependency conflicts on master (specifically regarding` syrupy` and `pytest-homeassistant-custom-component`), I ran a full static analysis scan (`mypy .`) to assess the state of the codebase.

I discovered several pre-existing type checking errors that were unrelated to the dependency conflict but were cluttering the analysis logs. I have fixed them in this PR to "clear the noise," making it easier to identify actual breakage caused by dependency updates in the future.

Changes included:

- **tests:** Corrected `AsyncGenerator` type hints in `test_fan_param.py` (updated from 3 arguments to 1).
- **tests:** Added missing return type annotations (e.g., `-> None`, `-> AsyncGenerator`) to fixtures in `test_bound_device.py` and `test_fan_param.py`.
- **docs:** Added an explicit type annotation to `exclude_patterns` in `docs/source/conf.py`.

This resolves the "Function is missing a return type annotation" and "Need type annotation for variable" errors.