### PR TITLE
fix: Handle null entries in known_list schema normalization (Fixes Issue #444)

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -160,10 +160,12 @@ def normalise_config(config: _SchemaT) -> tuple[str, _SchemaT, _SchemaT]:
 
     port_name, port_config = extract_serial_port(config.pop(SZ_SERIAL_PORT))
 
+    # Check if 'v' is truthy (not None) before calling .get()
+    # This prevents crashes when a known_list entry is null (e.g. "01:123456": null)
     remote_commands = {
         k: v.pop(CONF_COMMANDS)
         for k, v in config[SZ_KNOWN_LIST].items()
-        if v.get(CONF_COMMANDS)
+        if v and v.get(CONF_COMMANDS)
     }
 
     coordinator_keys = (CONF_SCAN_INTERVAL, CONF_ADVANCED_FEATURES, SZ_RESTORE_CACHE)


### PR DESCRIPTION
### The Problem:

Currently, the integration throws an `AttributeError: 'NoneType' object has no attribute 'get'` during the setup phase if a user defines a device in the `known_list` without any associated properties (e.g., `"01:123456":` or `"01:123456": null`). The YAML loader parses these as `None`, causing the code to crash when it attempts to check for `CONF_COMMANDS`.

### Consequences:

If this is not fixed, the integration fails to load entirely for users with incomplete but syntactically valid YAML configurations. This results in a persistent `ConfigEntryState.SETUP_ERROR`, forcing users to manually edit their configuration to add dummy aliases or remove the entries to restore functionality.

### The Fix:

I modified the `normalise_config` function in `schemas.py` to correctly handle `None` values in the `known_list`.

### Technical Implementation:

In `custom_components/ramses_cc/schemas.py`, I updated the dictionary comprehension used to extract `remote_commands`. I changed the condition from: `if v.get(CONF_COMMANDS)` to: `if v and v.get(CONF_COMMANDS)`

This ensures that the code first verifies that `v` (the device configuration object) is not `None` before attempting to access the `.get()` method.

### Testing Performed:

I ran the full `pytest` suite locally, and all tests passed, confirming no regressions were introduced. The fix logic was verified against the traceback provided in Issue #444 to ensure it specifically addresses the `NoneType` attribute error.

### Risks of NOT Implementing:

Leaving the code as is guarantees that any user with a "minimal" `known_list` entry (just the device ID) will experience an integration crash on startup, generating significant support volume and user frustration.

### Risks of Implementing:

The risk is extremely low. The only potential side effect is that a device explicitly set to `null` will have no commands registered, which is the intended and correct behavior.

### Mitigation Steps:

The change is purely defensive. By using short-circuit evaluation (`if v and ...`), we ensure that valid configurations are processed exactly as before, while invalid/null configurations are safely skipped without raising exceptions.