### PR TITLE
Enhance Type Safety and Resolve Mypy Compliance Issues

### DIFF
--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -63,7 +63,7 @@ def ramses_device_id_to_ha_device_id(
     if not device_entry:
         return None
 
-    return device_entry.id
+    return cast(str, device_entry.id)
 
 
 def fields_to_aware(dt_or_none: datetime | str | None) -> datetime | None:
@@ -93,7 +93,7 @@ def fields_to_aware(dt_or_none: datetime | str | None) -> datetime | None:
         return final_dt
 
     # If it is naive, assume it is Local Time (Wall Clock) and make it aware
-    return dt_util.as_local(final_dt)
+    return cast(datetime, dt_util.as_local(final_dt))
 
 
 def as_iso(val: Any) -> str:

--- a/tests/tests_new/conftest.py
+++ b/tests/tests_new/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Generator
 from typing import Any
 from unittest.mock import patch
 
@@ -17,25 +17,38 @@ from syrupy.assertion import SnapshotAssertion
 try:
     from ..virtual_rf import VirtualRf
 except (ImportError, ModuleNotFoundError):
-    VirtualRf = None  # type: ignore[assignment,misc]  # Windows: pty/termios unavailable
+    VirtualRf = None  # Windows: pty/termios unavailable
 
 
 @pytest.fixture(autouse=True)
-def auto_enable_custom_integrations(enable_custom_integrations: pytest.fixture):  # type: ignore[no-untyped-def]
+def auto_enable_custom_integrations(
+    enable_custom_integrations: Any,
+) -> Generator[None]:
+    """Automatically enable custom integrations for all tests.
+
+    :param enable_custom_integrations: The fixture to enable.
+    :yield: None.
+    """
     yield
 
 
 # NOTE: ? workaround for: https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/198
 @pytest.fixture  # not loading from pytest_homeassistant_custom_component.plugins
 def snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
-    """Return snapshot assertion fixture with the Home Assistant extension."""
+    """Return snapshot assertion fixture with the Home Assistant extension.
+
+    :param snapshot: The base snapshot fixture.
+    :return: SnapshotAssertion with HA extension.
+    """
     return snapshot.use_extension(HomeAssistantSnapshotExtension)
 
 
 @pytest.fixture(autouse=True)
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Apply necessary monkeypatches before running tests."""
+    """Apply necessary monkeypatches before running tests.
 
+    :param monkeypatch: The pytest monkeypatch fixture.
+    """
     with contextlib.suppress(AttributeError):
         monkeypatch.setattr(
             "ramses_tx.protocol._DBG_DISABLE_IMPERSONATION_ALERTS",
@@ -53,16 +66,19 @@ def patches_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture()  # add hass fixture to ensure hass/rf use same event loop
 async def rf(hass: HomeAssistant) -> AsyncGenerator[Any]:
-    """Utilize a virtual evofw3-compatible gateway."""
+    """Utilize a virtual evofw3-compatible gateway.
 
+    :param hass: The Home Assistant core fixture.
+    :yield: An instance of VirtualRf.
+    """
     if VirtualRf is None:
         pytest.skip("VirtualRf not available on this platform (requires pty/termios)")
 
-    rf = VirtualRf(2)
-    rf.set_gateway(rf.ports[0], "18:006402")
+    rf_instance = VirtualRf(2)
+    rf_instance.set_gateway(rf_instance.ports[0], "18:006402")
 
-    with patch("serial.tools.list_ports.comports", rf.comports):
+    with patch("serial.tools.list_ports.comports", rf_instance.comports):
         try:
-            yield rf
+            yield rf_instance
         finally:
-            await rf.stop()
+            await rf_instance.stop()

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -1323,7 +1323,9 @@ async def test_zigbee_single_device_label_in_port_picker(hass: HomeAssistant) ->
     selector_obj = schema[port_name_key]
     # SelectSelectorConfig is a TypedDict (plain dict at runtime)
     config = getattr(selector_obj, "config", {})
-    options: list[dict] = config.get("options", []) if isinstance(config, dict) else []
+    options: list[dict[str, Any]] = (
+        config.get("options", []) if isinstance(config, dict) else []
+    )
     opts_by_value = {opt.get("value"): opt.get("label", "") for opt in options}
 
     zigbee_label = opts_by_value.get(CONF_ZIGBEE_DEVICE, "")


### PR DESCRIPTION
## The Problem:

The codebase contained several typing gaps that triggered `no-any-return` and `untyped-decorator` errors when running Mypy. Specifically, `helpers.py` returned `Any` from functions declared as `str | None` or `datetime | None`, and MQTT callback functions were considered untyped due to how Home Assistant's `@callback` decorator interacts with Mypy's strict mode. Additionally, VS Code reported several "ambiguous type" warnings in the test suite.

## Consequences:

Without these fixes, the system is susceptible to silent failures where a variable expected to be a string or datetime is actually `None` or an unexpected type. Furthermore, a lack of strict typing prevents the CI/CD pipeline from catching regressions early, leading to potential runtime `AttributeError` or `TypeError` exceptions in production.

## The Fix:

I implemented explicit type narrowing and casting across the core utility and MQTT bridge modules. I also introduced a type-safe decorator wrapper to bridge the gap between Home Assistant's callback logic and Mypy's requirements, ensuring all event handlers are fully typed.

## Technical Implementation:
- **Type Casting:** Utilized `typing.cast` in `helpers.py` to assert types for Home Assistant registry IDs and parsed datetimes where the library returns `Any`.
- **Decorator Narrowing:** Implemented a `TypeVar` bound wrapper (`_typed_callback`) in `mqtt_bridge.py` to preserve function signatures under the `@callback` decorator.
- **Signature Updates:** Replaced `Any` with `ReceiveMessage` from `homeassistant.components.mqtt` for all MQTT-related handlers.
- **Test Alignment:** Updated `conftest.py` and `test_config_flow.py` to match the refined function signatures, ensuring the test suite remains valid under stricter type checking.

## Testing Performed:
- **Unit Testing:** Ran the full `pytest` suite; all tests passed with 0 failures.
- **Static Analysis:** Verified that `mypy` (standard) returns no errors.
- **IDE Verification:** Confirmed that VS Code / Pylance no longer reports "Any" leakages or untyped function warnings in the modified files.

## Risks of NOT Implementing:

The primary danger is technical debt and "type rot," where the code becomes increasingly difficult to refactor safely. Silent failures in the MQTT bridge could lead to unprocessed packets or failed handshake sequences without clear error logs.

## Risks of Implementing:

Explicit casting (`cast`) tells the compiler to trust the developer. If the underlying Home Assistant API changes its return structure significantly, these casts could mask the need for logic updates, though the risk is minimal given the stability of the targeted APIs.

## Mitigation Steps:

The risk is mitigated by the existing `pytest` suite, which validates that the actual runtime types handled by these functions remain consistent with the types we are now explicitly claiming in the code.

## AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
