### PR TITLE
WIP - Fix/numbers entity creation by ha

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -461,7 +461,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Platform unload completed with result: %s", result)
         return result
 
-    def _update_device(self, device: RamsesRFEntity) -> None:
+    async def _update_device(self, device: RamsesRFEntity) -> None:
         """Update device information in the device registry."""
         if hasattr(device, "name") and device.name:
             name = device.name
@@ -472,7 +472,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         else:
             name = device.id
 
-        if info := device._msg_value_code(Code._10E0):
+        if info := await device._msg_value_code(Code._10E0):
             model = info.get("description")
         else:
             model = device._SLUG
@@ -582,7 +582,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         for device in new_systems + new_dhws + new_zones + new_devices:
             await self.fan_handler.async_setup_fan_device(device)
             # Register device in registry once upon discovery
-            self._update_device(device)
+            await self._update_device(device)
 
         new_entities = new_systems + new_dhws + new_zones + new_devices
 

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -44,28 +44,26 @@ class RamsesFanHandler:
         :param param_id: The 2-character hex ID of the parameter.
         :return: The found entity or None if not found in the registry/platform.
         """
-        # Normalize device ID to use underscores and lowercase for entity ID
+        # Normalize device ID to use underscores and lowercase (matches number.py unique_id)
         safe_device_id = str(device_id).replace(":", "_").lower()
-        target_entity_id = f"number.{safe_device_id}_param_{param_id.lower()}"
+        unique_id = f"{safe_device_id}_param_{param_id.lower()}"
 
-        # First try to find the entity in the entity registry
+        # Look up the actual entity_id via the entity registry (do not assume naming)
         ent_reg = er.async_get(self.hass)
-        entity_entry = ent_reg.async_get(target_entity_id)
-        if entity_entry:
-            _LOGGER.debug("Found entity %s in entity registry", target_entity_id)
-            # Get the actual entity from the platform to make sure entity is fully loaded
-            platforms = self.coordinator.platforms.get(Platform.NUMBER, [])
-            for platform in platforms:
-                if (
-                    hasattr(platform, "entities")
-                    and target_entity_id in platform.entities
-                ):
-                    return platform.entities[target_entity_id]
-
-            # Entity exists in registry but not yet loaded in platform
+        entity_id = ent_reg.async_get_entity_id("number", DOMAIN, unique_id)
+        if entity_id is None:
+            _LOGGER.debug("Entity (unique_id=%s) not found in registry.", unique_id)
             return None
 
-        _LOGGER.debug("Entity %s not found in registry.", target_entity_id)
+        _LOGGER.debug("Found entity %s in entity registry", entity_id)
+
+        # Get the actual entity from the platform to make sure entity is fully loaded
+        platforms = self.coordinator.platforms.get(Platform.NUMBER, [])
+        for platform in platforms:
+            if hasattr(platform, "entities") and entity_id in platform.entities:
+                return platform.entities[entity_id]
+
+        # Entity exists in registry but not yet loaded in platform
         return None
 
     def create_parameter_entities(self, device: RamsesRFEntity) -> None:

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -48,13 +48,9 @@ from dataclasses import dataclass
 from types import UnionType
 from typing import Any
 
-from homeassistant.components.number import (
-    ENTITY_ID_FORMAT,
-    NumberEntity,
-    NumberEntityDescription,
-)
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import (
@@ -503,12 +499,9 @@ class RamsesNumberParam(RamsesNumberBase):
 
         # Create base ID with device ID and parameter ID
         base_id = f"{device_id}_param_{param_id}"
-        self.entity_id = ENTITY_ID_FORMAT.format(base_id)
         self._attr_unique_id = base_id
 
-        _LOGGER.debug(
-            "Found entity_id: %s, unique_id: %s", self.entity_id, self._attr_unique_id
-        )
+        _LOGGER.debug("Found unique_id: %s", self._attr_unique_id)
 
         param_id = getattr(entity_description, "ramses_rf_attr", "")
         if param_id:
@@ -607,7 +600,7 @@ class RamsesNumberParam(RamsesNumberBase):
         )
 
     @callback
-    def _async_param_updated(self, event: dict[str, Any]) -> None:
+    def _async_param_updated(self, event: Event | dict[str, Any]) -> None:
         """Handle parameter updates from the device.
 
         This callback is triggered when a fan parameter update event is received.
