### PR TITLE
Tweak extra requirements

### DIFF
--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -11,6 +11,7 @@
     "issue_tracker": "https://github.com/ramses-rf/ramses_cc/issues",
     "loggers": ["ramses_rf"],
     "requirements": [
+      "aioesphomeapi>=44.23.0",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
       "ramses-rf==0.56.7",

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -11,11 +11,10 @@
     "issue_tracker": "https://github.com/ramses-rf/ramses_cc/issues",
     "loggers": ["ramses_rf"],
     "requirements": [
-      "aioesphomeapi==44.23.0",
-      "aiousbwatcher>=1.1.1",
+      "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
       "ramses-rf==0.56.7",
-      "serialx==1.6.0"
+      "serialx>=1.6.0"
     ],
     "single_config_entry": true,
     "version": "0.56.7"

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -10,7 +10,7 @@
   ramses-rf             == 0.56.7                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
-  # serialx               >= 1.6.0                 # required by config_flow > homeassistant.components.usb, see issue #623
+  serialx               >= 1.6.0                 # required by config_flow > homeassistant.components.usb, see issue #623
 
 # libraries required for development (lint/type/test)...
 # - pip list | grep -E 'prek|ruff|mypy|types-|voluptuous'

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -5,12 +5,12 @@
 # - pip list | grep -E 'ramses|serial'
 
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.1
-  aioesphomeapi         >= 44.23.0               # required by config_flow > homeassistant.components.usb
+  # aioesphomeapi         >= 44.23.0               # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
   ramses-rf             == 0.56.7                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
-  serialx               >= 1.6.0                 # required by config_flow > homeassistant.components.usb, see issue #623
+  # serialx               >= 1.6.0                 # required by config_flow > homeassistant.components.usb, see issue #623
 
 # libraries required for development (lint/type/test)...
 # - pip list | grep -E 'prek|ruff|mypy|types-|voluptuous'

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -5,6 +5,7 @@
 # - pip list | grep -E 'ramses|serial'
 
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.1
+  aioesphomeapi         >= 44.23.0               # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
   ramses-rf             == 0.56.7                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -5,7 +5,6 @@
 # - pip list | grep -E 'ramses|serial'
 
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.1
-  # aioesphomeapi         >= 44.23.0               # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
   ramses-rf             == 0.56.7                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest


### PR DESCRIPTION
These 2 requirements cause an error on startup running HA Core pre 2026.5.0
But since 2026.5.0, both are required ?! PR on hold