### PR TITLE
fix bridge status discovery gap

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import re
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from copy import deepcopy
@@ -34,7 +35,7 @@ from ramses_rf.entity_base import Entity as RamsesRFEntity
 from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_rf.system import Evohome, System, Zone
 from ramses_rf.topology import Child
-from ramses_tx.const import Code
+from ramses_tx.const import SZ_ACTIVE_HGI, Code
 from ramses_tx.schemas import extract_serial_port
 
 from .const import (
@@ -71,6 +72,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 SAVE_STATE_INTERVAL: Final[timedelta] = timedelta(minutes=5)
+_DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9A-F]{2}:[0-9A-F]{6}$", re.I)
 
 
 class RamsesCoordinator(DataUpdateCoordinator):
@@ -592,6 +594,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
     async def _discover_new_entities(self) -> None:
         """Discover new devices in the client and register them with HA."""
         gwy: Gateway = self.client
+
+        engine = getattr(gwy, "_engine", None)
+        transport = getattr(engine, "_transport", None) or getattr(
+            gwy, "_transport", None
+        )
+        active_hgi_id = None
+        if transport is not None:
+            with suppress(Exception):
+                active_hgi_id = transport.get_extra_info(SZ_ACTIVE_HGI)
+        if not active_hgi_id:
+            active_hgi_id = getattr(engine, "_hgi_id", None)
+        if (
+            isinstance(active_hgi_id, str)
+            and _DEVICE_ID_RE.match(active_hgi_id)
+            and active_hgi_id not in gwy.device_registry.device_by_id
+        ):
+            with suppress(Exception):
+                gwy.device_registry.get_device(active_hgi_id)
 
         # Snapshot the lists to avoid RuntimeError if ramses_rf updates them continuously
         # This fixes the silent failure where list changes size during iteration

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -160,7 +160,8 @@ def resolve_async_attr(
                     # Update cache and trigger a state write if the value changed
                     if getattr(entity, cache_key, object()) != res:
                         setattr(entity, cache_key, res)
-                        entity.async_write_ha_state()
+                        if getattr(entity, "entity_id", None):
+                            entity.async_write_ha_state()
                 except Exception as err:
                     _LOGGER.debug("Error resolving async state %s: %s", attr_name, err)
                 finally:


### PR DESCRIPTION
Title: Fix timing issue in resolve_async_attr and restore gateway status discovery

The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
AI Coding Assistance disclosure: used for drafting/implementation assistance
PR Summary

This PR fixes a timing issue in resolve_async_attr() that could trigger async_write_ha_state() before Home Assistant had assigned an entity_id to the entity.

Problem
After the recent async-resolution compatibility changes, some entities could resolve background async attributes during setup and immediately write state back to HA. If this happened before the entity had been fully added, HA raised errors like:

No entity id specified for entity Battery
No entity id specified for entity Bypass position
At the same time, the gateway/bridge status binary sensor was no longer appearing reliably after startup.

Root cause
There were two related issues:

resolve_async_attr() updated HA state too early during entity setup
coordinator discovery relied on device_registry.devices, but the active HGI/gateway device was not always materialized there early enough to create the gateway status sensor
Changes
1. Guard early state writes in resolve_async_attr()
Only call entity.async_write_ha_state() when the entity already has an entity_id.

This prevents setup-time async resolution from causing HA entity lifecycle errors.

2. Ensure active HGI is materialized during discovery
In RamsesCoordinator._discover_new_entities():

read the active HGI ID from transport extra info or engine fallback
if it is a valid RAMSES device ID and is not yet present in the device registry, explicitly create/materialize it
This restores discovery of the gateway/HGI device so the Gateway status binary sensor can be created again.

Result
no more setup-time No entity id specified ... errors from async attribute resolution
gateway/bridge status sensor is discoverable again
binary sensor setup remains compatible with the recent ramses_rf changes
Testing
Tested locally with:

targeted binary sensor / discovery tests
full _cc local CI
Results:

21 passed for focused binary sensor/coordinator/init tests
462 passed
3 snapshots passed
make local-ci passed
Related issue
This PR fixes issue #532 - bridge issue

Status
PR text drafted
Ready to paste into the PR form