### PR TITLE
chore: update code formatting to match Ruff v0.15.0

### DIFF
--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -71,8 +71,8 @@ def mock_entry(mock_hass: MagicMock) -> MagicMock:
     entry.async_on_unload = MagicMock()
 
     # Register this entry with the mock hass instance
-    mock_hass.config_entries.async_get_entry.side_effect = (
-        lambda eid: entry if eid == entry.entry_id else None
+    mock_hass.config_entries.async_get_entry.side_effect = lambda eid: (
+        entry if eid == entry.entry_id else None
     )
 
     return entry

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -583,8 +583,8 @@ async def test_target_to_device_id_single_string(
         mock_entry.identifiers = {(DOMAIN, ramses_dev_id)}
 
         # Setup registry to return our entry when queried with the HA device ID
-        mock_reg.async_get.side_effect = (
-            lambda x: mock_entry if x == ha_device_id else None
+        mock_reg.async_get.side_effect = lambda x: (
+            mock_entry if x == ha_device_id else None
         )
 
         # Execute the method on service_handler


### PR DESCRIPTION
### The Problem:

The Continuous Integration (CI) pipeline is failing because the GitHub Action environment is using Ruff v0.15.0, while the local development environment was previously using v0.14.x. This caused a discrepancy in formatting rules, specifically regarding how lambda functions are wrapped in parentheses.

### Consequences:

If this is not fixed, the CI pipeline will continue to fail on the formatting check step. This blocks the merging of any code changes and creates noise in the build logs, preventing clean deployment.

### The Fix:

Ran the `ruff format .` command using Ruff v0.15.0 to align the local code style with the updated formatter rules used by the CI runner.

### Technical Implementation:

Ruff v0.15.0 changed the preferred formatting style for lambda functions split across lines.
- **Previous behavior:** Wrapped the entire lambda expression in parentheses.
- **New behavior:** Wraps only the body (return value) of the lambda in parentheses. The files `tests/tests_new/test_coordinator.py` and `tests/tests_new/test_fan_handler.py` were automatically updated to match this new rule.

### Testing Performed:
- Ran `ruff format --check .` locally to ensure no further formatting violations exist.
- Verified that the Python tests in the affected files still pass, confirming the logic remains unchanged.

### Risks of NOT Implementing:

The codebase will remain in a state where it passes local linting (on older versions) but fails in the shared CI environment, causing confusion for other contributors and blocking progress.

### Risks of Implementing:

None. This is a purely cosmetic change generated by the automated formatter. It does not alter code logic or functionality.

### Mitigation Steps:

N/A - The change is automated and safe.