### PR TITLE
Tweak param number naming

### DIFF
--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -93,7 +93,7 @@ def normalize_device_id(device_id: str) -> str:
 def _has_existing_param_entities(entity_registry: Any, device_id: str) -> bool:
     normalized_id = normalize_device_id(device_id)
     legacy_prefix = f"{normalized_id}_param_"
-    new_prefix = f"{device_id}_param_"
+    new_prefix = f"{device_id}-param_"
 
     entries = getattr(entity_registry, "entities", None)
     if entries is None:
@@ -530,7 +530,7 @@ class RamsesNumberParam(RamsesNumberBase):
             self._device.clear_fan_param(self._param_id)
 
         # Assign unique ID using standard device ID and parameter key format
-        self._attr_unique_id = f"{device.id}_{entity_description.key}"
+        self._attr_unique_id = f"{device.id}-{entity_description.key}"
 
         _LOGGER.debug("Found unique_id: %s", self._attr_unique_id)
 

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -122,7 +122,7 @@ def test_has_existing_param_entities() -> None:
     assert _has_existing_param_entities(mock_reg, "30:111222")
 
     # Case 3: New prefix match
-    mock_reg.entities = {"e2": MagicMock(unique_id="30:111222_param_01")}
+    mock_reg.entities = {"e2": MagicMock(unique_id="30:111222-param_01")}
     assert _has_existing_param_entities(mock_reg, "30:111222")
 
     # Case 4: No match


### PR DESCRIPTION
## PR Summary

This PR concludes issue #516

- prevent error: `Platform ramses_cc does not generate unique IDs. ID 37:153226_param_01 already exists - ignoring number.fan_37_153226_param_01_2`
- remove legacy_migrate in number.py and -tests to prevent breaking current setups
- unshadow `_device`, `_param_entities` from outer scope

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used