### PR TITLE
Remove unused `sqlite_index` option

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -50,7 +50,6 @@ from ramses_tx.schemas import (
     SZ_PORT_NAME,
     SZ_ROTATE_BYTES,
     SZ_SERIAL_PORT,
-    SZ_SQLITE_INDEX,
 )
 
 from .const import (
@@ -606,7 +605,6 @@ class BaseRamsesFlow(FlowHandler):
         managed_keys = (
             SZ_ENFORCE_KNOWN_LIST,
             SZ_LOG_ALL_MQTT,
-            SZ_SQLITE_INDEX,  # temporary 0.52.x dev option
         )
         errors: dict[str, str] = {}
         description_placeholders: dict[str, str] = {}
@@ -806,9 +804,6 @@ class BaseRamsesFlow(FlowHandler):
                 self.options[CONF_RAMSES_RF][SZ_LOG_ALL_MQTT] = user_input[
                     SZ_LOG_ALL_MQTT
                 ]
-                self.options[CONF_RAMSES_RF][SZ_SQLITE_INDEX] = user_input[
-                    SZ_SQLITE_INDEX  # temporary 0.52.x dev option
-                ]
                 if self._initial_setup:
                     return await self.async_step_advanced_features()
                 return self._async_save()
@@ -820,9 +815,6 @@ class BaseRamsesFlow(FlowHandler):
                     SZ_ENFORCE_KNOWN_LIST
                 ),
                 SZ_LOG_ALL_MQTT: self.options[CONF_RAMSES_RF].get(SZ_LOG_ALL_MQTT),
-                SZ_SQLITE_INDEX: self.options[CONF_RAMSES_RF].get(
-                    SZ_SQLITE_INDEX  # temporary 0.52.x dev option
-                ),
             }
 
         data_schema = {
@@ -845,11 +837,6 @@ class BaseRamsesFlow(FlowHandler):
                 SZ_LOG_ALL_MQTT,
                 default=False,
                 description={"suggested_value": suggested_values.get(SZ_LOG_ALL_MQTT)},
-            ): selector.BooleanSelector(),
-            vol.Optional(
-                SZ_SQLITE_INDEX,  # temporary 0.52.x dev option
-                default=False,
-                description={"suggested_value": suggested_values.get(SZ_SQLITE_INDEX)},
             ): selector.BooleanSelector(),
         }
 

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -72,14 +72,12 @@
                     "known_list": "Known device IDs",
                     "enforce_known_list": "Accept packets from known devices IDs only",
                     "log_all_mqtt": "Log all MQTT traffic",
