### PR TITLE
Refactor: Transition to Modern DTO-based Gateway Configuration

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -203,6 +203,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             packet_log = {**new_options["packet_log"]}
             # Remove deprecated key mentioned in issue #592
             packet_log.pop("file_name", None)
+            # Translate legacy rotate_backups to modern key
+            if "rotate_backups" in packet_log:
+                packet_log["packet_log_retention_days"] = packet_log.pop(
+                    "rotate_backups"
+                )
+
             new_options["packet_log"] = packet_log
 
         # 2. Clean up ramses_rf dictionary (legacy database storage flags)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import inspect
 import logging
 import re
@@ -37,6 +38,7 @@ from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_rf.system import Evohome, System, Zone
 from ramses_rf.topology import Child
 from ramses_tx import exceptions as exc
+from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI, Code
 from ramses_tx.schemas import extract_serial_port
 
@@ -301,49 +303,21 @@ class RamsesCoordinator(DataUpdateCoordinator):
     def _create_client(self, schema: dict[str, Any]) -> Gateway:
         """Create and configure a new RAMSES client instance."""
 
-        # 1. Get the raw dict config from HA options
         raw_config = self.options.get(CONF_RAMSES_RF, {}).copy()
 
-        # 2. Identify which keys belong to the new GatewayConfig dataclass
-        valid_config_keys = set(inspect.signature(GatewayConfig).parameters.keys())
+        engine_kwargs: dict[str, Any] = {}
+        gateway_kwargs: dict[str, Any] = {}
 
-        # 3. Identify which keys belong directly to Gateway.__init__
-        valid_gateway_keys = set(inspect.signature(Gateway.__init__).parameters.keys())
+        engine_fields = {f.name for f in dataclasses.fields(EngineConfig)}
+        gateway_fields = {f.name for f in dataclasses.fields(GatewayConfig)}
 
-        # 4. Split the dict: GatewayConfig args vs Gateway __init__ args
-        # Exclude app_context: it is injected explicitly below, not from HA options.
-        gwy_config_args = {
-            k: v
-            for k, v in raw_config.items()
-            if k in valid_config_keys and k != "app_context"
-        }
+        for k, v in raw_config.items():
+            if k in engine_fields:
+                engine_kwargs[k] = v
+            elif k in gateway_fields and k != "engine":
+                gateway_kwargs[k] = v
 
-        # Drop any deprecated keys that don't belong to either!
-        handled_keys = {
-            "self",
-            "kwargs",
-            "config",
-            "schema",
-            "packet_log",
-            "known_list",
-            "port_name",
-            "loop",
-        }
-        gateway_kwargs = {
-            k: v
-            for k, v in raw_config.items()
-            if k in valid_gateway_keys and k not in handled_keys
-        }
-
-        _config_kwargs = dict(gwy_config_args)
-
-        def route_special_arg(name: str, value: Any) -> None:
-            if name in valid_config_keys:
-                _config_kwargs[name] = value
-            elif name in valid_gateway_keys:
-                gateway_kwargs[name] = value
-
-        route_special_arg("app_context", self.hass)
+        engine_kwargs["app_context"] = self.hass
 
         raw_known_list = self.options.get(SZ_KNOWN_LIST, {})
         sanitized_known_list = {
@@ -354,20 +328,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             )
             for device_id, traits in raw_known_list.items()
         }
+        engine_kwargs["known_list"] = sanitized_known_list
 
         packet_log = self.options.get(SZ_PACKET_LOG, {})
-        route_special_arg("packet_log", packet_log)
-        route_special_arg("known_list", sanitized_known_list)
-        route_special_arg("schema", schema)
+        engine_kwargs["packet_log"] = packet_log
+
+        gateway_kwargs["schema"] = schema
+
         gateway_timeout = self.options.get(CONF_GATEWAY_TIMEOUT)
         if gateway_timeout is not None:
-            route_special_arg("gateway_timeout", gateway_timeout)
-        gwy_config = GatewayConfig(**_config_kwargs)
-
-        kwargs = {
-            "config": gwy_config,
-            **gateway_kwargs,
-        }
+            gateway_kwargs["gateway_timeout"] = gateway_timeout
 
         # Detect the transport type from port_name / flags.
         _serial_port_opts = self.options.get(SZ_SERIAL_PORT, {})
@@ -381,13 +351,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # ZigbeeTransport — handled natively by transport_factory in ramses_tx.
             # No MQTT broker is required; no RamsesMqttBridge is created.
             # hass reaches ZigbeeTransport via GatewayConfig.app_context (PR #505).
