### PR TITLE
Fix async boundary leaks in entity attributes and service calls

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -473,11 +473,13 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         return super().extra_state_attributes | {
             "params": resolve_async_attr(self, self._device, "params"),
             "zone_idx": self._device.idx,
-            "heating_type": getattr(self._device, "heating_type", None),
+            "heating_type": resolve_async_attr(self, self._device, "heating_type"),
             "mode": mode,
             "config": resolve_async_attr(self, self._device, "config"),
             "schedule": resolve_async_attr(self, self._device, "schedule"),
-            "schedule_version": getattr(self._device, "schedule_version", None),
+            "schedule_version": resolve_async_attr(
+                self, self._device, "schedule_version"
+            ),
         }
 
     @property
@@ -1006,8 +1008,8 @@ class RamsesClimateEntityDescription(RamsesEntityDescription, ClimateEntityDescr
     """Class describing Ramses binary sensor entities."""
 
     # integration-specific attributes
-    ramses_cc_class: type[Evohome] | type[Zone] | type[HvacVentilator]
-    ramses_rf_class: type[RamsesController] | type[RamsesZone] | type[RamsesHvac]
+    ramses_cc_class: type[RamsesController] | type[RamsesZone] | type[RamsesHvac]
+    ramses_rf_class: type[Evohome] | type[Zone] | type[HvacVentilator]
 
 
 CLIMATE_DESCRIPTIONS: tuple[RamsesClimateEntityDescription, ...] = (

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -66,7 +66,7 @@ class RamsesServiceHandler:
         device: Fakeable
 
         try:
-            device = self._coordinator.client.fake_device(call.data["device_id"])
+            device = await self._coordinator.client.fake_device(call.data["device_id"])
         except LookupError as err:
             _LOGGER.error("%s", err)
             raise HomeAssistantError(

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -145,7 +145,9 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
             "params": resolve_async_attr(self, self._device, "params"),
             "mode": mode,
             "schedule": resolve_async_attr(self, self._device, "schedule"),
-            "schedule_version": getattr(self._device, "schedule_version", None),
+            "schedule_version": resolve_async_attr(
+                self, self._device, "schedule_version"
+            ),
         }
 
     @property

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -106,7 +106,7 @@ async def test_bind_device_raises_ha_error(mock_coordinator: RamsesCoordinator) 
     mock_device._initiate_binding_process = AsyncMock(
         side_effect=BindingFlowFailed("Timeout waiting for confirm")
     )
-    mock_coordinator.client.fake_device.return_value = mock_device
+    mock_coordinator.client.fake_device = AsyncMock(return_value=mock_device)
 
     call = MagicMock()
     call.data = {
@@ -298,7 +298,7 @@ async def test_bind_device_success(mock_coordinator: RamsesCoordinator) -> None:
     mock_device = MagicMock()
     mock_device.id = "01:123456"
     mock_device._initiate_binding_process = AsyncMock(return_value=None)  # Success
-    mock_coordinator.client.fake_device.return_value = mock_device
+    mock_coordinator.client.fake_device = AsyncMock(return_value=mock_device)
 
     call = MagicMock()
     call.data = {
@@ -1126,7 +1126,7 @@ async def test_bind_device_generic_exception(
     # We must mock _initiate_binding_process on the device object itself,
     # NOT on the client.fake_device method (which only raises LookupError).
     mock_device = MagicMock()
-    mock_coordinator.client.fake_device.return_value = mock_device
+    mock_coordinator.client.fake_device = AsyncMock(return_value=mock_device)
     mock_device._initiate_binding_process = AsyncMock(
         side_effect=Exception("Surprise!")
     )


### PR DESCRIPTION
## The Problem:

The ongoing transition of the `ramses_rf` library to an asynchronous architecture created vulnerable boundaries within the integration. Synchronous Home Assistant properties (`extra_state_attributes`) and service handlers were directly accessing attributes or calling methods that could return un-awaited coroutines (specifically `schedule_version`, `heating_type`, and `fake_device()`). Additionally, `RamsesClimateEntityDescription` contained inverted Mypy type hints.

## Consequences:

If Home Assistant's synchronous state machine attempts to process a coroutine object instead of a primitive type, it causes the SQLite Recorder to crash with a `TypeError: Type is not JSON serializable: coroutine`. Furthermore, un-awaited coroutines in service handlers result in silent execution failures, meaning tasks like faking/binding a device simply do not happen.

## The Fix:

Audited and patched entity properties to use the `resolve_async_attr` helper, ensuring safe, synchronous value resolution for HA. Awaited the asynchronous `fake_device` call in the binding service, corrected the Mypy type hints, and updated the corresponding pytest mocks.

## Technical Implementation:
- **`climate.py` & `water_heater.py`**: Replaced raw `getattr()` lookups for `schedule_version` and `heating_type` inside `extra_state_attributes` with the `resolve_async_attr` helper.
- **`services.py`**: Added the `await` keyword to `self._coordinator.client.fake_device(call.data["device_id"])` within `async_bind_device`.
- **`climate.py`**: Swapped the type definitions for `ramses_cc_class` and `ramses_rf_class` in `RamsesClimateEntityDescription` to resolve Mypy assignment errors.
- **`test_services.py`**: Converted `mock_coordinator.client.fake_device` assignments to use `AsyncMock(return_value=mock_device)` to accommodate the updated service handler logic.

## Testing Performed:
- Ran strict Mypy type checking across the codebase with 0 errors reported.
- Ran the full pytest suite. Specifically verified that `test_services.py` successfully mocks the newly awaited `fake_device` call across the happy path, HA error simulation, and generic exception test cases.

## Risks of NOT Implementing:

The integration remains highly susceptible to critical HA Recorder crashes when serializing state histories. Service calls designed to bind fake devices will silently fail, leading to significant user confusion and broken configurations.

## Risks of Implementing:

Minimal. The `resolve_async_attr` helper acts as a safe bridge that handles both synchronous and asynchronous underlying methods dynamically, ensuring backwards compatibility regardless of the exact current state of the `ramses_rf` library refactor.

## Mitigation Steps:

Leveraged the heavily tested `resolve_async_attr` helper to gracefully handle background coroutine resolution without blocking the HA event loop. Updated automated tests to strictly enforce the new asynchronous behavior of the `fake_device` dependency.

## AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.