### PR TITLE
Fix: remove duplicate entity creation/check in `fan_handler`

### DIFF
--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -17,7 +17,6 @@ from ramses_tx.const import DevType
 from ramses_tx.typing import DeviceIdT
 
 from .const import DOMAIN, SIGNAL_NEW_DEVICES, SZ_BOUND_TO, SZ_KNOWN_LIST
-from .helpers import resolve_async_attr
 
 if TYPE_CHECKING:
     from .coordinator import RamsesCoordinator
@@ -227,23 +226,6 @@ class RamsesFanHandler:
                 device.set_param_update_callback(create_param_callback(device.id))
                 _LOGGER.debug(
                     "Set up parameter update callback for device %s", device.id
-                )
-
-            # Check if device is already initialized (e.g., from cached messages)
-            if (
-                hasattr(device, "supports_2411")
-                and device.supports_2411
-                and resolve_async_attr(self, device, "_initialized", False)
-            ):
-                _LOGGER.debug(
-                    "Device %s already initialized, creating parameter entities",
-                    device.id,
-                )
-                self.create_parameter_entities(device)
-                async_dispatcher_send(
-                    self.hass,
-                    SIGNAL_NEW_DEVICES.format(Platform.NUMBER),
-                    [device],
                 )
 
             call: dict[str, Any] = {

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -157,8 +157,9 @@ async def test_fan_setup_already_initialized(
         mock_create.return_value = [MagicMock()]
         await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
-        assert mock_create.called
-        # Should also request params
+        # Do not create (what would become rejected duplicates) in fan_handler
+        assert not mock_create.called
+        # Should only request params
         assert mock_coordinator.client.async_send_cmd.call_count >= 0
 
 


### PR DESCRIPTION
This PR fixes issue #585 

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used to identify cause of duplicates (thanks @wimpie70 )

**PR Summary**
- remove call to create param_entities, debug
- adapt test to confirm `create` is not called