### PR TITLE
Prune `ramses_cc_regex_event` data

### DIFF
--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -123,10 +123,8 @@ class RamsesEvent(EventEntity):
 
         _LOGGER.debug("handle event %s", self._type)
         self._trigger_event(
-            event,
-            {
-                "extra_data": self._data,
-            },
+            event
+            # no extra attributes required for the regex event
         )
         self.async_write_ha_state()
 


### PR DESCRIPTION
- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used

**PR Summary**
don't copy extra_data, see issue #624 