+            engine_config = EngineConfig(**engine_kwargs)
+            gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
+
             return Gateway(
                 port_name=_port_name_raw,
+                config=gwy_config,
                 loop=self.hass.loop,
-                **kwargs,
             )
 
-        elif _is_mqtt_ha:
+        if _is_mqtt_ha:
             # RamsesMqttBridge path — uses HA MQTT
             if not self.hass.config_entries.async_entries("mqtt"):
                 raise ConfigEntryNotReady(
@@ -403,57 +376,37 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # Ensure the bridge unsubscribes from MQTT on shutdown
             self.entry.async_on_unload(self.mqtt_bridge.close)
 
-            # Gateway.__init__ accepts transport_constructor directly.
-            kwargs["transport_constructor"] = self.mqtt_bridge.async_transport_factory
-
-            # We must provide a port_name to satisfy ramses_tx validation.
-            port_name = _port_name_raw or "mqtt"
-
             # Pass the configured HGI ID to ramses_rf.
-            if "hgi_id" in valid_config_keys:
-                gwy_config.hgi_id = hgi_id
-            elif "hgi_id" in valid_gateway_keys:
-                kwargs["hgi_id"] = hgi_id
+            engine_kwargs["hgi_id"] = hgi_id
 
             # Inject HGI into known_list (redundant but safe fallback — config_flow
             # handles this, but kept here to satisfy ramses_rf schema validation).
-            known_list = dict(
-                (
-                    getattr(gwy_config, "known_list", None)
-                    if "known_list" in valid_config_keys
-                    else kwargs.get("known_list")
-                )
-                or {}
-            )
-            device_entry = known_list.setdefault(hgi_id, {})
+            device_entry = sanitized_known_list.setdefault(hgi_id, {})
             device_entry["class"] = "HGI"
             device_entry.setdefault("alias", "ramses_esp")
-            if "known_list" in valid_config_keys:
-                gwy_config.known_list = known_list
-            elif "known_list" in valid_gateway_keys:
-                kwargs["known_list"] = known_list
 
-            client = Gateway(
-                port_name=port_name,
-                loop=self.hass.loop,
-                **kwargs,
-            )
-
-            return client
-
-        else:
-            # Standard Serial/USB setup
-            port_name, port_config = extract_serial_port(self.options[SZ_SERIAL_PORT])
-            if "port_config" in valid_config_keys:
-                gwy_config.port_config = port_config
-            elif "port_config" in valid_gateway_keys:
-                kwargs["port_config"] = port_config
+            engine_config = EngineConfig(**engine_kwargs)
+            gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
 
             return Gateway(
-                port_name=port_name,
+                port_name=_port_name_raw or "mqtt",
+                config=gwy_config,
                 loop=self.hass.loop,
-                **kwargs,
+                transport_constructor=self.mqtt_bridge.async_transport_factory,
             )
+
+        # Standard Serial/USB setup
+        port_name, port_config = extract_serial_port(self.options[SZ_SERIAL_PORT])
+        engine_kwargs["port_config"] = port_config
+
+        engine_config = EngineConfig(**engine_kwargs)
+        gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
+
+        return Gateway(
+            port_name=port_name,
+            config=gwy_config,
+            loop=self.hass.loop,
+        )
 
     async def _async_stop_client(self) -> None:
         """Safely stop the RAMSES client, catching transport exceptions on teardown."""

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -362,35 +362,11 @@ async def test_create_client_strips_commands_from_known_list(
         }
     }
 
-    class FakeGatewayConfig:
-        def __init__(
-            self,
-            *,
-            app_context: Any | None = None,
-            known_list: dict[str, Any] | None = None,
-            packet_log: dict[str, Any] | None = None,
-            port_config: dict[str, Any] | None = None,
-            schema: dict[str, Any] | None = None,
-            gateway_timeout: int | None = None,
-        ) -> None:
-            self.app_context = app_context
-            self.known_list = known_list
-            self.packet_log = packet_log
-            self.port_config = port_config
-            self.schema = schema
-            self.gateway_timeout = gateway_timeout
-
-    with (
-        patch(
-            "custom_components.ramses_cc.coordinator.GatewayConfig",
-            FakeGatewayConfig,
-        ),
-        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
-    ):
+    with patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy:
         mock_coordinator._create_client({})
 
         _, kwargs = mock_gwy.call_args
-        known_list = kwargs["config"].known_list
+        known_list = kwargs["config"].engine.known_list
 
         assert known_list["37:168270"]["class"] == "REM"
         assert CONF_COMMANDS not in known_list["37:168270"]
