### PR TITLE
fix: enforce state safety in parameter entities and tighten exception scoping

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -677,7 +677,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         )
         active_hgi_id = None
         if transport is not None:
-            with suppress(Exception):
+            with suppress(AttributeError, KeyError, TypeError):
                 active_hgi_id = transport.get_extra_info(SZ_ACTIVE_HGI)
         if not active_hgi_id:
             active_hgi_id = getattr(engine, "_hgi_id", None)

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -460,7 +460,7 @@ class RamsesNumberParam(RamsesNumberBase):
         - A pending state mechanism is implemented since we don't wait for a response on RQ
     """
 
-    _param_native_value: dict[str, float | None] = {}
+    _param_native_value: dict[str, float | None]
 
     @property
     def mode(self) -> str:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -2063,3 +2063,30 @@ async def test_discover_new_entities_hgi_registration(
         await mock_coordinator._discover_new_entities()
 
     mock_coordinator.client.device_registry.get_device.assert_called_with("18:111111")
+
+
+async def test_discover_entities_does_not_suppress_base_exceptions(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test that unexpected exceptions are not swallowed during discovery."""
+
+    # 1. Setup minimal safe state for discovery
+    mock_coordinator.client.device_registry.devices = []
+    mock_coordinator.client.device_registry.systems = []
+    mock_coordinator.client.device_registry.device_by_id = {}
+    mock_coordinator.client.device_registry.get_device = MagicMock()
+
+    # 2. Force the transport to raise a severe exception (RuntimeError)
+    # instead of an expected one like AttributeError or KeyError
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.side_effect = RuntimeError(
+        "Critical transport failure"
+    )
+
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_coordinator.client._engine = mock_engine
+
+    # 3. Call discovery and assert the RuntimeError successfully escapes
+    with pytest.raises(RuntimeError, match="Critical transport failure"):
+        await mock_coordinator._discover_new_entities()

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -908,3 +908,31 @@ async def test_number_entity_set_value_via_service(
     assert entity._is_pending is True
     assert entity._pending_value == 22.0
     assert entity.icon == "mdi:timer-sand"
+
+
+async def test_number_param_state_isolation(
+    mock_coordinator: MagicMock, mock_fan_device: MagicMock
+) -> None:
+    """Test that RamsesNumberParam instances do not share mutable state."""
+
+    # 1. Setup a second mock device to ensure isolation
+    mock_device2 = MagicMock()
+    mock_device2.id = "30:222222"
+    mock_device2.get_fan_param.return_value = None
+
+    # 2. Setup the entity description
+    desc = RamsesNumberEntityDescription(
+        key="param_75",
+        ramses_rf_attr="75",
+    )
+
+    # 3. Instantiate two separate entities
+    entity1 = RamsesNumberParam(mock_coordinator, mock_fan_device, desc)
+    entity2 = RamsesNumberParam(mock_coordinator, mock_device2, desc)
+
+    # 4. Modify the state of entity 1
+    entity1._param_native_value["75"] = 21.0
+
+    # 5. Assert entity 2 was completely unaffected
+    assert entity1._param_native_value.get("75") == 21.0
+    assert entity2._param_native_value.get("75") is None


### PR DESCRIPTION
### The Problem:
1. **Issue 1 (Class-Level Mutable State):** In `number.py`, the `RamsesNumberParam` class defined a mutable dictionary `_param_native_value = {}` at the class level.
2. **Issue 2 (Broad Exception Suppression):** In `coordinator.py`, the `_discover_new_entities` method used `with suppress(Exception):` when calling `transport.get_extra_info(SZ_ACTIVE_HGI)`.

### Consequences:
- **Mutable State:** Defining a mutable collection at the class level means all instances inherently share that object. While partially mitigated in `__init__`, it poses a severe risk of state leakage and cross-contamination between different fan parameter entities.
- **Broad Suppression:** Suppressing the base `Exception` class is a dangerous anti-pattern. It silently swallows legitimate bugs like `NameError`, `TypeError`, or `RuntimeError` that might occur during the discovery loop, making future debugging nearly impossible.

### The Fix:
- Removed the mutable class-level default assignment in `number.py`, converting it to a pure type hint.
- Scoped the exception handling in `coordinator.py` to only catch the specific exceptions that are expected to be thrown by the transport layer when missing HGI info.

### Technical Implementation:
- **`number.py`:** Refactored `_param_native_value: dict[str, float | None] = {}` to `_param_native_value: dict[str, float | None]`.
- **`coordinator.py`:** Replaced `with suppress(Exception):` with `with suppress(AttributeError, KeyError, TypeError):`.

### Testing Performed:
- **`test_number.py`:** Wrote `test_number_param_state_isolation` which instantiates two separate `RamsesNumberParam` entities, modifies the parameter dictionary of the first, and asserts that the second remains completely unaffected.
- **`test_coordinator.py`:** Wrote `test_discover_entities_does_not_suppress_base_exceptions` which purposely mocks the `transport.get_extra_info` call to raise a `RuntimeError`, asserting that the exception successfully escapes the discovery loop instead of being swallowed.
- Verified strict `mypy` compliance and a 100% pass rate across the full `pytest` suite.

### Risks of NOT Implementing:

Leaving the code as is maintains a fragile architecture where parameter states could bleed across devices under the right race conditions. Furthermore, any future breaking changes to the `ramses_tx` transport API would fail completely silently, leaving the integration in a zombie state with no logs.

### Risks of Implementing:

If the `ramses_tx` transport layer throws a benign but undocumented exception (other than `AttributeError`, `KeyError`, or `TypeError`) during `get_extra_info`, the discovery loop could unexpectedly fail.

### Mitigation Steps:

We bounded the exception scope to the most common dictionary/object retrieval errors and validated the execution pathways against the complete `pytest` integration test suite to ensure no standard execution paths were broken.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.