### PR TITLE
Clear caches when known_list is enforced

### DIFF
--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -75,7 +75,7 @@
                 "data_description": {
                     "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
                     "known_list": "A mapping of known device IDs and optionally their traits.",
-                    "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common.",
+                    "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. HA Restart required.",
                     "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console.",
                     "sqlite_index": "Under development! Missing messages or errors with Evohome (restart required)"
                 }

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -177,7 +177,7 @@
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
-                    "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen.",
+                    "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen. Vereist HA herstart!",
                     "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole.",
                     "sqlite_index": "In ontwikkeling! Kan berichten missen en fouten geven met Evohome. (herstart vereist)"
                 }


### PR DESCRIPTION
To assist users who turn on the "Accept from known device IDs only" config option, clears both caches immediately.
Adds this consequence + hint to restart HA in the system log and the Config pane.