### PR TITLE
Fix MQTT transport persistence regression and heal missing serial_port without config-entry version bump

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -14,6 +14,7 @@ import logging
 import os
 import sys
 from types import ModuleType
+from typing import Any
 
 # from collections.abc import Callable
 #
@@ -165,6 +166,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("Entry %s is already set up", entry.entry_id)
         return True
 
+    healed_options = _healed_serial_port_options(
+        {**entry.options},
+        mqtt_entries_present=bool(hass.config_entries.async_entries("mqtt")),
+    )
+    if healed_options is not None:
+        hass.config_entries.async_update_entry(entry, options=healed_options)
+        _LOGGER.warning(
+            "Healed missing serial_port for entry %s by defaulting to mqtt_ha. "
+            "Please verify transport settings in the options flow.",
+            entry.entry_id,
+        )
+
     coordinator = RamsesCoordinator(hass, entry)
 
     try:
@@ -208,7 +221,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate legacy configuration options to the current version 3.
+    """Migrate legacy configuration options to the current version 2.
 
     This handles the transition away from user-selectable database storage
     and removes deprecated packet log keys (e.g., `file_name`) that cause
@@ -220,59 +233,62 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     _LOGGER.debug("Migrating ramses_cc config entry from version %s", entry.version)
 
-    if entry.version < 3:
+    if entry.version == 1:
         # Create a deep copy of the immutable MappingProxyType to mutate it
         new_options = {**entry.options}
 
-        if entry.version == 1:
-            # 1. Clean up packet_log dictionary
-            if isinstance(new_options.get("packet_log"), dict):
-                packet_log = {**new_options["packet_log"]}
-                # Remove deprecated key mentioned in issue #592
-                packet_log.pop("file_name", None)
-                # Translate legacy rotate_backups to modern key
-                if "rotate_backups" in packet_log:
-                    packet_log["packet_log_retention_days"] = packet_log.pop(
-                        "rotate_backups"
-                    )
+        # 1. Clean up packet_log dictionary
+        if isinstance(new_options.get("packet_log"), dict):
+            packet_log = {**new_options["packet_log"]}
+            # Remove deprecated key mentioned in issue #592
+            packet_log.pop("file_name", None)
+            # Translate legacy rotate_backups to modern key
+            if "rotate_backups" in packet_log:
+                packet_log["packet_log_retention_days"] = packet_log.pop(
+                    "rotate_backups"
+                )
 
-                new_options["packet_log"] = packet_log
+            new_options["packet_log"] = packet_log
 
-            # 2. Clean up ramses_rf dictionary (legacy database storage flags)
-            if isinstance(new_options.get("ramses_rf"), dict):
-                ramses_rf = {**new_options["ramses_rf"]}
-                # Remove deprecated database keys
-                for deprecated_key in ["use_database", "database_file", "file_name"]:
-                    ramses_rf.pop(deprecated_key, None)
-                new_options["ramses_rf"] = ramses_rf
+        # 2. Clean up ramses_rf dictionary (legacy database storage flags)
+        if isinstance(new_options.get("ramses_rf"), dict):
+            ramses_rf = {**new_options["ramses_rf"]}
+            # Remove deprecated database keys
+            for deprecated_key in ["use_database", "database_file", "file_name"]:
+                ramses_rf.pop(deprecated_key, None)
+            new_options["ramses_rf"] = ramses_rf
 
-        serial_port = new_options.get(SZ_SERIAL_PORT)
-        serial_port_missing = not isinstance(serial_port, dict) or not serial_port.get(
-            SZ_PORT_NAME
-        )
-
-        mqtt_hints_present = bool(new_options.get(CONF_MQTT_USE_HA)) or any(
-            key in new_options for key in (CONF_MQTT_HGI_ID, CONF_MQTT_TOPIC)
-        )
-        mqtt_entries_present = bool(hass.config_entries.async_entries("mqtt"))
-
-        if serial_port_missing and (mqtt_hints_present or mqtt_entries_present):
-            new_options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "mqtt_ha"}
-            new_options.setdefault(CONF_MQTT_USE_HA, True)
-            _LOGGER.warning(
-                "Healed missing serial_port for entry %s by defaulting to mqtt_ha. "
-                "Please verify transport settings in the options flow.",
-                entry.entry_id,
-            )
-
-        # Update the entry with cleaned/healed options and bump version
-        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
+        # Update the entry with the cleaned options and bump version
+        hass.config_entries.async_update_entry(entry, options=new_options, version=2)
         _LOGGER.info(
-            "Successfully migrated ramses_cc config entry %s to version 3",
+            "Successfully migrated ramses_cc config entry %s to version 2",
             entry.entry_id,
         )
 
     return True
+
+
+def _healed_serial_port_options(
+    options: dict[str, Any], *, mqtt_entries_present: bool
+) -> dict[str, Any] | None:
+    """Return healed options if serial_port is missing and MQTT is implied."""
+
+    serial_port = options.get(SZ_SERIAL_PORT)
+    serial_port_missing = not isinstance(serial_port, dict) or not serial_port.get(
+        SZ_PORT_NAME
+    )
+
+    mqtt_hints_present = bool(options.get(CONF_MQTT_USE_HA)) or any(
+        key in options for key in (CONF_MQTT_HGI_ID, CONF_MQTT_TOPIC)
+    )
+
+    if not serial_port_missing or not (mqtt_hints_present or mqtt_entries_present):
+        return None
+
+    new_options = {**options}
+    new_options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "mqtt_ha"}
+    new_options.setdefault(CONF_MQTT_USE_HA, True)
+    return new_options
 
 
 async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -54,7 +54,16 @@ from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.service import verify_domain_control
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_ADVANCED_FEATURES, CONF_SEND_PACKET, DOMAIN
+from .const import (
+    CONF_ADVANCED_FEATURES,
+    CONF_MQTT_HGI_ID,
+    CONF_MQTT_TOPIC,
+    CONF_MQTT_USE_HA,
+    CONF_SEND_PACKET,
+    DOMAIN,
+    SZ_PORT_NAME,
+    SZ_SERIAL_PORT,
+)
 from .coordinator import RamsesCoordinator
 from .schemas import (
     SCH_BIND_DEVICE,
@@ -199,7 +208,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate legacy configuration options to the current version 2.
+    """Migrate legacy configuration options to the current version 3.
 
     This handles the transition away from user-selectable database storage
     and removes deprecated packet log keys (e.g., `file_name`) that cause
