### PR TITLE
Fix: Handle missing sensor in `async_fake_zone_temp` to prevent crash

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -29,6 +29,7 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     EntityPlatform,
@@ -454,7 +455,9 @@ class RamsesZone(RamsesEntity, ClimateEntity):
     def async_fake_zone_temp(self, temperature: float) -> None:
         """Cast the room temperature of this zone (if faked)."""
         if self._device.sensor is None:
-            raise  # TODO
+            raise HomeAssistantError(
+                f"Zone {self.entity_id} has no sensor to fake temperature on."
+            )
 
         self._device.sensor.temperature = temperature  # would accept None
 

--- a/tests/tests_new/test_climate_coverage.py
+++ b/tests/tests_new/test_climate_coverage.py
@@ -15,6 +15,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.ramses_cc.climate import (
     RamsesController,
@@ -203,6 +204,17 @@ async def test_zone_coverage(
     zone.async_set_zone_mode.assert_called_with(
         mode=ZoneMode.TEMPORARY, setpoint=21.0, duration=timedelta(hours=1), until=None
     )
+
+    # 5. Test async_fake_zone_temp
+    # Case: No sensor (should raise HomeAssistantError)
+    mock_device.sensor = None
+    with pytest.raises(HomeAssistantError):
+        zone.async_fake_zone_temp(20.0)
+
+    # Case: Sensor exists
+    mock_device.sensor = MagicMock()
+    zone.async_fake_zone_temp(21.0)
+    assert mock_device.sensor.temperature == 21.0
 
 
 async def test_hvac_coverage(


### PR DESCRIPTION
## Description
This PR fixes a stability issue in the `RamsesZone.async_fake_zone_temp` method. The method (line 456) contained a bare `raise`. If this method were called on a zone entity that does not have an associated sensor (`self._device.sensor` is `None`), Python would raise a `RuntimeError` (or simply re-raise the last active exception if one existed), causing the integration to crash or generate an unhelpful traceback in the logs. where a bare `raise` statement would cause a crash (or unhandled exception) if the zone did not have an associated sensor.

## Changes
- Modified `custom_components/ramses_cc/climate.py`: Replaced the bare `raise` with `raise HomeAssistantError(...)` to handle the missing sensor case gracefully.
- Updated `tests/tests_new/test_climate_coverage.py`: Added regression tests to verify that:
    1. A `HomeAssistantError` is raised when the sensor is missing.
    2. The temperature is correctly set when the sensor exists.

## Verification
- [x] Ran updated tests in `test_climate_coverage.py` (All passed).