### PR TITLE
Fix known_list in gateway status sensor details

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -216,7 +216,8 @@ class RamsesSystemBinarySensor(RamsesBinarySensor):
         :rtype: bool | None
         """
         is_on = super().is_on
-        return None if is_on is None else is_on  # no status sensor exposed in _rf 0.57.0 gwy
+        return None if is_on is None else is_on
+        # no status sensor exposed in _rf 0.57.0 gwy
 
 
 class RamsesGatewayBinarySensor(RamsesBinarySensor):

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -216,7 +216,7 @@ class RamsesSystemBinarySensor(RamsesBinarySensor):
         :rtype: bool | None
         """
         is_on = super().is_on
-        return None if is_on is None else not is_on
+        return None if is_on is None else is_on  # no status sensor exposed in _rf 0.57.0 gwy
 
 
 class RamsesGatewayBinarySensor(RamsesBinarySensor):

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -235,8 +235,11 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
         """
         gwy: Gateway = self._device._gwy
         engine = getattr(gwy, "_engine", None)
+        gwy_config = getattr(gwy, "_gwy_config", None)
 
-        known_list: Any = getattr(gwy, "known_list", None)
+        # TODO Q3 2026: return await gwy._config() (only) instead of all below code
+        # not yet working: self._cached_attrs = await gwy._config()
+        known_list: Any = getattr(gwy_config, "known_list", None)
         if not isinstance(known_list, dict):
             fallback = getattr(engine, "_include", None)
             if not isinstance(fallback, dict):
@@ -330,7 +333,7 @@ class RamsesBinarySensorEntityDescription(
 BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
     RamsesBinarySensorEntityDescription(
         key="status",
-        ramses_rf_attr="is_active",
+        ramses_rf_attr="status",  # "is_active",
         name="Gateway status",
         ramses_rf_class=HgiGateway,
         ramses_cc_class=RamsesGatewayBinarySensor,

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -337,7 +337,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
             )
             for device_id, traits in raw_known_list.items()
         }
-        engine_kwargs["known_list"] = sanitized_known_list
         # Device traits (class/alias/faked/bound/scheme) are consumed by
         # ramses_rf DeviceRegistry via GatewayConfig.known_list.
         gateway_kwargs["known_list"] = sanitized_known_list


### PR DESCRIPTION
- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used

**PR Summary**

- Fix call for known_list from _rf _gwy so it shows up under gwy status sensor details
- Remove dupl kl from eng_kwrgs
- Invert status sensor state (it will be Unknown on serious issues)