### PR TITLE
Fix Gateway serialization error and centralize entity availability logic

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -98,11 +98,6 @@ class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
         self._attr_unique_id = f"{device.id}-{entity_description.key}"
 
     @property
-    def available(self) -> bool:
-        """Return True if the entity is available."""
-        return self.state is not None
-
-    @property
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
         val = resolve_async_attr(
@@ -218,7 +213,13 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
                 }
 
             self._cached_attrs = {
-                SZ_SCHEMA: {gwy.tcs.id: gwy.tcs._schema_min} if gwy.tcs else {},
+                SZ_SCHEMA: {
+                    gwy.tcs.id: gwy.tcs._schema_min()
+                    if callable(gwy.tcs._schema_min)
+                    else gwy.tcs._schema_min
+                }
+                if gwy.tcs
+                else {},
                 SZ_CONFIG: {"enforce_known_list": enforce_known_list},
                 SZ_KNOWN_LIST: [{k: shrink(v)} for k, v in known_list.items()],
                 SZ_BLOCK_LIST: [{k: shrink(v)} for k, v in block_list.items()],

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import ATTR_ID
@@ -11,7 +12,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
+from ramses_rf.device import Fakeable
 from ramses_rf.entity_base import Entity as RamsesRFEntity
 
 from .const import DOMAIN, SIGNAL_UPDATE
@@ -67,6 +70,36 @@ class RamsesEntity(CoordinatorEntity):
 
         self._attr_unique_id = device.id
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device.id)})
+
+    @property
+    def available(self) -> bool:
+        """Return True if the entity is available based on recent communication.
+
+        Checks if the device is faked or if a valid packet has been received
+        within the last 60 minutes.
+
+        :return: True if the device is active and communicating, False otherwise.
+        """
+        if isinstance(self._device, Fakeable) and self._device.is_faked:
+            return True
+
+        state_store = getattr(self._device, "state_store", self._device)
+        msgs = getattr(state_store, "_msgs_", getattr(self._device, "_msgs", {}))
+
+        if not msgs:
+            return False
+
+        latest_dtm = None
+        for msg in msgs.values():
+            msg_dtm = getattr(msg, "dtm", None)
+            if msg_dtm:
+                if latest_dtm is None or msg_dtm > latest_dtm:
+                    latest_dtm = msg_dtm
+
+        if latest_dtm is None:
+            return False
+
+        return bool(dt_util.now() - dt_util.as_utc(latest_dtm) < timedelta(minutes=60))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -58,7 +58,6 @@ from ramses_rf.const import (
     SZ_SUPPLY_TEMP,
     SZ_TEMPERATURE,
 )