@@ -814,31 +790,7 @@ async def test_create_client_mqtt_success(
     # Mock HA to report MQTT entries exist
     mock_coordinator.hass.config_entries.async_entries.return_value = ["mqtt"]
 
-    class FakeGatewayConfig:
-        def __init__(
-            self,
-            *,
-            app_context: Any | None = None,
-            hgi_id: str | None = None,
-            known_list: dict[str, Any] | None = None,
-            packet_log: dict[str, Any] | None = None,
-            port_config: dict[str, Any] | None = None,
-            schema: dict[str, Any] | None = None,
-            gateway_timeout: int | None = None,
-        ) -> None:
-            self.app_context = app_context
-            self.hgi_id = hgi_id
-            self.known_list = known_list
-            self.packet_log = packet_log
-            self.port_config = port_config
-            self.schema = schema
-            self.gateway_timeout = gateway_timeout
-
     with (
-        patch(
-            "custom_components.ramses_cc.coordinator.GatewayConfig",
-            FakeGatewayConfig,
-        ),
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch(
             "custom_components.ramses_cc.coordinator.RamsesMqttBridge"
@@ -871,11 +823,9 @@ async def test_create_client_mqtt_success(
         )
         assert kwargs.get("port_name") == "/dev/ttyUSB0"
         assert "config" in kwargs
-        assert kwargs["config"].hgi_id == DEFAULT_HGI_ID
-        assert kwargs["config"].known_list is not None
-        assert DEFAULT_HGI_ID in kwargs["config"].known_list
-
-        # _extra is no longer populated by coordinator (PR #505)
+        assert kwargs["config"].engine.hgi_id == DEFAULT_HGI_ID
+        assert kwargs["config"].engine.known_list is not None
+        assert DEFAULT_HGI_ID in kwargs["config"].engine.known_list
 
 
 @pytest.mark.asyncio
@@ -903,8 +853,8 @@ async def test_create_client_zigbee_path(
         # Only check when the installed ramses_rf supports app_context.
         config = kwargs.get("config")
         assert config is not None
-        if hasattr(config, "app_context"):
-            assert config.app_context is mock_coordinator.hass
+        if hasattr(config, "engine") and hasattr(config.engine, "app_context"):
+            assert config.engine.app_context is mock_coordinator.hass
 
         # The method should return the Gateway instance
         assert result is mock_client

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -78,12 +78,16 @@ async def test_entities(
     ):
         pkt_log = config[DOMAIN]["packet_log"]
         if "file_name" in pkt_log:
-            pkt_log["packet_log_prefix"] = pkt_log.pop("file_name").split(".")[0]
+            file_prefix = pkt_log.pop("file_name").split(".")[0]
+            pkt_log["packet_log_prefix"] = file_prefix
         if "rotate_backups" in pkt_log:
             pkt_log["packet_log_retention_days"] = pkt_log.pop("rotate_backups")
 
+    # Ensure VirtualRf gateway is in known_list to prevent strict filtering drops
+    config[DOMAIN].setdefault("known_list", {})["18:006402"] = {"class": "HGI"}
+
     # Patch 'available' to always be True during setup so historical packet logs
-    # render fully populated states in the snapshot, bypassing the 60-minute timeout.
+    # render fully populated states in the snapshot, bypassing 60-min timeout.
     with (
         patch(
             "custom_components.ramses_cc.entity.RamsesEntity.available",
@@ -314,7 +318,12 @@ async def test_init_service_wrappers_advanced(
     await hass.services.async_call(
         DOMAIN,
         "send_packet",
-        {"device_id": DEVICE_ID, "verb": "RQ", "code": "1234", "payload": "00"},
+        {
+            "device_id": DEVICE_ID,
+            "verb": "RQ",
+            "code": "1234",
+            "payload": "00",
+        },
         blocking=True,
     )
     assert mock_coordinator.async_send_packet.called

--- a/tests/tests_old/test_evo_control.py
+++ b/tests/tests_old/test_evo_control.py
@@ -1,22 +1,22 @@
-"""Test the compatibility of the interface (/api/states) with EvoControl.
+"""Test compatibility of the interface (/api/states) with EvoControl.
 
 See: https://www.amazon.co.uk/dp/B0BL1CN6WS
 
-The intention here is to confirm the namespace remains consistent, so that the
-interface with EvoControl is not broken from one version of this integration to
-the next.
+The intention here is to confirm the namespace remains consistent,
+so that the interface with EvoControl is not broken from one version
+of this integration to the next.
 
-The test will check schema JSON, entity_id, attributes (attr_id and values).
+The test will check schema JSON, entity_id, attributes (attr_id and
+values).
 
-Note that EvoControl uses the /api/states endpoint to get its data (and that is
-tested only indirectly here).
+Note that EvoControl uses the /api/states endpoint to get its data
+(and that is tested only indirectly here).
 
 This does not test any service calls, or any other endpoints.
 """
 
 from __future__ import annotations
 
-import inspect
 import json
 from typing import Any
 
@@ -35,6 +35,7 @@ from custom_components.ramses_cc.sensor import SENSOR_DESCRIPTIONS
 from custom_components.ramses_cc.water_heater import WATER_HEATER_DESCRIPTIONS
 from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_rf.system import Evohome
+from ramses_tx.config import EngineConfig
 
 from .helpers import TEST_DIR
 
@@ -58,28 +59,24 @@ async def instantiate_entities(
     # 1. Provide the string path instead of an open file object
     log_path = f"{TEST_DIR}/{INPUT_FILE}"
 
-    config_kwargs: dict[str, Any] = {"disable_discovery": True}
-    gateway_kwargs: dict[str, Any] = {"port_name": None}
-
-    config_params = set(inspect.signature(GatewayConfig).parameters)
-    gateway_params = set(inspect.signature(Gateway).parameters)
-
-    if "input_file" in config_params:
-        config_kwargs["input_file"] = log_path
-    elif "input_file" in gateway_params:
-        gateway_kwargs["input_file"] = log_path
-
-    if "disable_qos" in config_params:
-        config_kwargs["disable_qos"] = True
-    elif "disable_qos" in gateway_params:
-        gateway_kwargs["disable_qos"] = True
-
-    gwy: Gateway = Gateway(
-        config=GatewayConfig(**config_kwargs),
-        **gateway_kwargs,
+    # Transport layer parameters go into EngineConfig
+    engine_config = EngineConfig(
+        disable_qos=True,
+        input_file=log_path,
     )
+
+    # Application layer parameters go into GatewayConfig
+    gwy_config = GatewayConfig(
+        disable_discovery=True,
+        engine=engine_config,
+    )
+
+    # Explicitly set port_name to None to bypass hardware serial initialization
+    gwy: Gateway = Gateway(port_name=None, config=gwy_config)
+
     await gwy.start()
-    await gwy.stop()  # have to stop MessageIndex thread, aka: gwy.msg_db.stop()
+    # have to stop MessageIndex thread, aka: gwy.msg_db.stop()
+    await gwy.stop()
 
     coordinator: RamsesCoordinator = MockRamsesCoordinator(hass)
 
@@ -130,7 +127,8 @@ async def instantiate_entities(
         and hasattr(device, description.ramses_rf_attr)
     ]
 
-    # Pre-resolve lazy async attributes to prevent test failures on first access
+    # Pre-resolve lazy async attributes to prevent test failures on
+    # first access
     for entity in climates + water_heaters + binary_sensors + sensors:
         entity.entity_id = f"test.{entity.unique_id}"
         entity.hass = hass
@@ -150,7 +148,8 @@ async def test_namespace(hass: HomeAssistant) -> None:
 
     with open(f"{TEST_DIR}/{SCHEMA_FILE}") as f:
         _SCHEMA: dict[str, dict[str, Any]] = json.load(f)
-        CTL_ID = list(_SCHEMA.keys())[0]  # ctl_id via a webform, from the user
+        # ctl_id via a webform, from the user
+        CTL_ID = list(_SCHEMA.keys())[0]
         SCHEMA = list(_SCHEMA.values())[0]
 
     # The intention here is check the namespace used by EvoControl
@@ -209,7 +208,8 @@ async def test_namespace(hass: HomeAssistant) -> None:
 
     #
     # evo_control uses: sensor.${dhwRelayId}_relay_demand
-    dhw_id = SCHEMA["stored_hotwater"]["hotwater_valve"]  # via walking the schema
+    # via walking the schema
+    dhw_id = SCHEMA["stored_hotwater"]["hotwater_valve"]
     uid = f"{dhw_id}-active"
 
     binary = [e for e in binary_sensors if e.unique_id == uid][0]
@@ -254,16 +254,17 @@ async def test_namespace(hass: HomeAssistant) -> None:
 
         climate = [e for e in climates if e.unique_id == uid][0]
         assert climate.unique_id == uid
-        # assert climate.name == SCHEMA["zones"][zon_idx]["_name"]  # TODO
+        # assert climate.name == SCHEMA["zones"][zon_idx]["_name"]
+        # TODO
 
         if zon_idx == "02":
             assert climate.extra_state_attributes["mode"] == {
                 "mode": "permanent_override",
                 "setpoint": 5.0,
             }
-            assert (
-                climate.current_temperature == 18.16
-            )  # equivalent to {"temperatureStatus": isAvailable: true, temperature: 18.16}
+            # equivalent to {"temperatureStatus": isAvailable: true,
+            # temperature: 18.16}
+            assert climate.current_temperature == 18.16
 
         else:
             mode_attr = climate.extra_state_attributes["mode"]

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -123,6 +123,7 @@ TEST_CONFIG: Final = {
     "advanced_features": {"send_packet": True},
     "known_list": {
         "03:123456": {"class": "THM", "faked": True},
+        "18:006402": {"class": "HGI"},
         "32:097710": {"class": "CO2"},
         "32:139773": {"class": "HUM"},
         "37:123456": {"class": "FAN"},
@@ -282,7 +283,10 @@ async def _setup_via_entry_(
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
-    # await hass.async_block_till_done()  # ?clear hass._tasks
+
+    # Await the Hass event loop to ensure the ramses_rf Engine has fully
+    # started before we start blasting it with virtual serial packets.
+    await hass.async_block_till_done()
 
     await _cast_packets_to_rf(hass, rf)
 


### PR DESCRIPTION
### The Problem:

The `ramses_cc` integration was utilizing a legacy flat `**kwargs` unpacking pattern to initialize the `ramses_rf.Gateway`. This approach broke encapsulation, bypassed strict type checking, and relied on internal backward-compatibility shims to resolve nested Home Assistant configuration dictionaries. Additionally, legacy mock classes in the test suite prevented the use of modern Python introspection, and legacy configuration keys threatened to pollute the runtime coordinator logic.

### Consequences:

Failure to modernize this integration would lead to:
- **Configuration Instability**: Implicit reliance on `**kwargs` and library-level deprecation shims makes the integration prone to silent failures if those shims are removed.
- **Brittle Tests**: Testing against fake mock classes rather than the true DTOs masked underlying typing issues and structural changes in the core library.
- **Architectural Debt**: Forcing the runtime coordinator to translate legacy Home Assistant configuration keys violates separation of concerns.

### The Fix:

Implemented a high-level modernization of the `RamsesCoordinator` to natively construct and pass `GatewayConfig` and `EngineConfig` DTOs. This was coupled with moving all legacy configuration translations to the HA migration lifecycle (`__init__.py`), keeping the runtime code strictly typed and clean. Finally, the test suite was upgraded to validate against the true nested DTO architecture.

### Technical Implementation:
- **DTO Composition**: Refactored `_create_client` in `coordinator.py` to utilize `dataclasses.fields()` for dynamic, type-safe filtering of HA configuration into isolated `EngineConfig` and `GatewayConfig` containers.
- **Configuration Migration**: Leveraged `async_migrate_entry` in `__init__.py` to permanently clean up and translate legacy configuration keys (like `file_name` and `rotate_backups`) on the user's disk upon version bump, protecting the coordinator from malformed data.
- **Test Suite Modernization**: Stripped legacy `FakeGatewayConfig` mock classes from `test_coordinator.py` to allow native `dataclasses.fields` introspection to succeed, and updated all assertions to correctly target nested properties (e.g., `kwargs["config"].engine.known_list`).

### Testing Performed:
- **Test Suite Pass**: Executed the `pytest` suite for `test_coordinator.py`, successfully clearing all `TypeError`s and achieving a 100% pass rate for the initialization logic.
- **Type Safety**: Ensured strict compatibility with the new nested DTO structures, passing Ruff and Mypy standards.

### Risks of NOT Implementing:

The integration will eventually crash as the `ramses_rf` core library moves closer to a 1.0 release and removes legacy `**kwargs` support entirely. Future test expansions will be blocked by brittle mocks that do not accurately represent the library's required data structures.

### Risks of Implementing:

Users with highly customized, legacy `configuration.yaml` entries may experience configuration drops if their legacy keys bypass the migration flow and do not map cleanly to the new DTO structure.

### Mitigation Steps:
- Implemented robust key translation and cleanup within the safe confines of `__init__.py`'s `async_migrate_entry`.
- Handled advanced routing (Zigbee URLs, MQTT Home Assistant integration) gracefully by mapping their specific overrides securely into the initialized DTOs before passing them to the Gateway.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini for code generation, architectural review, and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.  