@@ -211,35 +220,55 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     _LOGGER.debug("Migrating ramses_cc config entry from version %s", entry.version)
 
-    if entry.version == 1:
+    if entry.version < 3:
         # Create a deep copy of the immutable MappingProxyType to mutate it
         new_options = {**entry.options}
 
-        # 1. Clean up packet_log dictionary
-        if isinstance(new_options.get("packet_log"), dict):
-            packet_log = {**new_options["packet_log"]}
-            # Remove deprecated key mentioned in issue #592
-            packet_log.pop("file_name", None)
-            # Translate legacy rotate_backups to modern key
-            if "rotate_backups" in packet_log:
-                packet_log["packet_log_retention_days"] = packet_log.pop(
-                    "rotate_backups"
-                )
+        if entry.version == 1:
+            # 1. Clean up packet_log dictionary
+            if isinstance(new_options.get("packet_log"), dict):
+                packet_log = {**new_options["packet_log"]}
+                # Remove deprecated key mentioned in issue #592
+                packet_log.pop("file_name", None)
+                # Translate legacy rotate_backups to modern key
+                if "rotate_backups" in packet_log:
+                    packet_log["packet_log_retention_days"] = packet_log.pop(
+                        "rotate_backups"
+                    )
 
-            new_options["packet_log"] = packet_log
+                new_options["packet_log"] = packet_log
 
-        # 2. Clean up ramses_rf dictionary (legacy database storage flags)
-        if isinstance(new_options.get("ramses_rf"), dict):
-            ramses_rf = {**new_options["ramses_rf"]}
-            # Remove deprecated database keys
-            for deprecated_key in ["use_database", "database_file", "file_name"]:
-                ramses_rf.pop(deprecated_key, None)
-            new_options["ramses_rf"] = ramses_rf
+            # 2. Clean up ramses_rf dictionary (legacy database storage flags)
+            if isinstance(new_options.get("ramses_rf"), dict):
+                ramses_rf = {**new_options["ramses_rf"]}
+                # Remove deprecated database keys
+                for deprecated_key in ["use_database", "database_file", "file_name"]:
+                    ramses_rf.pop(deprecated_key, None)
+                new_options["ramses_rf"] = ramses_rf
 
