### PR TITLE
fix: Improve error handling for fan parameter service calls

### DIFF
--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -101,6 +101,14 @@
             }
         }
     },
+    "exceptions": {
+        "service_device_id_missing": {
+            "message": "Cannot get parameter: Destination 'device_id' is missing or invalid in call: {data}"
+        },
+        "service_param_invalid": {
+            "message": "Failed to get fan parameter. Error: {err}"
+        }
+    },
     "options": {
         "abort": {
             "cache_cleared": "Cache cleared."

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -101,6 +101,14 @@
             }
         }
     },
+    "exceptions": {
+        "service_device_id_missing": {
+            "message": "Kan parameter niet ophalen: Bestemming 'device_id' ontbreekt of is ongeldig in aanroep: {data}"
+        },
+        "service_param_invalid": {
+            "message": "Kon ventilatorparameter niet ophalen. Fout: {err}"
+        }
+    },
     "options": {
         "abort": {
             "cache_cleared": "Cache gewist."
@@ -221,7 +229,7 @@
                 },
                 "device_info": {
                     "name": "Apparaat-info",
-                    "description": "Het `device_info` commando van de aanvrager (voor sommige koppelingen vereist). Vereist als `10E0` (device info) in het koppelverzoek voorkomt. Dit moet de juiste `payload` zijn voor de apparaat-klasse."
+                    "description": "Het `device_info` commando van de aanvrager (voor sommige koppelingen vereist). Vereist als `10E0` (device info) in het koppelverzoek voorkomt. Dit moet de juiste `payload` voor de apparaat-klasse."
                 }
             }
         },

--- a/tests/tests_new/test_fan_param.py
+++ b/tests/tests_new/test_fan_param.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import (  # type: ignore[import-untyped]
     MockConfigEntry,
@@ -194,16 +195,9 @@ class TestFanParameterGet:
         caplog.clear()
         caplog.set_level(logging.ERROR)
 
-        # Act - Call the method under test
-        await self.coordinator.async_get_fan_param(call)
-
-        # Assert - Verify error was logged
-        error_message = "Missing required parameter: param_id"
-        assert any(
-            error_message in record.message
-            for record in caplog.records
-            if record.levelno >= logging.ERROR
-        ), f"Expected error message '{error_message}' not found in logs"
+        # Act & Assert - Expect ServiceValidationError instead of just logging
+        with pytest.raises(ServiceValidationError, match="service_param_invalid"):
+            await self.coordinator.async_get_fan_param(call)
 
         # Verify no command was sent
         self.mock_client.async_send_cmd.assert_not_called()

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -8,7 +8,7 @@ import pytest
 import voluptuous as vol
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from pytest_homeassistant_custom_component.common import (  # type: ignore[import-untyped]
     MockConfigEntry,
@@ -715,6 +715,7 @@ async def test_get_fan_param_value_error(mock_coordinator: RamsesCoordinator) ->
             "_get_device_and_from_id",
             return_value=("30:111111", "30_111111", "18:000000"),
         ),
+        pytest.raises(ServiceValidationError, match="service_param_invalid"),
     ):
         await mock_coordinator.async_get_fan_param(call)
         assert mock_err.called
@@ -1627,9 +1628,12 @@ async def test_get_fan_param_value_error_clears_pending(hass: HomeAssistant) -> 
 
     # 3. Patch Command.get_fan_param to raise ValueError
     # This ensures 'entity' is already assigned before the exception is raised
