### PR TITLE
fix: resolve static analysis errors for untyped test dependencies

### DIFF
--- a/tests/tests_new/common.py
+++ b/tests/tests_new/common.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from homeassistant.util.json import JsonObjectType
 from homeassistant.util.yaml import parse_yaml
-from pytest_homeassistant_custom_component.common import (
+from pytest_homeassistant_custom_component.common import (  # type: ignore[import-untyped]
     load_fixture,
     load_json_object_fixture,
 )

--- a/tests/tests_new/conftest.py
+++ b/tests/tests_new/conftest.py
@@ -8,7 +8,9 @@ from unittest.mock import patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.syrupy import HomeAssistantSnapshotExtension
+from pytest_homeassistant_custom_component.syrupy import (  # type: ignore[import-untyped]
+    HomeAssistantSnapshotExtension,
+)
 from syrupy.assertion import SnapshotAssertion
 
 from ..virtual_rf import VirtualRf


### PR DESCRIPTION
This PR resolves persistent static analysis (`mypy`) errors caused by the upstream testing library `pytest-homeassistant-custom-component`.

It applies explicit, localized `# type: ignore[import-untyped]` annotations to the specific import statements in our test suite. This ensures `mypy` passes cleanly without requiring broad, project-wide suppressions in `pyproject.toml`.

### The Issue

running `mypy .` was failing with:

Plaintext

```
error: Skipping analyzing "pytest_homeassistant_custom_component.syrupy": module is installed, but missing library stubs or py.typed marker [import-untyped]

```

### Investigation & Root Cause
- **Root Cause:** The library `pytest-homeassistant-custom-component` does not distribute type stubs (`.pyi`) or a `py.typed` marker. It is "untyped" by design.
- **Why now?** Our project's `mypy` configuration is strict (`warn_unused_ignores = true`).
- **Conflict:** We initially attempted to ignore this library globally in `pyproject.toml`. However, this caused a conflict with inline comments, leading to `unused-ignore` errors.

### The Fix

We chose **Explicit Local Ignores** over a global suppression.
- Added `# type: ignore[import-untyped]` strictly to the `from ... import (` lines in `common.py` and `conftest.py`.

**Why this approach?**
- **Clarity:** It makes it immediately obvious to any developer reading the code that this specific import is untyped.
- **Safety:** It prevents us from accidentally ignoring other unrelated errors that a global wildcard suppression might hide.