### PR TITLE
Fix: Poll device state on entity initialization to prevent Unknown states

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -39,6 +39,7 @@ from ramses_rf.entity_base import Entity as RamsesRFEntity
 from ramses_rf.gateway import Gateway
 from ramses_rf.schemas import SZ_BLOCK_LIST, SZ_CONFIG, SZ_KNOWN_LIST, SZ_SCHEMA
 from ramses_rf.system.heat import Logbook, System
+from ramses_tx.command import Command
 from ramses_tx.const import SZ_BYPASS_POSITION, SZ_IS_EVOFW3
 
 from .const import (
@@ -167,6 +168,24 @@ class RamsesLogbookBinarySensor(RamsesBinarySensor):
     """Representation of a fault log."""
 
     _device: Logbook
+
+    async def async_added_to_hass(self) -> None:
+        """Called when entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        if resolve_async_attr(self, self._device, "active_faults") is None:
+            try:
+                tcs = getattr(self._device, "_tcs", None)
+                if tcs and hasattr(tcs, "get_faultlog"):
+                    await tcs.get_faultlog(limit=1, force_refresh=True)
+                elif tcs and hasattr(tcs, "_gwy"):
+                    cmd = Command.from_cli(f"RQ {tcs.id} 0418 00")
+                    await tcs._gwy.async_send_cmd(cmd)
+            except Exception as err:
+                _LOGGER.debug(
+                    "Failed to poll active_faults for %s: %s",
+                    self.entity_id,
+                    err,
+                )
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -177,6 +177,18 @@ class RamsesController(RamsesEntity, ClimateEntity):
         self._last_known_curr_temp: float | None = None
         self._last_known_targ_temp: float | None = None
 
+    async def async_added_to_hass(self) -> None:
+        """Called when entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        if resolve_async_attr(self, self._device, "system_mode") is None:
+            try:
+                cmd = Command.from_cli(f"RQ {self._device.id} 2E04 FF")
+                await self._device._gwy.async_send_cmd(cmd)
+            except Exception as err:
+                _LOGGER.debug(
+                    "Failed to poll system_mode for %s: %s", self.entity_id, err
+                )
+
     @property
     def current_temperature(self) -> float | None:
         """Return the average current temperature of the heating Zones.
@@ -468,6 +480,18 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         super().__init__(coordinator, device, entity_description)
         self._last_known_curr_temp: float | None = None
         self._last_known_targ_temp: float | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Called when entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+        if resolve_async_attr(self, self._device, "mode") is None:
+            try:
+                cmd = Command.from_cli(
+                    f"RQ {self._device.tcs.id} 2349 {self._device.idx}"
+                )
+                await self._device._gwy.async_send_cmd(cmd)
+            except Exception as err:
+                _LOGGER.debug("Failed to poll mode for %s: %s", self.entity_id, err)
 
     @property
     def current_temperature(self) -> float | None:

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
@@ -359,3 +359,71 @@ async def test_gateway_binary_sensor_state(
     mock_device.is_active = False
     is_on_check_b = sensor.is_on
     assert is_on_check_b is True
+
+
+@patch("custom_components.ramses_cc.binary_sensor.Command")
+@patch("custom_components.ramses_cc.binary_sensor.resolve_async_attr")
+async def test_logbook_async_added_to_hass(
+    mock_resolve: MagicMock,
+    mock_cmd: MagicMock,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test RamsesLogbookBinarySensor.async_added_to_hass polling logic."""
+    description = RamsesBinarySensorEntityDescription(
+        key="active_fault",
+        name="Active fault",
+        ramses_rf_attr="active_faults",
+        ramses_cc_class=RamsesLogbookBinarySensor,
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    )
+    mock_device = MagicMock(spec=Logbook)
+    mock_device.id = "01:123456"
+    mock_device._tcs = MagicMock()
+    mock_device._tcs.id = "01:123456"
+    mock_device._tcs.get_faultlog = AsyncMock()
+
+    sensor: Any = RamsesLogbookBinarySensor(mock_coordinator, mock_device, description)
+
+    # 1. active_faults is None, tcs has get_faultlog
+    mock_resolve.return_value = None
+    with patch(
+        "custom_components.ramses_cc.binary_sensor."
+        "RamsesBinarySensor.async_added_to_hass"
+    ):
+        await sensor.async_added_to_hass()
+
+    mock_device._tcs.get_faultlog.assert_awaited_once_with(limit=1, force_refresh=True)
+
+    # 2. active_faults is None, tcs lacks get_faultlog but has _gwy
+    del mock_device._tcs.get_faultlog
+    mock_device._tcs._gwy = MagicMock()
+    mock_device._tcs._gwy.async_send_cmd = AsyncMock()
+    mock_cmd.from_cli.return_value = "mock_cmd"
+
+    with patch(
+        "custom_components.ramses_cc.binary_sensor."
+        "RamsesBinarySensor.async_added_to_hass"
+    ):
+        await sensor.async_added_to_hass()
+
+    mock_cmd.from_cli.assert_called_once_with("RQ 01:123456 0418 00")
+    mock_device._tcs._gwy.async_send_cmd.assert_awaited_once_with("mock_cmd")
+
+    # 3. Exception handling
+    mock_device._tcs._gwy.async_send_cmd.side_effect = Exception("Boom")
+    with patch(
+        "custom_components.ramses_cc.binary_sensor."
+        "RamsesBinarySensor.async_added_to_hass"
+    ):
+        await sensor.async_added_to_hass()  # Should not raise
+
+    # 4. active_faults is not None (should not poll)
+    mock_resolve.return_value = [{"fault": "error"}]
+    mock_cmd.from_cli.reset_mock()
+    with patch(
+        "custom_components.ramses_cc.binary_sensor."
+        "RamsesBinarySensor.async_added_to_hass"
+    ):
+        await sensor.async_added_to_hass()
+
+    mock_cmd.from_cli.assert_not_called()

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1336,3 +1336,87 @@ async def test_hvac_set_preset_mode(
     mock_device.set_preset_mode = AsyncMock(side_effect=TransportError("Comms down"))
     with pytest.raises(HomeAssistantError, match="Failed to set preset mode"):
         await hvac.async_set_preset_mode("eco")
+
+
+@patch("custom_components.ramses_cc.climate.Command")
+@patch("custom_components.ramses_cc.climate.resolve_async_attr")
+async def test_controller_async_added_to_hass(
+    mock_resolve: MagicMock,
+    mock_cmd: MagicMock,
+    mock_coordinator: MagicMock,
+    mock_description: MagicMock,
+) -> None:
+    """Test RamsesController.async_added_to_hass polling logic."""
+    mock_device = MagicMock()
+    mock_device.__class__ = Evohome
+    mock_device.id = "01:123456"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    controller = RamsesController(mock_coordinator, mock_device, mock_description)
+
+    # 1. system_mode is None
+    mock_resolve.return_value = None
+    mock_cmd.from_cli.return_value = "mock_cmd"
+
+    with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
+        await controller.async_added_to_hass()
+
+    mock_cmd.from_cli.assert_called_once_with("RQ 01:123456 2E04 FF")
+    mock_device._gwy.async_send_cmd.assert_awaited_once_with("mock_cmd")
+
+    # 2. Exception handling
+    mock_device._gwy.async_send_cmd.side_effect = Exception("Boom")
+    with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
+        await controller.async_added_to_hass()
+
+    # 3. system_mode is not None
+    mock_resolve.return_value = {"mode": "auto"}
+    mock_cmd.from_cli.reset_mock()
+    with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
+        await controller.async_added_to_hass()
+
+    mock_cmd.from_cli.assert_not_called()
+
+
+@patch("custom_components.ramses_cc.climate.Command")
+@patch("custom_components.ramses_cc.climate.resolve_async_attr")
+async def test_zone_async_added_to_hass(
+    mock_resolve: MagicMock,
+    mock_cmd: MagicMock,
+    mock_coordinator: MagicMock,
+    mock_description: MagicMock,
+) -> None:
+    """Test RamsesZone.async_added_to_hass polling logic."""
+    mock_device = MagicMock()
+    mock_device.id = "04:123456"
+    mock_device.idx = "01"
+    mock_device.tcs = MagicMock()
+    mock_device.tcs.id = "01:123456"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    zone = RamsesZone(mock_coordinator, mock_device, mock_description)
+
+    # 1. mode is None
+    mock_resolve.return_value = None
+    mock_cmd.from_cli.return_value = "mock_cmd"
+
+    with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
+        await zone.async_added_to_hass()
+
+    mock_cmd.from_cli.assert_called_once_with("RQ 01:123456 2349 01")
+    mock_device._gwy.async_send_cmd.assert_awaited_once_with("mock_cmd")
+
+    # 2. Exception handling
+    mock_device._gwy.async_send_cmd.side_effect = Exception("Boom")
+    with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
+        await zone.async_added_to_hass()
+
+    # 3. mode is not None
+    mock_resolve.return_value = {"mode": "schedule"}
+    mock_cmd.from_cli.reset_mock()
+    with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
+        await zone.async_added_to_hass()
+
+    mock_cmd.from_cli.assert_not_called()


### PR DESCRIPTION
### The Problem:

Following a Home Assistant restart or a system cache clear, entities (`system_mode` on the Controller, `mode` on Zones, and `active_fault` on the Logbook) frequently initialize as `null` or `Unknown`. This happens because the integration passively waits for broadcast packets from the controller rather than actively asking for its current state. (References Issue #583, points 1 and 2).

### Consequences:

If not fixed, this breaks HA startup automations that rely on `system_mode` or fault states. It also creates a confusing user experience where the dashboard shows `Unknown` entities for an extended period until a state change is natively triggered or broadcasted.

### The Fix:

Added active polling during the entity initialization lifecycle. If an entity's required state is missing upon creation, it will immediately request the data from the gateway.

### Technical Implementation:
- Overrode `async_added_to_hass` in `RamsesController`, `RamsesZone`, and `RamsesLogbookBinarySensor`.
- `RamsesController`: Evaluates `system_mode`. If `None`, issues `RQ {id} 2E04 FF`.
- `RamsesZone`: Evaluates `mode`. If `None`, issues `RQ {tcs.id} 2349 {zone.idx}`.
- `RamsesLogbookBinarySensor`: Evaluates `active_faults`. If `None`, calls the native `get_faultlog()` method, falling back to a raw `RQ {tcs.id} 0418 00` command if necessary.
- Wrapped all transmission logic in `try/except Exception` blocks so that if the gateway is overwhelmed during startup, the entity still successfully initializes (falling back to its passive listening behavior).

### Testing Performed:

Added targeted `async_added_to_hass` unit tests in `test_climate.py` and `test_binary_sensor.py`. The tests mock the gateway and verify that:
1. `RQ` commands are correctly formatted and dispatched when the state is `None`.
2. Polling is completely skipped if the cache already populated the state.
3. Network exceptions raised during polling do not crash the entity setup.
Mypy strict typing checks and the full pytest suite pass successfully.

### Risks of NOT Implementing:

Users who clear their cache or restart Home Assistant will continue to experience degraded stability, broken automations, and missing UI states.

### Risks of Implementing:

There will be a slight, localized burst of RF traffic (RQ packets) broadcast onto the network immediately as Home Assistant boots up and initializes the integration.

### Mitigation Steps:

Polling is strictly conditional; it only fires if the resolved attribute is currently `None` (meaning the cache failed or is empty). Catch-all exception handlers guarantee that any RF packet collisions or timeouts during this startup burst will not crash the entity loading process.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.  