### PR TITLE
fix: remove aioesphomeapi

### DIFF
--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -11,7 +11,6 @@
     "issue_tracker": "https://github.com/ramses-rf/ramses_cc/issues",
     "loggers": ["ramses_rf"],
     "requirements": [
-      "aioesphomeapi==44.23.0",
       "aiousbwatcher>=1.1.1",
       "pyserial-asyncio-fast>=0.16",
       "ramses-rf==0.56.7",


### PR DESCRIPTION
As discussed in #652 to fix HA compatibility error for now. May be reverted on a later version.

026-05-06 20:11:59.667 ERROR (SyncWorker_4) [homeassistant.util.package] Unable to install package aioesphomeapi==44.23.0: × No solution found when resolving dependencies:
  ╰─▶ Because aioesphomeapi==44.23.0 depends on cryptography>=47.0.0 and
      cryptography==46.0.7, we can conclude that aioesphomeapi==44.23.0 cannot
      be used.
      And because you require aioesphomeapi==44.23.0, we can conclude that
      your requirements are unsatisfiable.
2026-05-06 20:12:03.713 ERROR (SyncWorker_4) [homeassistant.util.package] Unable to install package aioesphomeapi==44.23.0: × No solution found when resolving dependencies:
  ╰─▶ Because aioesphomeapi==44.23.0 depends on cryptography>=47.0.0 and
      cryptography==46.0.7, we can conclude that aioesphomeapi==44.23.0 cannot
      be used.
      And because you require aioesphomeapi==44.23.0, we can conclude that
      your requirements are unsatisfiable.
2026-05-06 20:12:05.792 ERROR (SyncWorker_4) [homeassistant.util.package] Unable to install package aioesphomeapi==44.23.0: × No solution found when resolving dependencies:
  ╰─▶ Because aioesphomeapi==44.23.0 depends on cryptography>=47.0.0 and
      cryptography==46.0.7, we can conclude that aioesphomeapi==44.23.0 cannot
      be used.
      And because you require aioesphomeapi==44.23.0, we can conclude that
      your requirements are unsatisfiable.
2026-05-06 20:12:05.793 ERROR (MainThread) [homeassistant.setup] Setup failed for custom integration 'ramses_cc': Requirements for ramses_cc not found: ['aioesphomeapi==44.23.0'].
