### PR TITLE
fix: prevent event loop blocking in remote fan parameter update

### DIFF
--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -326,7 +326,10 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         if parent:
             kwargs[ATTR_DEVICE_ID] = parent
             kwargs["from_id"] = self._device.id  # replaces manual from_id entry
-            self._broker.get_all_fan_params(kwargs)
+            # Run synchronous I/O function in the executor to avoid blocking the loop
+            await self.hass.async_add_executor_job(
+                self._broker.get_all_fan_params, kwargs
+            )
         else:
             _LOGGER.warning("REM %s not bound to a FAN", self._device.id)
 


### PR DESCRIPTION
#### 1. The Issue

In the `RamsesRemote` entity, the method `async_update_fan_rem_params` (which handles the `update_fan_params` service call) was performing a direct synchronous call to `self._broker.get_all_fan_params`.

Because this method runs within an `async` function on the main Home Assistant event loop, calling a synchronous function that performs I/O (sending RF packets via the broker) causes the event loop to **block**.

#### 2. Effect on the System
- **Unresponsiveness:** While `get_all_fan_params` is executing (sending commands and waiting for serial I/O), the entire Home Assistant instance freezes.
- **Log Warnings:** This typically triggers "Detected blocking call in the event loop" warnings in the Home Assistant logs if the operation takes longer than a fraction of a second.
- **Broken Logic:** In previous iterations or if the method were async without an `await`, the code might simply fail to execute or behave unpredictably.

#### 3. The Fix

I wrapped the synchronous broker call using Home Assistant's `async_add_executor_job`:

Python

```
await self.hass.async_add_executor_job(
    self._broker.get_all_fan_params, kwargs
)

```

#### 4. How it Fixes the Problem
- **Offloading:** `async_add_executor_job` moves the execution of `get_all_fan_params` off the main event loop and into a separate thread pool (executor).
- **Non-Blocking:** The `await` keyword allows the `async_update_fan_rem_params` function to pause execution (yield) while waiting for the thread to finish, allowing the Home Assistant event loop to continue processing other tasks (like UI updates or automations) in the meantime.

#### 5. Verification & Testing

I updated `tests/tests_new/test_remote.py` to strictly verify this behavior:
- **Mocking:** I mocked `get_all_fan_params` as a synchronous function (standard `MagicMock`) and patched `hass.async_add_executor_job` to return an `asyncio.Future` (simulating a successful thread execution).
- **Assertion:** The test explicitly asserts that `async_add_executor_job` is called with the broker method and the correctly modified arguments (`device_id`, `from_id`, etc.).
- **Result:** All tests passed, confirming the method is now correctly awaited and offloaded to the executor.