### PR TITLE
Fix Services `hass.async_create_task` threading RuntimeError

### DIFF
--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -37,6 +37,12 @@ class RamsesServiceHandler:
         self._coordinator = coordinator
         self.hass = coordinator.hass
 
+    def _schedule_refresh(self, _: Any) -> None:
+        asyncio.run_coroutine_threadsafe(
+            self._coordinator.async_request_refresh(),
+            self.hass.loop,
+        )
+
     async def async_bind_device(self, call: ServiceCall) -> None:
         """Handle the bind_device service call to bind a device to the system."""
 
@@ -84,9 +90,7 @@ class RamsesServiceHandler:
         async_call_later(
             self.hass,
             _CALL_LATER_DELAY,
-            lambda _: self.hass.async_create_task(
-                self._coordinator.async_request_refresh()
-            ),
+            self._schedule_refresh,
         )
 
     async def async_send_packet(self, call: ServiceCall) -> None:
@@ -111,9 +115,7 @@ class RamsesServiceHandler:
         async_call_later(
             self.hass,
             _CALL_LATER_DELAY,
-            lambda _: self.hass.async_create_task(
-                self._coordinator.async_request_refresh()
-            ),
+            self._schedule_refresh,
         )
 
     def _adjust_sentinel_packet(self, cmd: Command) -> None:


### PR DESCRIPTION
I got several errors and warnings on 0.53.3 like:
```
2026-01-20 16:15:22.677 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'ramses_cc' calls hass.async_create_task from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt. For more information, see https://developers.home-assistant.io/docs/asyncio_thread_safety/#hassasync_create_task at custom_components/ramses_cc/services.py, line 114: lambda _: self.hass.async_create_task(. Please create a bug report at https://github.com/ramses-rf/ramses_cc/issues
2026-01-20 16:15:22.677 ERROR (MainThread) [homeassistant] Error doing job: Future exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/ramses_cc/services.py", line 114, in <lambda>
    lambda _: self.hass.async_create_task(
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self._coordinator.async_request_refresh()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 806, in async_create_task
    frame.report_non_thread_safe_operation("hass.async_create_task")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 417, in report_non_thread_safe_operation
    report_usage(
    ~~~~~~~~~~~~^
        f"calls {what} from a thread other than the event loop, "
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
        custom_integration_behavior=ReportBehavior.ERROR,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 218, in report_usage
    future.result()
    ~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 67, in run_callback
    future.set_result(callback(*args))
                      ~~~~~~~~^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 266, in _report_usage
    _report_usage_integration_frame(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        hass,
        ^^^^^
    ...<4 lines>...
        integration_behavior is ReportBehavior.ERROR,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 366, in _report_usage_integration_frame
    raise RuntimeError(
    ...<5 lines>...
    )
RuntimeError: Detected that custom integration 'ramses_cc' calls hass.async_create_task from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt. For more information, see https://developers.home-assistant.io/docs/asyncio_thread_safety/#hassasync_create_task at custom_components/ramses_cc/services.py, line 114: lambda _: self.hass.async_create_task(. Please create a bug report at https://github.com/ramses-rf/ramses_cc/issues
2026-01-20 16:15:22.774 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'ramses_cc' calls hass.async_create_task from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt. For more information, see https://developers.home-assistant.io/docs/asyncio_thread_safety/#hassasync_create_task at custom_components/ramses_cc/services.py, line 114: lambda _: self.hass.async_create_task(. Please create a bug report at https://github.com/ramses-rf/ramses_cc/issues
2026-01-20 16:15:22.775 ERROR (MainThread) [homeassistant] Error doing job: Future exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/ramses_cc/services.py", line 114, in <lambda>
    lambda _: self.hass.async_create_task(
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self._coordinator.async_request_refresh()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 806, in async_create_task
    frame.report_non_thread_safe_operation("hass.async_create_task")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 417, in report_non_thread_safe_operation
    report_usage(
    ~~~~~~~~~~~~^
        f"calls {what} from a thread other than the event loop, "
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
        custom_integration_behavior=ReportBehavior.ERROR,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 218, in report_usage
    future.result()
    ~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/src/homeassistant/homeassistant/util/async_.py", line 67, in run_callback
    future.set_result(callback(*args))
                      ~~~~~~~~^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 266, in _report_usage
    _report_usage_integration_frame(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        hass,
        ^^^^^
    ...<4 lines>...
        integration_behavior is ReportBehavior.ERROR,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/frame.py", line 366, in _report_usage_integration_frame
    raise RuntimeError(
    ...<5 lines>...
    )
RuntimeError: Detected that custom integration 'ramses_cc' calls hass.async_create_task from a thread other than the event loop, which may cause Home Assistant to crash or data to corrupt. For more information, see https://developers.home-assistant.io/docs/asyncio_thread_safety/#hassasync_create_task at custom_components/ramses_cc/services.py, line 114: lambda _: self.hass.async_create_task(. Please create a bug report at https://github.com/ramses-rf/ramses_cc/issues
```

This should fix it.

- Avoid calling `hass.async_create_task(...)` from the delayed callback.
- Use `asyncio.run_coroutine_threadsafe(..., hass.loop)` to schedule async_request_refresh() safely.