### PR TITLE
fix: Resolve deprecated Home Assistant imports and Pyright warnings

### DIFF
--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -50,9 +50,9 @@ from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
     EntityPlatform,

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -25,7 +25,6 @@ from ramses_rf.schemas import (
     SZ_RESTORE_CACHE,
     SZ_SENSOR,
     SZ_SYSTEM,
-    SZ_ZONES,
 )
 from ramses_tx import SZ_BOUND_TO
 from ramses_tx.const import (
@@ -36,6 +35,7 @@ from ramses_tx.const import (
     MAX_NUM_REPEATS,
     MIN_GAP_DURATION,  # renamed from local MIN_DELAY_SECS
     MIN_NUM_REPEATS,
+    SZ_ZONES,
 )
 from ramses_tx.schemas import (
     SCH_ENGINE_DICT,

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -59,19 +59,6 @@ from ramses_rf.const import (
     SZ_TEMPERATURE,
 )
 from ramses_rf.device.heat import (
-    SZ_BOILER_OUTPUT_TEMP,
-    SZ_BOILER_RETURN_TEMP,
-    SZ_BOILER_SETPOINT,
-    SZ_CH_MAX_SETPOINT,
-    SZ_CH_SETPOINT,
-    SZ_CH_WATER_PRESSURE,
-    SZ_DHW_FLOW_RATE,
-    SZ_DHW_SETPOINT,
-    SZ_DHW_TEMP,
-    SZ_MAX_REL_MODULATION,
-    SZ_OEM_CODE,
-    SZ_OUTSIDE_TEMP,
-    SZ_REL_MODULATION_LEVEL,
     DhwSensor,
     OtbGateway,
     OutSensor,
@@ -87,6 +74,21 @@ from ramses_rf.device.hvac import (
 from ramses_rf.entity_base import Entity as RamsesRFEntity
 from ramses_rf.system.heat import System
 from ramses_rf.system.zones import ZoneBase
+from ramses_tx.const import (
+    SZ_BOILER_OUTPUT_TEMP,
+    SZ_BOILER_RETURN_TEMP,
+    SZ_BOILER_SETPOINT,
+    SZ_CH_MAX_SETPOINT,
+    SZ_CH_SETPOINT,
+    SZ_CH_WATER_PRESSURE,
+    SZ_DHW_FLOW_RATE,
+    SZ_DHW_SETPOINT,
+    SZ_DHW_TEMP,
+    SZ_MAX_REL_MODULATION,
+    SZ_OEM_CODE,
+    SZ_OUTSIDE_TEMP,
+    SZ_REL_MODULATION_LEVEL,
+)
 
 from .const import ATTR_SETPOINT, DOMAIN, UnitOfVolumeFlowRate
 from .coordinator import RamsesCoordinator

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -9,14 +9,12 @@ from datetime import datetime as dt, timedelta as td
 from typing import Any, Final
 
 from homeassistant.components.water_heater import (
-    STATE_OFF,
-    STATE_ON,
     WaterHeaterEntity,
     WaterHeaterEntityDescription,
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import STATE_OFF, STATE_ON, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import (

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
-from syrupy import SnapshotAssertion
+from syrupy.assertion import SnapshotAssertion
 
 from custom_components.ramses_cc import (
     async_migrate_entry,

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import homeassistant.helpers.entity as ha_entity
 import pytest
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
@@ -25,14 +25,19 @@ from ramses_tx.const import Priority
 
 
 @pytest.fixture(autouse=True, scope="module")
-def _inject_entity_platform() -> None:
+def _inject_entity_platform() -> Iterator[None]:
     """Inject EntityPlatform into HA entity module for Python 3.14 autospec.
 
     This ensures that the `EntityPlatform` type hint is resolvable when
     `unittest.mock.patch` with `autospec=True` aggressively evaluates
     annotations, preventing a NameError in isolated CI workers.
     """
-    ha_entity.EntityPlatform = EntityPlatform
+    with patch(
+        "homeassistant.helpers.entity.EntityPlatform",
+        EntityPlatform,
+        create=True,
+    ):
+        yield
 
 
 # Constants for testing
@@ -66,9 +71,9 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     coordinator.async_refresh = AsyncMock()
 
     # Async methods for fan params
-    # NOTE: Even though these now delegate to service_handler in the real coordinator,
-    # mocking them here on the coordinator instance is correct because RamsesRemote
-    # calls them on the coordinator instance.
+    # NOTE: Even though these now delegate to service_handler in the real
+    # coordinator, mocking them here on the coordinator instance is correct
+    # because RamsesRemote calls them on the coordinator instance.
     coordinator.async_get_fan_param = AsyncMock()
     coordinator.async_set_fan_param = AsyncMock()
     coordinator.get_all_fan_params = MagicMock()
@@ -155,7 +160,7 @@ async def test_remote_validation_errors(remote_entity: RamsesRemote) -> None:
 
 
 async def test_kwargs_assertions(remote_entity: RamsesRemote) -> None:
-    """Test that unexpected kwargs raise AssertionError (covering assert not kwargs)."""
+    """Test that unexpected kwargs raise AssertionError."""
     # async_delete_command
     with pytest.raises(AssertionError):
         await remote_entity.async_delete_command("cmd", unexpected_arg=True)
@@ -232,7 +237,7 @@ async def test_remote_send_command_logic(
         await remote_entity.async_send_command("boost", num_repeats=2, delay_secs=0.5)
 
     # Expectation: Called ONCE, with QoS parameters passed in kwargs
-    # The coordinator client is responsible for the repeats, not the remote entity loop
+    # The coordinator client is responsible for repeats, not the entity loop
     assert mock_coordinator.client.async_send_cmd.call_count == 1
 
     call_args = mock_coordinator.client.async_send_cmd.call_args
@@ -242,7 +247,7 @@ async def test_remote_send_command_logic(
     assert isinstance(sent_cmd, Command)
     assert kwargs["priority"] == Priority.HIGH
     assert kwargs["num_repeats"] == 2
-    assert kwargs["gap_duration"] == 0.5  # delay_secs mapped 1-to-1 to gap_duration
+    assert kwargs["gap_duration"] == 0.5
 
     # Fixed: Verify async_refresh is called instead of async_update
     assert mock_coordinator.async_refresh.called
@@ -283,7 +288,7 @@ async def test_remote_learn_command_success(
     mock_coordinator: MagicMock,
     mock_remote_device: MagicMock,
 ) -> None:
-    """Test the successful learning of a command via learn_event state change listener."""
+    """Test successful learning via learn_event state change listener."""
     remote = RamsesRemote(
         mock_coordinator, mock_remote_device, RamsesRemoteEntityDescription()
     )
@@ -328,7 +333,8 @@ async def test_remote_learn_command_success(
     assert remote._commands.get("test_cmd") == "learned_pkt_123"
 
 
-# TODO(eb): adapt this LeChat test suggestion to the above test_remote_learn_command_success:
+# TODO(eb): adapt this LeChat test suggestion to the above
+# test_remote_learn_command_success:
 async def test_async_learn_command_callback() -> None:
     # Mock the class instance
     mock_instance = AsyncMock()
@@ -479,7 +485,7 @@ async def test_async_learn_command_kwargs_not_empty(
 async def test_remote_learn_filter_logic(
     mock_coordinator: MagicMock, mock_remote_device: MagicMock, hass: HomeAssistant
 ) -> None:
-    """Thoroughly test the event_filter logic for various packet scenarios."""
+    """Thoroughly test event_filter logic for packet scenarios."""
     remote = RamsesRemote(
         mock_coordinator, mock_remote_device, RamsesRemoteEntityDescription()
     )
@@ -572,7 +578,10 @@ async def test_send_command_failure(
     mock_coordinator.client.async_send_cmd.side_effect = Exception("RF Error")
 
     with (
-        patch("custom_components.ramses_cc.remote.Command", side_effect=lambda x: x),
+        patch(
+            "custom_components.ramses_cc.remote.Command",
+            side_effect=lambda x: x,
+        ),
         pytest.raises(HomeAssistantError, match="Error sending command "),
     ):
         # This will raise a HomeAssistantError for any error caught in remote.py
@@ -635,7 +644,10 @@ async def test_setup_entry_platform(hass: HomeAssistant) -> None:
     hass.data[DOMAIN][entry.entry_id] = mock_coordinator
 
     with (
-        patch("custom_components.ramses_cc.remote.RamsesRemote", autospec=True),
+        patch(
+            "custom_components.ramses_cc.remote.RamsesRemote",
+            autospec=True,
+        ),
         patch(
             "custom_components.ramses_cc.remote.async_get_current_platform",
             return_value=MagicMock(entities={}),
@@ -700,8 +712,9 @@ async def test_fan_param_methods(
 ) -> None:
     """Test fan parameter methods for bound and unbound scenarios.
 
-    This test consolidates bound, unbound, set, get, and update verifications,
-    including the recent thread-safety fix for async_update_fan_rem_params.
+    This test consolidates bound, unbound, set, get, and update
+    verifications, including the recent thread-safety fix for
+    async_update_fan_rem_params.
     """
     entity_id = "remote.test_remote"
     device_id = "12:123456"
@@ -742,8 +755,9 @@ async def test_fan_param_methods(
     mock_coordinator.async_set_fan_param.assert_awaited()
 
     # --- Test 3: Update Params (Bound + Thread Safety Check) ---
-    # Create a completed Future to simulate the return value of async_add_executor_job
-    # if it were improperly used. We assert that it is NOT used.
+    # Create a completed Future to simulate the return value of
+    # async_add_executor_job if it were improperly used. We assert
+    # that it is NOT used.
     future: asyncio.Future[None] = asyncio.Future()
     future.set_result(None)
 
@@ -755,7 +769,11 @@ async def test_fan_param_methods(
         mock_exec.assert_not_called()
 
         # Check that coordinator.get_all_fan_params was called directly
-        expected_kwargs = {"key": "value", "device_id": fan_id, "from_id": device_id}
+        expected_kwargs = {
+            "key": "value",
+            "device_id": fan_id,
+            "from_id": device_id,
+        }
         mock_coordinator.get_all_fan_params.assert_called_with(expected_kwargs)
 
     # --- Test 4: Unbound Scenarios ---
@@ -782,7 +800,9 @@ async def test_fan_param_methods(
 
 @pytest.mark.skip
 async def test_remote_learn_cleanup_on_timeout(
-    hass: HomeAssistant, mock_coordinator: MagicMock, mock_remote_device: MagicMock
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+    mock_remote_device: MagicMock,
 ) -> None:
     """Test that the event listener is removed even if learning times out."""
     remote = RamsesRemote(
@@ -794,7 +814,8 @@ async def test_remote_learn_cleanup_on_timeout(
     mock_unsubscribe = MagicMock()
 
     with patch(  # TODO(eb): when learn test works, copy patch here
-        "homeassistant.core.EventBus.async_listen", return_value=mock_unsubscribe
+        "homeassistant.core.EventBus.async_listen",
+        return_value=mock_unsubscribe,
     ):
         # Run learn command with a very short timeout
         await remote.async_learn_command("timeout_cmd", timeout=0.01)

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -25,8 +25,8 @@ from ramses_rf.schemas import (
     SZ_KNOWN_LIST,
     SZ_SENSOR,
     SZ_SYSTEM,
-    SZ_ZONES,
 )
+from ramses_tx.const import SZ_ZONES
 from ramses_tx.schemas import SZ_PORT_NAME, SZ_SERIAL_PORT
 
 

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -4,8 +4,8 @@ from datetime import timedelta as td
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
-from homeassistant.components.water_heater import STATE_OFF, STATE_ON
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.util import dt as dt_util

--- a/tests/tests_old/helpers.py
+++ b/tests/tests_old/helpers.py
@@ -11,7 +11,8 @@ from typing import Any
 from homeassistant.util import dt as dt_util
 
 from custom_components.ramses_cc.const import STORAGE_KEY, STORAGE_VERSION
-from ramses_rf.gateway import Command, Gateway
+from ramses_rf.gateway import Gateway
+from ramses_tx.command import Command
 
 from ..virtual_rf import VirtualRf
 

--- a/tests/tests_old/test_evo_control.py
+++ b/tests/tests_old/test_evo_control.py
@@ -21,7 +21,8 @@ import json
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.components.climate import PRESET_ECO, ClimateEntity, HVACMode
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import PRESET_ECO, HVACMode
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.water_heater import WaterHeaterEntity
 from homeassistant.const import STATE_OFF, STATE_ON

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import voluptuous as vol
-from homeassistant.components.climate import HVACMode
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError


### PR DESCRIPTION
### The Problem:

The integration was relying on deprecated Home Assistant import paths (such as fetching `EntityPlatform` from `homeassistant.helpers.entity` and various constants/enums from outdated locations). This was cluttering the Pyright output with `reportPrivateImportUsage` errors and relying on outdated HA core structures.

### Consequences:

If this isn't fixed, the integration will experience hard crashes in a future Home Assistant release when these deprecated paths are officially removed from HA core. It also causes friction in CI/CD pipelines by failing strict type-checking checks.

### The Fix:

Updated all internal references and test files to use the officially supported, modern Home Assistant import paths and safely injected missing platform attributes in the test suite.

### Technical Implementation:

Re-architected test fixtures (specifically `_inject_entity_platform`) to use a `unittest.mock.patch` context manager with `create=True`. This allows for dynamic injection of `EntityPlatform` during `autospec=True` evaluations without resorting to `setattr` (which triggers Ruff B010) or using `# pyright: ignore` directives. Standardized all other imports (constants, entity categories) to their correct exported modules.

### Testing Performed:

Ran the full test suite locally. **It has been pytested using the latest master of ramses_rf**, resulting in a clean pass (501 passed, 10 skipped). Mypy (strict mode) and Pyright both report zero issues across the source files.

### Risks of NOT Implementing:

There is a high risk of the integration silently failing or crashing upon initialization for users who upgrade to upcoming Home Assistant core versions that drop the deprecated paths.

### Risks of Implementing:

Extremely low. The changes are strictly isolated to import path resolutions and test fixture mocking. No core integration logic or `ramses_rf` communication logic was altered.

### Mitigation Steps:

Mitigated any risk of initialization failures by ensuring the full pytest suite passes with 100% success alongside strict type validation, confirming the Home Assistant runtime environment is correctly simulated.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.