@@ -625,7 +618,12 @@ class RamsesNumberParam(RamsesNumberBase):
             return
 
         # Extract data from event
-        event_data = event.data if hasattr(event, "data") else event
+        if isinstance(event, dict):
+            event_data = event
+        elif isinstance(event, Event):
+            event_data = event.data
+        else:
+            event_data = getattr(event, "data", {})
 
         # Only process if this is our parameter
         if (
@@ -1013,6 +1011,10 @@ def create_parameter_entities(
         # Create a unique ID for this parameter entity
         unique_id = f"{device_id}_param_{param_id.lower()}"
 
+        slug = getattr(device, "_SLUG", "")
+        slug_prefix = f"{slug.lower()}_" if slug else ""
+        suggested_object_id = f"{slug_prefix}{device_id}_param_{param_id.lower()}"
+
         # The entity key is already set correctly in get_param_descriptions()
         # No need to modify the frozen dataclass attribute
 
@@ -1026,7 +1028,7 @@ def create_parameter_entities(
                     "number",
                     "ramses_cc",
                     unique_id,
-                    suggested_object_id=f"{device_id}_param_{param_id.lower()}",
+                    suggested_object_id=suggested_object_id,
                     config_entry=coordinator.entry,
                 )
             else:

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -51,7 +51,6 @@ from typing import Any
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
@@ -994,70 +993,22 @@ def create_parameter_entities(
     )
 
     param_descriptions = get_param_descriptions(device)
-    entities: list[RamsesNumberParam] = []
-
-    # Get entity registry for proper entity creation
-    ent_reg = er.async_get(coordinator.hass)
-
-    for description in param_descriptions:
-        if not description.ramses_rf_attr:
-            _LOGGER.debug(
-                "Skipping parameter %s - no ramses_rf_attr",
-                getattr(description, "key", "unknown"),
-            )
-            continue
-
-        param_id = getattr(description, "ramses_rf_attr", "unknown")
-        # Create a unique ID for this parameter entity
-        unique_id = f"{device_id}_param_{param_id.lower()}"
-
-        slug = getattr(device, "_SLUG", "")
-        slug_prefix = f"{slug.lower()}_" if slug else ""
-        suggested_object_id = f"{slug_prefix}{device_id}_param_{param_id.lower()}"
-
-        # The entity key is already set correctly in get_param_descriptions()
-        # No need to modify the frozen dataclass attribute
-
-        try:
-            # Check if entity already exists in registry to avoid duplicate registry entries
-            entity_id = ent_reg.async_get_entity_id("number", "ramses_cc", unique_id)
-            if entity_id is None:
-                # Entity doesn't exist in registry, create it
-                _LOGGER.debug("Creating new entity in registry: %s", unique_id)
-                ent_reg.async_get_or_create(
-                    "number",
-                    "ramses_cc",
-                    unique_id,
-                    suggested_object_id=suggested_object_id,
-                    config_entry=coordinator.entry,
-                )
-            else:
-                _LOGGER.debug(
-                    "Entity %s already exists in registry as %s, using existing",
-                    unique_id,
-                    entity_id,
-                )
-
-            # Always create the entity object for the platform
-            # Home Assistant will restore state from registry for existing entities
-            entity = description.ramses_cc_class(coordinator, device, description)
-            entities.append(entity)
-            _LOGGER.info(
-                "Created parameter entity: %s for %s (param_id=%s)",
-                entity.entity_id,
-                device_id,
-                param_id,
-            )
-        except Exception as e:
-            _LOGGER.error(
-                "Error creating parameter entity: %s",
-                str(e),
-                exc_info=True,
-            )
 
     _LOGGER.debug(
-        "Processed %d parameter entities for %s using async_get_or_create",
-        len(param_descriptions),
-        device_id,
+        "Creating %d parameter entities for %s", len(param_descriptions), device_id
     )
+
+    entities = [
+        description.ramses_cc_class(coordinator, device, description)
+        for description in param_descriptions
+        if description.ramses_rf_attr
+    ]
+
+    if entities:
+        _LOGGER.debug(
+            "Created %d parameter entities for %s",
+            len(entities),
+            device_id,
+        )
+
     return entities

--- a/tests/tests_new/conftest.py
+++ b/tests/tests_new/conftest.py
@@ -17,7 +17,7 @@ from syrupy.assertion import SnapshotAssertion
 try:
     from ..virtual_rf import VirtualRf
 except (ImportError, ModuleNotFoundError):
-    VirtualRf = None  # type: ignore[assignment,misc]  # Windows: pty/termios unavailable
+    VirtualRf = None  # Windows: pty/termios unavailable
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -1323,7 +1323,9 @@ async def test_zigbee_single_device_label_in_port_picker(hass: HomeAssistant) ->
     selector_obj = schema[port_name_key]
     # SelectSelectorConfig is a TypedDict (plain dict at runtime)
     config = getattr(selector_obj, "config", {})
-    options: list[dict] = config.get("options", []) if isinstance(config, dict) else []
+    options: list[dict[str, Any]] = (
+        config.get("options", []) if isinstance(config, dict) else []
+    )
     opts_by_value = {opt.get("value"): opt.get("label", "") for opt in options}
 
     zigbee_label = opts_by_value.get(CONF_ZIGBEE_DEVICE, "")

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -163,12 +163,12 @@ async def test_device_registry_update_slugs(
     mock_device._SLUG = "FAN"
     # Ensure name is None so coordinator falls back to slug-based logic
     mock_device.name = None
-    mock_device._msg_value_code.return_value = None  # No 10E0 info
+    mock_device._msg_value_code = AsyncMock(return_value=None)  # No 10E0 info
 
     with patch("homeassistant.helpers.device_registry.async_get") as mock_dr_get:
         mock_reg = mock_dr_get.return_value
 
-        mock_coordinator._update_device(mock_device)
+        await mock_coordinator._update_device(mock_device)
 
         # Verify the name and model were derived from the SLUG
         call_kwargs = mock_reg.async_get_or_create.call_args[1]
@@ -224,12 +224,12 @@ async def test_update_device_relationships(mock_coordinator: RamsesCoordinator) 
         mock_zone.id = "04:123456"
         mock_zone.tcs = MagicMock()
         mock_zone.tcs.id = "01:999999"
-        mock_zone._msg_value_code.return_value = {"description": "Zone Name"}
+        mock_zone._msg_value_code = AsyncMock(return_value={"description": "Zone Name"})
         mock_zone.name = "Custom Zone"
 
         with patch("homeassistant.helpers.device_registry.async_get") as mock_dr_get:
             mock_reg = mock_dr_get.return_value
-            mock_coordinator._update_device(mock_zone)
+            await mock_coordinator._update_device(mock_zone)
 
             # Verify via_device was set to TCS ID
             call_kwargs = mock_reg.async_get_or_create.call_args[1]
@@ -245,13 +245,13 @@ async def test_update_device_child_parent(mock_coordinator: RamsesCoordinator) -
     mock_child.id = "13:123456"
     mock_child._parent = MagicMock()
     mock_child._parent.id = "04:123456"
-    mock_child._msg_value_code.return_value = None
+    mock_child._msg_value_code = AsyncMock(return_value=None)
     mock_child._SLUG = "BDR"
     mock_child.name = None
 
     with patch("homeassistant.helpers.device_registry.async_get") as mock_dr_get:
         mock_reg = mock_dr_get.return_value
-        mock_coordinator._update_device(mock_child)
+        await mock_coordinator._update_device(mock_child)
 
         call_kwargs = mock_reg.async_get_or_create.call_args[1]
         assert call_kwargs["via_device"] == (DOMAIN, "04:123456")
@@ -329,11 +329,32 @@ async def test_async_update_discovery(mock_coordinator: RamsesCoordinator) -> No
     # Setup mock entities in client
     mock_system = MagicMock(spec=Evohome)
     mock_system.id = "01:123456"
-    mock_system.dhw = MagicMock()  # Has DHW
-    mock_system.zones = [MagicMock()]  # Has Zone
+    mock_system._msg_value_code = AsyncMock(return_value=None)
+    mock_system._SLUG = "EVO"
+    mock_system.name = None
+
+    # Setup dhw with required async method
+    mock_dhw = MagicMock()
+    mock_dhw.id = "01:123456"
+    mock_dhw._msg_value_code = AsyncMock(return_value=None)
+    mock_dhw._SLUG = "DHW"
+    mock_dhw.name = None
+    mock_system.dhw = mock_dhw
+
+    # Setup zones with required async method
+    mock_zone = MagicMock()
+    mock_zone.id = "04:111111"
+    mock_zone._msg_value_code = AsyncMock(return_value=None)
+    mock_zone._SLUG = "ZON"
+    mock_zone.name = None
+    mock_zone.tcs = None
+    mock_system.zones = [mock_zone]
 
     mock_device = MagicMock()
     mock_device.id = "04:123456"  # Device
+    mock_device._msg_value_code = AsyncMock(return_value=None)
+    mock_device._SLUG = "DEV"
+    mock_device.name = None
 
     mock_coordinator.client.systems = [mock_system]
     mock_coordinator.client.devices = [mock_device]
@@ -437,12 +458,12 @@ async def test_update_device_system_naming(mock_coordinator: RamsesCoordinator) 
         mock_system._SLUG = None
 
         # Ensure the method returns None as expected
-        mock_system._msg_value_code.return_value = None
+        mock_system._msg_value_code = AsyncMock(return_value=None)
 
         with patch("homeassistant.helpers.device_registry.async_get") as mock_dr_get:
             mock_reg = mock_dr_get.return_value
 
-            mock_coordinator._update_device(mock_system)
+            await mock_coordinator._update_device(mock_system)
 
             # Verify the name format "Controller {id}"
             call_kwargs = mock_reg.async_get_or_create.call_args[1]
@@ -462,7 +483,7 @@ async def test_async_update_adds_systems_and_guards(
         name: str | None = None
         _SLUG: str = "EVO"
 
-        def _msg_value_code(self, *args: Any, **kwargs: Any) -> Any:
+        async def _msg_value_code(self, *args: Any, **kwargs: Any) -> Any:
             return None
 
     # Patch Evohome in the coordinator with our dummy CLASS (using new=...)
@@ -587,14 +608,14 @@ async def test_update_device_name_fallback_to_id(
     mock_device._SLUG = None  # Fails 'elif device._SLUG'
 
     # Stub helper method to return None (affects 'model' variable, not 'name')
-    mock_device._msg_value_code.return_value = None
+    mock_device._msg_value_code = AsyncMock(return_value=None)
 
     # 3. Patch the device registry to verify the result
     with patch("homeassistant.helpers.device_registry.async_get") as mock_dr_get:
         mock_reg = mock_dr_get.return_value
 
         # 4. Call the method under test
-        mock_coordinator._update_device(mock_device)
+        await mock_coordinator._update_device(mock_device)
 
         # 5. Verify device_registry was called with name == device.id
         call_kwargs = mock_reg.async_get_or_create.call_args[1]
@@ -1038,18 +1059,18 @@ async def test_update_device_skips_redundant_update(
     mock_device = MagicMock()
     mock_device.id = "01:000000"
     mock_device.name = "Test Device"
-    mock_device._msg_value_code.return_value = None
+    mock_device._msg_value_code = AsyncMock(return_value=None)
     mock_device._SLUG = "TST"
 
     with patch("homeassistant.helpers.device_registry.async_get") as mock_dr_get:
         mock_reg = mock_dr_get.return_value
 
         # First call: Should create
-        mock_coordinator._update_device(mock_device)
+        await mock_coordinator._update_device(mock_device)
         assert mock_reg.async_get_or_create.call_count == 1
 
         # Second call: Should return early
-        mock_coordinator._update_device(mock_device)
+        await mock_coordinator._update_device(mock_device)
         assert mock_reg.async_get_or_create.call_count == 1
 
 

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -149,10 +149,20 @@ async def test_fan_setup_already_initialized(
     mock_fan_device._initialized = True
     mock_fan_device.supports_2411 = True
 
+    class MockHvacVentilator:
+        pass
+
+    mock_fan_device.__class__ = MockHvacVentilator  # type: ignore[assignment]
+
     # Patch the function where it is DEFINED, which is used by the import in coordinator.py
-    with patch(
-        "custom_components.ramses_cc.number.create_parameter_entities"
-    ) as mock_create:
+    with (
+        patch(
+            "custom_components.ramses_cc.number.create_parameter_entities"
+        ) as mock_create,
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
+        ),
+    ):
         mock_create.return_value = [MagicMock()]
         await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
@@ -367,7 +377,7 @@ async def test_find_param_entity_logic(
     with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
         mock_registry = MagicMock()
         mock_er_get.return_value = mock_registry
-        mock_registry.async_get.return_value = None
+        mock_registry.async_get_entity_id.return_value = None
 
         res = mock_coordinator.fan_handler.find_param_entity(FAN_ID, "10")
         assert res is None
@@ -376,7 +386,9 @@ async def test_find_param_entity_logic(
     with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
         mock_registry = MagicMock()
         mock_er_get.return_value = mock_registry
-        mock_registry.async_get.return_value = MagicMock()  # Found in registry
+        mock_registry.async_get_entity_id.return_value = (
+            "number.some_entity"  # Found in registry
+        )
 
         # Ensure platforms dict is empty or platform has no entities
         mock_coordinator.platforms = {}
@@ -388,13 +400,12 @@ async def test_find_param_entity_logic(
     with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
         mock_registry = MagicMock()
         mock_er_get.return_value = mock_registry
-        mock_registry.async_get.return_value = MagicMock()  # Found in registry
+        target_id = "number.fan_30_123456_param_10"
+        mock_registry.async_get_entity_id.return_value = target_id  # Found in registry
 
         # Setup fake platform
         mock_entity = MagicMock()
         mock_platform = MagicMock()
-        # Entity ID format from logic: number.{device_id}_{param_id}
-        target_id = f"number.{FAN_ID.replace(':', '_').lower()}_param_10"
         mock_platform.entities = {target_id: mock_entity}
 
         mock_coordinator.platforms = {Platform.NUMBER: [mock_platform]}
@@ -437,9 +448,17 @@ async def test_fan_setup_already_initialized_exception(
     mock_fan_device._initialized = True
     mock_fan_device.supports_2411 = True
 
+    class MockHvacVentilator:
+        pass
+
+    mock_fan_device.__class__ = MockHvacVentilator  # type: ignore[assignment]
+
     with (
         patch("custom_components.ramses_cc.number.create_parameter_entities"),
         patch.object(mock_coordinator, "get_all_fan_params") as mock_get_params,
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacVentilator", MockHvacVentilator
+        ),
     ):
         mock_get_params.side_effect = RuntimeError("Request Failed")
 

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -372,6 +372,27 @@ async def test_events_handling(number_entity: RamsesNumberParam) -> None:
     assert number_entity._param_native_value["01"] == 0.5
 
 
+async def test_events_handling_with_event_object(
+    number_entity: RamsesNumberParam,
+) -> None:
+    """Test event handling with actual Event object for isinstance branch coverage."""
+    from homeassistant.core import Event
+
+    await number_entity.async_added_to_hass()
+    callback = number_entity.hass.bus.async_listen.call_args[0][1]
+
+    event = Event(
+        "ramses_cc.fan_param_updated",
+        {
+            "device_id": number_entity._device.id,
+            "param_id": "01",
+            "value": 0.75,
+        },
+    )
+    callback(event)
+    assert number_entity._param_native_value["01"] == 0.75
+
+
 async def test_events_handling_no_param_id(number_entity: RamsesNumberParam) -> None:
     """Test event handling return when no param id."""
     # Remove attr from description

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -588,40 +588,13 @@ async def test_icon_logic(number_entity: RamsesNumberParam) -> None:
         assert number_entity.icon == "mdi:counter"
 
 
-async def test_create_parameter_entities_registry(
-    mock_coordinator: MagicMock, mock_fan_device: MagicMock
-) -> None:
-    """Test registry interaction in create_parameter_entities."""
-    mock_reg = MagicMock()
-    # First call returns ID (exists), Second returns None (create new)
-    mock_reg.async_get_entity_id.side_effect = ["number.existing", None]
-
-    with (
-        patch("homeassistant.helpers.entity_registry.async_get", return_value=mock_reg),
-        patch(
-            "custom_components.ramses_cc.number.get_param_descriptions"
-        ) as mock_get_desc,
-    ):
-        mock_get_desc.return_value = [
-            RamsesNumberEntityDescription(key="p1", ramses_rf_attr="01"),
-            RamsesNumberEntityDescription(key="p2", ramses_rf_attr="02"),
-        ]
-
-        entities = create_parameter_entities(mock_coordinator, mock_fan_device)
-        assert len(entities) == 2
-        assert mock_reg.async_get_or_create.call_count == 1
-
-
 async def test_create_parameter_entities_skip_empty_attr(
     mock_coordinator: MagicMock, mock_fan_device: MagicMock
 ) -> None:
     """Test skipping parameters with no attribute ID."""
-    with (
-        patch("homeassistant.helpers.entity_registry.async_get"),
-        patch(
-            "custom_components.ramses_cc.number.get_param_descriptions"
-        ) as mock_get_desc,
-    ):
+    with patch(
+        "custom_components.ramses_cc.number.get_param_descriptions"
+    ) as mock_get_desc:
         mock_get_desc.return_value = [
             RamsesNumberEntityDescription(key="no_attr", ramses_rf_attr=""),
             RamsesNumberEntityDescription(key="ok_attr", ramses_rf_attr="01"),
@@ -640,22 +613,22 @@ async def test_create_parameter_entities_no_support(
     assert len(entities) == 0
 
 
-async def test_create_parameter_entities_error(
+async def test_create_parameter_entities_multiple(
     mock_coordinator: MagicMock, mock_fan_device: MagicMock
 ) -> None:
-    """Test error handling in entity creation."""
-    mock_reg = MagicMock()
-    mock_reg.async_get_entity_id.side_effect = ValueError("Processing Error")
+    """Test creating multiple parameter entities."""
+    with patch(
+        "custom_components.ramses_cc.number.get_param_descriptions"
+    ) as mock_get_desc:
+        mock_get_desc.return_value = [
+            RamsesNumberEntityDescription(key="p1", ramses_rf_attr="01"),
+            RamsesNumberEntityDescription(key="p2", ramses_rf_attr="02"),
+        ]
 
-    with (
-        patch("homeassistant.helpers.entity_registry.async_get", return_value=mock_reg),
-        patch(
-            "custom_components.ramses_cc.number.get_param_descriptions",
-            return_value=[RamsesNumberEntityDescription(key="p1", ramses_rf_attr="01")],
-        ),
-    ):
         entities = create_parameter_entities(mock_coordinator, mock_fan_device)
-        assert len(entities) == 0
+        assert len(entities) == 2
+        assert entities[0].entity_description.key == "p1"
+        assert entities[1].entity_description.key == "p2"
 
 
 async def test_create_parameter_entities_logic(


### PR DESCRIPTION
This PR targets https://github.com/ramses-rf/ramses_cc/issues/516

I ran into some problems with async compatiblility with _rf. We need to wait for #520 is merged and stable before merging this !

Also I will need to test this on HA and probably need additional async changes on other properties (if not done in #520 ).

I did include changes on coordinator that overlap with #520 


## Summary
Optimizes number entity creation and fixes async compatibility with ramses_rf 0.55.4+

## Changes
1. **number.py**: Remove unnecessary manual entity registry manipulation (~48 lines)
   - Simplifies [create_parameter_entities](cci:1://file:///home/willem/dev/ramses_cc/custom_components/ramses_cc/number.py:964:0-1014:19) to match [sensor.py](cci:7://file:///home/willem/dev/ramses_cc/custom_components/ramses_cc/sensor.py:0:0-0:0) pattern
   - Relies on HA's [async_add_entities()](cci:1://file:///home/willem/dev/ramses_cc/custom_components/ramses_cc/coordinator.py:548:8-556:13) for registry management
   
2. **coordinator.py**: Fix async compatibility for [_msg_value_code()](cci:1://file:///home/willem/dev/ramses_rf/src/ramses_rf/entity_base.py:430:4-480:58)
   - Make [_update_device()](cci:1://file:///home/willem/dev/ramses_cc/custom_components/ramses_cc/coordinator.py:463:4-505:9) async and await [device._msg_value_code()](cci:1://file:///home/willem/dev/ramses_rf/src/ramses_rf/entity_base.py:430:4-480:58)
   - Required for ramses_rf 0.55.4+ where this became async
   - Aligns with #520

## Testing
- ✅ All 462 tests pass
- ✅ mypy clean
- ✅ ruff clean

## Dependencies
- Requires ramses_rf >= 0.55.4
- Related to #520 (overlaps on coordinator.py fix)

## Notes
This PR targets ramses_rf **0.55.4** (stable). Additional changes may be needed for ramses_rf master (bleeding edge) where some properties became async methods.