-        # Update the entry with the cleaned options and bump version
-        hass.config_entries.async_update_entry(entry, options=new_options, version=2)
+        serial_port = new_options.get(SZ_SERIAL_PORT)
+        serial_port_missing = not isinstance(serial_port, dict) or not serial_port.get(
+            SZ_PORT_NAME
+        )
+
+        mqtt_hints_present = bool(new_options.get(CONF_MQTT_USE_HA)) or any(
+            key in new_options for key in (CONF_MQTT_HGI_ID, CONF_MQTT_TOPIC)
+        )
+        mqtt_entries_present = bool(hass.config_entries.async_entries("mqtt"))
+
+        if serial_port_missing and (mqtt_hints_present or mqtt_entries_present):
+            new_options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "mqtt_ha"}
+            new_options.setdefault(CONF_MQTT_USE_HA, True)
+            _LOGGER.warning(
+                "Healed missing serial_port for entry %s by defaulting to mqtt_ha. "
+                "Please verify transport settings in the options flow.",
+                entry.entry_id,
+            )
+
+        # Update the entry with cleaned/healed options and bump version
+        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
         _LOGGER.info(
-            "Successfully migrated ramses_cc config entry %s to version 2",
+            "Successfully migrated ramses_cc config entry %s to version 3",
             entry.entry_id,
         )
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1190,7 +1190,7 @@ class BaseRamsesFlow:
 class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Config flow for Ramses."""
 
-    VERSION = 2
+    VERSION = 3
     MINOR_VERSION = 1
 
     def __init__(self) -> None:
@@ -1241,15 +1241,16 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         :param config_entry: The loaded configuration entry.
         :return: An instance of the OptionsFlow handler.
         """
-        return RamsesOptionsFlowHandler()
+        return RamsesOptionsFlowHandler(config_entry)
 
 
 class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
     """Options config flow handler for Ramses."""
 
-    def __init__(self) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize Ramses config options flow."""
         super().__init__()
+        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1190,7 +1190,7 @@ class BaseRamsesFlow:
 class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Config flow for Ramses."""
 
-    VERSION = 3
+    VERSION = 2
     MINOR_VERSION = 1
 
     def __init__(self) -> None:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -351,7 +351,28 @@ class RamsesCoordinator(DataUpdateCoordinator):
         _is_zigbee = isinstance(_port_name_raw, str) and _port_name_raw.startswith(
             "zigbee://"
         )
-        _is_mqtt_ha = self.options.get(CONF_MQTT_USE_HA)
+        _is_mqtt_ha_port = (
+            isinstance(_port_name_raw, str) and _port_name_raw == "mqtt_ha"
+        )
+        _is_mqtt_flag = bool(self.options.get(CONF_MQTT_USE_HA))
+
+        if not _port_name_raw:
+            mqtt_entries = self.hass.config_entries.async_entries("mqtt")
+            if mqtt_entries:
+                _LOGGER.warning(
+                    "No serial_port configured; defaulting to Home Assistant MQTT transport. "
+                    "Please re-open the Ramses RF options and re-save the chosen transport."
+                )
+                _serial_port_opts[SZ_PORT_NAME] = "mqtt_ha"
+                _port_name_raw = "mqtt_ha"
+                _is_mqtt_ha_port = True
+                _is_mqtt_flag = True
+            else:
+                raise ConfigEntryNotReady(
+                    "No serial port configured. Open the Ramses RF options flow to select a transport."
+                )
+
+        _is_mqtt_ha = _is_mqtt_flag or _is_mqtt_ha_port
 
         if _is_zigbee:
             # ZigbeeTransport — handled natively by transport_factory in ramses_tx.

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -481,6 +481,43 @@ async def test_options_flow_serial_port_save(hass: HomeAssistant) -> None:
     assert data[SZ_SERIAL_PORT][SZ_PORT_NAME] == "/dev/ttyUSB_NEW"
 
 
