### PR TITLE
Refactor: Extract Storage Logic (Phase 2.1 of Broker Refactor)

### DIFF
--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -1,0 +1,47 @@
+"""Storage handler for RAMSES integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import (
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    SZ_CLIENT_STATE,
+    SZ_PACKETS,
+    SZ_REMOTES,
+    SZ_SCHEMA,
+)
+
+
+class RamsesStore:
+    """Class to handle persistence of RAMSES configuration and state."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the storage helper."""
+        self._store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+
+    async def async_load(self) -> dict[str, Any]:
+        """Load the data from the persistent storage.
+
+        :return: The stored data or an empty dictionary if no data exists
+        """
+        return await self._store.async_load() or {}
+
+    async def async_save(
+        self, schema: dict[str, Any], packets: dict[str, str], remotes: dict[str, Any]
+    ) -> None:
+        """Save the current state to persistent storage.
+
+        :param schema: The current device schema
+        :param packets: The cached packet log
+        :param remotes: The known remotes and their commands
+        """
+        data = {
+            SZ_CLIENT_STATE: {SZ_SCHEMA: schema, SZ_PACKETS: packets},
+            SZ_REMOTES: remotes,
+        }
+        await self._store.async_save(data)

--- a/tests/tests_new/test_broker_services.py
+++ b/tests/tests_new/test_broker_services.py
@@ -147,14 +147,16 @@ async def test_save_client_state_remotes(mock_broker: RamsesBroker) -> None:
     """
     mock_broker.client.get_state.return_value = ({}, {})
     mock_broker._remotes = {REM_ID: {"boost": "packet_data"}}
-    mock_broker._store = MagicMock(spec=mock_broker._store)
-    mock_broker._store.async_save = AsyncMock()
+    mock_broker.store = MagicMock(spec=mock_broker.store)
+    mock_broker.store.async_save = AsyncMock()
 
     await mock_broker.async_save_client_state()
 
     # Verify remotes were included in the save payload
-    save_data = mock_broker._store.async_save.call_args[0][0]
-    assert save_data["remotes"][REM_ID]["boost"] == "packet_data"
+    args = mock_broker.store.async_save.call_args[0]
+    saved_remotes = args[2]
+
+    assert saved_remotes[REM_ID]["boost"] == "packet_data"
 
 
 async def test_device_registry_update_slugs(mock_broker: RamsesBroker) -> None:

--- a/tests/tests_new/test_broker_startup.py
+++ b/tests/tests_new/test_broker_startup.py
@@ -64,7 +64,7 @@ async def test_setup_with_corrupted_storage_dates(
         }
     }
 
-    broker._store.async_load = AsyncMock(return_value=mock_storage_data)
+    broker.store.async_load = AsyncMock(return_value=mock_storage_data)
     broker._create_client = MagicMock()
     broker.client = MagicMock()
     broker.client.start = AsyncMock()
@@ -93,7 +93,7 @@ async def test_setup_fails_gracefully_on_bad_config(
     :param mock_entry: Mock ConfigEntry.
     """
     broker = RamsesBroker(mock_hass, mock_entry)
-    broker._store.async_load = AsyncMock(return_value={})
+    broker.store.async_load = AsyncMock(return_value={})
 
     # Force _create_client to raise vol.Invalid (simulation of bad schema)
     broker._create_client = MagicMock(side_effect=vol.Invalid("Invalid config"))

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -91,7 +91,7 @@ async def test_setup_fails_gracefully_on_bad_config(
 ) -> None:
     """Test that startup catches client creation errors and logs them."""
     broker = RamsesBroker(mock_hass, mock_entry)
-    broker._store.async_load = AsyncMock(return_value={})
+    broker.store.async_load = AsyncMock(return_value={})
 
     # Force _create_client to raise vol.Invalid (simulation of bad schema)
     broker._create_client = MagicMock(side_effect=vol.Invalid("Invalid config"))
@@ -128,7 +128,7 @@ async def test_setup_schema_merge_failure(
     broker = RamsesBroker(mock_hass, mock_entry)
 
     # Provide a non-empty schema so the code enters the "merge" block
-    broker._store.async_load = AsyncMock(
+    broker.store.async_load = AsyncMock(
         return_value={SZ_CLIENT_STATE: {SZ_SCHEMA: {"existing": "data"}}}
     )
 
@@ -330,7 +330,7 @@ async def test_setup_ignores_invalid_cached_packet_timestamps(
     valid_dtm = dt.now().isoformat()
     invalid_dtm = "invalid-iso-format"
 
-    broker._store.async_load = AsyncMock(
+    broker.store.async_load = AsyncMock(
         return_value={
             SZ_CLIENT_STATE: {
                 SZ_PACKETS: {
@@ -436,7 +436,7 @@ async def test_setup_uses_merged_schema_on_success(
 
     # 1. Setup storage to provide a cached schema so we enter the conditional block
     cached_schema = {"cached_key": "cached_val"}
-    broker._store.async_load = AsyncMock(
+    broker.store.async_load = AsyncMock(
         return_value={SZ_CLIENT_STATE: {SZ_SCHEMA: cached_schema}}
     )
 
@@ -483,7 +483,7 @@ async def test_setup_logs_warning_on_non_minimal_schema(
 ) -> None:
     """Test that a warning is logged when the schema is not minimal (Line 155)."""
     broker = RamsesBroker(mock_hass, mock_entry)
-    broker._store.async_load = AsyncMock(return_value={})
+    broker.store.async_load = AsyncMock(return_value={})
 
     # Mock success path for client creation so setup completes
     mock_client = MagicMock()

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -943,7 +943,7 @@ async def test_cached_packets_filtering(mock_broker: RamsesBroker) -> None:
     filtered_dt = (dt_now - timedelta(minutes=1)).isoformat()
 
     # Mock store load
-    mock_broker._store.async_load = AsyncMock(
+    mock_broker.store.async_load = AsyncMock(
         return_value={
             SZ_CLIENT_STATE: {
                 SZ_PACKETS: {
@@ -1136,7 +1136,7 @@ async def test_setup_schema_merge_failure(hass: HomeAssistant) -> None:
     broker = RamsesBroker(hass, entry)
 
     # Mock store load to return a cached schema
-    broker._store.async_load = AsyncMock(
+    broker.store.async_load = AsyncMock(
         return_value={"client_state": {"schema": {"mock": "schema"}, "packets": {}}}
     )
 


### PR DESCRIPTION
## Summary
This PR implements **Phase 2, Step 1** of the `broker.py` refactoring plan described in issue #414.

The goal is to dismantle the "God Object" nature of the central Broker by extracting distinct responsibilities. This step focuses on **Persistence**.

## Changes
- **New Component:** Created `custom_components/ramses_cc/store.py` containing the `RamsesStore` class.
- **Broker Update:** `RamsesBroker` now delegates all `async_load` and `async_save` operations to this new helper class.
- **Tests:** Updated `test_storage.py` and `test_broker_services.py` to mock and assert against the new `store` object instead of the raw `homeassistant.helpers.storage.Store`.

## Verification
- [x] `pytest` passes (100% tests passing).
- [x] Logic verifies that client state, schema, and packet logs are correctly routed to the storage helper.