### PR TITLE
Refactor broker service calls to use HomeAssistantError for failures

### DIFF
--- a/custom_components/ramses_cc/broker.py
+++ b/custom_components/ramses_cc/broker.py
@@ -14,6 +14,7 @@ import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import (
@@ -28,6 +29,7 @@ from ramses_rf.device import Fakeable
 from ramses_rf.device.base import Device
 from ramses_rf.device.hvac import HvacRemoteBase, HvacVentilator
 from ramses_rf.entity_base import Child, Entity as RamsesRFEntity
+from ramses_rf.exceptions import BindingFlowFailed
 from ramses_rf.gateway import Gateway
 from ramses_rf.schemas import SZ_SCHEMA
 from ramses_rf.system import Evohome, System, Zone
@@ -732,6 +734,7 @@ class RamsesBroker:
         :param call: Service call containing binding parameters
         :type call: ServiceCall
         :raises LookupError: If the specified device ID is not found
+        :raises HomeAssistantError: If the binding process fails
 
         .. note::
             The service call should include:
@@ -749,7 +752,9 @@ class RamsesBroker:
             device = self.client.fake_device(call.data["device_id"])
         except LookupError as err:
             _LOGGER.error("%s", err)
-            return
+            raise HomeAssistantError(
+                f"Device not found: {call.data.get('device_id')}"
+            ) from err
 
         cmd = Command(call.data["device_info"]) if call.data["device_info"] else None
 
@@ -766,9 +771,15 @@ class RamsesBroker:
                 "Success! Binding process completed for device %s", device.id
             )
 
-        except Exception as e:
-            _LOGGER.error("Binding process failed for device %s: %s", device.id, e)
-            raise
+        except BindingFlowFailed as err:
+            raise HomeAssistantError(
+                f"Binding failed for device {device.id}: {err}"
+            ) from err
+        except Exception as err:
+            _LOGGER.error("Binding process failed for device %s: %s", device.id, err)
+            raise HomeAssistantError(
+                f"Unexpected error during binding for {device.id}: {err}"
+            ) from err
 
         async_call_later(self.hass, _CALL_LATER_DELAY, self.async_update)
 
@@ -1269,10 +1280,7 @@ class RamsesBroker:
 
         :param call: Dictionary containing device info or ServiceCall object
         :type call: dict[str, Any] | ServiceCall
-        :raises ValueError: If required parameters are missing or invalid
-        :raises ValueError: If parameter ID is not a valid 2-digit hex value
-        :raises ValueError: If device is not found or not a FAN device
-        :raises RuntimeError: If communication with device fails or times out
+        :raises HomeAssistantError: If validation fails or communication errors occur
 
         The call dict should contain:
             - device_id (str): Target device ID (supports colon/underscore formats)
@@ -1293,12 +1301,12 @@ class RamsesBroker:
 
             # Check if we got valid source device info
             if not all([original_device_id, normalized_device_id, from_id]):
