### PR TITLE
Refactor packet injection logic to isolate encapsulation violations

### DIFF
--- a/custom_components/ramses_cc/broker.py
+++ b/custom_components/ramses_cc/broker.py
@@ -810,19 +810,36 @@ class RamsesBroker:
 
         cmd = self.client.create_cmd(**kwargs)
 
-        # HACK: to fix the device_id when GWY announcing, will be:
-        #    I --- 18:000730 18:006402 --:------ 0008 002 00C3  # because src != dst
-        # ... should be:
-        #    I --- 18:000730 --:------ 18:006402 0008 002 00C3  # 18:730 is sentinel
-        if cmd.src.id == "18:000730" and cmd.dst.id == self.client.hgi.id:
-            try:
-                pkt_addrs(self.client.hgi.id + cmd._frame[16:37])
-            except PacketAddrSetInvalid:
-                cmd._addrs[1], cmd._addrs[2] = cmd._addrs[2], cmd._addrs[1]
-                cmd._repr = None
+        self._adjust_sentinel_packet(cmd)
 
         await self.client.async_send_cmd(cmd)
         async_call_later(self.hass, _CALL_LATER_DELAY, self.async_update)
+
+    def _adjust_sentinel_packet(self, cmd: Command) -> None:
+        """Fix address positioning for specific sentinel packets (18:000730).
+
+        This checks if the packet addresses are valid for the HGI gateway and
+        swaps address 1 and address 2 if necessary to ensure protocol compliance.
+
+        :param cmd: The command object to check and adjust
+        :type cmd: Command
+        """
+        # HACK: to fix the device_id when GWY announcing.
+        # Current: I --- 18:000730 18:006402 --:------ 0008 002 00C3
+        # Target:  I --- 18:000730 --:------ 18:006402 0008 002 00C3
+        if cmd.src.id != "18:000730" or cmd.dst.id != self.client.hgi.id:
+            return
+
+        try:
+            # Validate if the current address structure is acceptable
+            pkt_addrs(self.client.hgi.id + cmd._frame[16:37])
+        except PacketAddrSetInvalid:
+            # If invalid, swap addr1 and addr2 to correct the structure
+            cmd._addrs[1], cmd._addrs[2] = cmd._addrs[2], cmd._addrs[1]
+            cmd._repr = None  # Invalidate cached representation
+            _LOGGER.debug(
+                "Swapped addresses for sentinel packet 18:000730 to maintain protocol validity"
+            )
 
     # fan_param (2411) private and service methods.
     # Called from climate.py and remote.py as service @callback, or directly with dict (only)

