### PR TITLE
Refactor climate platform for robust error handling, UI feedback, and 100% test coverage

### DIFF
--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -896,7 +896,7 @@ async def test_set_system_mode_fail2(
         await _test_entity_service_call(
             hass, SVC_SET_SYSTEM_MODE, data, schemas=SVCS_RAMSES_CLIMATE
         )
-    except vol.MultipleInvalid:
+    except ServiceValidationError:  # WAS: vol.MultipleInvalid
         pass
     else:
         raise AssertionError("Expected Wrong Argument exception")
@@ -1068,7 +1068,7 @@ async def test_set_zone_mode_fail2(
         await _test_entity_service_call(
             hass, SVC_SET_ZONE_MODE, data, schemas=SVCS_RAMSES_CLIMATE
         )
-    except vol.MultipleInvalid:
+    except ServiceValidationError:  # WAS: vol.MultipleInvalid
         pass
     else:
         raise AssertionError("Expected Wrong Argument exception")


### PR DESCRIPTION
### The Problem:

The current `climate.py` implementation lacks consistent error handling for the underlying `ramses_rf` library. Exceptions such as `ProtocolSendFailed`, `TransportError`, or `TimeoutError` are often allowed to bubble up uncaught or are swallowed silently. Additionally, schema validation errors (`vol.Invalid`) are not consistently converted into user-friendly Home Assistant exceptions, leading to raw tracebacks or generic "Unknown Error" messages in the frontend.

### Consequences:

If not fixed, users receive poor feedback when commands fail (e.g., setting a temperature that fails due to radio interference). This leads to confusion, increased support requests, and a fragile user experience where the UI may not reflect the actual state of the device after a failed command.

### The Fix:

I have refactored `custom_components/ramses_cc/climate.py` to implement a defensive programming pattern. All methods that interact with the RF network or modify device state now run within `try...except` blocks. These blocks catch specific library exceptions and re-raise them as appropriate Home Assistant errors (`ServiceValidationError` for inputs, `HomeAssistantError` for comms).

### Technical Implementation:
- **Imports:** Added `ServiceValidationError`, `HomeAssistantError`, and `ramses_rf` specific exceptions (`RamsesException`, `ProtocolSendFailed`, `TransportError`).
- **Command Wrapping:** Wrapped all service calls (e.g., `async_set_hvac_mode`, `async_set_zone_mode`, `async_set_temperature`) in `try...except` blocks.
- **Exception Mapping:**
  - `vol.Invalid` is now caught and raised as `ServiceValidationError` with a translated message.
  - `RamsesException`, `ProtocolSendFailed`, and `TransportError` are caught and raised as `HomeAssistantError` to inform the user of communication failures.
- **Test Updates:**
  - Updated `tests/tests_new/test_climate.py` to include mock-based tests for these failure paths, ensuring 100% code coverage for `climate.py`.
  - Updated `tests/tests_old/test_services.py` to assert that the new, correct exceptions are raised instead of the old raw types.

### Testing Performed:
- **Unit Testing:** Ran `tests/tests_new/test_climate.py` with `pytest --cov`. Confirmed 100% line coverage, specifically verifying that schema validation failures and transport errors trigger the correct exception handling blocks.
- **Integration Testing:** Ran `tests/tests_old/test_services.py` to verify that legacy service call tests pass with the new exception hierarchy.

### Risks of NOT Implementing:

Leaving the code as-is results in a brittle integration where network glitches cause unhandled stack traces in the logs, making debugging difficult for users and developers.

### Risks of Implementing:
- **Over-suppression:** There is a slight risk of masking legitimate code bugs if the `try...except` blocks are too broad (e.g., catching `Exception`).
- **Regression:** Changes to exception types might break automations that rely on parsing specific text from raw Python errors (though this is considered bad practice in HA).

### Mitigation Steps:
- **Specific Trapping:** I have strictly limited exception catching to known library errors (`RamsesException` and subclasses) and `vol.Invalid`, avoiding bare `except Exception:` clauses in command logic.
- **Comprehensive Coverage:** The addition of tests hitting every exception path ensures that the error mapping logic itself does not contain bugs.