### PR TITLE
List serial ports with the `usb.scan_serial_ports` helper

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -26,7 +26,6 @@ from homeassistant.helpers import (
     selector,
 )
 from homeassistant.helpers.storage import Store
-from serial.tools import list_ports  # type: ignore[import-untyped]
 
 from ramses_rf.schemas import (
     SCH_GATEWAY_DICT,
@@ -82,25 +81,19 @@ CONF_ZIGBEE_DEVICE: Final = "Zigbee device"
 
 def get_usb_ports() -> dict[str, str]:
     """Return a dict of USB ports and their friendly names."""
-    ports = list_ports.comports()
     port_descriptions = {}
-    for port in ports:
-        vid: str | None = None
-        pid: str | None = None
-        if port.vid is not None and port.pid is not None:
-            usb_device = usb.usb_device_from_port(port)
-            vid = usb_device.vid
-            pid = usb_device.pid
-        dev_path = usb.get_serial_by_id(port.device)
+    for port in usb.scan_serial_ports():
+        vid = port.vid if isinstance(port, usb.USBDevice) else None
+        pid = port.pid if isinstance(port, usb.USBDevice) else None
         human_name = usb.human_readable_device_name(
-            dev_path,
+            port.device,
             port.serial_number,
             port.manufacturer,
             port.description,
             vid,
             pid,
         )
-        port_descriptions[dev_path] = human_name
+        port_descriptions[port.device] = human_name
     return port_descriptions
 
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -78,23 +78,52 @@ CONF_MQTT_PATH: Final = "MQTT Broker..."
 CONF_HA_MQTT_PATH: Final = "Use Home Assistant MQTT - In development!"
 CONF_ZIGBEE_DEVICE: Final = "Zigbee device"
 
+if hasattr(usb, "async_scan_serial_ports"):
+    # Compatible with Home Assistant Core 2026.5.0
+    def get_usb_ports() -> dict[str, str]:
+        """Return a dict of USB ports and their friendly names."""
+        port_descriptions = {}
+        for port in usb.scan_serial_ports():
+            vid = port.vid if isinstance(port, usb.USBDevice) else None
+            pid = port.pid if isinstance(port, usb.USBDevice) else None
+            human_name = usb.human_readable_device_name(
+                port.device,
+                port.serial_number,
+                port.manufacturer,
+                port.description,
+                vid,
+                pid,
+            )
+            port_descriptions[port.device] = human_name
+        return port_descriptions
 
-def get_usb_ports() -> dict[str, str]:
-    """Return a dict of USB ports and their friendly names."""
-    port_descriptions = {}
-    for port in usb.scan_serial_ports():
-        vid = port.vid if isinstance(port, usb.USBDevice) else None
-        pid = port.pid if isinstance(port, usb.USBDevice) else None
-        human_name = usb.human_readable_device_name(
-            port.device,
-            port.serial_number,
-            port.manufacturer,
-            port.description,
-            vid,
-            pid,
-        )
-        port_descriptions[port.device] = human_name
-    return port_descriptions
+else:
+    from serial.tools import list_ports  # type: ignore[import-untyped]
+
+    # Compatible with all earlier versions.
+    # TODO: remove Q3 2026
+    def get_usb_ports() -> dict[str, str]:
+        """Return a dict of USB ports and their friendly names."""
+        ports = list_ports.comports()
+        port_descriptions = {}
+        for port in ports:
+            vid: str | None = None
+            pid: str | None = None
+            if port.vid is not None and port.pid is not None:
+                usb_device = usb.usb_device_from_port(port)
+                vid = usb_device.vid
+                pid = usb_device.pid
+            dev_path = usb.get_serial_by_id(port.device)
+            human_name = usb.human_readable_device_name(
+                dev_path,
+                port.serial_number,
+                port.manufacturer,
+                port.description,
+                vid,
+                pid,
+            )
+            port_descriptions[dev_path] = human_name
+        return port_descriptions
 
 
 async def async_get_usb_ports(hass: HomeAssistant) -> dict[str, str]:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -6,12 +6,13 @@ options menu (OptionsFlow).
 
 from collections.abc import Callable, Iterator
 from datetime import timedelta as td
+from importlib.metadata import version
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import voluptuous as vol
-from homeassistant.components.usb import SerialDevice, USBDevice
+from homeassistant.components.usb import USBDevice
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -47,6 +48,8 @@ from ramses_tx.schemas import (
     SZ_PORT_NAME,
     SZ_SERIAL_PORT,
 )
+
+HOMEASSISTANT_VERSION = version("homeassistant")
 
 
 @pytest.fixture(autouse=True)
@@ -536,8 +539,9 @@ async def test_configure_serial_port_error_logic(hass: HomeAssistant) -> None:
     assert result["step_id"] == "configure_serial_port"
 
 
-def test_get_usb_ports_full() -> None:
-    """Test get_usb_ports with VID/PID present."""
+@pytest.mark.skipif(HOMEASSISTANT_VERSION < "2026.5.0", reason="requires HA 2026.5.0+")
+def test_get_usb_ports_full_new() -> None:
+    """Test get_usb_ports with VID/PID present, HA Core 2026.5.0."""
     usb_device = USBDevice(
         device="/dev/ttyUSB0",
         vid="1234",
@@ -560,8 +564,11 @@ def test_get_usb_ports_full() -> None:
         assert ports == {"/dev/ttyUSB0": "USB Device"}
 
 
-def test_get_usb_ports_logic_edge_case() -> None:
-    """Test get_usb_ports when VID is missing (non-USB SerialDevice)."""
+@pytest.mark.skipif(HOMEASSISTANT_VERSION < "2026.5.0", reason="requires HA 2026.5.0+")
+def test_get_usb_ports_logic_edge_case_new() -> None:
+    """Test get_usb_ports when VID is missing (non-USB SerialDevice), HA Core 2026.5.0."""
+    from homeassistant.components.usb import SerialDevice
+
     serial_device = SerialDevice(
         device="/dev/serial/by-id/usb-Acme_Device_123",
         serial_number=None,
@@ -580,6 +587,66 @@ def test_get_usb_ports_logic_edge_case() -> None:
     ):
         ports = get_usb_ports()
         assert ports == {"/dev/serial/by-id/usb-Acme_Device_123": "USB Device"}
+
+
+# TODO: remove Q3 2026
+@pytest.mark.skipif(
+    HOMEASSISTANT_VERSION >= "2026.5.0", reason="requires HA < 2026.5.0"
+)
+def test_get_usb_ports_full_old() -> None:
+    """Test get_usb_ports with VID/PID present (Lines 76-78), older Core."""
+    with (
+        patch("serial.tools.list_ports.comports") as mock_ports,
+        patch("homeassistant.components.usb.usb_device_from_port") as mock_usb_dev,
+        patch(
+            "homeassistant.components.usb.get_serial_by_id", return_value="/dev/ttyUSB0"
+        ),
+        patch(
+            "homeassistant.components.usb.human_readable_device_name",
+            return_value="USB Device",
+        ),
+    ):
+        mock_port = MagicMock()
+        mock_port.vid = "1234"
+        mock_port.pid = "5678"
+        mock_port.device = "/dev/ttyUSB0"
+        mock_ports.return_value = [mock_port]
+
+        mock_device = MagicMock()
+        mock_device.vid = "1234"
+        mock_device.pid = "5678"
+        mock_usb_dev.return_value = mock_device
+
+        ports = get_usb_ports()
+        assert "/dev/ttyUSB0" in ports
+        mock_usb_dev.assert_called_once()
+
+
+# TODO: remove Q3 2026
+@pytest.mark.skipif(
+    HOMEASSISTANT_VERSION >= "2026.5.0", reason="requires HA < 2026.5.0"
+)
+def test_get_usb_ports_logic_edge_case_old() -> None:
+    """Test get_usb_ports when VID is missing (Lines 161-164), older Core."""
+    with (
+        patch("serial.tools.list_ports.comports") as mock_ports,
+        patch(
+            "homeassistant.components.usb.get_serial_by_id",
+            return_value="/dev/serial/by-id/usb-Acme_Device_123",
+        ),
+        patch(
+            "homeassistant.components.usb.human_readable_device_name",
+            return_value="USB Device",
+        ),
+    ):
+        mock_port = MagicMock()
+        mock_port.vid = None  # Forces skip of line 78-81
+        mock_port.device = "/dev/ttyUSB0"
+        mock_ports.return_value = [mock_port]
+
+        ports = get_usb_ports()
+        assert "/dev/serial/by-id/usb-Acme_Device_123" in ports
+        assert ports["/dev/serial/by-id/usb-Acme_Device_123"] == "USB Device"
 
 
 async def test_configure_serial_port_validation_error(hass: HomeAssistant) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import voluptuous as vol
+from homeassistant.components.usb import SerialDevice, USBDevice
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
@@ -536,55 +537,49 @@ async def test_configure_serial_port_error_logic(hass: HomeAssistant) -> None:
 
 
 def test_get_usb_ports_full() -> None:
-    """Test get_usb_ports with VID/PID present (Lines 76-78)."""
+    """Test get_usb_ports with VID/PID present."""
+    usb_device = USBDevice(
+        device="/dev/ttyUSB0",
+        vid="1234",
+        pid="5678",
+        serial_number="SN123",
+        manufacturer="Acme",
+        description="Acme Device",
+    )
     with (
-        patch("serial.tools.list_ports.comports") as mock_ports,
-        patch("homeassistant.components.usb.usb_device_from_port") as mock_usb_dev,
         patch(
-            "homeassistant.components.usb.get_serial_by_id", return_value="/dev/ttyUSB0"
+            "homeassistant.components.usb.scan_serial_ports",
+            return_value=[usb_device],
         ),
         patch(
             "homeassistant.components.usb.human_readable_device_name",
             return_value="USB Device",
         ),
     ):
-        mock_port = MagicMock()
-        mock_port.vid = "1234"
-        mock_port.pid = "5678"
-        mock_port.device = "/dev/ttyUSB0"
-        mock_ports.return_value = [mock_port]
-
-        mock_device = MagicMock()
-        mock_device.vid = "1234"
-        mock_device.pid = "5678"
-        mock_usb_dev.return_value = mock_device
-
         ports = get_usb_ports()
-        assert "/dev/ttyUSB0" in ports
-        mock_usb_dev.assert_called_once()
+        assert ports == {"/dev/ttyUSB0": "USB Device"}
 
 
 def test_get_usb_ports_logic_edge_case() -> None:
-    """Test get_usb_ports when VID is missing (Lines 161-164)."""
+    """Test get_usb_ports when VID is missing (non-USB SerialDevice)."""
+    serial_device = SerialDevice(
+        device="/dev/serial/by-id/usb-Acme_Device_123",
+        serial_number=None,
+        manufacturer=None,
+        description=None,
+    )
     with (
-        patch("serial.tools.list_ports.comports") as mock_ports,
         patch(
-            "homeassistant.components.usb.get_serial_by_id",
-            return_value="/dev/serial/by-id/usb-Acme_Device_123",
+            "homeassistant.components.usb.scan_serial_ports",
+            return_value=[serial_device],
         ),
         patch(
             "homeassistant.components.usb.human_readable_device_name",
             return_value="USB Device",
         ),
     ):
-        mock_port = MagicMock()
-        mock_port.vid = None  # Forces skip of line 78-81
-        mock_port.device = "/dev/ttyUSB0"
-        mock_ports.return_value = [mock_port]
-
         ports = get_usb_ports()
-        assert "/dev/serial/by-id/usb-Acme_Device_123" in ports
-        assert ports["/dev/serial/by-id/usb-Acme_Device_123"] == "USB Device"
+        assert ports == {"/dev/serial/by-id/usb-Acme_Device_123": "USB Device"}
 
 
 async def test_configure_serial_port_validation_error(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Home Assistant Core is moving to using the USB integration directly to list serial ports. This is one of the few custom components that does it completely manually but still uses helpers from the USB integration so I'm opening this PR to align it with how Core will function next release.

CI will fail for this PR until the next Core release/beta is made in a few weeks.

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used

**PR Summary**
