### PR TITLE
mqtt_bridge: accept non-zero integer !V replies

### DIFF
--- a/custom_components/ramses_cc/mqtt_bridge.py
+++ b/custom_components/ramses_cc/mqtt_bridge.py
@@ -202,12 +202,12 @@ class RamsesMqttBridge:
                 result_str = ""
 
                 # Handle Integer vs String return types
-                # Scenario A: Firmware returns an int (e.g. 0)
-                # We must convert to string and synthesize a handshake response if needed.
+                # Scenario A: Firmware returns an int instead of console output.
+                # Current ramses_esp MQTT builds can do this for !V even when the
+                # command itself is not implemented, so synthesize a compatible
+                # handshake banner for any integer !V result.
                 if isinstance(return_val, int):
-                    # If this was a handshake request (!V) and it succeeded (0),
-                    # we MUST return a valid evofw3 signature or ramses_rf will abort.
-                    if cmd_val == "!V" and return_val == 0:
+                    if cmd_val == "!V":
                         result_str = "# evofw3 0.1.0"  # Fake response for compatibility
                     else:
                         result_str = str(return_val)

--- a/tests/tests_new/test_mqtt_bridge.py
+++ b/tests/tests_new/test_mqtt_bridge.py
@@ -426,7 +426,16 @@ async def test_bridge_handle_cmd_result_int(
     expected_response = "# evofw3 0.1.0\r\n"
     bridge._transport.receive_frame.assert_called_with(expected_response)
 
-    # Scenario 2: Other command returns int -> Handled by ELSE block (lines 194-197)
+    # Scenario 2: !V command returns a non-zero integer with an error string.
+    # Some ramses_esp MQTT builds publish this shape when !V is unsupported.
+    msg.payload = json.dumps(
+        {"cmd": "!V", "err": "ESP_ERR_NOT_FOUND", "return": 1107995988}
+    )
+    bridge._handle_cmd_message(msg)
+
+    bridge._transport.receive_frame.assert_called_with(expected_response)
+
+    # Scenario 3: Other command returns int -> Handled by ELSE block
     msg.payload = json.dumps({"cmd": "!C", "return": 0})
     bridge._handle_cmd_message(msg)
 


### PR DESCRIPTION
this is one part of a 3-PR interoperability set around `ramses_cc` MQTT transport and `ramses_esp` MQTT `!V` handling. The goal of opening all three together is to make review easier and keep the full failure chain visible in one place.

## Related WIP PRs

same firmware-side fix for the active ESP32-C6 fork that I am using
- https://github.com/IMMRMKW/ramses_esp/pull/3: 
- https://github.com/IMMRMKW/ramses_esp/pull/4

My view of merge order:
- this PR can merge independently as the compatibility fix for gateways already in the field
- the firmware PRs are the cleaner long-term fix and should make the `!V` handshake explicit instead of relying on bridge-side synthesis
- even if the firmware PRs merge, this bridge-side tolerance still looks worthwhile because it hardens recovery against older firmware already deployed

## Full context

I hit this while restoring a Home Assistant Orcon setup after the gateway rebooted.

At the time of failure:
- the gateway was back on Wi-Fi
- broker LWT was healthy again
- normal MQTT traffic existed on `RAMSES/GATEWAY/<id>/rx`
- the HA host could reach the gateway IP again
- but Home Assistant still could not finish loading `ramses_cc`

The Home Assistant symptom was repeated startup failure in the integration:

```text
Transport did not bind to Protocol within 60.0 secs
```

That left:
- `ramses_cc.send_packet` missing
- Orcon FAN/REM entities unavailable
- direct packet scripts dead even though MQTT transport was otherwise back

## Exact failure payload

The reconnect handshake path publishes `!V`.
The live gateway reply captured on `.../cmd/result` was:

```json
{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":1107995988}
```

This matters because `_handle_cmd_message()` currently only synthesizes the evofw3 compatibility banner when:
- `cmd == "!V"`
- integer `return == 0`

For the payload above, the bridge instead forwarded:

```text
# 1107995988\r\n
```

That is not a usable evofw3 handshake string, so `ramses_rf` never transitions cleanly and the integration keeps retrying startup.

## Root cause

The MQTT bridge currently assumes a very narrow `ramses_esp` integer handshake shape:
- integer `0` for `!V` means “synthesize `# evofw3 0.1.0`”
- any other integer just becomes a numeric string

That assumption is too strict for real deployed firmware.
Current `ramses_esp` MQTT implementations can publish integer `!V` results even when `!V` is unsupported, including non-zero/error cases.

## What this PR changes

This PR keeps the fix deliberately narrow:
- only affects `cmd == "!V"`
- only affects integer `return` values
- leaves all other integer command results unchanged

Behavior change:
- any integer `!V` reply is normalized to the existing synthetic handshake banner `# evofw3 0.1.0`

## Why this belongs in `ramses_cc`

`ramses_cc` already documents support for MQTT dongles running `ramses_esp`.
If the bridge uses `!V` as a reconnect handshake, it needs to be tolerant of the reply shapes that current `ramses_esp` MQTT firmware actually emits.

This is the compatibility/recovery fix for deployed systems.
The sibling firmware PRs are still valuable because they make the MQTT `!V` contract explicit and remove the bad payload at the source.

## Test coverage

Added a regression case for the exact payload above in `tests/tests_new/test_mqtt_bridge.py`.

## Validation

Locally validated:
- `git diff --check`
- `python3 -m py_compile custom_components/ramses_cc/mqtt_bridge.py tests/tests_new/test_mqtt_bridge.py`
- isolated Python 3.14 test run in a disposable container/venv:
  - `docker run --rm -v /workspaces/for_codex/upstreams/ramses_cc:/src -w /src python:3.14 bash -lc 'python -m venv .venv && . .venv/bin/activate && pip install -q --upgrade pip && pip install -q -r requirements/requirements_test.txt && pytest -q tests/tests_new/test_mqtt_bridge.py'`
  - result: `9 passed in 0.37s`

## Review questions

The main questions I would want maintainers to answer are:

1. whether `!V` should remain the reconnect handshake for MQTT transports at all
2. whether broader `ramses_esp` detection should eventually use a different signal, for example the MQTT `info/*` topics
3. whether this compatibility tolerance should stay even after firmware-side fixes merge, to avoid breaking existing deployed gateways
