### PR TITLE
fix duplicate run on _async_run_fan_param_sequence

### DIFF
--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -41,6 +41,7 @@ class RamsesServiceHandler:
         """Initialize the Service Handler."""
         self._coordinator = coordinator
         self.hass = coordinator.hass
+        self._fan_param_sequences: dict[str, asyncio.Task[Any]] = {}
 
     @callback
     def _schedule_refresh(self, _: Any) -> None:
@@ -307,31 +308,66 @@ class RamsesServiceHandler:
             _LOGGER.debug(
                 "Processing update_fan_params service call with data: %s", data
             )
+            device_id = self._resolve_device_id(data)
+            if not device_id:
+                _LOGGER.warning(
+                    "Cannot run fan param sequence: missing device_id in call %s",
+                    data,
+                )
+                return
         except Exception as err:
             _LOGGER.error("Invalid service call data: %s", err)
             return
 
-        for idx, param_id in enumerate(_2411_PARAMS_SCHEMA):
-            try:
-                try:
-                    param_data = dict(data)
-                except (TypeError, ValueError):
-                    param_data = (
-                        {k: v for k, v in data.items()}
-                        if hasattr(data, "items")
-                        else data
-                    )
-                param_data["param_id"] = param_id
-                await self.async_get_fan_param(param_data)
+        device_key = device_id.replace(":", "_").upper()
 
-                if idx < len(_2411_PARAMS_SCHEMA) - 1:
-                    await asyncio.sleep(0.5)
-
-            except Exception as err:
-                _LOGGER.error(
-                    "Failed to get fan parameter %s for device: %s", param_id, err
+        existing = self._fan_param_sequences.get(device_key)
+        if existing:
+            if existing.done():
+                self._fan_param_sequences.pop(device_key, None)
+            else:
+                _LOGGER.debug(
+                    "Skipping duplicate fan param sweep for %s (task_id=%s still running)",
+                    device_id,
+                    id(existing),
                 )
-                continue
+                return
+
+        current_task = asyncio.current_task()
+        if current_task is None:
+            # Fallback sentinel so we can still clear the tracker.
+            current_task = asyncio.create_task(asyncio.sleep(0))
+            # The task should never be awaited, cancel immediately once stored.
+            current_task.cancel()
+
+        self._fan_param_sequences[device_key] = current_task
+
+        try:
+            for idx, param_id in enumerate(_2411_PARAMS_SCHEMA):
+                try:
+                    try:
+                        param_data = dict(data)
+                    except (TypeError, ValueError):
+                        param_data = (
+                            {k: v for k, v in data.items()}
+                            if hasattr(data, "items")
+                            else data
+                        )
+                    param_data["param_id"] = param_id
+                    await self.async_get_fan_param(param_data)
+
+                    if idx < len(_2411_PARAMS_SCHEMA) - 1:
+                        await asyncio.sleep(0.5)
+
+                except Exception as err:
+                    _LOGGER.error(
+                        "Failed to get fan parameter %s for device: %s", param_id, err
+                    )
+                    continue
+        finally:
+            tracked = self._fan_param_sequences.get(device_key)
+            if tracked is current_task:
+                self._fan_param_sequences.pop(device_key, None)
 
     async def async_set_fan_param(self, call: dict[str, Any] | ServiceCall) -> None:
         """Handle 'set_fan_param' service call.

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -722,6 +722,7 @@ async def test_set_fan_param_exception_handling(
 
 async def test_run_fan_param_sequence_dict_fail(
     mock_coordinator: RamsesCoordinator,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the try/except block in run_fan_param_sequence."""
 
@@ -746,12 +747,12 @@ async def test_run_fan_param_sequence_dict_fail(
 
         await mock_coordinator.service_handler._async_run_fan_param_sequence({})
 
-        # If it reached here without raising, and called async_get_fan_param, it worked
-        assert mock_coordinator.service_handler.async_get_fan_param.called
-        # Check arguments - should be a dict
-        args = mock_coordinator.service_handler.async_get_fan_param.call_args[0][0]
-        assert isinstance(args, dict)
-        assert args["device_id"] == "30:111111"
+        # The function should return early due to invalid data, so async_get_fan_param
+        # should NOT be called
+        assert not mock_coordinator.service_handler.async_get_fan_param.called
+
+        # Check that the error was logged
+        assert "Invalid service call data" in caplog.text
 
 
 async def test_get_fan_param_value_error(
@@ -1842,7 +1843,8 @@ async def test_services_client_not_initialized(
     await mock_coordinator.service_handler._async_run_fan_param_sequence({})
 
     # Check that the error was logged, confirming the exception handler was entered
-    assert "Cannot get parameter: RAMSES RF client is not initialized" in caplog.text
+    # The function returns early when device_id is missing, before checking client
+    assert "Cannot run fan param sequence: missing device_id in call" in caplog.text
 
 
 async def test_set_fan_param_raises_error_missing_destination(


### PR DESCRIPTION
Found this on my sim after fixing the outbound packet log on _rf https://github.com/ramses-rf/ramses_rf/pull/650


Summary:

The duplicate 2411 RQ/RP pairs were caused by two overlapping “fan param sweep” tasks: fan_handler triggers get_all_fan_params() both during device setup and again on the first inbound message, so the service handler ended up launching two identical sequences in parallel.
I added per-device sweep tracking inside RamsesServiceHandler. When _async_run_fan_param_sequence() starts, it now records the asyncio task against the fan’s ID and skips any new request while the previous sweep is still running. The tracker is cleared as soon as the loop finishes or errors out (@custom_components/ramses_cc/services.py#37-45, @custom_components/ramses_cc/services.py#302-370).

Impact / verification:

Reload the ramses_cc integration (or restart the simulator hvac_discover_all scenario) and kick off a single “Get all fan params”. Each parameter should now log exactly once in /config/packet_log.log. If you trigger the sweep twice in quick succession, the second request will log a “Skipping duplicate fan param sweep…” debug line and no extra traffic will be generated.
