### PR TITLE
Fix `known_list` trait propagation in `coordinator.py`

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -338,6 +338,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
             for device_id, traits in raw_known_list.items()
         }
         engine_kwargs["known_list"] = sanitized_known_list
+        # Device traits (class/alias/faked/bound/scheme) are consumed by
+        # ramses_rf DeviceRegistry via GatewayConfig.known_list.
+        gateway_kwargs["known_list"] = sanitized_known_list
 
         packet_log = self.options.get(SZ_PACKET_LOG, {})
         engine_kwargs["packet_log"] = packet_log


### PR DESCRIPTION
This PR fixes (the second part of) issue #702 (and part of #701 ?).

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 100.0%

**PR Summary**

**Problem**: HVAC entities were not created even with known_list class hints (FAN/REM).
**Root cause**: known_list traits were passed only to EngineConfig, while device trait lookup uses GatewayConfig.known_list.
**Fix**: also pass sanitized known_list into GatewayConfig in [coordinator.py](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
**Result**: explicit class/bound/scheme traits are applied during device instantiation, enabling expected HVAC entity creation.

**Full story**: after investigating the code base with Copilot, I updated my known_lists to:

```yaml
"32:125274":
  class: REM
  scheme: orcon
"32:137527":
  class: FAN
  scheme: orcon
```

however, I still saw no entities being created in my HA. After further investigation by the Copilot, it proposed the fix in this PR, after which the entities appeared.