### PR TITLE
test: optimize fan_param tests speed & coverage clarifications

### DIFF
--- a/tests/tests_new/test_broker_fan.py
+++ b/tests/tests_new/test_broker_fan.py
@@ -278,7 +278,9 @@ async def test_param_validation_logic(mock_broker: RamsesBroker) -> None:
 
 
 async def test_update_fan_params_sequence(
-    mock_broker: RamsesBroker, mock_gateway: MagicMock
+    mock_broker: RamsesBroker,
+    mock_gateway: MagicMock,
+    mock_fan_device: MagicMock,  # <--- Added fixture here
 ) -> None:
     """Test the sequential update of fan parameters with mocked schema.
 
@@ -288,7 +290,11 @@ async def test_update_fan_params_sequence(
 
     :param mock_broker: The mock broker fixture.
     :param mock_gateway: The mock gateway fixture.
+    :param mock_fan_device: The mock fan device fixture.
     """
+    # Register the mock device so the broker can find the bound remote (source ID)
+    mock_broker._devices = [mock_fan_device]
+
     # Define a tiny schema for testing (just 2 params) to avoid 30+ iterations
     tiny_schema = ["11", "22"]
 


### PR DESCRIPTION
## Description
This PR addresses the performance feedback from @wimpie70 regarding the `update_fan_params` tests in the recently merged PR #390.

### Changes
- **Optimized Tests:** Patched `_2411_PARAMS_SCHEMA` to a minimal set and mocked `asyncio.sleep` in `test_broker_fan.py`. The tests now run instantly instead of waiting ~15 seconds.

### Context & Testing Strategy
I also wanted to clarify my current approach to testing as I prepare for **PR #381 (MQTT IoC transport factory)**.

I am well aware that these tests primarily cover the "happy path" to bump the code coverage metrics. I am not attempting to cover every complex edge case right now, as I am still deepening my understanding of the full codebase.

My goal is to establish a solid testing baseline to ensure I can test my major addition (MQTT support) as best as possible, given my current knowledge of the system. I want to ensure I don't introduce regressions while implementing the new transport factory.

## Type of change
- [x] Test optimization / Fix