+async def test_options_flow_schema_save_preserves_serial_port(
+    hass: HomeAssistant,
+) -> None:
+    """Ensure schema-step saves do not drop an existing serial_port."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt://user:pass@broker:1883"},
+            CONF_RAMSES_RF: {SZ_ENFORCE_KNOWN_LIST: False},
+            SZ_KNOWN_LIST: {},
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "schema"}
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCHEMA: {},
+            SZ_KNOWN_LIST: {},
+            SZ_ENFORCE_KNOWN_LIST: False,
+            SZ_LOG_ALL_MQTT: True,
+        },
+    )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    data = result.get("data")
+    assert data is not None
+    assert data[SZ_SERIAL_PORT][SZ_PORT_NAME] == "mqtt://user:pass@broker:1883"
+
+
 async def test_choose_serial_port_defaults(hass: HomeAssistant) -> None:
     """Test choose_serial_port defaults to stored port if present."""
     config_entry = MockConfigEntry(

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -329,8 +329,8 @@ async def test_init_service_wrappers_advanced(
     assert mock_coordinator.async_send_packet.called
 
 
-async def test_async_migrate_entry_v1_to_v2(hass: HomeAssistant) -> None:
-    """Test the migration of a config entry from version 1 to 2."""
+async def test_async_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
+    """Test the migration of a config entry from version 1 to 3."""
     entry = MagicMock()
     entry.version = 1
     entry.entry_id = "test_migration_v1_v2"
@@ -364,12 +364,12 @@ async def test_async_migrate_entry_v1_to_v2(hass: HomeAssistant) -> None:
                 },
                 "other_setting": "kept",
             },
-            version=2,
+            version=3,
         )
 
 
-async def test_async_migrate_entry_v2_no_change(hass: HomeAssistant) -> None:
-    """Test that a version 2 config entry is not migrated or modified."""
+async def test_async_migrate_entry_v2_to_v3_no_change(hass: HomeAssistant) -> None:
+    """Test that a version 2 config entry is bumped to version 3 unchanged."""
     entry = MagicMock()
     entry.version = 2
     entry.entry_id = "test_no_migration_v2"
@@ -379,4 +379,37 @@ async def test_async_migrate_entry_v2_no_change(hass: HomeAssistant) -> None:
         result = await async_migrate_entry(hass, entry)
 
         assert result is True
-        mock_update.assert_not_called()
+        mock_update.assert_called_once_with(
+            entry,
+            options={"packet_log": {}},
+            version=3,
+        )
+
+
+async def test_async_migrate_entry_heals_missing_serial_port_to_mqtt(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration heals missing serial_port when MQTT is configured."""
+    entry = MagicMock()
+    entry.version = 2
+    entry.entry_id = "test_heal_missing_serial_port"
+    entry.options = {
+        "serial_port": {},
+        "ramses_rf": {"log_all_mqtt": True},
+        "mqtt_topic": "RAMSES/GATEWAY_SIM",
+    }
+
+    with patch.object(hass.config_entries, "async_update_entry") as mock_update:
+        result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        mock_update.assert_called_once_with(
+            entry,
+            options={
+                "serial_port": {"port_name": "mqtt_ha"},
+                "ramses_rf": {"log_all_mqtt": True},
+                "mqtt_topic": "RAMSES/GATEWAY_SIM",
+                "mqtt_use_ha": True,
+            },
+            version=3,
+        )

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -13,6 +13,7 @@ from homeassistant.setup import async_setup_component
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.ramses_cc import (
+    _healed_serial_port_options,
     async_migrate_entry,
     async_register_domain_services,
     async_unload_entry,
@@ -329,8 +330,8 @@ async def test_init_service_wrappers_advanced(
     assert mock_coordinator.async_send_packet.called
 
 
-async def test_async_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
-    """Test the migration of a config entry from version 1 to 3."""
+async def test_async_migrate_entry_v1_to_v2(hass: HomeAssistant) -> None:
+    """Test the migration of a config entry from version 1 to 2."""
     entry = MagicMock()
     entry.version = 1
     entry.entry_id = "test_migration_v1_v2"
@@ -364,12 +365,12 @@ async def test_async_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
                 },
                 "other_setting": "kept",
             },
-            version=3,
+            version=2,
         )
 
 
-async def test_async_migrate_entry_v2_to_v3_no_change(hass: HomeAssistant) -> None:
-    """Test that a version 2 config entry is bumped to version 3 unchanged."""
+async def test_async_migrate_entry_v2_no_change(hass: HomeAssistant) -> None:
+    """Test that a version 2 config entry is not migrated or modified."""
     entry = MagicMock()
     entry.version = 2
     entry.entry_id = "test_no_migration_v2"
@@ -379,37 +380,35 @@ async def test_async_migrate_entry_v2_to_v3_no_change(hass: HomeAssistant) -> No
         result = await async_migrate_entry(hass, entry)
 
         assert result is True
