### PR TITLE
Style: Enforce and apply `datetime` as `dt` and `timedelta` as `td` import aliases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-
 # exclude: ^(.secrets|docs|misc)/
 
 repos:
@@ -81,6 +80,13 @@ repos:
       entry: ' as exc?:'
       language: pygrep
       args: [-i]
+      exclude: .pre-commit-config.yaml  # avoid false +ve
+
+    - id: datetime_aliases
+      name: enforce datetime as dt and timedelta as td
+      entry: 'from datetime import.*\b(datetime(?! as dt)|timedelta(?! as td))\b'
+      language: pygrep
+      types: [python]
       exclude: .pre-commit-config.yaml  # avoid false +ve
 
     # - id: private imports

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from typing import Any, Final
 
 import voluptuous as vol
@@ -375,8 +375,8 @@ class RamsesController(RamsesEntity, ClimateEntity):
     async def async_set_system_mode(
         self,
         mode: str,
-        period: timedelta | None = None,
-        duration: timedelta | None = None,
+        period: td | None = None,
+        duration: td | None = None,
     ) -> None:
         """Set the (native) operating mode of the Controller.
 
@@ -408,8 +408,8 @@ class RamsesController(RamsesEntity, ClimateEntity):
             until = None
         elif period.seconds == period.microseconds == 0:
             # this is the behaviour of an evohome controller
-            date_ = dt_util.now().date() + timedelta(days=1) + period
-            until = dt_util.as_utc(datetime(date_.year, date_.month, date_.day))
+            date_ = dt_util.now().date() + td(days=1) + period
+            until = dt_util.as_utc(dt(date_.year, date_.month, date_.day))
         else:
             until = dt_util.now() + period
         # duration and/or period are now in until
@@ -628,7 +628,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
                 setpoint=self.target_temperature
                 if preset_mode != PRESET_NONE
                 else None,
-                duration=timedelta(hours=1)
+                duration=td(hours=1)
                 if preset_mode == PRESET_TEMPORARY
                 else None,  # why 1H?
             )
@@ -642,8 +642,8 @@ class RamsesZone(RamsesEntity, ClimateEntity):
     async def async_set_temperature(
         self,
         temperature: float | None = None,
-        duration: timedelta | None = None,
-        until: datetime | None = None,
+        duration: td | None = None,
+        until: dt | None = None,
         **kwargs: Any,
     ) -> None:
         """Set a new target temperature.
@@ -745,8 +745,8 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         self,
         mode: str | None = None,
         setpoint: float | None = None,
-        duration: timedelta | None = None,
-        until: datetime | None = None,
+        duration: td | None = None,
+        until: dt | None = None,
     ) -> None:
         """Set the (native) operating mode of the Zone.
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -9,7 +9,7 @@ import re
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from threading import Semaphore
 from typing import TYPE_CHECKING, Any, Final
 
@@ -71,7 +71,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-SAVE_STATE_INTERVAL: Final[timedelta] = timedelta(minutes=5)
+SAVE_STATE_INTERVAL: Final[td] = td(minutes=5)
 _DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9A-F]{2}:[0-9A-F]{6}$", re.I)
 
 
@@ -123,7 +123,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=scan_interval),
+            update_interval=td(seconds=scan_interval),
         )
 
     def _get_saved_packets(self, client_state: dict[str, Any]) -> dict[str, str]:
@@ -138,7 +138,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Iterate over packets from storage
         for dtm, pkt in client_state.get(SZ_PACKETS, {}).items():
             try:
-                dt_obj = datetime.fromisoformat(dtm)
+                dt_obj = dt.fromisoformat(dtm)
                 if dt_obj.tzinfo is None:
                     dt_obj = dt_obj.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
             except ValueError:
@@ -149,7 +149,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
             # Check age (keep last 24 hours) and known list enforcement
             if (
-                dt_obj > now - timedelta(days=1)
+                dt_obj > now - td(days=1)
                 and pkt[41:45] not in msg_code_filter
                 and (
                     not enforce_known_list
@@ -235,7 +235,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             async_track_time_interval(
                 self.hass,
                 self._async_discovery_task,
-                timedelta(seconds=self.entry.options.get(CONF_SCAN_INTERVAL, 60)),
+                td(seconds=self.entry.options.get(CONF_SCAN_INTERVAL, 60)),
             )
         )
 
@@ -405,7 +405,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 **kwargs,
             )
 
-    async def async_save_client_state(self, _: datetime | None = None) -> None:
+    async def async_save_client_state(self, _: dt | None = None) -> None:
         """Save the current state of the RAMSES client to persistent storage.
 
         :param _: Optional datetime argument from async_track_time_interval.
