### PR TITLE
Refactor coordinator for ramses_rf async compatibility

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -8,7 +8,6 @@ import logging
 from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from datetime import datetime, timedelta
-from threading import Semaphore
 from typing import TYPE_CHECKING, Any, Final
 
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
@@ -92,8 +91,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self._zones: list[Zone] = []
         self._dhws: list[Zone] = []
         self._parameter_entities_created: set[str] = set()
-
-        self._sem = Semaphore(value=1)
 
         # Initialize platforms dictionary to store platform references
         self.platforms: dict[str, Any] = {}
@@ -226,7 +223,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             **schema,
         )
 
-    async def async_save_client_state(self, _: dt_util | None = None) -> None:
+    async def async_save_client_state(self, _: datetime | None = None) -> None:
         """Save the current state of the RAMSES client to persistent storage."""
 
         if not self.client:


### PR DESCRIPTION
### The Problem:

The `coordinator.py` contained legacy defensive coding mechanisms, specifically a `threading.Semaphore`, which were implemented to mitigate blocking I/O and "slow database" issues present in older versions of the underlying library. These workarounds added unnecessary complexity and were essentially hacks to prevent the main loop from stalling during database operations.

### Consequences:

Retaining these workarounds creates technical debt and complicates the codebase. It creates a false impression that the integration still needs to manage blocking I/O manually, potentially confusing future contributors. Furthermore, using threading primitives like `Semaphore` in an `asyncio` loop without strict necessity can lead to subtle race conditions or maintenance overhead.

### The Fix:

I removed the unused semaphore and cleaned up the `async_save_client_state` method. The integration now fully relies on the architectural improvements made in `ramses_rf`, specifically the refactor to use `StorageWorker` and WAL mode.

### Technical Implementation:
1. **Removed Semaphore:** Deleted the `self._sem = Semaphore(value=1)` initialization and the `threading.Semaphore` import in `coordinator.py`.
2. **Type Hinting Updates:** Corrected type hints in `async_save_client_state` to properly reflect `datetime` usage instead of the module alias `dt_util`.
3. **Async/Await Verification:** Verified that `async_save_client_state` retains compatibility with the `ramses_rf` `get_state()` method via `inspect.isawaitable`, ensuring it correctly awaits the new async implementation.

This work follows the upstream changes in **ramses_rf Pull Request #412: Async Database I/O with StorageWorker & WAL Mode**, which resolved the underlying blocking I/O issues.

### Testing Performed:
- **Static Analysis:** Validated code against `mypy` strict typing and `ruff` linting standards.
- **pytest:** pytest run with all tests passing, there is 100% code coverage of the files in custom_components/ramses_cc

### Risks of NOT Implementing:

Leaving the code as-is results in "dead code" (the semaphore was initialized but largely redundant after the library fix) and maintains technical debt that implies the underlying library is still unstable regarding I/O.

### Risks of Implementing:

If the underlying `ramses_rf` library version is not strictly pinned or if the upstream fix (PR #412) has regressions, removing the defensive semaphore might expose the integration to race conditions during state saving, though this is unlikely given the architectural shift to WAL mode.

### Mitigation Steps:
- Ensured `manifest.json` pins `ramses-rf` to version `0.53.4` (or higher) where the I/O fix is present.
- Retained the `inspect.isawaitable` check to ensure backward compatibility if the method signature varies slightly between patch versions.