### PR TITLE
Refactor: Rename `broker` to `coordinator` (Phase 3.1 & 3.2 of refactor)

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -687,7 +687,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
     ) -> FlowResult:
         """Clear cache step."""
         if user_input is not None:
-            # Unload immediately to stop scheduled broker state saves
+            # Unload immediately to stop scheduled coordinator state saves
             if self.config_entry.state == ConfigEntryState.LOADED:
                 await self.hass.config_entries.async_unload(self.config_entry.entry_id)
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1,4 +1,4 @@
-"""Broker for RAMSES integration."""
+"""Coordinator for RAMSES integration."""
 
 from __future__ import annotations
 
@@ -61,11 +61,11 @@ _LOGGER = logging.getLogger(__name__)
 SAVE_STATE_INTERVAL: Final[timedelta] = timedelta(minutes=5)
 
 
-class RamsesBroker:
+class RamsesCoordinator:
     """Central coordinator for the RAMSES integration."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize the RAMSES broker and its data structures."""
+        """Initialize the RAMSES coordinator and its data structures."""
         self.hass = hass
         self.entry = entry
         self.options = deepcopy(dict(entry.options))
@@ -168,7 +168,7 @@ class RamsesBroker:
         self.entry.async_on_unload(self.client.stop)
 
     async def async_start(self) -> None:
-        """Initialize the update cycle for the RAMSES broker."""
+        """Initialize the update cycle for the RAMSES coordinator."""
         await self.async_update()
 
         self.entry.async_on_unload(
@@ -223,7 +223,7 @@ class RamsesBroker:
         platform: EntityPlatform,
         add_new_devices: Callable[[RamsesRFEntity], None],
     ) -> None:
-        """Register a platform that has entities with the broker."""
+        """Register a platform that has entities with the coordinator."""
         platform_str = platform.domain if hasattr(platform, "domain") else platform
         _LOGGER.debug("Registering platform %s", platform_str)
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -152,7 +152,7 @@ SCH_MINIMUM_TCS = vol.Schema(
 
 
 def normalise_config(config: _SchemaT) -> tuple[str, _SchemaT, _SchemaT]:
-    """Return a port/client_config/broker_config for the library."""
+    """Return a port/client_config/coordinator_config for the library."""
 
     config = deepcopy(config)
 
@@ -166,12 +166,12 @@ def normalise_config(config: _SchemaT) -> tuple[str, _SchemaT, _SchemaT]:
         if v.get(CONF_COMMANDS)
     }
 
-    broker_keys = (CONF_SCAN_INTERVAL, CONF_ADVANCED_FEATURES, SZ_RESTORE_CACHE)
+    coordinator_keys = (CONF_SCAN_INTERVAL, CONF_ADVANCED_FEATURES, SZ_RESTORE_CACHE)
     return (  # type: ignore[return-value]
         port_name,
-        {k: v for k, v in config.items() if k not in broker_keys}
+        {k: v for k, v in config.items() if k not in coordinator_keys}
         | {SZ_PORT_CONFIG: port_config},
-        {k: v for k, v in config.items() if k in broker_keys}
+        {k: v for k, v in config.items() if k in coordinator_keys}
         | {"remotes": remote_commands},
     )
 
