### PR TITLE
Bump version in manifest,python>=3.14 in gh actions

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-test.yml
+++ b/.github/workflows/check-test.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-type.yml
+++ b/.github/workflows/check-type.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.15.5
     hooks:
-      - id: ruff         # linter
+      - id: ruff-check   # linter
       - id: ruff-format  # formatter
 
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.7.0
+    rev: v0.8.1
     hooks:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.
@@ -18,13 +18,13 @@ repos:
       - id: python-typing-update
         stages: [manual]
         args:
-          - --py311-plus
+          - --py314-plus
           - --force
           - --keep-updates
         files: ^(custom_components|tests|docs)/.+\.py$
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
         args:

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -2,7 +2,7 @@
     "domain": "ramses_cc",
     "name": "RAMSES RF",
     "after_dependencies": ["mqtt"],
-    "codeowners": ["@zxdavb","@silverailscolo"],
+    "codeowners": ["@silverailscolo"],
     "config_flow": true,
     "dependencies": ["usb"],
     "documentation": "https://github.com/ramses-rf/ramses_cc",
@@ -13,8 +13,8 @@
     "requirements": [
       "aiousbwatcher>=1.1.1",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.55.3"
+      "ramses-rf==0.55.5"
     ],
     "single_config_entry": true,
-    "version": "0.55.3"
+    "version": "0.55.5"
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,25 @@
 #
 ### project ##########################################################################
-# last checked/updated: 2026-03-03
+# last checked/updated: 2026-03-12
 #
+[project]
+  name = "ramses_cc"
+  description = "Home Assistant custom integration for s stateful RAMSES-II protocol decoder & analyser."
+  readme = "README.md"
+  authors = [
+    {name = "Egbert Broerse", email = "dcc2@ebroerse.nl"}  # and many others
+  ]
+  maintainers = [
+    {name = "Egbert Broerse", email = "dcc2@ebroerse.nl"}
+  ]
+  license = "MIT"
+  license-files = ["LICENSE*"]
 
+  classifiers = [
+    "Topic :: Home Automation",
+    "Programming Language :: Python :: 3.14",
+  ]
+  requires-python = ">=3.14.2"        # HA core >=3.14.2
 #
 ### pytest ###########################################################################
 
@@ -110,7 +127,7 @@ directory = "coverage_html"
 [tool.ruff]
   # exclude = ["tests/deprecated/*.py"]
   src = ["custom_components"]
-  target-version = "py313"
+  target-version = "py313"  # to prevent except Err1, Err2: without () to pass
 
 
 [tool.ruff.lint]

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,5 +1,5 @@
 # Requirements to dev the source code
-# - last checked/updated: 2026-03-07 (c.f. HA 2026.3.1)
+# - last checked/updated: 2026-03-12 (c.f. HA 2026.3.1)
 
 # requirements (dependencies) are in manifest.json
 # - pip list | grep -E 'ramses|serial'
@@ -15,8 +15,8 @@
 
 # used for development (linting)
     prek == 0.3.4                                # HA core 2026.2.3 uses 0.2.28
-    ruff >= 0.13.0                               # latest: 0.15.0 See also: pre-commit-config.yaml
+    ruff >= 0.15.5                               # latest: 0.15.5 See also: pre-commit-config.yaml
 
 # used for development (typing)
-    mypy >= 1.18.0                               # latest: 1.18.2
-    voluptuous >= 0.15.2                         # latest: 0.15.2 = HA
+    mypy >= 1.18.0                               # latest: 1.19.1
+    voluptuous >= 0.15.2                         # latest: 0.16.0 = HA

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -1,5 +1,5 @@
 # Requirements to test the source code
-# - last checked/updated: 2026-03-03 (c.f. HA 2026.2.3)
+# - last checked/updated: 2026-03-12 (c.f. HA 2026.3.1)
 #
 
 # may need to use this version of ramses_rf...
@@ -14,4 +14,4 @@
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest
   # coverage >= 7.10.6 included in next item
-  pytest_homeassistant_custom_component >= 0.13.316
+  pytest_homeassistant_custom_component >= 0.13.317


### PR DESCRIPTION
- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used

**PR Summary**
Bump version, _rf dependency to 0.55.5, python to 3.14