### PR TITLE
Fix duplicate unique_id errors in number platform

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from types import ModuleType
 
 # from collections.abc import Callable
 #
@@ -51,8 +52,6 @@ from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.service import verify_domain_control
 from homeassistant.helpers.typing import ConfigType
 
-from ramses_tx import exceptions as exc
-
 from .const import CONF_ADVANCED_FEATURES, CONF_SEND_PACKET, DOMAIN
 from .coordinator import RamsesCoordinator
 from .schemas import (
@@ -77,6 +76,20 @@ from .schemas import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+_RAMSES_TX_EXC: ModuleType | None = None
+
+
+def _get_ramses_tx_exceptions() -> ModuleType:
+    """Import ramses_tx.exceptions lazily to avoid circular import issues."""
+
+    global _RAMSES_TX_EXC
+    if _RAMSES_TX_EXC is None:
+        from ramses_tx import exceptions as exc_module
+
+        _RAMSES_TX_EXC = exc_module
+    return _RAMSES_TX_EXC
+
 
 CONFIG_SCHEMA = vol.All(
     cv.deprecated(DOMAIN, raise_if_present=False),
@@ -134,6 +147,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     _LOGGER.debug("Setting up entry %s...", entry.entry_id)
 
+    tx_exc = _get_ramses_tx_exceptions()
+
     # Check if this entry is already set up
     if entry.entry_id in hass.data[DOMAIN]:
         _LOGGER.debug("Entry %s is already set up", entry.entry_id)
@@ -145,11 +160,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Store the coordinator in hass.data before setting it up
         hass.data[DOMAIN][entry.entry_id] = coordinator
         await coordinator.async_setup()
-    except exc.TransportSourceInvalid as err:  # not TransportSerialError
+    except tx_exc.TransportSourceInvalid as err:  # not TransportSerialError
         _LOGGER.error("Unrecoverable problem with the serial port: %s", err)
         hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
         return False
-    except exc.TransportError as err:
+    except tx_exc.TransportError as err:
         msg = f"There is a problem with the serial port: {err} (check config)"
         _LOGGER.warning(
             "Failed to set up entry %s (will retry): %s", entry.entry_id, msg

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -73,6 +73,7 @@ from .store import RamsesStore
 
 if TYPE_CHECKING:
     from .entity import RamsesEntity
+    from .number import RamsesNumberParam
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -112,7 +113,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self._systems: list[System] = []
         self._zones: list[Zone] = []
         self._dhws: list[Zone] = []
-        self._parameter_entities_created: set[str] = set()
+        self._parameter_entities_pending: set[str] = set()
+        self._parameter_entities_loaded: set[str] = set()
+        self._parameter_entities_created: dict[str, RamsesNumberParam] = {}
 
         self._sem = Semaphore(value=1)
 

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -62,33 +62,24 @@ class RamsesFanHandler:
         return None
 
     def create_parameter_entities(self, device: RamsesRFEntity) -> None:
-        """Create parameter entities for a device that supports 2411 parameters.
+        """Signal the number platform to create parameter entities for a device.
 
-        Delegates to the number platform to create entities and signals the
-        platform to add them.
+        The number platform handles entity creation via its device discovery callback.
+        This method just signals that a new FAN device with 2411 support has been
+        discovered.
 
         :param device: The ramses_rf device instance to create parameters for.
         """
         device_id = device.id
-        from .number import create_parameter_entities
-
-        entities = create_parameter_entities(self.coordinator, device)
         _LOGGER.debug(
-            "create_parameter_entities returned %d entities for %s",
-            len(entities),
+            "Signaling number platform about FAN device %s with 2411 support",
             device_id,
         )
-        if entities:
-            _LOGGER.info(
-                "Adding %d parameter entities for %s", len(entities), device_id
-            )
-            async_dispatcher_send(
-                self.hass,
-                SIGNAL_NEW_DEVICES.format(Platform.NUMBER),
-                entities,
-            )
-        else:
-            _LOGGER.debug("No parameter entities created for %s", device_id)
+        async_dispatcher_send(
+            self.hass,
+            SIGNAL_NEW_DEVICES.format(Platform.NUMBER),
+            [device],
+        )
 
     async def setup_fan_bound_devices(self, device: Device) -> None:
         """Set up bound devices for a FAN device.

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -132,6 +132,9 @@ async def async_setup_entry(
     """
 
     coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator._parameter_entities_pending.clear()
+    coordinator._parameter_entities_loaded.clear()
+    coordinator._parameter_entities_created.clear()
     platform: EntityPlatform = async_get_current_platform()
     ent_reg = er.async_get(hass)
     # Initialize entities list for both new and existing devices
@@ -157,24 +160,39 @@ async def async_setup_entry(
             return
 
         # If we received entities directly (not devices), just add them
+        pending_entities = coordinator._parameter_entities_pending
+        loaded_entities = coordinator._parameter_entities_loaded
+
         if all(isinstance(d, RamsesNumberParam) for d in devices):
             _LOGGER.debug("Adding %d entities directly", len(devices))
             # Filter out entities that are already loaded in the platform
             entities_to_add = []
             for entity in devices:
                 entity_id = entity.entity_id
-                # Check if entity already exists in platform
+                unique_id = entity.unique_id
+
+                # Check if entity already exists in platform by entity_id
                 if hasattr(platform, "entities") and entity_id in platform.entities:
                     _LOGGER.debug(
                         "Entity %s already loaded in platform, skipping",
                         entity_id,
                     )
-                else:
-                    entities_to_add.append(entity)
+                    continue
+
+                if unique_id in pending_entities:
+                    _LOGGER.debug(
+                        "Entity with unique_id %s already scheduled/created, skipping",
+                        unique_id,
+                    )
+                    continue
+
+                pending_entities.add(unique_id)
+                entities_to_add.append(entity)
 
             if entities_to_add:
                 _LOGGER.debug("Adding %d new entities directly", len(entities_to_add))
                 async_add_entities(entities_to_add)
+                loaded_entities.update(entity.unique_id for entity in entities_to_add)
             return
 
         # Otherwise, process as devices and create entities
@@ -191,14 +209,24 @@ async def async_setup_entry(
                 # Filter out entities that are already loaded in the platform
                 for entity in _param_entities:
                     entity_id = entity.entity_id
-                    # Check if entity already exists in platform
+                    unique_id = entity.unique_id
+                    # Check if entity already exists in platform by entity_id
                     if hasattr(platform, "entities") and entity_id in platform.entities:
                         _LOGGER.debug(
                             "Entity %s already loaded in platform, skipping",
                             entity_id,
                         )
-                    else:
-                        new_entities.append(entity)
+                        continue
+
+                    if unique_id in pending_entities:
+                        _LOGGER.debug(
+                            "Entity with unique_id %s already scheduled/created, skipping",
+                            unique_id,
+                        )
+                        continue
+
+                    pending_entities.add(unique_id)
+                    new_entities.append(entity)
 
             # Future: Add other entity types here
             # if other_entities := await async_create_other_entities(coordinator, devices):
@@ -218,6 +246,7 @@ async def async_setup_entry(
                     entity._device.id if hasattr(entity, "_device") else "no device",
                 )
             async_add_entities(new_entities, update_before_add=True)
+            loaded_entities.update(entity.unique_id for entity in new_entities)
 
             # After adding entities, request their current values
             for entity in new_entities:
@@ -247,13 +276,37 @@ async def async_setup_entry(
         if fan_devices:
             _LOGGER.debug("Found %d FAN devices to process", len(fan_devices))
             # Load entities from registry for existing devices
+            pending_entities = coordinator._parameter_entities_pending
+
             for device in fan_devices:
                 _LOGGER.debug(
                     "Loading parameter entities from registry for %s", device.id
                 )
                 param_entities = create_parameter_entities(coordinator, device)
                 if param_entities:
-                    entities.extend(param_entities)
+                    for entity in param_entities:
+                        entity_id = entity.entity_id
+                        unique_id = entity.unique_id
+
+                        if (
+                            hasattr(platform, "entities")
+                            and entity_id in platform.entities
+                        ):
+                            _LOGGER.debug(
+                                "Entity %s already loaded in platform, skipping",
+                                entity_id,
+                            )
+                            continue
+
+                        if unique_id in pending_entities:
+                            _LOGGER.debug(
+                                "Entity with unique_id %s already scheduled/created, skipping",
+                                unique_id,
+                            )
+                            continue
+
+                        pending_entities.add(unique_id)
+                        entities.append(entity)
 
     # Add all collected entities to the platform
     if entities:
@@ -703,6 +756,7 @@ class RamsesNumberParam(RamsesNumberBase):
             return False
 
         value = self._param_native_value.get(self._normalized_param_id)
+
         return value is not None
 
     async def _request_parameter_value(self) -> None:
@@ -1058,6 +1112,7 @@ def create_parameter_entities(
     )
 
     param_descriptions = get_param_descriptions(device, force=restore_from_registry)
+    created_param_entities = coordinator._parameter_entities_created
     entities: list[RamsesNumberParam] = []
 
     for description in param_descriptions:
@@ -1073,22 +1128,34 @@ def create_parameter_entities(
         old_unique_id = f"{device_id}_param_{param_id.lower()}"
         new_unique_id = f"{device.id}-{description.key}"
 
+        if new_unique_id in created_param_entities:
+            _LOGGER.debug(
+                "Parameter entity %s already scheduled/loaded, skipping duplicate creation",
+                new_unique_id,
+            )
+            continue
+
         # The entity key is already set correctly in get_param_descriptions()
         # No need to modify the frozen dataclass attribute
 
         try:
             # Check if entity already exists in registry to avoid duplicate
             # registry entries
-            entity_id = ent_reg.async_get_entity_id("number", DOMAIN, old_unique_id)
-            if entity_id is not None:
-                ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
+            existing_entity_id = ent_reg.async_get_entity_id(
+                "number", DOMAIN, old_unique_id
+            )
+            if existing_entity_id is not None:
+                ent_reg.async_update_entity(
+                    existing_entity_id, new_unique_id=new_unique_id
+                )
 
             entity = description.ramses_cc_class(coordinator, device, description)
             entities.append(entity)
+            created_param_entities[new_unique_id] = entity
             _LOGGER.info(
-                "Created parameter entity: %s for %s (param_id=%s)",
-                entity.entity_id,
-                device_id,
+                "Prepared parameter entity (unique_id=%s) for %s (param_id=%s)",
+                new_unique_id,
+                device.id,
                 param_id,
             )
         except Exception as e:


### PR DESCRIPTION
I still had duplicate errors on params. This should fix it.

Fix duplicate unique_id errors and circular import
Changes
Fix duplicate unique_id errors in number platform
Added coordinator tracking for parameter entities with three sets:
_parameter_entities_pending: entities scheduled for addition
_parameter_entities_loaded: entities successfully added to platform
_parameter_entities_created: entities instantiated in create_parameter_entities

Clear all tracking sets during platform setup to ensure clean state on reload
Check pending set before adding entities to prevent duplicate scheduling
Track created entities at source in create_parameter_entities to skip duplicate instantiations
Log with actual unique_id for easier debugging of registry migrations


Fix circular import with ramses_tx
Removed top-level from ramses_tx import exceptions as exc which triggered circular import at module load
Added lazy import helper _get_ramses_tx_exceptions() that imports ramses_tx.exceptions only when needed
Use the helper in async_setup_entry to catch TransportSourceInvalid and TransportError exceptions
This allows Home Assistant to load the integration without triggering the ramses_tx ↔ ramses_rf circular dependency