-                _LOGGER.warning(
-                    "Cannot set parameter: No valid source device available from %s. "
-                    "Need either: explicit from_id, or a REM/DIS device that was 'bound' in the configuration.",
-                    data,
+                msg = (
+                    f"Cannot set parameter: No valid source device available from {data}. "
+                    "Need either: explicit from_id, or a REM/DIS device that was 'bound' in the configuration."
                 )
-                return
+                _LOGGER.warning(msg)
+                raise HomeAssistantError(msg)
 
             param_id = self._get_param_id(data)
 
@@ -1333,9 +1341,10 @@ class RamsesBroker:
                 asyncio.create_task(entity._clear_pending_after_timeout(30))
 
         except ValueError as err:
-            # Log validation errors but don't re-raise them
-            _LOGGER.error("Failed to set fan parameter: %s", err)
-            return
+            # Raise friendly error for UI
+            raise HomeAssistantError(
+                f"Invalid parameter for set_fan_param: {err}"
+            ) from err
         except Exception as err:
             _LOGGER.error("Failed to set fan parameter: %s", err, exc_info=True)
-            raise
+            raise HomeAssistantError(f"Failed to set fan parameter: {err}") from err

--- a/tests/tests_new/test_broker_error_handling.py
+++ b/tests/tests_new/test_broker_error_handling.py
@@ -1,0 +1,88 @@
+"""Tests for error handling in broker service calls."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.ramses_cc.broker import RamsesBroker
+from custom_components.ramses_cc.const import DOMAIN
+from ramses_rf.exceptions import BindingFlowFailed
+
+
+@pytest.fixture
+def mock_broker(hass: HomeAssistant) -> RamsesBroker:
+    """Return a mock broker with an entry attached."""
+    entry = MagicMock()
+    entry.entry_id = "service_test_entry"
+    entry.options = {"ramses_rf": {}, "serial_port": "/dev/ttyUSB0"}
+
+    broker = RamsesBroker(hass, entry)
+    broker.client = MagicMock()
+    broker.client.async_send_cmd = AsyncMock()
+
+    hass.data[DOMAIN] = {entry.entry_id: broker}
+    return broker
+
+
+async def test_bind_device_raises_ha_error(mock_broker: RamsesBroker) -> None:
+    """Test that async_bind_device raises HomeAssistantError on binding failure."""
+
+    # Mock the device
+    mock_device = MagicMock()
+    mock_device.id = "01:123456"
+    # Setup the binding process to raise BindingFlowFailed
+    mock_device._initiate_binding_process = AsyncMock(
+        side_effect=BindingFlowFailed("Timeout waiting for confirm")
+    )
+
+    mock_broker.client.fake_device.return_value = mock_device
+
+    # USE MagicMock instead of ServiceCall to ensure .data is a simple, accessible dict
+    call = MagicMock()
+    call.data = {
+        "device_id": "01:123456",
+        "offer": {"key": "val"},
+        "confirm": {"key": "val"},
+        "device_info": None,
+    }
+
+    # Assert that HomeAssistantError is raised (wrapping the original error)
+    # instead of the raw BindingFlowFailed exception
+    with pytest.raises(HomeAssistantError, match="Binding failed for device"):
+        await mock_broker.async_bind_device(call)
+
+
+async def test_set_fan_param_raises_ha_error_invalid_value(
+    mock_broker: RamsesBroker,
+) -> None:
+    """Test that async_set_fan_param raises HomeAssistantError on invalid input."""
+
+    # Call with missing value to trigger ValueError in validation
+    call_data = {
+        "device_id": "30:111222",
+        "param_id": "0A",
+        # "value": missing -> This triggers the ValueError
+        "from_id": "32:111111",
+    }
+
+    # Verify that ValueError is caught and re-raised as HomeAssistantError
+    with pytest.raises(HomeAssistantError, match="Invalid parameter for set_fan_param"):
+        await mock_broker.async_set_fan_param(call_data)
+
+
+async def test_set_fan_param_raises_ha_error_no_source(
+    mock_broker: RamsesBroker,
+) -> None:
+    """Test that async_set_fan_param raises HomeAssistantError when no source device is found."""
+
+    call_data = {
+        "device_id": "30:111222",
+        "param_id": "0A",
+        "value": 1,
+        # No from_id and no bound device configured in mock -> triggers logic error
+    }
+
+    with pytest.raises(HomeAssistantError, match="No valid source device available"):
+        await mock_broker.async_set_fan_param(call_data)


### PR DESCRIPTION
### Problem
The current error handling in `broker.py` regarding service calls is inconsistent:
1. `async_bind_device` catches generic `Exception`s and re-raises them, resulting in raw Python tracebacks in the Home Assistant logs but often opaque errors for the user.
2. `async_set_fan_param` catches `ValueError` (e.g., for invalid parameters) and logs it to `_LOGGER.error`, but effectively suppresses the error from the UI. The user sees a "success" indication even though the operation failed.

### Consequences
* **Poor UX:** Users do not get immediate feedback when an action fails (e.g., setting an invalid fan parameter).
* **Support Burden:** Raw tracebacks for expected failures (like binding timeouts) look like system crashes, leading to unnecessary bug reports.

### Fix
This PR refactors `async_bind_device` and `async_set_fan_param` to use `homeassistant.exceptions.HomeAssistantError`.

* **Binding:** Explicitly catches `BindingFlowFailed` (from `ramses_rf`) and raises a `HomeAssistantError` with a descriptive message.
* **Fan Parameters:** Catches `ValueError` during input validation and raises `HomeAssistantError` so the UI displays the validation error to the user.
* **General Safety:** Catches unexpected `Exception`s during these specific operations and wraps them in `HomeAssistantError` to ensure the integration remains stable while still informing the user.

### How it works
* Imported `HomeAssistantError` and `BindingFlowFailed`.
* Wrapped critical logic blocks in `try/except` structures.
* Used `raise ... from err` to preserve the original traceback for debugging while presenting a clean error to the HA Core.

### Testing
* **Unit Tests:** Added `tests/tests_new/test_broker_error_handling.py` covering:
    * `test_bind_device_raises_ha_error`: Mocks binding failure and asserts `HomeAssistantError` is raised.
    * `test_set_fan_param_raises_ha_error_invalid_value`: Calls service with missing data and asserts `HomeAssistantError`.
* **Regression Testing:** Ran full `pytest` suite (157 tests passed).

### Risks
* **Not Implementing:** Users continue to experience "silent failures" or confusing tracebacks.
* **Implementing:**
    * *Risk:* Changes to `ramses_rf` internals (exception names) could break imports.
    * *Mitigation:* Verified imports against current codebase usage.
    * *Risk:* Breaking automations that relied on "silent failure" (fire-and-forget).
    * *Mitigation:* This is a breaking change for automations that send invalid data; however, failing loudly on invalid data is standard HA practice. Valid automations are unaffected.