-    with patch(
-        "custom_components.ramses_cc.services.Command.get_fan_param",
-        side_effect=ValueError("Simulated Error"),
+    with (
+        patch(
+            "custom_components.ramses_cc.services.Command.get_fan_param",
+            side_effect=ValueError("Simulated Error"),
+        ),
+        pytest.raises(ServiceValidationError, match="service_param_invalid"),
     ):
         call = {"device_id": "32:111111", "param_id": "01"}
 
@@ -1781,20 +1785,57 @@ async def test_set_fan_param_raises_error_missing_destination(
         await mock_coordinator.async_set_fan_param(call_data)
 
 
-async def test_get_fan_param_logs_error_missing_destination(
+async def test_get_fan_param_raises_error_missing_destination(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Test that async_get_fan_param logs specific error for missing destination."""
+    """Test that async_get_fan_param raises specific error for missing destination."""
     call_data = {
         # "device_id": "30:111222", # Missing
         "param_id": "0A",
         "from_id": "32:111111",
     }
 
-    # get_fan_param catches ValueErrors and logs them as Errors
-    with patch("custom_components.ramses_cc.services._LOGGER.error") as mock_err:
+    # Expect ServiceValidationError directly
+    with pytest.raises(ServiceValidationError, match="service_device_id_missing"):
         await mock_coordinator.async_get_fan_param(call_data)
 
-        assert mock_err.called
-        # Verify it hit the ValueError catch block with our specific message
-        assert "Destination 'device_id' is missing" in str(mock_err.call_args)
+
+async def test_get_fan_param_service_validation_error_clears_pending(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test that ServiceValidationError raised in get_fan_param clears pending state.
+
+    This targets the specific 'except ServiceValidationError' block (lines 212-216)
+    ensuring that if a validation error occurs after the entity is found (e.g. during sending),
+    the pending state is cleared immediately.
+    """
+    # 1. Setup valid IDs so execution proceeds past initial checks
+    mock_coordinator.service_handler._get_device_and_from_id = MagicMock(
+        return_value=("30:111111", "30_111111", "18:000000")
+    )
+
+    # 2. Setup Mock Entity with the required async method
+    mock_entity = MagicMock()
+    mock_entity._clear_pending_after_timeout = AsyncMock()
+    mock_coordinator.fan_handler.find_param_entity = MagicMock(return_value=mock_entity)
+
+    # 3. Patch Command to succeed, but Client to raise ServiceValidationError
+    with patch(
+        "custom_components.ramses_cc.services.Command.get_fan_param",
+        return_value=MagicMock(),
+    ):
+        # Simulate a downstream validation error (e.g. from the transport layer)
+        mock_coordinator.client.async_send_cmd.side_effect = ServiceValidationError(
+            "Downstream Validation Failure"
+        )
+
+        call = {"device_id": "30:111111", "param_id": "01"}
+
+        # 4. Assert the specific exception bubbles up
+        with pytest.raises(
+            ServiceValidationError, match="Downstream Validation Failure"
+        ):
+            await mock_coordinator.async_get_fan_param(call)
+
+    # 5. Verify _clear_pending_after_timeout(0) was called (Line 215)
+    mock_entity._clear_pending_after_timeout.assert_called_with(0)


### PR DESCRIPTION
### The Problem:

Currently, the `get_fan_param` service call handles input errors inconsistently. If a user provides an invalid parameter ID (e.g., a typo or non-hex string) or omits the destination device, the integration often catches the exception and logs a generic error or fails silently. This forces users to check the logs to understand why a simple service call did not work.

### Consequences:
- **Silent Failures:** Users may trigger the service and receive no feedback in the UI, leading them to believe the command was sent when it was actually rejected.
- **Poor User Experience:** Without localized, specific error messages (e.g., "Invalid parameter ID"), users cannot self-diagnose configuration issues.
- **Debugging Friction:** Troubleshooting simple typos requires context switching to the Home Assistant logs.

### The Fix:

I have refactored the `async_get_fan_param` method in `services.py` to utilize Home Assistant's `ServiceValidationError`. This ensures that validation failures propagate immediately to the UI with clear, translated error messages.

### Technical Implementation:
- **`services.py`**:
  - Added an explicit check for missing `device_id` which raises a `ServiceValidationError` with the key `service_device_id_missing`.
  - Wrapped the parameter extraction logic (`_get_param_id`) in a `try/except ValueError` block. Instead of logging an error and returning, it now re-raises a `ServiceValidationError` with the key `service_param_invalid`.
  - Added a specific exception handler to ensure `ServiceValidationError` bubbles up correctly while still performing necessary cleanup (like clearing the "pending" state of entities).
- **Translations**: Added an `exceptions` block to `custom_components/ramses_cc/translations/en.json` and `nl.json` to provide user-friendly text for these errors.

### Testing Performed:

I have updated and expanded the test suite to verify this new behavior:
- **`tests/tests_new/test_fan_param.py`**: Updated `test_missing_required_param_id` to assert that `ServiceValidationError` is raised, rather than checking `caplog` for a logged error.
- **`tests/tests_new/test_services.py`**:
  - Added `test_set_fan_param_raises_error_missing_destination` to verify missing device handling.
  - Added `test_get_fan_param_service_validation_error_clears_pending` to ensure that if a validation error occurs *after* an entity is marked as pending, the pending state is correctly cleared.
  - Verified full code coverage for the new exception handling blocks.

### Risks of NOT Implementing:

Leaving the code as-is results in a "black box" experience for users. Use of invalid parameters in automations or scripts might go unnoticed until the user realizes their ventilation unit isn't responding, increasing the support burden.

### Risks of Implementing:
- **Breaking Changes for Scripts:** Any existing scripts or automations that were sending invalid data (and previously failing silently/logging) will now halt execution due to the raised exception. This is generally considered "correct" behavior but is technically a change in runtime flow.

### Mitigation Steps:
- **Localized Strings:** Provided Dutch (`nl.json`) translations
- **Cleanup Logic:** Implemented a `finally`-style cleanup within the exception handler to ensure that `entity.set_pending()` is reversed even when validation fails, preventing entities from getting stuck in a "spinning" state in the UI.