@@ -759,5 +759,5 @@ SVCS_RAMSES_REMOTE = {
 
 # Service schemas for number platform
 SVCS_RAMSES_NUMBER: dict[str, Any] = {
-    # set_fan_param is registered as a broker/domain service (not an entity service)
+    # set_fan_param is registered as a coordinator/domain service (not an entity service)
 }

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -93,8 +93,8 @@ from ramses_tx.const import (
 )
 
 from . import RamsesEntity, RamsesEntityDescription
-from .broker import RamsesBroker
 from .const import ATTR_SETPOINT, DOMAIN, UnitOfVolumeFlowRate
+from .coordinator import RamsesCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,13 +104,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up the sensor platform."""
 
-    broker: RamsesBroker = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
     platform: EntityPlatform = async_get_current_platform()
 
     @callback
     def add_devices(devices: list[RamsesRFEntity]) -> None:
         entities = [
-            description.ramses_cc_class(broker, device, description)
+            description.ramses_cc_class(coordinator, device, description)
             for device in devices
             for description in SENSOR_DESCRIPTIONS
             if isinstance(device, description.ramses_rf_class)
@@ -118,7 +118,7 @@ async def async_setup_entry(
         ]
         async_add_entities(entities)
 
-    broker.async_register_platform(platform, add_devices)
+    coordinator.async_register_platform(platform, add_devices)
 
 
 class RamsesSensor(RamsesEntity, SensorEntity):
@@ -128,13 +128,13 @@ class RamsesSensor(RamsesEntity, SensorEntity):
 
     def __init__(
         self,
-        broker: RamsesBroker,
+        coordinator: RamsesCoordinator,
         device: RamsesRFEntity,
         entity_description: RamsesEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         _LOGGER.info("Found %s: %s", device.id, entity_description.key)
-        super().__init__(broker, device, entity_description)
+        super().__init__(coordinator, device, entity_description)
 
         self.entity_id = ENTITY_ID_FORMAT.format(
             f"{device.id}_{entity_description.key}"

--- a/tests/tests_new/test_bound_device.py
+++ b/tests/tests_new/test_bound_device.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.core import HomeAssistant  # , ServiceCall
 
-from custom_components.ramses_cc.broker import RamsesBroker
+from custom_components.ramses_cc.coordinator import RamsesCoordinator
 
 # Test constants
 TEST_DEVICE_ID = "32:153289"  # FAN device ID
@@ -41,7 +41,7 @@ class TestBoundDeviceFunctionality:
         """Set up test environment for bound device operations.
 
         This fixture runs before each test method and sets up:
-        - A real RamsesBroker instance
+        - A real RamsesCoordinator instance
         - A mock client with an HGI device
         - Patches for Command.set_fan_param and Command.get_fan_param
         - Test command objects for bound device operations
@@ -49,13 +49,13 @@ class TestBoundDeviceFunctionality:
         Args:
             hass: Home Assistant fixture for creating a test environment.
         """
-        # Create a real broker instance with a mock config entry
-        self.broker = RamsesBroker(hass, MagicMock())
+        # Create a real coordinator instance with a mock config entry
+        self.coordinator = RamsesCoordinator(hass, MagicMock())
 
         # Create a mock client with HGI device
         self.mock_client = AsyncMock()
-        self.broker.client = self.mock_client
-        self.broker.client.hgi = MagicMock(id=TEST_FROM_ID)
+        self.coordinator.client = self.mock_client
+        self.coordinator.client.hgi = MagicMock(id=TEST_FROM_ID)
 
         # Create a mock device and add it to the client's registry
         self.mock_device = MagicMock()
@@ -63,7 +63,7 @@ class TestBoundDeviceFunctionality:
         self.mock_device.get_bound_rem.return_value = None
 
         # Ensure device_by_id behaves like a dict (synchronous .get)
-        self.broker.client.device_by_id = {TEST_DEVICE_ID: self.mock_device}
+        self.coordinator.client.device_by_id = {TEST_DEVICE_ID: self.mock_device}
 
         # Patch Command.set_fan_param to control command creation
         self.set_patcher = patch(
@@ -118,7 +118,7 @@ class TestBoundDeviceFunctionality:
         call = service_data
 
         # Act - Call the method under test
-        await self.broker.async_set_fan_param(call)
+        await self.coordinator.async_set_fan_param(call)
 
         # Assert - Verify explicit from_id was used
         self.mock_set_fan_param.assert_called_once_with(
@@ -152,7 +152,7 @@ class TestBoundDeviceFunctionality:
         call = service_data
 
         # Act - Call the method under test
-        await self.broker.async_get_fan_param(call)
+        await self.coordinator.async_get_fan_param(call)
 
         # Assert - Verify explicit from_id was used for get operation
         self.mock_get_fan_param.assert_called_once_with(
@@ -189,7 +189,7 @@ class TestBoundDeviceFunctionality:
         call = service_data
 
         # Act - Call the method under test
-        await self.broker.async_set_fan_param(call)
+        await self.coordinator.async_set_fan_param(call)
 
         # Assert - Verify fan_id was used as target, explicit from_id as source
         self.mock_set_fan_param.assert_called_once_with(

--- a/tests/tests_new/test_coordinator_packet_logic.py
+++ b/tests/tests_new/test_coordinator_packet_logic.py
@@ -14,10 +14,10 @@ def test_adjust_sentinel_packet_swaps_on_invalid() -> None:
     """Test that addresses are swapped when validation fails for sentinel packet."""
     # Setup
     # Use generic MagicMock because 'client' is an instance attribute
-    broker = MagicMock()
-    # Logic Update: The handler expects self._broker.client..., so we self-reference
-    broker._broker = broker
-    broker.client.hgi.id = HGI_ID
+    coordinator = MagicMock()
+    # Logic Update: The handler expects self._coordinator.client..., so we self-reference
+    coordinator._coordinator = coordinator
+    coordinator.client.hgi.id = HGI_ID
 
     # Mock Command
     # Use generic MagicMock to avoid attribute issues with 'src'/'dst'
@@ -32,7 +32,7 @@ def test_adjust_sentinel_packet_swaps_on_invalid() -> None:
         mock_validate.side_effect = PacketAddrSetInvalid("Invalid structure")
 
         # Execute using the unbound method call, passing our mock as 'self'
-        RamsesServiceHandler._adjust_sentinel_packet(broker, cmd)
+        RamsesServiceHandler._adjust_sentinel_packet(coordinator, cmd)
 
         # Verify swap occurred
         assert cmd._addrs[1] == "addr2"
@@ -43,9 +43,9 @@ def test_adjust_sentinel_packet_swaps_on_invalid() -> None:
 def test_adjust_sentinel_packet_no_swap_on_valid() -> None:
     """Test that addresses are NOT swapped when validation passes."""
     # Setup
-    broker = MagicMock()
-    broker._broker = broker
-    broker.client.hgi.id = HGI_ID
+    coordinator = MagicMock()
+    coordinator._coordinator = coordinator
+    coordinator.client.hgi.id = HGI_ID
 
     cmd = MagicMock()
     cmd.src.id = SENTINEL_ID
@@ -56,7 +56,7 @@ def test_adjust_sentinel_packet_no_swap_on_valid() -> None:
     with patch("custom_components.ramses_cc.services.pkt_addrs") as mock_validate:
         mock_validate.return_value = True  # Validation passes
 
-        RamsesServiceHandler._adjust_sentinel_packet(broker, cmd)
+        RamsesServiceHandler._adjust_sentinel_packet(coordinator, cmd)
 
         # Verify NO swap
         assert cmd._addrs[1] == "addr1"
@@ -65,9 +65,9 @@ def test_adjust_sentinel_packet_no_swap_on_valid() -> None:
 
 def test_adjust_sentinel_packet_ignores_other_devices() -> None:
     """Test that logic is skipped for non-sentinel devices."""
-    broker = MagicMock()
-    broker._broker = broker
-    broker.client.hgi.id = HGI_ID
+    coordinator = MagicMock()
+    coordinator._coordinator = coordinator
+    coordinator.client.hgi.id = HGI_ID
 
     cmd = MagicMock()
     cmd.src.id = "01:123456"  # Not sentinel
@@ -75,7 +75,7 @@ def test_adjust_sentinel_packet_ignores_other_devices() -> None:
     cmd._addrs = ["addr0", "addr1", "addr2"]
 
     # Execute
-    RamsesServiceHandler._adjust_sentinel_packet(broker, cmd)
+    RamsesServiceHandler._adjust_sentinel_packet(coordinator, cmd)
 
     # Verify no swap and repr is untouched
     assert cmd._addrs == ["addr0", "addr1", "addr2"]

--- a/tests/tests_new/test_coordinator_services.py
+++ b/tests/tests_new/test_coordinator_services.py
@@ -1,6 +1,6 @@
-"""Tests for ramses_cc broker service coordination and entity creation.
+"""Tests for ramses_cc coordinator service coordination and entity creation.
 
-This module tests the service registration in broker.py, the
+This module tests the service registration in coordinator.py, the
 entity creation factory in number.py, and utility mapping in helpers.py.
 """
 
@@ -13,8 +13,8 @@ from pytest_homeassistant_custom_component.common import (  # type: ignore[impor
     MockConfigEntry,
 )
 
-from custom_components.ramses_cc.broker import RamsesBroker
 from custom_components.ramses_cc.const import DOMAIN
+from custom_components.ramses_cc.coordinator import RamsesCoordinator
 from custom_components.ramses_cc.helpers import (
     ha_device_id_to_ramses_device_id,
     ramses_device_id_to_ha_device_id,
@@ -31,23 +31,23 @@ RAMSES_ID = "32:153289"
 
 
 @pytest.fixture
-def mock_broker(hass: HomeAssistant) -> RamsesBroker:
-    """Return a mock broker with an entry attached.
+def mock_coordinator(hass: HomeAssistant) -> RamsesCoordinator:
+    """Return a mock coordinator with an entry attached.
 
     :param hass: The Home Assistant instance.
-    :return: A configured RamsesBroker.
+    :return: A configured RamsesCoordinator.
     """
     entry = MagicMock()
     entry.entry_id = "service_test_entry"
     entry.options = {"ramses_rf": {}, "serial_port": "/dev/ttyUSB0"}
 
-    broker = RamsesBroker(hass, entry)
-    broker.client = MagicMock()
-    broker.client.device_by_id = {}
-    broker.client.async_send_cmd = AsyncMock()
+    coordinator = RamsesCoordinator(hass, entry)
+    coordinator.client = MagicMock()
+    coordinator.client.device_by_id = {}
+    coordinator.client.async_send_cmd = AsyncMock()
 
-    hass.data[DOMAIN] = {entry.entry_id: broker}
-    return broker
+    hass.data[DOMAIN] = {entry.entry_id: coordinator}
+    return coordinator
 
 
 @pytest.fixture
@@ -63,13 +63,13 @@ def mock_fan_device() -> MagicMock:
 
 
 async def test_create_parameter_entities_logic(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test the factory function for creating number entities.
 
     This targets the create_parameter_entities logic in number.py.
 
-    :param mock_broker: The mock broker fixture.
+    :param mock_coordinator: The mock coordinator fixture.
     :param mock_fan_device: The mock fan device fixture.
     """
     with patch("custom_components.ramses_cc.number.er.async_get") as mock_ent_reg:
@@ -77,7 +77,7 @@ async def test_create_parameter_entities_logic(
         mock_reg = mock_ent_reg.return_value
         mock_reg.async_get_entity_id.return_value = None
 
-        entities = create_parameter_entities(mock_broker, mock_fan_device)
+        entities = create_parameter_entities(mock_coordinator, mock_fan_device)
 
         # Verify entities were created
         assert len(entities) > 0
@@ -86,15 +86,15 @@ async def test_create_parameter_entities_logic(
         assert entities[0]._device == mock_fan_device
 
 
-async def test_broker_service_presence(
-    hass: HomeAssistant, mock_broker: RamsesBroker
+async def test_coordinator_service_presence(
+    hass: HomeAssistant, mock_coordinator: RamsesCoordinator
 ) -> None:
     """Test that the expected services are registered with Home Assistant.
 
     :param hass: The Home Assistant instance.
-    :param mock_broker: The mock broker fixture.
+    :param mock_coordinator: The mock coordinator fixture.
     """
-    # Services are registered during integration setup or broker init.
+    # Services are registered during integration setup or coordinator init.
     # We verify their presence in the Home Assistant ServiceRegistry.
     services = hass.services.async_services()
 
@@ -104,81 +104,85 @@ async def test_broker_service_presence(
         assert "set_fan_param" in services[DOMAIN]
 
 
-async def test_broker_device_lookup_fail(mock_broker: RamsesBroker) -> None:
-    """Test broker handling when a device lookup fails.
+async def test_coordinator_device_lookup_fail(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test coordinator handling when a device lookup fails.
 
-    :param mock_broker: The mock broker fixture.
+    :param mock_coordinator: The mock coordinator fixture.
     """
     # 1. Test get_fan_param with non-existent device
     call_data = {"device_id": "99:999999", "param_id": "01"}
 
     # We expect a warning in the log but no crash
-    # UPDATED: Log is now generated in services.py, not broker.py
+    # UPDATED: Log is now generated in services.py, not coordinator.py
     with patch("custom_components.ramses_cc.services._LOGGER.warning") as mock_warn:
-        await mock_broker.async_get_fan_param(call_data)
+        await mock_coordinator.async_get_fan_param(call_data)
         assert mock_warn.called
         assert "No valid source device available" in mock_warn.call_args[0][0]
 
 
-def test_get_param_id_validation(mock_broker: RamsesBroker) -> None:
+def test_get_param_id_validation(mock_coordinator: RamsesCoordinator) -> None:
     """Test validation of parameter IDs in service calls.
 
-    This targets _get_param_id in services.py (via broker delegate).
+    This targets _get_param_id in services.py (via coordinator delegate).
 
-    :param mock_broker: The mock broker fixture.
+    :param mock_coordinator: The mock coordinator fixture.
     """
     # 1. Valid hex
     # UPDATED: Access via 'service_handler', not 'services'
-    assert mock_broker.service_handler._get_param_id({"param_id": "0a"}) == "0A"
+    assert mock_coordinator.service_handler._get_param_id({"param_id": "0a"}) == "0A"
 
     # 2. Invalid: too long
     with pytest.raises(ValueError, match="Invalid parameter ID"):
-        mock_broker.service_handler._get_param_id({"param_id": "001"})
+        mock_coordinator.service_handler._get_param_id({"param_id": "001"})
 
     # 3. Invalid: non-hex
     with pytest.raises(ValueError, match="Invalid parameter ID"):
-        mock_broker.service_handler._get_param_id({"param_id": "ZZ"})
+        mock_coordinator.service_handler._get_param_id({"param_id": "ZZ"})
 
 
-async def test_save_client_state_remotes(mock_broker: RamsesBroker) -> None:
+async def test_save_client_state_remotes(mock_coordinator: RamsesCoordinator) -> None:
     """Test saving remote commands to persistent storage.
 
-    This targets async_save_client_state in broker.py.
+    This targets async_save_client_state in coordinator.py.
 
-    :param mock_broker: The mock broker fixture.
+    :param mock_coordinator: The mock coordinator fixture.
     """
-    mock_broker.client.get_state.return_value = ({}, {})
-    mock_broker._remotes = {REM_ID: {"boost": "packet_data"}}
-    mock_broker.store = MagicMock(spec=mock_broker.store)
-    mock_broker.store.async_save = AsyncMock()
+    mock_coordinator.client.get_state.return_value = ({}, {})
+    mock_coordinator._remotes = {REM_ID: {"boost": "packet_data"}}
+    mock_coordinator.store = MagicMock(spec=mock_coordinator.store)
+    mock_coordinator.store.async_save = AsyncMock()
 
-    await mock_broker.async_save_client_state()
+    await mock_coordinator.async_save_client_state()
 
     # Verify remotes were included in the save payload
-    args = mock_broker.store.async_save.call_args[0]
+    args = mock_coordinator.store.async_save.call_args[0]
     saved_remotes = args[2]
 
     assert saved_remotes[REM_ID]["boost"] == "packet_data"
 
 
-async def test_device_registry_update_slugs(mock_broker: RamsesBroker) -> None:
+async def test_device_registry_update_slugs(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
     """Test registry update logic for different device slugs.
 
-    This targets _update_device in broker.py.
+    This targets _update_device in coordinator.py.
 
-    :param mock_broker: The mock broker fixture.
+    :param mock_coordinator: The mock coordinator fixture.
     """
     mock_device = MagicMock()
     mock_device.id = FAN_ID
     mock_device._SLUG = "FAN"
-    # Ensure name is None so broker falls back to slug-based logic
+    # Ensure name is None so coordinator falls back to slug-based logic
     mock_device.name = None
     mock_device._msg_value_code.return_value = None  # No 10E0 info
 
     with patch("homeassistant.helpers.device_registry.async_get") as mock_dr_get:
         mock_reg = mock_dr_get.return_value
 
-        mock_broker._update_device(mock_device)
+        mock_coordinator._update_device(mock_device)
 
         # Verify the name and model were derived from the SLUG
         call_kwargs = mock_reg.async_get_or_create.call_args[1]

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -1,4 +1,4 @@
-"""Tests for the Fan Handler aspect of RamsesBroker (2411 logic, parameters)."""
+"""Tests for the Fan Handler aspect of RamsesCoordinator (2411 logic, parameters)."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -6,8 +6,8 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from custom_components.ramses_cc.broker import RamsesBroker
 from custom_components.ramses_cc.const import DOMAIN, SZ_BOUND_TO, SZ_KNOWN_LIST
+from custom_components.ramses_cc.coordinator import RamsesCoordinator
 from custom_components.ramses_cc.number import (
     RamsesNumberEntityDescription,
     RamsesNumberParam,
@@ -33,21 +33,21 @@ def mock_gateway() -> MagicMock:
 
 
 @pytest.fixture
-def mock_broker(hass: HomeAssistant, mock_gateway: MagicMock) -> RamsesBroker:
-    """Return a configured RamsesBroker."""
+def mock_coordinator(hass: HomeAssistant, mock_gateway: MagicMock) -> RamsesCoordinator:
+    """Return a configured RamsesCoordinator."""
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {}
 
-    broker = RamsesBroker(hass, entry)
-    broker.client = mock_gateway
+    coordinator = RamsesCoordinator(hass, entry)
+    coordinator.client = mock_gateway
     # Create fake devices list if needed, or we patch _get_device
-    broker._device_info = []
+    coordinator._device_info = []
 
     # Mock the hass.data structure
-    hass.data[DOMAIN] = {entry.entry_id: broker}
+    hass.data[DOMAIN] = {entry.entry_id: coordinator}
 
-    return broker
+    return coordinator
 
 
 @pytest.fixture
@@ -61,24 +61,24 @@ def mock_fan_device() -> MagicMock:
     return device
 
 
-async def test_broker_init(mock_broker: RamsesBroker) -> None:
-    """Test broker initialization."""
-    assert mock_broker.client is not None
-    assert mock_broker._devices == []
+async def test_coordinator_init(mock_coordinator: RamsesCoordinator) -> None:
+    """Test coordinator initialization."""
+    assert mock_coordinator.client is not None
+    assert mock_coordinator._devices == []
 
 
-async def test_broker_get_fan_param(
-    mock_broker: RamsesBroker, mock_gateway: MagicMock
+async def test_coordinator_get_fan_param(
+    mock_coordinator: RamsesCoordinator, mock_gateway: MagicMock
 ) -> None:
     """Test async_get_fan_param service call."""
     call_data = {"device_id": FAN_ID, "param_id": PARAM_ID_HEX, "from_id": REM_ID}
 
-    with patch.object(mock_broker, "_get_device") as mock_get_dev:
+    with patch.object(mock_coordinator, "_get_device") as mock_get_dev:
         mock_dev = MagicMock()
         mock_dev.id = FAN_ID
         mock_get_dev.return_value = mock_dev
 
-        await mock_broker.async_get_fan_param(call_data)
+        await mock_coordinator.async_get_fan_param(call_data)
 
     assert mock_gateway.async_send_cmd.called
     cmd = mock_gateway.async_send_cmd.call_args[0][0]
@@ -86,8 +86,8 @@ async def test_broker_get_fan_param(
     assert cmd is not None
 
 
-async def test_broker_set_fan_param(
-    mock_broker: RamsesBroker, mock_gateway: MagicMock
+async def test_coordinator_set_fan_param(
+    mock_coordinator: RamsesCoordinator, mock_gateway: MagicMock
 ) -> None:
     """Test async_set_fan_param service call."""
     call_data = {
@@ -98,17 +98,19 @@ async def test_broker_set_fan_param(
     }
 
     # Patch _get_device so valid check passes
-    with patch.object(mock_broker, "_get_device") as mock_get_dev:
+    with patch.object(mock_coordinator, "_get_device") as mock_get_dev:
         mock_dev = MagicMock()
         mock_dev.id = FAN_ID
         mock_get_dev.return_value = mock_dev
 
-        await mock_broker.async_set_fan_param(call_data)
+        await mock_coordinator.async_set_fan_param(call_data)
 
     assert mock_gateway.async_send_cmd.called
 
 
-async def test_broker_set_fan_param_no_value(mock_broker: RamsesBroker) -> None:
+async def test_coordinator_set_fan_param_no_value(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
     """Test async_set_fan_param raises error when value is missing."""
     call_data = {
         "device_id": FAN_ID,
@@ -117,7 +119,7 @@ async def test_broker_set_fan_param_no_value(mock_broker: RamsesBroker) -> None:
     }
 
     # Patch _get_device so valid check passes and we hit the value check
-    with patch.object(mock_broker, "_get_device") as mock_get_dev:
+    with patch.object(mock_coordinator, "_get_device") as mock_get_dev:
         mock_dev = MagicMock()
         mock_dev.id = FAN_ID
         mock_get_dev.return_value = mock_dev
@@ -125,14 +127,16 @@ async def test_broker_set_fan_param_no_value(mock_broker: RamsesBroker) -> None:
         with pytest.raises(
             HomeAssistantError, match="Invalid parameter.*Missing required parameter"
         ):
-            await mock_broker.async_set_fan_param(call_data)
+            await mock_coordinator.async_set_fan_param(call_data)
 
 
-async def test_broker_set_fan_param_no_binding(
-    mock_broker: RamsesBroker, mock_gateway: MagicMock, mock_fan_device: MagicMock
+async def test_coordinator_set_fan_param_no_binding(
+    mock_coordinator: RamsesCoordinator,
+    mock_gateway: MagicMock,
+    mock_fan_device: MagicMock,
 ) -> None:
     """Test set_fan_param when the fan has NO bound remote (unbound)."""
-    mock_broker._devices = [mock_fan_device]
+    mock_coordinator._devices = [mock_fan_device]
     mock_fan_device.get_bound_rem = MagicMock(return_value=None)
 
     call_data = {"device_id": FAN_ID, "param_id": PARAM_ID_HEX, "value": 21.5}
@@ -140,13 +144,13 @@ async def test_broker_set_fan_param_no_binding(
     with pytest.raises(
         HomeAssistantError, match="Cannot set parameter: No valid source device"
     ):
-        await mock_broker.async_set_fan_param(call_data)
+        await mock_coordinator.async_set_fan_param(call_data)
 
     mock_gateway.async_send_cmd.assert_not_called()
 
 
 async def test_number_entity_state(
-    hass: HomeAssistant, mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    hass: HomeAssistant, mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test RamsesNumberParam entity initialization and state updates."""
     desc = RamsesNumberEntityDescription(
@@ -157,7 +161,7 @@ async def test_number_entity_state(
         unit_of_measurement="°C",
         mode="slider",
     )
-    entity = RamsesNumberParam(mock_broker, mock_fan_device, desc)
+    entity = RamsesNumberParam(mock_coordinator, mock_fan_device, desc)
     entity.hass = hass
 
     assert entity.native_value is None
@@ -171,7 +175,7 @@ async def test_number_entity_state(
 
 
 async def test_number_entity_set_value(
-    hass: HomeAssistant, mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    hass: HomeAssistant, mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test RamsesNumberParam set value logic."""
     desc = RamsesNumberEntityDescription(
@@ -182,7 +186,7 @@ async def test_number_entity_set_value(
         unit_of_measurement="°C",
         mode="slider",
     )
-    entity = RamsesNumberParam(mock_broker, mock_fan_device, desc)
+    entity = RamsesNumberParam(mock_coordinator, mock_fan_device, desc)
     entity.hass = hass
 
     mock_service_handler = AsyncMock()
@@ -201,24 +205,26 @@ async def test_number_entity_set_value(
     assert entity._pending_value == 22.0
 
 
-async def test_broker_fan_setup(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+async def test_coordinator_fan_setup(
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test fan_handler.async_setup_fan_device logic."""
     mock_fan_device.set_initialized_callback = MagicMock()
     mock_fan_device.set_param_update_callback = MagicMock()
 
-    await mock_broker.fan_handler.async_setup_fan_device(mock_fan_device)
+    await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
     assert mock_fan_device.set_initialized_callback.called
     assert mock_fan_device.set_param_update_callback.called
 
     callback_fn = mock_fan_device.set_param_update_callback.call_args[0][0]
     event_callback = MagicMock()
-    mock_broker.hass.bus.async_listen("ramses_cc.fan_param_updated", event_callback)
+    mock_coordinator.hass.bus.async_listen(
+        "ramses_cc.fan_param_updated", event_callback
+    )
 
     callback_fn(PARAM_ID_HEX, 19.5)
-    await mock_broker.hass.async_block_till_done()
+    await mock_coordinator.hass.async_block_till_done()
 
     assert event_callback.called
     event = event_callback.call_args[0][0]
@@ -227,10 +233,12 @@ async def test_broker_fan_setup(
 
 
 async def test_update_fan_params_sequence(
-    mock_broker: RamsesBroker, mock_gateway: MagicMock, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator,
+    mock_gateway: MagicMock,
+    mock_fan_device: MagicMock,
 ) -> None:
     """Test the sequential update of fan parameters."""
-    mock_broker._devices = [mock_fan_device]
+    mock_coordinator._devices = [mock_fan_device]
     tiny_schema = ["11", "22"]
 
     with (
@@ -238,21 +246,21 @@ async def test_update_fan_params_sequence(
         patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         call_data = {"device_id": FAN_ID}
-        # UPDATED: Call method on service_handler, not broker
-        await mock_broker.service_handler._async_run_fan_param_sequence(call_data)
+        # UPDATED: Call method on service_handler, not coordinator
+        await mock_coordinator.service_handler._async_run_fan_param_sequence(call_data)
 
     assert mock_gateway.async_send_cmd.call_count == 2
 
 
 async def test_create_parameter_entities_logic(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test the factory function for creating number entities."""
     with patch("custom_components.ramses_cc.number.er.async_get") as mock_ent_reg:
         mock_reg = mock_ent_reg.return_value
         mock_reg.async_get_entity_id.return_value = None
 
-        entities = create_parameter_entities(mock_broker, mock_fan_device)
+        entities = create_parameter_entities(mock_coordinator, mock_fan_device)
 
         assert len(entities) > 0
         assert all(isinstance(e, RamsesNumberParam) for e in entities)
@@ -260,54 +268,54 @@ async def test_create_parameter_entities_logic(
 
 
 async def test_setup_fan_bound_invalid_type(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test _setup_fan_bound_devices with invalid config type."""
     # Mock known_list with a non-string bound_to value (e.g. an integer)
-    mock_broker.options[SZ_KNOWN_LIST] = {
+    mock_coordinator.options[SZ_KNOWN_LIST] = {
         FAN_ID: {"bound_to": 12345}  # Invalid type
     }
 
     # Trigger the warning and return early
-    await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+    await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     # Verify no binding occurred
     mock_fan_device.add_bound_device.assert_not_called()
 
 
 async def test_setup_fan_bound_not_rem(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test _setup_fan_bound_devices with a device that is not REM or DIS."""
     # Mock a device that is neither HvacRemoteBase nor has _SLUG='DIS'
     bound_dev = MagicMock()
     bound_dev.id = "01:999999"
     # Ensure it fails isinstance(HvacRemoteBase) and checks
-    mock_broker.client.devices = [bound_dev]
+    mock_coordinator.client.devices = [bound_dev]
 
-    mock_broker.options[SZ_KNOWN_LIST] = {FAN_ID: {"bound_to": bound_dev.id}}
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {"bound_to": bound_dev.id}}
 
-    await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+    await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     mock_fan_device.add_bound_device.assert_not_called()
 
 
 async def test_fan_setup_callbacks_execution(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test execution of the initialization callbacks."""
     mock_fan_device.set_initialized_callback = MagicMock()
 
     # Call setup
-    await mock_broker.fan_handler.async_setup_fan_device(mock_fan_device)
+    await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
     # Get the lambda passed to callback
     init_lambda = mock_fan_device.set_initialized_callback.call_args[0][0]
 
     # Use patch.object on the specific instance's attribute
     with (
-        patch.object(mock_broker, "get_all_fan_params") as mock_get_params,
-        patch.object(mock_broker.hass, "async_create_task") as mock_create_task,
+        patch.object(mock_coordinator, "get_all_fan_params") as mock_get_params,
+        patch.object(mock_coordinator.hass, "async_create_task") as mock_create_task,
     ):
         mock_create_task.side_effect = lambda coro: coro
 
@@ -319,44 +327,44 @@ async def test_fan_setup_callbacks_execution(
 
 
 async def test_fan_setup_already_initialized(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test fan_handler.async_setup_fan_device when device is already initialized."""
     mock_fan_device._initialized = True
     mock_fan_device.supports_2411 = True
 
-    # Patch the function where it is DEFINED, which is used by the import in broker.py
+    # Patch the function where it is DEFINED, which is used by the import in coordinator.py
     with patch(
         "custom_components.ramses_cc.number.create_parameter_entities"
     ) as mock_create:
         mock_create.return_value = [MagicMock()]
-        await mock_broker.fan_handler.async_setup_fan_device(mock_fan_device)
+        await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
         assert mock_create.called
         # Should also request params
-        assert mock_broker.client.async_send_cmd.call_count >= 0
+        assert mock_coordinator.client.async_send_cmd.call_count >= 0
 
 
 async def test_get_device_and_from_id_fallback(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test fallback to bound device when from_id is missing."""
-    mock_broker._devices = [mock_fan_device]
+    mock_coordinator._devices = [mock_fan_device]
     mock_fan_device.get_bound_rem.return_value = REM_ID
 
     # Must provide param_id to pass _get_param_id validation (called inside async_get_fan_param)
     call_data = {"device_id": FAN_ID, "param_id": PARAM_ID_HEX}
 
     # This calls _get_device_and_from_id internally
-    await mock_broker.async_get_fan_param(call_data)
+    await mock_coordinator.async_get_fan_param(call_data)
 
     # Check if the command was sent using the bound REM_ID
-    cmd = mock_broker.client.async_send_cmd.call_args[0][0]
+    cmd = mock_coordinator.client.async_send_cmd.call_args[0][0]
     assert cmd.src.id == REM_ID
 
 
 async def test_run_fan_param_sequence_bad_data(
-    mock_broker: RamsesBroker, mock_gateway: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_gateway: MagicMock
 ) -> None:
     """Test that sequence handles non-dict data gracefully."""
     bad_data = MagicMock()
@@ -369,13 +377,13 @@ async def test_run_fan_param_sequence_bad_data(
 
     bad_data_obj = NotADict()
 
-    # UPDATED: Patch on services.RamsesServiceHandler, not broker
+    # UPDATED: Patch on services.RamsesServiceHandler, not coordinator
     with patch(
         "custom_components.ramses_cc.services.RamsesServiceHandler._normalize_service_call",
         return_value=bad_data_obj,
     ):
         # UPDATED: Call via service_handler
-        await mock_broker.service_handler._async_run_fan_param_sequence({})
+        await mock_coordinator.service_handler._async_run_fan_param_sequence({})
     pass
 
     bad_data_mock = MagicMock(spec=dict)
@@ -387,26 +395,26 @@ async def test_run_fan_param_sequence_bad_data(
         return_value=bad_data_mock,
     ):
         # UPDATED: Call via service_handler
-        await mock_broker.service_handler._async_run_fan_param_sequence({})
+        await mock_coordinator.service_handler._async_run_fan_param_sequence({})
 
     assert mock_gateway.async_send_cmd.call_count >= 0
 
 
 async def test_setup_fan_bound_success_rem(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test successful binding of a FAN to a REM device."""
     bound_id = "32:111111"
 
     # Configure the known list with the bound device
-    mock_broker.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
 
     # Create the bound device object
     bound_device = MagicMock()
     bound_device.id = bound_id
-    mock_broker.client.devices = [bound_device]
+    mock_coordinator.client.devices = [bound_device]
 
-    # Helper classes to satisfy isinstance checks in broker.py
+    # Helper classes to satisfy isinstance checks in coordinator.py
     class MockHvacVentilator:
         pass
 
@@ -417,7 +425,7 @@ async def test_setup_fan_bound_success_rem(
     mock_fan_device.__class__ = MockHvacVentilator  # type: ignore[assignment]
     bound_device.__class__ = MockHvacRemoteBase  # type: ignore[assignment]
 
-    # Patch the classes in the broker module so isinstance checks pass
+    # Patch the classes in the coordinator module so isinstance checks pass
     with (
         patch(
             "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
@@ -426,25 +434,25 @@ async def test_setup_fan_bound_success_rem(
             "custom_components.ramses_cc.fan_handler.HvacRemoteBase", MockHvacRemoteBase
         ),
     ):
-        await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     # Verify binding was added with correct type
     mock_fan_device.add_bound_device.assert_called_once_with(bound_id, DevType.REM)
-    assert mock_broker.fan_handler._fan_bound_to_remote[bound_id] == FAN_ID
+    assert mock_coordinator.fan_handler._fan_bound_to_remote[bound_id] == FAN_ID
 
 
 async def test_setup_fan_bound_success_dis(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test successful binding of a FAN to a DIS device."""
     bound_id = "32:222222"
 
-    mock_broker.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
 
     bound_device = MagicMock()
     bound_device.id = bound_id
     bound_device._SLUG = DevType.DIS
-    mock_broker.client.devices = [bound_device]
+    mock_coordinator.client.devices = [bound_device]
 
     class MockHvacVentilator:
         pass
@@ -456,22 +464,22 @@ async def test_setup_fan_bound_success_dis(
     with patch(
         "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
     ):
-        await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     mock_fan_device.add_bound_device.assert_called_once_with(bound_id, DevType.DIS)
-    assert mock_broker.fan_handler._fan_bound_to_remote[bound_id] == FAN_ID
+    assert mock_coordinator.fan_handler._fan_bound_to_remote[bound_id] == FAN_ID
 
 
 async def test_setup_fan_bound_device_not_found(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test binding when the bound device is not found in client.devices."""
     bound_id = "32:333333"
 
-    mock_broker.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
 
     # Ensure device list is empty
-    mock_broker.client.devices = []
+    mock_coordinator.client.devices = []
 
     class MockHvacVentilator:
         pass
@@ -481,18 +489,18 @@ async def test_setup_fan_bound_device_not_found(
     with patch(
         "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
     ):
-        await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     # Should log warning and not add binding
     mock_fan_device.add_bound_device.assert_not_called()
-    assert bound_id not in mock_broker.fan_handler._fan_bound_to_remote
+    assert bound_id not in mock_coordinator.fan_handler._fan_bound_to_remote
 
 
 async def test_setup_fan_bound_no_config(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test binding when no bound device is configured (early return)."""
-    mock_broker.options[SZ_KNOWN_LIST] = {FAN_ID: {}}
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {}}
 
     class MockHvacVentilator:
         pass
@@ -502,24 +510,24 @@ async def test_setup_fan_bound_no_config(
     with patch(
         "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
     ):
-        await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     mock_fan_device.add_bound_device.assert_not_called()
 
 
 async def test_setup_fan_bound_bad_device_type(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test binding when device exists but is incompatible (not REM/DIS)."""
     bound_id = "32:444444"
 
-    mock_broker.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
 
     # Device exists but is generic (not REM, no DIS slug)
     bound_device = MagicMock()
     bound_device.id = bound_id
     del bound_device._SLUG  # Ensure no _SLUG attribute exists or it is not DIS
-    mock_broker.client.devices = [bound_device]
+    mock_coordinator.client.devices = [bound_device]
 
     class MockHvacVentilator:
         pass
@@ -529,17 +537,17 @@ async def test_setup_fan_bound_bad_device_type(
     with patch(
         "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
     ):
-        await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     mock_fan_device.add_bound_device.assert_not_called()
 
 
 async def test_setup_fan_bound_invalid_id_type(
-    mock_broker: RamsesBroker, mock_fan_device: MagicMock
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test binding when the bound device ID is not a string (e.g. integer)."""
     # Configure known_list with an integer instead of a string for bound_to
-    mock_broker.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: 12345}}
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: 12345}}
 
     class MockHvacVentilator:
         pass
@@ -550,14 +558,14 @@ async def test_setup_fan_bound_invalid_id_type(
     with patch(
         "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
     ):
-        await mock_broker.fan_handler.setup_fan_bound_devices(mock_fan_device)
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
 
     # Verify no binding occurred and code returned early
     mock_fan_device.add_bound_device.assert_not_called()
 
 
 async def test_target_to_device_id_single_string(
-    mock_broker: RamsesBroker,
+    mock_coordinator: RamsesCoordinator,
 ) -> None:
     """Test _target_to_device_id when device_id is a single string (lines 1009-1010)."""
     ha_device_id = "ha_dev_123"
@@ -580,14 +588,14 @@ async def test_target_to_device_id_single_string(
         )
 
         # Execute the method on service_handler
-        result = mock_broker.service_handler._target_to_device_id(target)
+        result = mock_coordinator.service_handler._target_to_device_id(target)
 
     # Verify the resolution worked
     assert result == ramses_dev_id
 
 
 async def test_target_to_device_id_single_area_string(
-    mock_broker: RamsesBroker,
+    mock_coordinator: RamsesCoordinator,
 ) -> None:
     """Test _target_to_device_id when area_id is a single string."""
     area_id = "living_room"
@@ -608,18 +616,18 @@ async def test_target_to_device_id_single_area_string(
         mock_reg.devices.values.return_value = [mock_entry]
 
         # Execute on service_handler
-        result = mock_broker.service_handler._target_to_device_id(target)
+        result = mock_coordinator.service_handler._target_to_device_id(target)
 
     assert result == ramses_dev_id
 
 
-async def test_target_empty(mock_broker: RamsesBroker) -> None:
+async def test_target_empty(mock_coordinator: RamsesCoordinator) -> None:
     """Test _target_to_device_id with empty or None input."""
-    assert mock_broker.service_handler._target_to_device_id({}) is None
-    assert mock_broker.service_handler._target_to_device_id(None) is None
+    assert mock_coordinator.service_handler._target_to_device_id({}) is None
+    assert mock_coordinator.service_handler._target_to_device_id(None) is None
 
 
-async def test_target_entity_id_resolution(mock_broker: RamsesBroker) -> None:
+async def test_target_entity_id_resolution(mock_coordinator: RamsesCoordinator) -> None:
     """Test resolution via entity_id (single string and list)."""
     target_single = {"entity_id": "sensor.temp"}
     target_list = {"entity_id": ["sensor.temp"]}
@@ -645,16 +653,18 @@ async def test_target_entity_id_resolution(mock_broker: RamsesBroker) -> None:
 
         # Test Single String
         assert (
-            mock_broker.service_handler._target_to_device_id(target_single) == ramses_id
+            mock_coordinator.service_handler._target_to_device_id(target_single)
+            == ramses_id
         )
 
         # Test List
         assert (
-            mock_broker.service_handler._target_to_device_id(target_list) == ramses_id
+            mock_coordinator.service_handler._target_to_device_id(target_list)
+            == ramses_id
         )
 
 
-async def test_target_device_id_resolution(mock_broker: RamsesBroker) -> None:
+async def test_target_device_id_resolution(mock_coordinator: RamsesCoordinator) -> None:
     """Test resolution via device_id (single string and list) when entity_id is missing."""
     target_single = {"device_id": "ha_dev_1"}
     target_list = {"device_id": ["ha_dev_1"]}
@@ -670,16 +680,18 @@ async def test_target_device_id_resolution(mock_broker: RamsesBroker) -> None:
 
         # Test Single String
         assert (
-            mock_broker.service_handler._target_to_device_id(target_single) == ramses_id
+            mock_coordinator.service_handler._target_to_device_id(target_single)
+            == ramses_id
         )
 
         # Test List
         assert (
-            mock_broker.service_handler._target_to_device_id(target_list) == ramses_id
+            mock_coordinator.service_handler._target_to_device_id(target_list)
+            == ramses_id
         )
 
 
-async def test_target_priority_order(mock_broker: RamsesBroker) -> None:
+async def test_target_priority_order(mock_coordinator: RamsesCoordinator) -> None:
     """Test that Entity ID takes priority over Device ID, which takes priority over Area ID."""
     target = {
         "entity_id": "sensor.exists",
@@ -713,11 +725,12 @@ async def test_target_priority_order(mock_broker: RamsesBroker) -> None:
 
         # Should return the one found via entity_id, ignoring device_id/area_id logic
         assert (
-            mock_broker.service_handler._target_to_device_id(target) == id_from_entity
+            mock_coordinator.service_handler._target_to_device_id(target)
+            == id_from_entity
         )
 
 
-async def test_target_resolution_failures(mock_broker: RamsesBroker) -> None:
+async def test_target_resolution_failures(mock_coordinator: RamsesCoordinator) -> None:
     """Test that it returns None when lookups fail or entries lack correct domain."""
     target = {"device_id": "ha_dev_bad"}
 
@@ -729,11 +742,11 @@ async def test_target_resolution_failures(mock_broker: RamsesBroker) -> None:
         mock_entry.identifiers = {("other_domain", "some_id")}
         mock_dev_reg.async_get.return_value = mock_entry
 
-        assert mock_broker.service_handler._target_to_device_id(target) is None
+        assert mock_coordinator.service_handler._target_to_device_id(target) is None
 
         # Case 2: Device entry is None (device not found in registry)
         mock_dev_reg.async_get.return_value = None
-        assert mock_broker.service_handler._target_to_device_id(target) is None
+        assert mock_coordinator.service_handler._target_to_device_id(target) is None
 
     # Case 3: Entity found, but has no device_id
     with patch("custom_components.ramses_cc.services.er.async_get") as mock_er_get:
@@ -741,7 +754,7 @@ async def test_target_resolution_failures(mock_broker: RamsesBroker) -> None:
         mock_ent_reg.async_get.return_value = MagicMock(device_id=None)
 
         assert (
-            mock_broker.service_handler._target_to_device_id(
+            mock_coordinator.service_handler._target_to_device_id(
                 {"entity_id": "sensor.orphan"}
             )
             is None
@@ -749,7 +762,7 @@ async def test_target_resolution_failures(mock_broker: RamsesBroker) -> None:
 
 
 async def test_get_fan_param_fallback_hgi(
-    mock_broker: RamsesBroker,
+    mock_coordinator: RamsesCoordinator,
     mock_gateway: MagicMock,
     mock_fan_device: MagicMock,
     caplog: pytest.LogCaptureFixture,
@@ -763,8 +776,8 @@ async def test_get_fan_param_fallback_hgi(
     mock_gateway.hgi.id = hgi_id
 
     # 2. Setup Device to have NO bound remote
-    # This forces the broker to look for a fallback (the HGI)
-    mock_broker._devices = [mock_fan_device]
+    # This forces the coordinator to look for a fallback (the HGI)
+    mock_coordinator._devices = [mock_fan_device]
     mock_fan_device.get_bound_rem.return_value = None
 
     # 3. Prepare call data without an explicit 'from_id'
@@ -772,7 +785,7 @@ async def test_get_fan_param_fallback_hgi(
 
     # 4. Run with log capture to verify the debug logic
     with caplog.at_level(logging.DEBUG):
-        await mock_broker.async_get_fan_param(call_data)
+        await mock_coordinator.async_get_fan_param(call_data)
 
     # 5. Verify the fallback logic triggered
     # Check the specific debug message matches the code path

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -43,11 +43,11 @@ def test_normalise_config() -> None:
         CONF_ADVANCED_FEATURES: {"dev_mode": True},
     }
 
-    port, client_config, broker_config = normalise_config(config)
+    port, client_config, coordinator_config = normalise_config(config)
 
     assert port == "/dev/ttyUSB0"
     assert client_config["config"] == {"disable_discovery": True}
-    assert broker_config["remotes"]["18:111111"] == {"boost": "packet_data"}
+    assert coordinator_config["remotes"]["18:111111"] == {"boost": "packet_data"}
     assert CONF_COMMANDS not in client_config[SZ_KNOWN_LIST]["18:111111"]
 
 

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -55,16 +55,18 @@ def mock_device() -> MagicMock:
 
 
 @pytest.fixture
-def mock_broker() -> MagicMock:
-    """Return a mock RamsesBroker."""
+def mock_coordinator() -> MagicMock:
+    """Return a mock RamsesCoordinator."""
     return MagicMock()
 
 
 @pytest.fixture
-def water_heater(mock_broker: MagicMock, mock_device: MagicMock) -> RamsesWaterHeater:
+def water_heater(
+    mock_coordinator: MagicMock, mock_device: MagicMock
+) -> RamsesWaterHeater:
     """Return an instantiated RamsesWaterHeater entity."""
     description = MagicMock()
-    entity = RamsesWaterHeater(mock_broker, mock_device, description)
+    entity = RamsesWaterHeater(mock_coordinator, mock_device, description)
     entity.hass = MagicMock()
     # Mock the internal delayed writer
     entity.async_write_ha_state_delayed = MagicMock()
@@ -78,9 +80,9 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     mock_entry = MagicMock(spec=ConfigEntry)
     mock_entry.entry_id = "test_entry_id"
 
-    # Mock Broker
-    mock_broker = MagicMock()
-    hass.data[DOMAIN] = {mock_entry.entry_id: mock_broker}
+    # Mock Coordinator
+    mock_coordinator = MagicMock()
+    hass.data[DOMAIN] = {mock_entry.entry_id: mock_coordinator}
 
     # Mock AddEntitiesCallback
     mock_add_entities = MagicMock()
@@ -96,8 +98,8 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
         await async_setup_entry(hass, mock_entry, mock_add_entities)
 
         # Assert register_platform called
-        mock_broker.async_register_platform.assert_called_once()
-        call_args = mock_broker.async_register_platform.call_args
+        mock_coordinator.async_register_platform.assert_called_once()
+        call_args = mock_coordinator.async_register_platform.call_args
         assert call_args[0][0] == mock_platform
         callback_func = call_args[0][1]
 

--- a/tests/tests_old/test_init_config.py
+++ b/tests/tests_old/test_init_config.py
@@ -15,7 +15,7 @@ from pytest_homeassistant_custom_component.common import (  # type: ignore[impor
     MockConfigEntry,
 )
 
-from custom_components.ramses_cc import CONFIG_SCHEMA, DOMAIN, RamsesBroker
+from custom_components.ramses_cc import CONFIG_SCHEMA, DOMAIN, RamsesCoordinator
 from custom_components.ramses_cc.config_flow import SZ_RESTORE_CACHE
 from ramses_rf.gateway import Gateway
 
@@ -87,7 +87,7 @@ async def _test_common(hass: HomeAssistant, entry: ConfigEntry = None) -> None:
     """The main tests are here."""
 
     # hass.data["custom_components"][DOMAIN]  # homeassistant.loader.Integration
-    assert isinstance(list(hass.data[DOMAIN].values())[0], RamsesBroker)
+    assert isinstance(list(hass.data[DOMAIN].values())[0], RamsesCoordinator)
     assert isinstance(list(hass.data[DOMAIN].values())[0].client, Gateway)
 
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -99,10 +99,10 @@ async def _test_common(hass: HomeAssistant, entry: ConfigEntry = None) -> None:
     assert entry.state is ConfigEntryState.LOADED
 
     assert hass.data["setup_tasks"] == {}
-    assert isinstance(hass.data[DOMAIN][entry.entry_id], RamsesBroker)
+    assert isinstance(hass.data[DOMAIN][entry.entry_id], RamsesCoordinator)
 
-    broker: RamsesBroker = hass.data[DOMAIN][entry.entry_id]
-    assert len(broker._devices) == 1  # 18_000730
+    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    assert len(coordinator._devices) == 1  # 18_000730
 
     assert (
         len(hass.states.async_entity_ids(Platform.BINARY_SENSOR)) == 1


### PR DESCRIPTION
## Summary

This PR implements **Phase 3, Steps 1 & 2** of the refactoring plan described in issue [#414](https://github.com/ramses-rf/ramses_cc/issues/414).

Following the successful extraction of Storage, Fan Logic, and Services in Phase 2, this PR performs the structural rename required to align the integration with Home Assistant's standard `Coordinator` pattern. The "Broker" concept is formally retired in favor of `RamsesCoordinator`.

## Changes

* **File Rename:** `custom_components/ramses_cc/broker.py` → `coordinator.py`
* **Class Rename:** `RamsesBroker` → `RamsesCoordinator`
* **Dependency Updates:**
    * Updated `__init__.py` to instantiate the Coordinator.
    * Updated all entity platforms (`climate.py`, `sensor.py`, etc.) to type-hint and import `RamsesCoordinator`.
    * Updated `fan_handler.py` and `services.py` to reference the parent Coordinator.
* **Test Suite:** Updated all 388 tests to import from the new module path.

## Verification

- [x] `pytest` passes (388/388 tests passed).
- [x] Verified that circular imports are resolved.
- [x] Verified loads without warnings on HA kit (by @silverailscolo ).