-                    "sqlite_index": "Use SQLite MessageIndex"
                 },
                 "data_description": {
                     "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
                     "known_list": "A mapping of known device IDs and optionally their traits.",
                     "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. HA Restart required.",
                     "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console.",
-                    "sqlite_index": "Under development! Missing messages or errors with Evohome (restart required)"
                 }
             },
             "advanced_features": {
@@ -184,14 +182,12 @@
                     "known_list": "Known device IDs",
                     "enforce_known_list": "Accept packets from known devices IDs only",
                     "log_all_mqtt": "Log all MQTT traffic",
-                    "sqlite_index": "Use SQLite MessageIndex"
                 },
                 "data_description": {
                     "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
                     "known_list": "A mapping of known device IDs and optionally their traits.",
                     "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. After activating, clear the discovered system schemas cache before restarting.",
                     "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console.",
-                    "sqlite_index": "Under development! Missing messages or errors with Evohome (restart required)"                }
             },
             "advanced_features": {
                 "title": "Advanced features",

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -71,13 +71,13 @@
                     "schema": "System schema(s)",
                     "known_list": "Known device IDs",
                     "enforce_known_list": "Accept packets from known devices IDs only",
-                    "log_all_mqtt": "Log all MQTT traffic",
+                    "log_all_mqtt": "Log all MQTT traffic"
                 },
                 "data_description": {
                     "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
                     "known_list": "A mapping of known device IDs and optionally their traits.",
                     "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. HA Restart required.",
-                    "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console.",
+                    "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console."
                 }
             },
             "advanced_features": {
@@ -181,13 +181,14 @@
                     "schema": "System schema(s)",
                     "known_list": "Known device IDs",
                     "enforce_known_list": "Accept packets from known devices IDs only",
-                    "log_all_mqtt": "Log all MQTT traffic",
+                    "log_all_mqtt": "Log all MQTT traffic"
                 },
                 "data_description": {
-                    "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
-                    "known_list": "A mapping of known device IDs and optionally their traits.",
-                    "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. After activating, clear the discovered system schemas cache before restarting.",
-                    "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console.",
+                  "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
+                  "known_list": "A mapping of known device IDs and optionally their traits.",
+                  "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. After activating, clear the discovered system schemas cache before restarting.",
+                  "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console."
+                }
             },
             "advanced_features": {
                 "title": "Advanced features",

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -71,13 +71,13 @@
                     "schema": "Systeemschema(s)",
                     "known_list": "Erkende device_id's",
                     "enforce_known_list": "Accepteer alleen berichten van erkende device ID's",
-                    "log_all_mqtt": "Log alle MQTT-topics",
+                    "log_all_mqtt": "Log alle MQTT-topics"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
                     "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor. Wis wel 1x de systeem-cache nadat je deze optie activeert.",
-                    "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole.",
+                    "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole."
                 }
             },
             "advanced_features": {
@@ -181,13 +181,13 @@
                     "schema": "Systeemschema('s)",
                     "known_list": "Erkende device_id's",
                     "enforce_known_list": "Accepteer alleen berichten van erkende device ID's",
-                    "log_all_mqtt": "Log alle MQTT-topics",
+                    "log_all_mqtt": "Log alle MQTT-topics"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
                     "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen. Vereist HA herstart!",
-                    "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole.",
+                    "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole."
                 }
             },
             "advanced_features": {

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -72,14 +72,12 @@
                     "known_list": "Erkende device_id's",
                     "enforce_known_list": "Accepteer alleen berichten van erkende device ID's",
                     "log_all_mqtt": "Log alle MQTT-topics",
-                    "sqlite_index": "Gebruik SQLite MessageIndex"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
                     "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor. Wis wel 1x de systeem-cache nadat je deze optie activeert.",
                     "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole.",
-                    "sqlite_index": "In ontwikkeling! Kan berichten missen en fouten geven met Evohome. (herstart vereist)"
                 }
             },
             "advanced_features": {
@@ -184,14 +182,12 @@
                     "known_list": "Erkende device_id's",
                     "enforce_known_list": "Accepteer alleen berichten van erkende device ID's",
                     "log_all_mqtt": "Log alle MQTT-topics",
-                    "sqlite_index": "Gebruik SQLite MessageIndex"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
                     "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen. Vereist HA herstart!",
                     "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole.",
-                    "sqlite_index": "In ontwikkeling! Kan berichten missen en fouten geven met Evohome. (herstart vereist)"
                 }
             },
             "advanced_features": {

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -368,7 +368,6 @@ async def test_options_flow_defaults_and_branches(hass: HomeAssistant) -> None:
         user_input={
             SZ_ENFORCE_KNOWN_LIST: False,
             SZ_LOG_ALL_MQTT: False,
-            "sqlite_index": False,
         },
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -374,7 +374,7 @@ async def test_backend_error_handling(
 ) -> None:
     """Test that backend errors raise ServiceValidationError or HomeAssistantError."""
     # Test set_mode error
-    mock_device.set_mode.side_effect = ValueError("SQLite error")
+    mock_device.set_mode.side_effect = ValueError("SetMmode error")
     with pytest.raises(ServiceValidationError) as excinfo:
         await water_heater.async_set_operation_mode(STATE_AUTO)
     assert excinfo.value.translation_key == "error_set_mode"


### PR DESCRIPTION
Fixes #593 
Also removed kwarg, schema import from ramses_rf

This PR should be merged before/simultaneously with matching [ramses_rf PR](https://github.com/ramses-rf/ramses_rf/pull/564) 