@@ -586,7 +586,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         return None
 
-    async def _async_discovery_task(self, _now: datetime | None = None) -> None:
+    async def _async_discovery_task(self, _now: dt | None = None) -> None:
         """Wrapper to call discovery from the interval listener."""
         try:
             await self._discover_new_entities()

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from datetime import timedelta
+from datetime import timedelta as td
 from typing import Any, Final, NewType
 
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
@@ -90,8 +90,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NUM_REPEATS: Final[int] = 3  # override ramses_rf DEFAULT_NUM_REPEATS
 
 # Configuration schema for Integration/domain
-SCAN_INTERVAL_DEFAULT = timedelta(seconds=60)
-SCAN_INTERVAL_MINIMUM = timedelta(seconds=3)
+SCAN_INTERVAL_DEFAULT = td(seconds=60)
+SCAN_INTERVAL_MINIMUM = td(seconds=3)
 
 # Schema regex matches
 _SCH_DEVICE_ID = cv.matches_regex(r"^[0-9]{2}:[0-9]{6}$")
@@ -362,10 +362,10 @@ SVCS_RAMSES_SENSOR = {
 
 SCH_DURATION = vol.All(  # of time (<=24h)
     cv.time_period,
-    vol.Range(min=timedelta(hours=1), max=timedelta(hours=24)),
+    vol.Range(min=td(hours=1), max=td(hours=24)),
 )
 SCH_PERIOD = vol.All(  # of days (0-99)
-    cv.time_period, vol.Range(min=timedelta(days=0), max=timedelta(days=99))
+    cv.time_period, vol.Range(min=td(days=0), max=td(days=99))
 )
 
 SVC_SET_SYSTEM_MODE: Final = "set_system_mode"
@@ -450,7 +450,7 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
         vol.Optional(ATTR_UNTIL): cv.datetime,
         vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
-            vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+            vol.Range(min=td(minutes=5), max=td(days=1)),
         ),
     }
 )
@@ -476,9 +476,9 @@ SCH_SET_ZONE_MODE_EXTRA = (
                 vol.Required(ATTR_SETPOINT): vol.All(
                     cv.positive_float, vol.Range(min=5, max=35)
                 ),
-                vol.Required(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
+                vol.Required(ATTR_DURATION, default=td(hours=1)): vol.All(
                     cv.time_period,
-                    vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+                    vol.Range(min=td(minutes=5), max=td(days=1)),
                 ),
             },
             {  # D
@@ -638,7 +638,7 @@ SCH_SET_DHW_MODE = cv.make_entity_service_schema(
         vol.Optional(ATTR_UNTIL): cv.datetime,
         vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
-            vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+            vol.Range(min=td(minutes=5), max=td(days=1)),
         ),
     }
 )
