### PR TITLE
Relax config schema

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -182,7 +182,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate legacy configuration options to the current version.
+    """Migrate legacy configuration options to the current version 2.
 
     This handles the transition away from user-selectable database storage
     and removes deprecated packet log keys (e.g., `file_name`) that cause
@@ -208,8 +208,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # 2. Clean up ramses_rf dictionary (legacy database storage flags)
         if isinstance(new_options.get("ramses_rf"), dict):
             ramses_rf = {**new_options["ramses_rf"]}
-            # Remove deprecated database keys. Add any other specific keys
-            # related to your SQLite/in-memory refactor here.
+            # Remove deprecated database keys
             for deprecated_key in ["use_database", "database_file", "file_name"]:
                 ramses_rf.pop(deprecated_key, None)
             new_options["ramses_rf"] = ramses_rf

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -848,7 +848,9 @@ class BaseRamsesFlow(FlowHandler):
         return self.async_show_form(
             step_id="schema",
             data_schema=vol.Schema(
-                cv.deprecated("sqlite_index", raise_if_present=False),
+                cv.deprecated(
+                    "sqlite_index", raise_if_present=False
+                ),  # TODO remove Q3 2026
                 data_schema,
                 extra=vol.ALLOW_EXTRA,
             ),  # extra = migration from v1
@@ -1031,8 +1033,10 @@ class BaseRamsesFlow(FlowHandler):
         }
 
         return self.async_show_form(
-            cv.deprecated("file_name", raise_if_present=False),
-            cv.deprecated("rotate_backups", raise_if_present=False),
+            cv.deprecated("file_name", raise_if_present=False),  # TODO remove Q3 2026
+            cv.deprecated(
+                "rotate_backups", raise_if_present=False
+            ),  # TODO remove Q3 2026
             step_id="packet_log",
             data_schema=vol.Schema(
                 data_schema, extra=vol.ALLOW_EXTRA

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -856,9 +856,9 @@ class BaseRamsesFlow(FlowHandler):
         return self.async_show_form(
             step_id="schema",
             data_schema=vol.Schema(
-                cv.deprecated(
-                    "sqlite_index", raise_if_present=False
-                ),  # TODO remove Q3 2026
+                # cv.deprecated(
+                #     "sqlite_index", raise_if_present=False
+                # ),  # Deprecated Q3 2026
                 data_schema,
                 extra=vol.ALLOW_EXTRA,
             ),  # extra = migration from v1
@@ -1043,9 +1043,12 @@ class BaseRamsesFlow(FlowHandler):
         return self.async_show_form(
             step_id="packet_log",
             data_schema=vol.Schema(
-                cv.deprecated(
-                    ("file_name", "rotate_backups"), raise_if_present=False
-                ),  # TODO remove Q3 2026
+                # cv.deprecated(
+                #     "file_name", raise_if_present=False
+                # ),  # Deprecated Q3 2026
+                # cv.deprecated(
+                #     "rotate_backups", raise_if_present=False
+                # ),    # Deprecated Q3 2026
                 data_schema,
                 extra=vol.ALLOW_EXTRA,
             ),  # extra = migration from v1

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -848,7 +848,9 @@ class BaseRamsesFlow(FlowHandler):
         return self.async_show_form(
             step_id="schema",
             data_schema=vol.Schema(
-                data_schema, extra=vol.ALLOW_EXTRA
+                cv.deprecated("sqlite_index", raise_if_present=False),
+                data_schema,
+                extra=vol.ALLOW_EXTRA,
             ),  # extra = migration from v1
             description_placeholders=description_placeholders,
             errors=errors,
@@ -1029,6 +1031,8 @@ class BaseRamsesFlow(FlowHandler):
         }
 
         return self.async_show_form(
+            cv.deprecated("file_name", raise_if_present=False),
+            cv.deprecated("rotate_backups", raise_if_present=False),
             step_id="packet_log",
             data_schema=vol.Schema(
                 data_schema, extra=vol.ALLOW_EXTRA

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -636,8 +636,12 @@ class BaseRamsesFlow(FlowHandler):
                 description_placeholders["error_detail"] = err.msg
 
             if not errors:
-                self.options[CONF_SCAN_INTERVAL] = user_input[CONF_SCAN_INTERVAL]
-                self.options[CONF_GATEWAY_TIMEOUT] = user_input[CONF_GATEWAY_TIMEOUT]
+                self.options[CONF_SCAN_INTERVAL] = user_input.get(
+                    CONF_SCAN_INTERVAL, 60
+                )
+                self.options[CONF_GATEWAY_TIMEOUT] = user_input.get(
+                    CONF_GATEWAY_TIMEOUT, 10
+                )
                 self.options[CONF_RAMSES_RF] = gateway_config
                 if CONF_MQTT_HGI_ID in user_input:
                     hgi_id = user_input[CONF_MQTT_HGI_ID]
@@ -760,7 +764,7 @@ class BaseRamsesFlow(FlowHandler):
         description_placeholders: dict[str, str] = {}
         self.get_options()  # was not available during init
         enforce_known_was_on: bool = self.options[CONF_RAMSES_RF].get(
-            SZ_ENFORCE_KNOWN_LIST
+            SZ_ENFORCE_KNOWN_LIST, False
         )
 
         if user_input is not None:
@@ -783,11 +787,13 @@ class BaseRamsesFlow(FlowHandler):
             if not errors:
                 self.options[CONF_SCHEMA] = user_input.get(CONF_SCHEMA, {})
                 self.options[SZ_KNOWN_LIST] = user_input.get(SZ_KNOWN_LIST, {})
-                self.options[CONF_RAMSES_RF][SZ_ENFORCE_KNOWN_LIST] = user_input[
-                    SZ_ENFORCE_KNOWN_LIST
-                ]
+                self.options[CONF_RAMSES_RF][SZ_ENFORCE_KNOWN_LIST] = user_input.get(
+                    SZ_ENFORCE_KNOWN_LIST, False
+                )
                 # if ENFORCE_KNOWN_LIST changed from Off to On, also clear both caches
-                if (not enforce_known_was_on) and (user_input[SZ_ENFORCE_KNOWN_LIST]):
+                if (not enforce_known_was_on) and (
+                    user_input.get(SZ_ENFORCE_KNOWN_LIST, False)
+                ):
                     # Unload immediately to stop scheduled coordinator state saves
                     await self.hass.config_entries.async_unload(
                         self.config_entry.entry_id
@@ -802,9 +808,9 @@ class BaseRamsesFlow(FlowHandler):
                     _LOGGER.warning(
                         "Caches were cleared after enforcing Known List. Restart HA next."
                     )
-                self.options[CONF_RAMSES_RF][SZ_LOG_ALL_MQTT] = user_input[
-                    SZ_LOG_ALL_MQTT
-                ]
+                self.options[CONF_RAMSES_RF][SZ_LOG_ALL_MQTT] = user_input.get(
+                    SZ_LOG_ALL_MQTT, False
+                )
                 if self._initial_setup:
                     return await self.async_step_advanced_features()
                 return self._async_save()
@@ -813,9 +819,11 @@ class BaseRamsesFlow(FlowHandler):
                 CONF_SCHEMA: self.options.get(CONF_SCHEMA),
                 SZ_KNOWN_LIST: self.options.get(SZ_KNOWN_LIST),
                 SZ_ENFORCE_KNOWN_LIST: self.options[CONF_RAMSES_RF].get(
-                    SZ_ENFORCE_KNOWN_LIST
+                    SZ_ENFORCE_KNOWN_LIST, False
                 ),
-                SZ_LOG_ALL_MQTT: self.options[CONF_RAMSES_RF].get(SZ_LOG_ALL_MQTT),
+                SZ_LOG_ALL_MQTT: self.options[CONF_RAMSES_RF].get(
+                    SZ_LOG_ALL_MQTT, False
+                ),
             }
 
         data_schema = {
@@ -1036,10 +1044,7 @@ class BaseRamsesFlow(FlowHandler):
             step_id="packet_log",
             data_schema=vol.Schema(
                 cv.deprecated(
-                    "file_name", raise_if_present=False
-                ),  # TODO remove Q3 2026
-                cv.deprecated(
-                    "rotate_backups", raise_if_present=False
+                    ("file_name", "rotate_backups"), raise_if_present=False
                 ),  # TODO remove Q3 2026
                 data_schema,
                 extra=vol.ALLOW_EXTRA,

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -50,6 +50,7 @@ from ramses_tx.schemas import (
     SZ_PORT_NAME,
     SZ_ROTATE_BYTES,
     SZ_SERIAL_PORT,
+    # deprecated 0.56.0 but allowed as extras: SZ_FILE_NAME, SZ_ROTATE_BACKUPS, SZ_SQLITE_INDEX
 )
 
 from .const import (
@@ -74,7 +75,7 @@ from .schemas import SCH_GLOBAL_TRAITS_DICT
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_MANUAL_PATH: Final = "Enter Manually..."  # TODO i18n this string
+CONF_MANUAL_PATH: Final = "Enter Manually..."  # TODO i18n these strings
 CONF_MQTT_PATH: Final = "MQTT Broker..."
 CONF_HA_MQTT_PATH: Final = "Use Home Assistant MQTT - In development!"
 CONF_ZIGBEE_DEVICE: Final = "Zigbee device"
@@ -846,7 +847,9 @@ class BaseRamsesFlow(FlowHandler):
 
         return self.async_show_form(
             step_id="schema",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol.Schema(
+                data_schema, extra=vol.ALLOW_EXTRA
+            ),  # extra = migration from v1
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -1026,7 +1029,10 @@ class BaseRamsesFlow(FlowHandler):
         }
 
         return self.async_show_form(
-            step_id="packet_log", data_schema=vol.Schema(data_schema)
+            step_id="packet_log",
+            data_schema=vol.Schema(
+                data_schema, extra=vol.ALLOW_EXTRA
+            ),  # extra = migration from v1
         )
 
 
@@ -1034,6 +1040,7 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
     """Config flow for Ramses."""
 
     VERSION = 2
+    MINOR_VERSION = 1
 
     def __init__(self) -> None:
         """Initialize Ramses config flow."""

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1033,13 +1033,16 @@ class BaseRamsesFlow(FlowHandler):
         }
 
         return self.async_show_form(
-            cv.deprecated("file_name", raise_if_present=False),  # TODO remove Q3 2026
-            cv.deprecated(
-                "rotate_backups", raise_if_present=False
-            ),  # TODO remove Q3 2026
             step_id="packet_log",
             data_schema=vol.Schema(
-                data_schema, extra=vol.ALLOW_EXTRA
+                cv.deprecated(
+                    "file_name", raise_if_present=False
+                ),  # TODO remove Q3 2026
+                cv.deprecated(
+                    "rotate_backups", raise_if_present=False
+                ),  # TODO remove Q3 2026
+                data_schema,
+                extra=vol.ALLOW_EXTRA,
             ),  # extra = migration from v1
         )
 

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -13,8 +13,8 @@
     "requirements": [
       "aiousbwatcher>=1.1.1",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.56.3"
+      "ramses-rf==0.56.4"
     ],
     "single_config_entry": true,
-    "version": "0.56.3"
+    "version": "0.56.4"
   }

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,12 +1,12 @@
 # Requirements to dev the source code
-# - last checked/updated: 2026-04-08 (c.f. HA 2026.4.1)
+# - last checked/updated: 2026-04-09 (c.f. HA 2026.4.1)
 
 # requirements (dependencies) are in manifest.json
 # - pip list | grep -E 'ramses|serial'
 
   aiousbwatcher         >= 1.1.1                 # as per: manifest.json latest: 1.1.1
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.56.3                # as per: manifest.json latest:
+  ramses-rf             == 0.56.4                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
 

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -15,7 +15,6 @@ from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from mypy.types import Iterable
 from pytest_homeassistant_custom_component.common import (  # type: ignore[import-untyped]
     MockConfigEntry,
 )
@@ -781,7 +780,6 @@ async def test_ha_mqtt_flow(hass: HomeAssistant) -> None:
         # To verify injection happened, we check that it is offered as a suggested_value.
         assert result["step_id"] == "schema"
         schema = result["data_schema"]
-        assert isinstance(schema, Iterable)
         # Find the key for SZ_KNOWN_LIST
         key = next(k for k in schema.schema if k == SZ_KNOWN_LIST)
         suggested = getattr(key, "description", {}).get("suggested_value", "not found")

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from mypy.types import Iterable
 from pytest_homeassistant_custom_component.common import (  # type: ignore[import-untyped]
     MockConfigEntry,
 )
@@ -780,9 +781,10 @@ async def test_ha_mqtt_flow(hass: HomeAssistant) -> None:
         # To verify injection happened, we check that it is offered as a suggested_value.
         assert result["step_id"] == "schema"
         schema = result["data_schema"]
+        assert isinstance(schema, Iterable)
         # Find the key for SZ_KNOWN_LIST
         key = next(k for k in schema.schema if k == SZ_KNOWN_LIST)
-        suggested = key.description["suggested_value"]
+        suggested = getattr(key, "description", {}).get("suggested_value", "not found")
         assert test_hgi_id in suggested
 
         # Submit Schema Step (MUST submit the suggested value to preserve it)
@@ -1335,6 +1337,7 @@ async def test_zigbee_single_device_label_in_port_picker(hass: HomeAssistant) ->
     # Extract the options list from the SelectSelector for SZ_PORT_NAME.
     # vol.Required("key").schema == "key", and SelectSelector.config is TypedDict.
     schema = result["data_schema"].schema
+    assert isinstance(schema, dict)
     port_name_key = next(
         (k for k in schema if getattr(k, "schema", None) == SZ_PORT_NAME), None
     )


### PR DESCRIPTION
- to allow extra keys (during migration from V1 to V2)
- log as deprecated using HA built in cv.deprecated("key") << not yet active
- add MINOR_VERSION (explicitly show current default value = 1)
- edit comments
- safe get(attr) replacing [attr]