### PR TITLE
test: Fix race condition in virtual RF packet casting caused by upstream async changes

### DIFF
--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -260,6 +260,10 @@ async def _cast_packets_to_rf(hass: HomeAssistant, rf: VirtualRf) -> None:
 
     await cast_packets_to_rf(rf, f"{TEST_DIR}/system_1.log", gwy=gwy)
 
+    # Allow the HA event loop to drain the queued EntityState._delete_msg tasks
+    # before we assert the final device count.
+    await hass.async_block_till_done()
+
     try:
         assert (
             len(gwy.device_registry.devices) == NUM_DEVS_AFTER


### PR DESCRIPTION
### The Problem:

The `ramses_cc` integration test suite (`tests/tests_old/test_services.py`) began failing with `AssertionError`s (e.g., `assert 13 == 15`) during setup fixtures. This was caused by upstream architectural changes in `ramses_rf` (Phase 2.76) that properly queued background tasks (like `EntityState._delete_msg`) onto the active `asyncio` event loop. Blasting the virtual RF network with thousands of packets flooded the Home Assistant event loop, meaning assertions were firing *before* the Gateway had finished fully building the Device Registry.

### Consequences:

If not fixed, the `ramses_cc` CI/CD pipeline will remain broken or highly flaky, generating false-negative test failures. This effectively blocks `ramses_cc` from integrating any further upstream improvements from the `ramses_rf` OSI Decoupling Master Plan.

### The Fix:

Added an explicit event loop synchronization step inside the test suite's packet-casting fixture to allow Home Assistant to settle before evaluating assertions.

### Technical Implementation:

Inserted `await hass.async_block_till_done()` immediately after `await cast_packets_to_rf(rf, f"{TEST_DIR}/system_1.log", gwy=gwy)` inside the `_cast_packets_to_rf` function in `tests/tests_old/test_services.py`. This yields execution back to the HA event loop, ensuring all background state-deletion tasks initiated by `ramses_rf` are fully processed and the network topology is stabilized before the test asserts the final length of the `DeviceRegistry`.

### Testing Performed:

Ran the full `ramses_cc` pytest suite locally. Confirmed that previous event-loop congestion failures (`test_set_zone_mode_fail` and `test_put_indoor_humidity`) were successfully resolved and that 100% of the tests now pass silently.

### Risks of NOT Implementing:

The `ramses_cc` repository will remain incompatible with the latest `ramses_rf` architecture, halting integration progress.

### Risks of Implementing:

Extremely low. This is strictly a test-suite infrastructure change. No production code in `ramses_cc` was altered. It may very slightly increase the execution time of the setup fixture as it actively waits for the event loop to drain.

### Mitigation Steps:

Kept the scope strictly constrained to the `_cast_packets_to_rf` test fixture. No production application logic or timing was altered.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.
