### PR TITLE
Fix 'duplicate id' errors on numbers (2411_params)

### DIFF
--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -114,7 +114,7 @@ def _migrate_legacy_param_entity_ids(hass: HomeAssistant) -> None:
     if entries is None:
         entries = getattr(registry, "_entities", {})
 
-    values = entries.values() if hasattr(entries, "values") else ()
+    values = list(entries.values()) if hasattr(entries, "values") else []
     for entity in values:
         if getattr(entity, "domain", None) != "number":
             continue

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -106,6 +106,51 @@ def _has_existing_param_entities(entity_registry: Any, device_id: str) -> bool:
     return False
 
 
+def _migrate_legacy_param_entity_ids(hass: HomeAssistant) -> None:
+    registry = er.async_get(hass)
+    migrated_count = 0
+
+    entries = getattr(registry, "entities", None)
+    if entries is None:
+        entries = getattr(registry, "_entities", {})
+
+    values = entries.values() if hasattr(entries, "values") else ()
+    for entity in values:
+        if getattr(entity, "domain", None) != "number":
+            continue
+
+        if entity.platform != DOMAIN:
+            continue
+
+        entity_id = entity.entity_id
+        if not entity_id.startswith("number."):
+            continue
+
+        suffix = entity_id.removeprefix("number.")
+        if "_param_" not in suffix or not suffix.startswith("fan_"):
+            continue
+
+        new_entity_id = f"number.{suffix.removeprefix('fan_')}"
+        if registry.async_get(new_entity_id) is not None:
+            continue
+
+        try:
+            registry.async_update_entity(entity_id, new_entity_id=new_entity_id)
+            migrated_count += 1
+        except ValueError as err:
+            _LOGGER.warning(
+                "Failed to migrate param entity %s to %s: %s",
+                entity_id,
+                new_entity_id,
+                err,
+            )
+
+    if migrated_count:
+        _LOGGER.info(
+            "Migrated %d fan parameter entities to unprefixed IDs", migrated_count
+        )
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -123,6 +168,8 @@ async def async_setup_entry(
     :return: None
     :rtype: None
     """
+
+    _migrate_legacy_param_entity_ids(hass)
 
     coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
     platform: EntityPlatform = async_get_current_platform()
@@ -1033,9 +1080,7 @@ def create_parameter_entities(
 
         param_id = getattr(description, "ramses_rf_attr", "unknown")
         unique_id = f"{device_id}_param_{param_id.lower()}"
-        slug = getattr(device, "_SLUG", "")
-        slug_prefix = f"{slug.lower()}_" if slug else ""
-        suggested_object_id = f"{slug_prefix}{device_id}_param_{param_id.lower()}"
+        suggested_object_id = f"{device_id}_param_{param_id.lower()}"
         desired_entity_id = f"number.{suggested_object_id}"
 
         # The entity key is already set correctly in get_param_descriptions()

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -376,7 +376,7 @@ async def test_find_param_entity_logic(
     with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
         mock_registry = MagicMock()
         mock_er_get.return_value = mock_registry
-        mock_registry.async_get_entity_id.return_value = "number.fan_30_123456_param_10"
+        mock_registry.async_get_entity_id.return_value = "number.30_123456_param_10"
 
         # Ensure platforms dict is empty or platform has no entities
         mock_coordinator.platforms = {}
@@ -388,7 +388,7 @@ async def test_find_param_entity_logic(
     with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
         mock_registry = MagicMock()
         mock_er_get.return_value = mock_registry
-        target_id = "number.fan_30_123456_param_10"
+        target_id = "number.30_123456_param_10"
         mock_registry.async_get_entity_id.return_value = target_id
 
         # Setup fake platform

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -9,12 +9,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant, ServiceRegistry
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.ramses_cc.const import DOMAIN
 from custom_components.ramses_cc.number import (
     RamsesNumberBase,
     RamsesNumberEntityDescription,
     RamsesNumberParam,
+    _migrate_legacy_param_entity_ids,
     async_setup_entry,
     create_parameter_entities,
     get_param_descriptions,
@@ -617,6 +619,86 @@ async def test_create_parameter_entities_no_support(
     mock_fan_device.supports_2411 = False
     entities = create_parameter_entities(mock_coordinator, mock_fan_device)
     assert len(entities) == 0
+
+
+def test_migrate_legacy_param_entity_ids(hass: HomeAssistant) -> None:
+    """Test migration of legacy fan-prefixed parameter entity IDs."""
+    ent_reg = er.async_get(hass)
+    legacy = ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        "30_999888_param_01",
+        suggested_object_id="fan_30_999888_param_01",
+    )
+
+    assert legacy.entity_id == "number.fan_30_999888_param_01"
+
+    _migrate_legacy_param_entity_ids(hass)
+
+    migrated = ent_reg.async_get_entity_id("number", DOMAIN, "30_999888_param_01")
+    assert migrated == "number.30_999888_param_01"
+    assert ent_reg.async_get("number.fan_30_999888_param_01") is None
+
+
+def test_migrate_legacy_param_entity_ids_skips_existing_target(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration skip when the unprefixed target already exists."""
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        "30_999888_param_01",
+        suggested_object_id="fan_30_999888_param_01",
+    )
+    ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        "30_999888_param_02",
+        suggested_object_id="30_999888_param_02",
+    )
+    legacy = ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        "30_999888_param_02_legacy",
+        suggested_object_id="fan_30_999888_param_02",
+    )
+
+    _migrate_legacy_param_entity_ids(hass)
+
+    assert legacy.entity_id == "number.fan_30_999888_param_02"
+    assert ent_reg.async_get("number.30_999888_param_02") is not None
+
+
+def test_migrate_legacy_param_entity_ids_ignores_unrelated_entries(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration ignores unrelated entries."""
+    ent_reg = er.async_get(hass)
+    switch_entry = ent_reg.async_get_or_create(
+        "switch",
+        DOMAIN,
+        "30_999888_param_03_switch",
+        suggested_object_id="fan_30_999888_param_03",
+    )
+    other_platform = ent_reg.async_get_or_create(
+        "number",
+        "other_domain",
+        "30_999888_param_04_other",
+        suggested_object_id="fan_30_999888_param_04",
+    )
+    missing_prefix = ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        "30_999888_param_05",
+        suggested_object_id="30_999888_param_05",
+    )
+
+    _migrate_legacy_param_entity_ids(hass)
+
+    assert switch_entry.entity_id == "switch.fan_30_999888_param_03"
+    assert other_platform.entity_id == "number.fan_30_999888_param_04"
+    assert missing_prefix.entity_id == "number.30_999888_param_05"
 
 
 async def test_create_parameter_entities_error(


### PR DESCRIPTION
This PR rolls back the slug prefix naming that was also rolled back for other entities.

Without this PR we can see duplicate id Errors on FAN devices.
It also includes a migration to rename existing entities to the format without slug prefix.

c26a835 removed manual entity_id handling for other platforms like binary_sensor.py and climate.py, letting HA generate IDs.
c27d6e2 rolled back binary sensor changes.
In number.py, the fan_ object-id prefix came from ed5d894:
suggested_object_id = f"{slug_prefix}{device_id}_param_{param_id.lower()}"