-        mock_update.assert_called_once_with(
-            entry,
-            options={"packet_log": {}},
-            version=3,
-        )
+        mock_update.assert_not_called()
 
 
-async def test_async_migrate_entry_heals_missing_serial_port_to_mqtt(
-    hass: HomeAssistant,
-) -> None:
-    """Test migration heals missing serial_port when MQTT is configured."""
-    entry = MagicMock()
-    entry.version = 2
-    entry.entry_id = "test_heal_missing_serial_port"
-    entry.options = {
-        "serial_port": {},
-        "ramses_rf": {"log_all_mqtt": True},
-        "mqtt_topic": "RAMSES/GATEWAY_SIM",
-    }
+def test_healed_serial_port_options_from_mqtt_hints() -> None:
+    """Test setup-time healing when MQTT hints exist in options."""
 
-    with patch.object(hass.config_entries, "async_update_entry") as mock_update:
-        result = await async_migrate_entry(hass, entry)
+    healed = _healed_serial_port_options(
+        {
+            "serial_port": {},
+            "ramses_rf": {"log_all_mqtt": True},
+            "mqtt_topic": "RAMSES/GATEWAY_SIM",
+        },
+        mqtt_entries_present=False,
+    )
 
-        assert result is True
-        mock_update.assert_called_once_with(
-            entry,
-            options={
-                "serial_port": {"port_name": "mqtt_ha"},
-                "ramses_rf": {"log_all_mqtt": True},
-                "mqtt_topic": "RAMSES/GATEWAY_SIM",
-                "mqtt_use_ha": True,
-            },
-            version=3,
-        )
+    assert healed is not None
+    assert healed["serial_port"] == {"port_name": "mqtt_ha"}
+    assert healed["mqtt_use_ha"] is True
+
+
+def test_healed_serial_port_options_no_heal_without_mqtt() -> None:
+    """Test no healing occurs when MQTT is not implied."""
+
+    healed = _healed_serial_port_options(
+        {
+            "serial_port": {},
+            "ramses_rf": {"log_all_mqtt": False},
+        },
+        mqtt_entries_present=False,
+    )
+
+    assert healed is None


### PR DESCRIPTION
Fixes #655 

Note: my first idea was to bump Config version to v3, but reverted this.

## Summary
This PR fixes a regression where RAMSES RF transport settings could be lost from options storage (ending up as `serial_port: {}`), which can cause startup failures with:

```
TypeError: Either a port_name or an input_file must be specified
```

The fix is implemented in a rollback-safe way (no config-entry major version bump).

## Root Cause
In options flow, transport-related options could be saved from incomplete state in some paths.

Existing entries that already had missing/empty serial_port.port_name were not automatically healed.

Unrelated options saves (e.g. schema/logging toggles) could then persist the broken transport block.

## What Changed

### 1) Options flow persistence fix

Explicitly bind the active config_entry when creating the options flow handler.
This ensures `get_options()` always starts from persisted entry options (including serial_port), preventing accidental overwrites with empty data.

Files:

`custom_components/ramses_cc/config_flow.py`

### 2) Rollback-safe setup-time healing (no major version bump)

Added setup-time healing for entries with missing serial_port.port_name.
If MQTT usage is implied (mqtt_use_ha, mqtt_hgi_id, mqtt_topic, or existing HA MQTT entry), the integration now heals options to:
```
serial_port.port_name = "mqtt_ha"
mqtt_use_ha = True (if absent)
```
Healing is persisted via `async_update_entry` during setup.

Files:

`custom_components/ramses_cc/__init__.py`

### 3) Keep config-entry VERSION = 2

Intentionally did not bump major config-entry version.

Preserves downgrade compatibility with builds expecting version 2.

Existing v1->v2 migration remains unchanged for legacy cleanup.

Files:

- `custom_components/ramses_cc/config_flow.py`
- `custom_components/ramses_cc/__init__.py`

### 4) Coordinator fallback

Kept existing coordinator fallback as an additional safety net for already-corrupted entries and unexpected edge cases.

## Tests
Added/updated tests covering:

- options flow schema save preserves existing serial_port
- migration behavior remains v1->v2
- v2 entries are not migrated
- setup-time serial-port healing helper behavior (heal + no-heal cases)

Files:

- `tests/tests_new/test_config_flow.py`
- `tests/tests_new/test_init.py`

## Validation

Targeted tests passed locally:

`pytest tests/tests_new/test_init.py -k 'migrate_entry or healed_serial_port_options'`

`pytest tests/tests_new/test_config_flow.py -k 'options_flow_schema_save_preserves_serial_port'`

## Impact

- Prevents future accidental loss of transport settings in options flow.
- Auto-recovers affected MQTT-based entries during setup.
- Maintains rollback safety by avoiding a new config-entry major version.