--- a/tests/tests_new/test_broker_packet_logic.py
+++ b/tests/tests_new/test_broker_packet_logic.py
@@ -1,0 +1,78 @@
+"""Tests for packet injection logic and address manipulation."""
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.ramses_cc.broker import RamsesBroker
+from ramses_tx.exceptions import PacketAddrSetInvalid
+
+# Constants
+HGI_ID = "18:006402"
+SENTINEL_ID = "18:000730"
+
+
+def test_adjust_sentinel_packet_swaps_on_invalid() -> None:
+    """Test that addresses are swapped when validation fails for sentinel packet."""
+    # Setup
+    # Use generic MagicMock because 'client' is an instance attribute
+    broker = MagicMock()
+    broker.client.hgi.id = HGI_ID
+
+    # Mock Command
+    # Use generic MagicMock to avoid attribute issues with 'src'/'dst'
+    cmd = MagicMock()
+    cmd.src.id = SENTINEL_ID
+    cmd.dst.id = HGI_ID
+    cmd._frame = "X" * 40  # Dummy frame data
+    cmd._addrs = ["addr0", "addr1", "addr2"]
+
+    # Patch pkt_addrs to raise PacketAddrSetInvalid
+    with patch("custom_components.ramses_cc.broker.pkt_addrs") as mock_validate:
+        mock_validate.side_effect = PacketAddrSetInvalid("Invalid structure")
+
+        # Execute using the unbound method call, passing our mock as 'self'
+        RamsesBroker._adjust_sentinel_packet(broker, cmd)
+
+        # Verify swap occurred
+        assert cmd._addrs[1] == "addr2"
+        assert cmd._addrs[2] == "addr1"
+        assert cmd._repr is None
+
+
+def test_adjust_sentinel_packet_no_swap_on_valid() -> None:
+    """Test that addresses are NOT swapped when validation passes."""
+    # Setup
+    broker = MagicMock()
+    broker.client.hgi.id = HGI_ID
+
+    cmd = MagicMock()
+    cmd.src.id = SENTINEL_ID
+    cmd.dst.id = HGI_ID
+    cmd._frame = "X" * 40
+    cmd._addrs = ["addr0", "addr1", "addr2"]
+
+    with patch("custom_components.ramses_cc.broker.pkt_addrs") as mock_validate:
+        mock_validate.return_value = True  # Validation passes
+
+        RamsesBroker._adjust_sentinel_packet(broker, cmd)
+
+        # Verify NO swap
+        assert cmd._addrs[1] == "addr1"
+        assert cmd._addrs[2] == "addr2"
+
+
+def test_adjust_sentinel_packet_ignores_other_devices() -> None:
+    """Test that logic is skipped for non-sentinel devices."""
+    broker = MagicMock()
+    broker.client.hgi.id = HGI_ID
+
+    cmd = MagicMock()
+    cmd.src.id = "01:123456"  # Not sentinel
+    cmd.dst.id = HGI_ID
+    cmd._addrs = ["addr0", "addr1", "addr2"]
+
+    # Execute
+    RamsesBroker._adjust_sentinel_packet(broker, cmd)
+
+    # Verify no swap and repr is untouched
+    assert cmd._addrs == ["addr0", "addr1", "addr2"]
+    assert cmd._repr is not None  # Should not be reset


### PR DESCRIPTION
### Problem:
The `async_send_packet` method previously contained a "hack" (lines 642-654) that directly modified the protected attributes `_addrs` and `_repr` of the `Command` object. This violated encapsulation and coupled the main service flow to the internal implementation details of the `ramses_rf` library. Additionally, the logic for why this swap was occurring was buried inside the service handler, making it difficult to test or maintain.

### Consequences:
If the `ramses_rf` library changes its internal structure (e.g., renaming `_addrs`), the entire `send_packet` service could break. Furthermore, mixing this complex protocol patching logic with the high-level service call flow increases the cognitive load for maintainers and makes unit testing the service difficult without mocking deep library internals.

### Fix:
 I have extracted the logic into a dedicated, private helper method: `_adjust_sentinel_packet`.
- This method checks if the command is targeting the specific sentinel scenario (Source: `18:000730`, Dest: HGI).
- It performs the validation using `pkt_addrs`.
- It performs the address swap only if required.

### How it works:
The `async_send_packet` method now delegates the protocol compliance check to `_adjust_sentinel_packet` before sending the command. The helper method handles the `PacketAddrSetInvalid` exception internally. If the exception is raised (indicating the packet structure is invalid for this context), the method swaps the position of address 1 and address 2 in the packet and invalidates the cached representation (`_repr`), forcing the library to rebuild the frame correctly.

### Testing:
I have added a new test suite `tests/tests_new/test_broker_packet_logic.py` that specifically targets this new helper method.
- **Test 1:** Verifies that addresses are swapped when `pkt_addrs` raises `PacketAddrSetInvalid`.
- **Test 2:** Verifies that addresses remain untouched if `pkt_addrs` returns successfully.
- **Test 3:** Verifies that the logic is completely skipped for non-sentinel devices.

Existing regression tests (`tests/tests_old/test_services.py`) were also run to ensure the service registration remains valid.

### Risks:
- **Risk:** The refactor might inadvertently alter the logic, breaking the "spoofing" capability for the sentinel device.
- **Mitigation:** The logic has been preserved exactly as it was, simply moved. The new unit tests explicitly verify that the swap occurs under the exact same conditions (exception raised) as before, ensuring behavior parity.