-from ramses_rf.device import Fakeable
 from ramses_rf.device.heat import (
     SZ_BOILER_OUTPUT_TEMP,
     SZ_BOILER_RETURN_TEMP,
@@ -137,14 +136,6 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         self._attr_unique_id = f"{device.id}-{entity_description.key}"
 
     @property
-    def available(self) -> bool:
-        """Return True if the entity is available."""
-        # TODO: Should use dtm of last packet received, rather than is not None
-        return (
-            isinstance(self._device, Fakeable) and self._device.is_faked
-        ) or self.state is not None  # TODO: but what if None _is_ its state?
-
-    @property
     def native_value(self) -> Any | None:
         """Return the native value of the sensor."""
         val = resolve_async_attr(
@@ -196,7 +187,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         assert self.native_unit_of_measurement == UnitOfTemperature.CELSIUS
 
         if not isinstance(self._device, DhwSensor):
-            raise TypeError(f"Cannot set CO2 level on {self._device}")
+            raise TypeError(f"Cannot set DHW temperature on {self._device}")
         # TODO: Until here
 
         # setter will raise an exception if device is not faked
@@ -234,7 +225,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         assert self.native_unit_of_measurement == UnitOfTemperature.CELSIUS
 
         if not isinstance(self._device, Thermostat):
-            raise TypeError(f"Cannot set CO2 level on {self._device}")
+            raise TypeError(f"Cannot set room temperature on {self._device}")
         # TODO: Until here
 
         # setter will raise an exception if device is not faked

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -43,6 +43,7 @@
       'attributes': ReadOnlyDict({
         'friendly_name': 'CTL 01:145038 Heat demand',
         'icon': 'mdi:radiator-off',
+        'id': '01:145038',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': '%',
       }),
@@ -51,7 +52,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'unavailable',
+      'state': 'unknown',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -89,6 +89,13 @@ async def test_generic_binary_sensor(mock_coordinator: MagicMock) -> None:
     mock_device = MagicMock()
     mock_device.id = "01:123456"
 
+    # Mock a recent message so availability check passes
+    # Assign to the state_store mock so the base RamsesEntity successfully evaluates it
+    msg_recent = MagicMock()
+    msg_recent.dtm = dt_util.now()
+    mock_device.state_store = MagicMock()
+    mock_device.state_store._msgs_ = {"0000": msg_recent}
+
     sensor = RamsesBinarySensor(mock_coordinator, mock_device, description)
 
     assert sensor.unique_id == "01:123456-test_sensor"
@@ -288,7 +295,11 @@ async def test_gateway_binary_sensor_attrs(mock_coordinator: MagicMock) -> None:
     # Setup the gateway mock to match the expected structure
     gwy = MagicMock()
     gwy.tcs.id = "01:111111"
-    gwy.tcs._schema_min = {"system_schema": "test"}
+
+    # Explicitly mock _schema_min as a callable to test the callable() check fix
+    mock_schema = MagicMock(return_value={"system_schema": "test"})
+    gwy.tcs._schema_min = mock_schema
+
     gwy.known_list = {"10:1": {"alias": "test", "class": "RAD", "faked": True}}
     gwy._engine = MagicMock()
     gwy._engine._enforce_known_list = True
@@ -299,11 +310,12 @@ async def test_gateway_binary_sensor_attrs(mock_coordinator: MagicMock) -> None:
 
     sensor: Any = RamsesGatewayBinarySensor(mock_coordinator, mock_device, description)
 
-    # Fetch attributes (should cache)
+    # Fetch attributes (should cache and unpack the callable)
     attrs = sensor.extra_state_attributes
 
     assert attrs["config"]["enforce_known_list"] is True
     assert "01:111111" in attrs["schema"]
+    assert attrs["schema"]["01:111111"] == {"system_schema": "test"}
     assert attrs[SZ_IS_EVOFW3] is True
 
     # Verify filtering/shrinking of known_list, ensure falsey/none values don't block

--- a/tests/tests_new/test_entity.py
+++ b/tests/tests_new/test_entity.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.const import ATTR_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.util import dt as dt_util
 
 from custom_components.ramses_cc.const import DOMAIN, SIGNAL_UPDATE
 from custom_components.ramses_cc.entity import RamsesEntity, RamsesEntityDescription
+from ramses_rf.device import Fakeable
 from ramses_rf.entity_base import Entity as RamsesRFEntity
 
 # Constants
@@ -18,7 +22,7 @@ DEVICE_ID = "32:123456"
 
 
 @pytest.fixture
-def mock_coordinator(hass: HomeAssistant) -> MagicMock:
+def mock_coordinator(hass: HomeAssistant) -> Any:
     """Return a mock coordinator."""
     coordinator = MagicMock()
     coordinator.hass = hass
@@ -27,14 +31,14 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
 
 
 @pytest.fixture
-def mock_device() -> MagicMock:
+def mock_device() -> Any:
     """Return a mock RAMSES RF entity."""
     device = MagicMock(spec=RamsesRFEntity)
     device.id = DEVICE_ID
     return device
 
 
-def test_init(mock_coordinator: MagicMock, mock_device: MagicMock) -> None:
+def test_init(mock_coordinator: Any, mock_device: Any) -> None:
     """Test entity initialization and default attributes."""
     description = RamsesEntityDescription(key="test_key")
     entity = RamsesEntity(mock_coordinator, mock_device, description)
@@ -45,9 +49,7 @@ def test_init(mock_coordinator: MagicMock, mock_device: MagicMock) -> None:
     assert entity.has_entity_name is True
 
 
-def test_extra_state_attributes_basic(
-    mock_coordinator: MagicMock, mock_device: MagicMock
-) -> None:
+def test_extra_state_attributes_basic(mock_coordinator: Any, mock_device: Any) -> None:
     """Test extra_state_attributes returns the device ID by default."""
     description = RamsesEntityDescription(key="test_key")
     entity = RamsesEntity(mock_coordinator, mock_device, description)
@@ -57,7 +59,7 @@ def test_extra_state_attributes_basic(
 
 
 def test_extra_state_attributes_with_extras(
-    mock_coordinator: MagicMock, mock_device: MagicMock
+    mock_coordinator: Any, mock_device: Any
 ) -> None:
     """Test extra_state_attributes includes mapped attributes from the device."""
     # Setup device with specific attributes
@@ -81,15 +83,56 @@ def test_extra_state_attributes_with_extras(
     assert "output_missing" not in attrs
 
 
+def test_available_property(mock_coordinator: Any, mock_device: Any) -> None:
+    """Test the 'available' property based on message timestamps."""
+    description = RamsesEntityDescription(key="test_key")
+    entity = RamsesEntity(mock_coordinator, mock_device, description)
+
+    # 1. No messages, not faked -> False
+    mock_device._msgs = {}
+    assert entity.available is False
+
+    # 2. Recent message -> True
+    msg_recent = MagicMock()
+    msg_recent.dtm = dt_util.now() - timedelta(minutes=30)
+    mock_device._msgs = {"1234": msg_recent}
+    assert entity.available is True
+
+    # 3. Old message (> 60 mins) -> False
+    msg_old = MagicMock()
+    msg_old.dtm = dt_util.now() - timedelta(minutes=65)
+    mock_device._msgs = {"1234": msg_old}
+    assert entity.available is False
+
+    # 4. State store overrides raw _msgs -> True
+    msg_recent_store = MagicMock()
+    msg_recent_store.dtm = dt_util.now() - timedelta(minutes=5)
+    mock_device.state_store = MagicMock()
+    mock_device.state_store._msgs_ = {"5678": msg_recent_store}
+    assert entity.available is True
+
+
+def test_available_property_faked(mock_coordinator: Any) -> None:
+    """Test the 'available' property for faked devices."""
+    description = RamsesEntityDescription(key="test_key")
+
+    # 5. Faked device -> True (even without messages)
+    mock_fake_device = MagicMock(spec=Fakeable)
+    mock_fake_device.id = "02:000000"
+    mock_fake_device.is_faked = True
+    mock_fake_device._msgs = {}
+    entity_fake = RamsesEntity(mock_coordinator, mock_fake_device, description)
+    assert entity_fake.available is True
+
+
 async def test_async_added_to_hass(
-    hass: HomeAssistant, mock_coordinator: MagicMock, mock_device: MagicMock
+    hass: HomeAssistant, mock_coordinator: Any, mock_device: Any
 ) -> None:
     """Test lifecycle hook when entity is added to Home Assistant."""
     description = RamsesEntityDescription(key="test_key")
     entity = RamsesEntity(mock_coordinator, mock_device, description)
     entity.hass = hass
 
-    # Mock the dispatcher connect function to verify subscription
     with (
         patch(
             "custom_components.ramses_cc.entity.async_dispatcher_connect"
@@ -108,5 +151,4 @@ async def test_async_added_to_hass(
         )
 
         # 3. Verify the signal listener cleanup is registered
-        # CoordinatorEntity also calls async_on_remove, so we check using assert_any_call
         mock_on_remove.assert_any_call(mock_connect.return_value)

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from homeassistant.config_entries import ConfigEntryState
@@ -73,8 +73,15 @@ async def test_entities(
     config = configuration_fixture(instance)
     config[DOMAIN]["serial_port"] = rf.ports[0]
 
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done()
+    # Patch 'available' to always be True during setup so historical packet logs
+    # render fully populated states in the snapshot, bypassing the 60-minute timeout.
+    with patch(
+        "custom_components.ramses_cc.entity.RamsesEntity.available",
+        new_callable=PropertyMock,
+        return_value=True,
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
 
     try:
         entry = hass.config_entries.async_entries(DOMAIN)[0]

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
@@ -19,7 +19,6 @@ from custom_components.ramses_cc.sensor import (
     RamsesSensor,
     async_setup_entry,
 )
-from ramses_rf.device import Fakeable
 from ramses_rf.device.heat import DhwSensor, Thermostat
 from ramses_rf.device.hvac import HvacCarbonDioxideSensor, HvacHumiditySensor
 from ramses_rf.entity_base import Entity as RamsesRFEntity
@@ -115,47 +114,6 @@ def test_sensor_init_and_properties(
     sensor = RamsesSensor(mock_coordinator, mock_device, desc)
 
     assert sensor.unique_id == "01:123456-test_key"
-    # assert sensor.entity_id == "sensor.01_123456_test_key"  # isn't set
-
-
-def test_sensor_available_property(
-    mock_coordinator: MagicMock, mock_device: MagicMock
-) -> None:
-    """Test the 'available' property logic."""
-    desc = MagicMock(spec=SensorEntityDescription)
-    desc.key = "test"
-    desc.ramses_rf_attr = "attr"
-    # Ensure translation_key is None to avoid ValueError in validation if called
-    desc.translation_key = None
-
-    sensor = RamsesSensor(mock_coordinator, mock_device, desc)
-
-    # 1. Not Fakeable, State is None -> False
-    # We patch SensorEntity.state because RamsesSensor inherits from it
-    with patch(
-        "homeassistant.components.sensor.SensorEntity.state", new_callable=PropertyMock
-    ) as mock_state:
-        mock_state.return_value = None
-        # Assign to variable to avoid Mypy narrowing the property permanently
-        is_available = sensor.available
-        assert is_available is False
-
-        # 2. Not Fakeable, State is 'active' (not None) -> True
-        mock_state.return_value = "21.5"
-        is_available = sensor.available
-        assert is_available is True
-
-        # 3. Fakeable and is_faked -> True (even if state is None)
-        mock_fake_device = MagicMock(spec=Fakeable)
-        mock_fake_device.id = "02:000000"
-        mock_fake_device.is_faked = True
-        sensor_fake = RamsesSensor(mock_coordinator, mock_fake_device, desc)
-
-        mock_state.return_value = None
-        # We must verify available on the sensor_fake instance
-        # Since logic calls self.state, which is inherited, patching the class affects it
-        is_available = sensor_fake.available
-        assert is_available is True
 
 
 def test_sensor_native_value(
@@ -264,8 +222,7 @@ def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:
     sensor_bad._attr_device_class = SensorDeviceClass.TEMPERATURE
     sensor_bad._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    # Error message in code is "Cannot set CO2 level on..." (copy-paste error in source)
-    with pytest.raises(TypeError, match="Cannot set CO2 level"):
+    with pytest.raises(TypeError, match="Cannot set DHW temperature"):
         sensor_bad.async_put_dhw_temp(50.0)
 
 
@@ -319,6 +276,5 @@ def test_async_put_room_temp(mock_coordinator: MagicMock) -> None:
     sensor_bad._attr_device_class = SensorDeviceClass.TEMPERATURE
     sensor_bad._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
-    # Error message in code is "Cannot set CO2 level on..."
-    with pytest.raises(TypeError, match="Cannot set CO2 level"):
+    with pytest.raises(TypeError, match="Cannot set room temperature"):
         sensor_bad.async_put_room_temp(21.0)


### PR DESCRIPTION
## The Problem:

This PR addresses two primary issues:
1. **Issue #532:** The integration was crashing during JSON serialization because `RamsesGatewayBinarySensor` was passing the `_schema_min` method object directly into Home Assistant state attributes instead of invoking it.
2. **Fragile Availability Logic:** As noted in existing code `TODO`s, entities were marked "Unavailable" based solely on whether their state was `None`. This caused many sensors (especially OpenTherm attributes) to drop offline unnecessarily if a specific packet hadn't been seen recently, even if the device was communicating perfectly.

## Consequences:

Failure to fix these issues results in:
- Home Assistant core components (Recorder, WebSocket API) crashing when attempting to process gateway attributes.
- Entities frequently and incorrectly flapping between "Available" and "Unavailable," breaking dashboards and long-term statistics.

## The Fix:

I have implemented a safe evaluation for gateway schema attributes and refactored the base `RamsesEntity` class to handle availability based on device communication timestamps rather than state values.

## Technical Implementation:
- **`binary_sensor.py`**: Added a `callable()` check when accessing `_schema_min` to ensure the payload is extracted before being passed to Home Assistant.
- **`entity.py`**: Implemented a centralized `available` property in the base class. It now scans the device's internal message log (`state_store._msgs_` or `_msgs`) for the most recent timestamp (`dtm`) and enforces a 60-minute timeout. It also explicitly handles `Fakeable` devices.
- **`sensor.py`**: Removed redundant availability overrides and corrected exception string typos.
- **`test_init.py`**: Patched the `available` property during integration tests to allow historical packet logs to render states correctly without causing asyncio event loop deadlocks.

## Testing Performed:
- **Mypy:** Passed strict type checking.
- **Ruff:** All files are compliant with linting and import sorting standards.
- **Pytest:** - Added unit tests in `test_entity.py` for the new timeout logic and `Fakeable` device support.
  - Updated `test_binary_sensor.py` to verify the `callable()` fix for the gateway.
  - Updated `test_init.py` snapshots and verified all 462 tests pass.

## Risks of NOT Implementing:

The integration will remain prone to JSON serialization crashes and will continue to provide a "brittle" user experience where sensors disappear from the UI due to logical errors rather than actual device failure.

## Risks of Implementing:

Entities that have truly gone offline will now take up to 60 minutes to show as "Unavailable" in the UI (previously they might have dropped sooner if their specific attribute was missing).

## Mitigation Steps:

The 60-minute window was chosen as a conservative balance to prevent false positives during normal RF quiet periods while still accurately flagging dead devices.

## AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
