### PR TITLE
chore: Update ramses_rf import paths to support new package structure

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from ramses_rf.device.base import BatteryState, HgiGateway
 from ramses_rf.device.heat import BdrSwitch, OtbGateway, TrvActuator
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.gateway import Gateway
 from ramses_rf.schemas import SZ_CONFIG, SZ_SCHEMA
 from ramses_rf.system.heat import Logbook, System

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -33,7 +33,7 @@ from homeassistant.util import dt as dt_util
 
 from ramses_rf.device import Device
 from ramses_rf.device.hvac import HvacRemoteBase, HvacVentilator
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.gateway import Gateway, GatewayConfig
 from ramses_rf.system import Evohome, System, Zone
 from ramses_rf.topology import Child

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from ramses_rf.device import Fakeable
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 
 from .const import DOMAIN, SIGNAL_UPDATE
 from .helpers import resolve_async_attr

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from ramses_rf.message import Message
+from ramses_rf.messages import Message
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.exceptions import PacketInvalid
 

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from ramses_rf.device import Device
 from ramses_rf.device.hvac import HvacRemoteBase, HvacVentilator
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_tx import Command
 from ramses_tx.const import DevType
 from ramses_tx.typing import DeviceIdT

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -60,7 +60,7 @@ from homeassistant.helpers.entity_platform import (
     async_get_current_platform,
 )
 
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_tx import (
     _2411_PARAMS_SCHEMA,
     SZ_DATA_TYPE,

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.event import async_track_state_change_event
 
 from ramses_rf.device.hvac import HvacRemote
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_tx.command import Command
 from ramses_tx.const import DEFAULT_GAP_DURATION, Priority
 from ramses_tx.exceptions import ProtocolError, ProtocolSendFailed, ProtocolTimeoutError

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -73,7 +73,7 @@ from ramses_rf.device.hvac import (
     HvacHumiditySensor,
     HvacVentilator,
 )
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.system.heat import System
 from ramses_rf.system.zones import ZoneBase
 from ramses_tx.const import (

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.entity_platform import (
 )
 from homeassistant.util import dt as dt_util
 
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.system.heat import StoredHw
 from ramses_rf.system.zones import DhwZone
 from ramses_tx.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE

--- a/tests/tests_new/test_entity.py
+++ b/tests/tests_new/test_entity.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from custom_components.ramses_cc.const import DOMAIN, SIGNAL_UPDATE
 from custom_components.ramses_cc.entity import RamsesEntity, RamsesEntityDescription
 from ramses_rf.device import Fakeable
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 
 # Constants
 DEVICE_ID = "32:123456"

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -22,7 +22,7 @@ from custom_components.ramses_cc.number import (
     get_param_descriptions,
     normalize_device_id,
 )
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 
 # Constants
 FAN_ID = "30:999888"

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -21,7 +21,7 @@ from custom_components.ramses_cc.sensor import (
 )
 from ramses_rf.device.heat import DhwSensor, OtbGateway, Thermostat
 from ramses_rf.device.hvac import HvacCarbonDioxideSensor, HvacHumiditySensor
-from ramses_rf.entity_base import Entity as RamsesRFEntity
+from ramses_rf.entity import Entity as RamsesRFEntity
 
 
 @pytest.fixture


### PR DESCRIPTION
### The Problem: 
The upstream `ramses_rf` library recently underwent a significant structural refactor, which included renaming and moving several core modules. Because of this, `ramses_cc` threw fatal `ModuleNotFoundError` exceptions during initialization and test collection (specifically failing to find `ramses_rf.entity_base` and `ramses_rf.message`).

### Consequences: 
If left unpatched, `ramses_cc` is fundamentally incompatible with the latest version of `ramses_rf`. The integration will silently fail to initialize, crash the setup process, and entirely break functionality for users updating their environments.

### The Fix: 
Updated all internal import paths within the `ramses_cc` codebase to accurately reflect the newly consolidated and renamed modules in `ramses_rf`.

### Technical Implementation:
- Executed a global update mapping `ramses_rf.entity_base` to the new root-level `ramses_rf.entity` module.
- Executed a global update mapping the singular `ramses_rf.message` file to the new plural `ramses_rf.messages` directory package.

### Testing Performed:
- Executed the complete `pytest` suite, transitioning from widespread collection failures to a 100% pass rate.
- Ran `mypy` across the codebase to ensure static typing and interfaces remained intact with the new paths. Zero errors reported.

### Risks of NOT Implementing:
The `ramses_cc` integration will remain hard-broken against the current `ramses_rf` branch. This will halt ongoing development and ultimately break the integration for end-users when the upstream changes are formally released.

### Risks of Implementing:
The risk is very low, as these are primarily structural path updates rather than logical rewrites. However, there is a minor risk that if `ramses_rf` altered underlying logic alongside the structural changes, some edge cases might behave differently.

### Mitigation Steps:
Fully verified the changes against the existing `pytest` suite to confirm behavioral expectations. Strict type checking via `mypy` was also used to ensure that the contracts between `ramses_cc` and the imported `ramses_rf` classes remain valid.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