@@ -657,9 +657,9 @@ SCH_SET_DHW_MODE_EXTRA = vol.Schema(  # original Entity Service action validatio
         {  # B a.k.a DHW boost
             vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
             vol.Required(ATTR_ACTIVE): True,  # TODO: vol.Any(truthy)
-            vol.Required(ATTR_DURATION, default=timedelta(hours=1)): vol.All(
+            vol.Required(ATTR_DURATION, default=td(hours=1)): vol.All(
                 cv.time_period,
-                vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+                vol.Range(min=td(minutes=5), max=td(days=1)),
             ),
         },
         {  # C
@@ -667,7 +667,7 @@ SCH_SET_DHW_MODE_EXTRA = vol.Schema(  # original Entity Service action validatio
             vol.Required(ATTR_ACTIVE): cv.boolean,
             vol.Required(ATTR_DURATION): vol.All(
                 cv.time_period,
-                vol.Range(min=timedelta(minutes=5), max=timedelta(days=1)),
+                vol.Range(min=td(minutes=5), max=td(days=1)),
             ),
         },
         {  # D

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from typing import Any, Final
 
 from homeassistant.components.water_heater import (
@@ -174,11 +174,11 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         :raises ServiceValidationError: If the backend call fails.
         """
         active: bool | None = None
-        until: datetime | None = None  # for STATE_AUTO
+        until: dt | None = None  # for STATE_AUTO
 
         if operation_mode == STATE_BOOST:
             active = True
-            until = dt_util.now() + timedelta(hours=1)
+            until = dt_util.now() + td(hours=1)
         elif operation_mode == STATE_OFF:
             active = False
         elif operation_mode == STATE_ON:
@@ -276,8 +276,8 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         self,
         mode: str | None = None,
         active: bool | None = None,
-        duration: timedelta | None = None,
-        until: datetime | None = None,
+        duration: td | None = None,
+        until: dt | None = None,
     ) -> None:
         """Set the (native) operating mode of the water heater.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime as dt
 
 # sys.path.insert(0, os.path.abspath("."))  # required to import src
 sys.path.insert(0, os.path.abspath("../../custom_components"))
@@ -23,7 +23,7 @@ authors = "D. Bonnes, E. Broerse"
 # see https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Ramses RF"
-copyright = f"{datetime.now().year}, {authors}"
+copyright = f"{dt.now().year}, {authors}"
 author = authors
 release = version
 

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1,6 +1,6 @@
 """Tests for the ramses_cc climate platform to achieve 100% coverage."""
 
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -137,7 +137,7 @@ async def test_controller_properties_and_attributes(
 
     # Coverage for lines 213-214: system_mode with 'until'
     # Inject a naive datetime to verify fields_to_aware processing
-    naive_dt = datetime(2023, 1, 1, 12, 0, 0)
+    naive_dt = dt(2023, 1, 1, 12, 0, 0)
     mock_device.system_mode = MagicMock(
         return_value={SZ_SYSTEM_MODE: SystemMode.AUTO, "until": naive_dt}
     )
@@ -300,26 +300,26 @@ async def test_controller_services(
         freezer.move_to("2023-01-01 12:00:00")
 
         # Case B: Duration provided (Coverage for lines 266 & 273)
-        test_duration = timedelta(hours=1)
+        test_duration = td(hours=1)
         await controller.async_set_system_mode("auto", duration=test_duration)
 
         # 12:00 + 1h = 13:00
-        expected_until_dur = dt_util.as_utc(datetime(2023, 1, 1, 13, 0, 0))
+        expected_until_dur = dt_util.as_utc(dt(2023, 1, 1, 13, 0, 0))
         mock_device.set_mode.assert_awaited_with("auto", until=expected_until_dur)
 
         # Case C: Period 0 (Next Day)
-        zero_period = timedelta(0)
+        zero_period = td(0)
         await controller.async_set_system_mode("auto", period=zero_period)
 
         # Calculation for next day 00:00:00 local time
-        expected_midnight = dt_util.as_utc(datetime(2023, 1, 2, 0, 0, 0))
+        expected_midnight = dt_util.as_utc(dt(2023, 1, 2, 0, 0, 0))
         mock_device.set_mode.assert_awaited_with("auto", until=expected_midnight)
 
         # Case D: Standard Period
-        std_period = timedelta(hours=2)
+        std_period = td(hours=2)
         await controller.async_set_system_mode("auto", period=std_period)
         # Use dt_util.as_utc to ensure the object matches the aware datetime from the mock
-        expected_std_until = dt_util.as_utc(datetime(2023, 1, 1, 14, 0, 0))
+        expected_std_until = dt_util.as_utc(dt(2023, 1, 1, 14, 0, 0))
         mock_device.set_mode.assert_awaited_with("auto", until=expected_std_until)
 
     # 3. Service Calls
@@ -378,7 +378,7 @@ async def test_zone_properties_and_config(
     assert attrs["zone_idx"] == "01"
 
     # Coverage for mode with 'until'
-    naive_dt = datetime(2023, 1, 1, 12, 0, 0)
+    naive_dt = dt(2023, 1, 1, 12, 0, 0)
     mock_device.mode = MagicMock(
         return_value={SZ_MODE: ZoneMode.TEMPORARY, "until": naive_dt}
     )
@@ -560,13 +560,13 @@ async def test_zone_methods_and_services(
             mode=ZoneMode.ADVANCED, setpoint=21.0, duration=None, until=None
         )
         # C. Duration -> Temporary
-        dur = timedelta(hours=1)
+        dur = td(hours=1)
         await zone.async_set_temperature(temperature=21.0, duration=dur)
         mock_set.assert_called_with(
             mode=ZoneMode.TEMPORARY, setpoint=21.0, duration=dur, until=None
         )
         # D. Until -> Temporary (Covering 'or until is not None' branch)
-        until = datetime(2023, 1, 1, 12, 0, 0)
+        until = dt(2023, 1, 1, 12, 0, 0)
         await zone.async_set_temperature(temperature=21.0, until=until)
         mock_set.assert_called_with(
             mode=ZoneMode.TEMPORARY, setpoint=21.0, duration=None, until=until
@@ -582,23 +582,23 @@ async def test_zone_methods_and_services(
 
         # Case: Duration provided (schema returns dict with duration)
         m_sch.side_effect = None
-        m_sch.return_value = {"duration": timedelta(hours=1)}
+        m_sch.return_value = {"duration": td(hours=1)}
         freezer.move_to("2023-01-01 12:00:00")
 
-        await zone.async_set_zone_mode(mode="temp", duration=timedelta(hours=1))
+        await zone.async_set_zone_mode(mode="temp", duration=td(hours=1))
 
         # Expected is now 13:00 UTC
-        expected_until = dt_util.as_utc(datetime(2023, 1, 1, 13, 0, 0))
+        expected_until = dt_util.as_utc(dt(2023, 1, 1, 13, 0, 0))
         mock_device.set_mode.assert_awaited_with(
             mode="temp", setpoint=None, until=expected_until
         )
 
         # Case: Duration provided BUT until is ALSO provided
         # if until is None and "duration" in checked_entry: -> False because until is NOT None
-        m_sch.return_value = {"duration": timedelta(hours=1)}
-        explicit_until = datetime(2023, 1, 1, 15, 0, 0)
+        m_sch.return_value = {"duration": td(hours=1)}
+        explicit_until = dt(2023, 1, 1, 15, 0, 0)
         await zone.async_set_zone_mode(
-            mode="temp", duration=timedelta(hours=1), until=explicit_until
+            mode="temp", duration=td(hours=1), until=explicit_until
         )
         # Expectation: The loop calculation for until is SKIPPED, uses explicit_until
         mock_device.set_mode.assert_awaited_with(
@@ -917,7 +917,7 @@ async def test_zone_extended_coverage(
     with patch.object(zone, "async_set_zone_mode") as mock_set:
         await zone.async_set_preset_mode(PRESET_TEMPORARY)
         mock_set.assert_called_with(
-            mode=ZoneMode.TEMPORARY, setpoint=20.0, duration=timedelta(hours=1)
+            mode=ZoneMode.TEMPORARY, setpoint=20.0, duration=td(hours=1)
         )
 
     # 2. Preset Permanent

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5,7 +5,7 @@ options menu (OptionsFlow).
 """
 
 from collections.abc import Callable, Iterator
-from datetime import timedelta
+from datetime import timedelta as td
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -438,7 +438,7 @@ async def test_import_flow(hass: HomeAssistant) -> None:
             DOMAIN,
             context={"source": "import"},
             data={
-                CONF_SCAN_INTERVAL: timedelta(seconds=60),
+                CONF_SCAN_INTERVAL: td(seconds=60),
                 SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
                 CONF_RAMSES_RF: {},
                 "restore_cache": True,  # Should be popped

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncGenerator
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
@@ -452,7 +452,7 @@ async def test_setup_ignores_invalid_cached_packet_timestamps(
     coordinator = RamsesCoordinator(mock_hass, mock_entry)
 
     # Use a fresh timestamp for the valid packet so it isn't filtered out by the 24h check
-    now: datetime = dt_util.now()
+    now: dt = dt_util.now()
     valid_dtm: str = now.isoformat()
     invalid_dtm = "invalid-iso-format"
 
@@ -950,7 +950,7 @@ async def test_setup_with_corrupted_storage_dates(
     # 2. Mock Storage with corrupted date
     # Valid date: 2023-01-01T12:00:00
     # Invalid date: "INVALID-DATE-STRING"
-    now: datetime = dt_util.now()
+    now: dt = dt_util.now()
     timestamp: str = now.isoformat()
     mock_storage_data = {
         SZ_CLIENT_STATE: {
@@ -992,9 +992,9 @@ async def test_setup_packet_filtering(
     mock_client.start = AsyncMock()
     coordinator._create_client = MagicMock(return_value=mock_client)
 
-    now: datetime = dt_util.now()
-    old_date = (now - timedelta(days=2)).isoformat()
-    recent_date = (now - timedelta(hours=1)).isoformat()
+    now: dt = dt_util.now()
+    old_date = (now - td(days=2)).isoformat()
+    recent_date = (now - td(hours=1)).isoformat()
 
     # Known list contains a device 01:123456
     coordinator.options[SZ_KNOWN_LIST] = {"01:123456": {}}
@@ -1012,7 +1012,7 @@ async def test_setup_packet_filtering(
             SZ_PACKETS: {
                 old_date: valid_packet,  # Too old
                 recent_date: valid_packet,  # Good
-                (now - timedelta(minutes=1)).isoformat(): unknown_packet,  # Unknown
+                (now - td(minutes=1)).isoformat(): unknown_packet,  # Unknown
             }
         }
     }
@@ -1079,7 +1079,7 @@ async def test_setup_handles_naive_timestamps(
 
     # Patch dt_util.now() to ensure the packet isn't discarded as too old
     # Packet is 2023-01-01, so we pretend "now" is 2023-01-01 13:00
-    fake_now = datetime(2023, 1, 1, 13, 0, 0, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    fake_now = dt(2023, 1, 1, 13, 0, 0, tzinfo=dt_util.DEFAULT_TIME_ZONE)
 
     with patch("homeassistant.util.dt.now", return_value=fake_now):
         await coordinator.async_setup()

--- a/tests/tests_new/test_helpers.py
+++ b/tests/tests_new/test_helpers.py
@@ -5,7 +5,7 @@ mappings between Home Assistant and RAMSES RF hardware IDs, as well as
 datetime utility functions.
 """
 
-from datetime import datetime
+from datetime import datetime as dt
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -96,7 +96,7 @@ def test_fields_to_aware_parsing() -> None:
     # Test valid ISO string
     iso_str = "2024-01-20T12:00:00"
     result = fields_to_aware(iso_str)
-    assert isinstance(result, datetime)
+    assert isinstance(result, dt)
     assert result.year == 2024
 
     # Test invalid string that fails parsing
@@ -110,7 +110,7 @@ def test_fields_to_aware_logic() -> None:
     assert fields_to_aware(aware_dt) == aware_dt
 
     # Test naive datetime conversion
-    naive_dt = datetime(2024, 1, 20, 12, 0, 0)
+    naive_dt = dt(2024, 1, 20, 12, 0, 0)
     result = fields_to_aware(naive_dt)
     assert result is not None
     assert result.tzinfo is not None

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -1,6 +1,6 @@
 """Tests for the Services aspect of RamsesCoordinator (Bind, Send Packet, Service Calls)."""
 
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -1011,8 +1011,8 @@ async def test_set_fan_param_value_error_in_command(
 async def test_cached_packets_filtering(mock_coordinator: RamsesCoordinator) -> None:
     """Test the packet caching logic in async_setup."""
     # Setup storage with valid, old, and invalid packets
-    dt_now: datetime = dt_util.now()
-    dt_old: datetime = dt_now - timedelta(days=2)
+    dt_now: dt = dt_util.now()
+    dt_old: dt = dt_now - td(days=2)
     valid_dt: str = dt_now.isoformat()
     old_dt: str = dt_old.isoformat()
 
@@ -1020,7 +1020,7 @@ async def test_cached_packets_filtering(mock_coordinator: RamsesCoordinator) -> 
     # 01234567890123456789012345678901234567890 (41 chars)
     padding = "X" * 41
     filtered_pkt = f"{padding}313F"
-    filtered_dt: datetime = dt_now - timedelta(minutes=1)
+    filtered_dt: dt = dt_now - td(minutes=1)
     filtered_dt_str: str = filtered_dt.isoformat()
 
     # Mock store load

--- a/tests/tests_new/test_store.py
+++ b/tests/tests_new/test_store.py
@@ -1,7 +1,7 @@
 """Tests for the storage aspect of RamsesCoordinator (Persistence)."""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -127,7 +127,7 @@ async def test_setup_with_corrupted_storage_dates(
     coordinator = RamsesCoordinator(hass, mock_entry)
 
     # 2. Mock Storage with corrupted date
-    now: datetime = dt_util.now()
+    now: dt = dt_util.now()
     timestamp: str = now.isoformat()
     mock_storage_data = {
         SZ_CLIENT_STATE: {
@@ -192,9 +192,9 @@ async def test_setup_packet_filtering(
     mock_client.start = AsyncMock()
     coordinator._create_client = MagicMock(return_value=mock_client)
 
-    now: datetime = dt_util.now()
-    old_date = (now - timedelta(days=2)).isoformat()
-    recent_date = (now - timedelta(hours=1)).isoformat()
+    now: dt = dt_util.now()
+    old_date = (now - td(days=2)).isoformat()
+    recent_date = (now - td(hours=1)).isoformat()
 
     coordinator.options[SZ_KNOWN_LIST] = {"01:123456": {}}
     coordinator.options[CONF_RAMSES_RF] = {"enforce_known_list": True}
@@ -208,7 +208,7 @@ async def test_setup_packet_filtering(
             SZ_PACKETS: {
                 old_date: valid_packet,
                 recent_date: valid_packet,
-                (now - timedelta(minutes=1)).isoformat(): unknown_packet,
+                (now - td(minutes=1)).isoformat(): unknown_packet,
             }
         }
     }

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -1,6 +1,6 @@
 """Tests for the water heater platform in ramses_cc."""
 
-from datetime import timedelta
+from datetime import timedelta as td
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -239,7 +239,7 @@ async def test_async_set_operation_mode_boost(
 
     # Verify 'until' is approximately 1 hour from now (allow 1s tolerance)
     # We cannot check for exact equality due to execution time
-    assert abs((kwargs["until"] - (now + timedelta(hours=1))).total_seconds()) < 1.0
+    assert abs((kwargs["until"] - (now + td(hours=1))).total_seconds()) < 1.0
 
 
 async def test_async_set_operation_mode_on(
@@ -295,7 +295,7 @@ async def test_async_set_dhw_mode_with_duration(
 ) -> None:
     """Test setting DHW mode with a duration string."""
     now = dt_util.now()
-    duration = timedelta(hours=2)
+    duration = td(hours=2)
 
     await water_heater.async_set_dhw_mode(
         mode=ZoneMode.TEMPORARY, active=True, duration=duration

--- a/tests/tests_old/helpers.py
+++ b/tests/tests_old/helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, timedelta
+from datetime import datetime as dt, timedelta as td
 from pathlib import Path
 from typing import Any
 
@@ -25,9 +25,9 @@ def normalise_storage_file(file_name: str) -> dict[str, Any]:
         storage = json.load(f)
 
     # correct the keys (which are dtm) to be recent, else they'll be dropped as expired
-    now: datetime = dt_util.now()
+    now: dt = dt_util.now()
     storage["data"]["client_state"]["packets"] = {
-        (now - timedelta(seconds=i)).isoformat(): v
+        (now - td(seconds=i)).isoformat(): v
         for i, v in enumerate(storage["data"]["client_state"]["packets"].values())
     }
 

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from datetime import timedelta
+from datetime import timedelta as td
 from typing import Any, Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -99,18 +99,15 @@ NUM_ENTS_AFTER_ALT = (
 # no problem if datetime is in the past, as it is not verified anywhere
 
 # until an hour from "now",  min. 1, max. 24:
-_ASS_UNTIL = (dt_util.now().replace(microsecond=0) + timedelta(hours=1)).replace(
-    tzinfo=None
-)
+_ASS_UNTIL = (dt_util.now().replace(microsecond=0) + td(hours=1)).replace(tzinfo=None)
 _ASS_UNTIL_3DAYS = (
-    dt_util.now().replace(minute=0, second=0, microsecond=0) + timedelta(days=3)
+    dt_util.now().replace(minute=0, second=0, microsecond=0) + td(days=3)
 ).replace(tzinfo=None)
 _ASS_UNTIL_MIDNIGHT = (
-    dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+    dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0) + td(days=1)
 ).replace(tzinfo=None)
 _ASS_UNTIL_10D = (
-    dt_util.now().replace(minute=0, second=0, microsecond=0)
-    + timedelta(days=10, hours=4)
+    dt_util.now().replace(minute=0, second=0, microsecond=0) + td(days=10, hours=4)
 ).replace(tzinfo=None)  # min. 1, max. 24
 
 # same item in service call entry format, calculated from their assert expected form above:
@@ -650,8 +647,7 @@ TESTS_SET_DHW_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
         "mode": "temporary_override",
         "active": True,
         "until": (
-            dt_util.now().replace(minute=0, second=0, microsecond=0)
-            + timedelta(hours=4)
+            dt_util.now().replace(minute=0, second=0, microsecond=0) + td(hours=4)
         ).replace(tzinfo=None),
     },
     "62": {
@@ -815,8 +811,7 @@ TESTS_SET_SYSTEM_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
     "03": {
         # "mode": "eco_boost",
         "until": (
-            dt_util.now().replace(minute=0, second=0, microsecond=0)
-            + timedelta(minutes=180)
+            dt_util.now().replace(minute=0, second=0, microsecond=0) + td(minutes=180)
         ).replace(tzinfo=None),
     },
 }
@@ -968,8 +963,7 @@ TESTS_SET_ZONE_MODE_GOOD_ASSERTS: dict[str, dict[str, Any]] = {
         "mode": "temporary_override",
         "setpoint": 15.1,
         "until": (
-            dt_util.now().replace(minute=0, second=0, microsecond=0)
-            + timedelta(hours=3)
+            dt_util.now().replace(minute=0, second=0, microsecond=0) + td(hours=3)
         ).replace(tzinfo=None),
     },
     "62": {"mode": "temporary_override", "setpoint": 16.1, "until": _ASS_UNTIL},


### PR DESCRIPTION
### The Problem:
The project lacked a programmatic way to enforce specific import aliases for `datetime` and `timedelta`, leading to inconsistent import styles (e.g., `from datetime import datetime, timedelta`). The maintainer explicitly requested standardizing on the `dt` and `td` aliases.

### Consequences:
Without an automated check, future contributors might continue to introduce inconsistent imports. 

### The Fix:
Added a custom pre-commit hook to strictly enforce the requested aliases and refactored the existing codebase to comply with this rule.

### Technical Implementation:
- Added a new `datetime_aliases` hook to `.pre-commit-config.yaml` under the local pygrep repository.
- Utilized a regex with negative lookaheads (`from datetime import.*\b(datetime(?! as dt)|timedelta(?! as td))\b`) to flag any `datetime` or `timedelta` imports from the `datetime` module that lack the correct aliases.
- Updated 14 files across `custom_components`, `tests`, and `docs` to align with the new hook.

### Testing Performed:
- Ran the full pre-commit suite (`prek run -a`) locally on the new feature branch.
- Verified that the custom `datetime_aliases` hook correctly flags non-compliant files and passes once the `dt` and `td` aliases are applied. 
- Verified that Ruff linting and formatting pass with the new aliases in place.

### Risks of NOT Implementing:
Ongoing style inconsistencies and unnecessary manual review overhead for maintainers dealing with import formatting on future pull requests.

### Risks of Implementing:
The risk is extremely minimal as this is a purely stylistic change. The only theoretical risk would be if the new `dt` or `td` aliases shadowed an existing local variable within one of the modified files.

### Mitigation Steps:
Ran the project's strict Ruff linter via the pre-commit suite. Ruff successfully validated the changes, ensuring that the new aliases did not introduce any undefined variables, shadowed variables, or scope resolution issues.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
