### PR TITLE
Fix: Update Gateway binary sensor known_list resolution for ramses_rf Phase 2.77 compatibility

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -236,7 +236,7 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
         """
         gwy: Gateway = self._device._gwy
         engine = getattr(gwy, "_engine", None)
-        gwy_config = getattr(gwy, "_gwy_config", None)
+        gwy_config = getattr(gwy, "config", getattr(gwy, "_gwy_config", None))
 
         # TODO Q3 2026: return await gwy._config() (only) instead of all below code
         # not yet working: self._cached_attrs = await gwy._config()

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -47,30 +47,26 @@ async def test_async_setup_entry(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     entry = MagicMock()
     entry.entry_id = "test_entry"
     hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
 
     mock_add_entities = MagicMock()
-
-    with patch("custom_components.ramses_cc.binary_sensor.entity_platform"):
-        await async_setup_entry(hass, entry, mock_add_entities)
-
-    assert mock_coordinator.async_register_platform.called
-
-    # Extract the callback passed to async_register_platform
-    add_callback = mock_coordinator.async_register_platform.call_args[0][1]
-
-    # Create a mock device that matches one of the descriptions
     mock_device = MagicMock(spec=HgiGateway)
     mock_device.id = "18:123456"
 
-    # Call the callback with the mock device
-    add_callback([mock_device])
+    # Act
+    with patch("custom_components.ramses_cc.binary_sensor.entity_platform"):
+        await async_setup_entry(hass, entry, mock_add_entities)
 
-    # Verify async_add_entities was called with the created entity
-    assert mock_add_entities.called
+    add_callback = mock_coordinator.async_register_platform.call_args[0][1]
+    add_callback([mock_device])
     created_entities = mock_add_entities.call_args[0][0]
+
+    # Assert
+    assert mock_coordinator.async_register_platform.called
+    assert mock_add_entities.called
     assert len(created_entities) == 1
     assert isinstance(created_entities[0], RamsesGatewayBinarySensor)
 
@@ -86,6 +82,7 @@ async def test_generic_binary_sensor(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="test_sensor",
         ramses_rf_attr="test_attr",
@@ -96,34 +93,41 @@ async def test_generic_binary_sensor(
 
     mock_device = MagicMock()
     mock_device.id = "01:123456"
-
     # Mock library availability delegation so the base RamsesEntity evaluates it correctly
     mock_device.is_available = True
 
+    # Act
     sensor = RamsesBinarySensor(mock_coordinator, mock_device, description)
-
-    assert sensor.unique_id == "01:123456-test_sensor"
-
-    # Assign to a variable first to satisfy Mypy
     avail_state = sensor.available
+
+    # Assert
+    assert sensor.unique_id == "01:123456-test_sensor"
+    # Assign to a variable first to satisfy Mypy
     assert avail_state is True
 
-    # Test is_on and icon resolution based on patched async resolve
+    # Act (is_on true)
     mock_resolve_async_attr.return_value = True
     state_1 = sensor.is_on
-    assert state_1 is True
     icon_1 = sensor.icon
+
+    # Assert
+    assert state_1 is True
     assert icon_1 == "mdi:test"
 
+    # Act (is_on false)
     mock_resolve_async_attr.return_value = False
     state_2 = sensor.is_on
-    assert state_2 is False
     icon_2 = sensor.icon
+
+    # Assert
+    assert state_2 is False
     assert icon_2 == "mdi:test-off"
 
-    # Test callable attribute support (Duck-Typing backwards compat)
+    # Act (Duck-Typing backwards compat)
     mock_resolve_async_attr.return_value = True
     state_3 = sensor.is_on
+
+    # Assert
     assert state_3 is True
 
 
@@ -138,6 +142,7 @@ async def test_battery_binary_sensor(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="test_battery",
         ramses_rf_attr="battery_low",
@@ -162,17 +167,22 @@ async def test_battery_binary_sensor(
             return True
         return None
 
+    # Act (Battery state present)
     # 1. Battery state present - Mocked via async resolve
     mock_resolve_async_attr.side_effect = mock_resolve_state
-
     state_1 = sensor.is_on
-    assert state_1 is True
     attrs = sensor.extra_state_attributes
+
+    # Assert
+    assert state_1 is True
     assert attrs[ATTR_BATTERY_LEVEL] == 0.5
 
+    # Act (Battery state missing)
     # 2. Battery state missing
     mock_resolve_async_attr.side_effect = lambda e, d, a: None
     attrs_2 = sensor.extra_state_attributes
+
+    # Assert
     assert attrs_2[ATTR_BATTERY_LEVEL] is None
 
 
@@ -184,6 +194,7 @@ async def test_logbook_binary_sensor_availability(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="active_fault",
         name="Active fault",
@@ -198,12 +209,18 @@ async def test_logbook_binary_sensor_availability(
 
     sensor: Any = RamsesLogbookBinarySensor(mock_coordinator, mock_device, description)
 
+    # Act (Case A: Device unavailable)
     # Case A: Device is not available (Delegated to library's is_available property)
     mock_device.is_available = False
+
+    # Assert
     assert sensor.available is False
 
+    # Act (Case B: Device available)
     # Case B: Device is available (Delegated to library's is_available property)
     mock_device.is_available = True
+
+    # Assert
     assert sensor.available is True
 
 
@@ -218,6 +235,7 @@ async def test_logbook_binary_sensor_state(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="active_fault",
         name="Active fault",
@@ -231,14 +249,20 @@ async def test_logbook_binary_sensor_state(
 
     sensor: Any = RamsesLogbookBinarySensor(mock_coordinator, mock_device, description)
 
+    # Act (is_on = False)
     # 1. Test is_on = False (No faults)
     mock_resolve_async_attr.return_value = []
     initial_state = sensor.is_on
+
+    # Assert
     assert initial_state is False
 
+    # Act (is_on = True)
     # 2. Test is_on = True (Has faults)
     mock_resolve_async_attr.return_value = [{"fault": "error"}]
     final_state = sensor.is_on
+
+    # Assert
     assert final_state is True
 
 
@@ -250,6 +274,7 @@ async def test_system_binary_sensor_availability(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="status",
         ramses_rf_attr="id",
@@ -264,10 +289,12 @@ async def test_system_binary_sensor_availability(
 
     sensor: Any = RamsesSystemBinarySensor(mock_coordinator, mock_device, description)
 
+    # Act & Assert (Case A: Device unavailable)
     # Case A: Device is not available (Delegated to library's is_available property)
     mock_device.is_available = False
     assert sensor.available is False
 
+    # Act & Assert (Case B: Device available)
     # Case B: Device is available (Delegated to library's is_available property)
     mock_device.is_available = True
     assert sensor.available is True
@@ -284,6 +311,7 @@ async def test_gateway_binary_sensor_attrs(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="status",
         ramses_rf_attr="is_active",
@@ -302,7 +330,10 @@ async def test_gateway_binary_sensor_attrs(
     # Mock the resolve_async_attr helper to return a safe schema dict
     mock_resolve_async_attr.return_value = {"system_schema": "test"}
 
-    gwy.known_list = {"10:1": {"alias": "test", "class": "RAD", "faked": True}}
+    # Mock the Phase 2.77 configuration facade
+    gwy.config = MagicMock()
+    gwy.config.known_list = {"10:1": {"alias": "test", "class": "RAD", "faked": True}}
+
     gwy._engine = MagicMock()
     gwy._engine._enforce_known_list = True
     gwy._engine._exclude = {}
@@ -312,9 +343,11 @@ async def test_gateway_binary_sensor_attrs(
 
     sensor: Any = RamsesGatewayBinarySensor(mock_coordinator, mock_device, description)
 
+    # Act
     # Fetch attributes (should cache and utilize the mocked async helper)
     attrs = sensor.extra_state_attributes
 
+    # Assert
     mock_resolve_async_attr.assert_called_once_with(sensor, gwy.tcs, "_schema_min")
 
     assert attrs["config"]["enforce_known_list"] is True
@@ -337,6 +370,7 @@ async def test_gateway_binary_sensor_state(
     :param mock_coordinator: The mock coordinator fixture.
     :type mock_coordinator: MagicMock
     """
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="status",
         ramses_rf_attr="is_active",
@@ -350,6 +384,7 @@ async def test_gateway_binary_sensor_state(
 
     sensor: Any = RamsesGatewayBinarySensor(mock_coordinator, mock_device, description)
 
+    # Act & Assert
     # 1. Case A: Gateway active -> is_on False (Problem = False -> OK)
     mock_device.is_active = True
     is_on_check_a = sensor.is_on
@@ -369,6 +404,7 @@ async def test_logbook_async_added_to_hass(
     mock_coordinator: MagicMock,
 ) -> None:
     """Test RamsesLogbookBinarySensor.async_added_to_hass polling logic."""
+    # Arrange
     description = RamsesBinarySensorEntityDescription(
         key="active_fault",
         name="Active fault",
@@ -384,6 +420,7 @@ async def test_logbook_async_added_to_hass(
 
     sensor: Any = RamsesLogbookBinarySensor(mock_coordinator, mock_device, description)
 
+    # Act (active_faults None)
     # 1. active_faults is None, tcs has get_faultlog
     mock_resolve.return_value = None
     with patch(
@@ -392,38 +429,48 @@ async def test_logbook_async_added_to_hass(
     ):
         await sensor.async_added_to_hass()
 
+    # Assert
     mock_device._tcs.get_faultlog.assert_awaited_once_with(limit=1, force_refresh=True)
 
+    # Arrange (Missing get_faultlog)
     # 2. active_faults is None, tcs lacks get_faultlog but has _gwy
     del mock_device._tcs.get_faultlog
     mock_device._tcs._gwy = MagicMock()
     mock_device._tcs._gwy.async_send_cmd = AsyncMock()
     mock_cmd.from_cli.return_value = "mock_cmd"
 
+    # Act
     with patch(
         "custom_components.ramses_cc.binary_sensor."
         "RamsesBinarySensor.async_added_to_hass"
     ):
         await sensor.async_added_to_hass()
 
+    # Assert
     mock_cmd.from_cli.assert_called_once_with("RQ 01:123456 0418 00")
     mock_device._tcs._gwy.async_send_cmd.assert_awaited_once_with("mock_cmd")
 
+    # Act (Exception handling)
     # 3. Exception handling
     mock_device._tcs._gwy.async_send_cmd.side_effect = Exception("Boom")
     with patch(
         "custom_components.ramses_cc.binary_sensor."
         "RamsesBinarySensor.async_added_to_hass"
     ):
-        await sensor.async_added_to_hass()  # Should not raise
+        # Should not raise
+        await sensor.async_added_to_hass()
 
+    # Arrange (active_faults present)
     # 4. active_faults is not None (should not poll)
     mock_resolve.return_value = [{"fault": "error"}]
     mock_cmd.from_cli.reset_mock()
+
+    # Act
     with patch(
         "custom_components.ramses_cc.binary_sensor."
         "RamsesBinarySensor.async_added_to_hass"
     ):
         await sensor.async_added_to_hass()
 
+    # Assert
     mock_cmd.from_cli.assert_not_called()

--- a/tests/tests_new/test_known_list.py
+++ b/tests/tests_new/test_known_list.py
@@ -1,0 +1,112 @@
+"""Tests for the extraction and sanitisation of the known_list."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.ramses_cc.const import (
+    CONF_COMMANDS,
+    CONF_MQTT_HGI_ID,
+    CONF_MQTT_USE_HA,
+    CONF_RAMSES_RF,
+    SZ_KNOWN_LIST,
+    SZ_PORT_NAME,
+    SZ_SERIAL_PORT,
+)
+from custom_components.ramses_cc.coordinator import RamsesCoordinator
+from ramses_rf.gateway import GatewayConfig
+
+
+@patch("custom_components.ramses_cc.coordinator.Gateway")
+async def test_known_list_sanitised_for_serial(
+    mock_gateway_class: MagicMock, hass: HomeAssistant
+) -> None:
+    """Test commands are stripped before passing to ramses_rf via serial.
+
+    :param mock_gateway_class: Mock for the ramses_rf Gateway class.
+    :type mock_gateway_class: MagicMock
+    :param hass: The Home Assistant instance fixture.
+    :type hass: HomeAssistant
+    """
+    # Arrange
+    mock_entry = MagicMock()
+    mock_entry.options = {
+        CONF_RAMSES_RF: {},
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        SZ_KNOWN_LIST: {
+            "01:123456": {"class": "controller", CONF_COMMANDS: {"ping": "A"}},
+            "04:654321": {"class": "TRV", "faked": True},
+        },
+    }
+
+    coordinator = RamsesCoordinator(hass, mock_entry)
+
+    # Act
+    coordinator._create_client({})
+
+    # Assert
+    mock_gateway_class.assert_called_once()
+    call_kwargs = cast(dict[str, Any], mock_gateway_class.call_args.kwargs)
+    gwy_config = cast(GatewayConfig, call_kwargs["config"])
+
+    passed_known_list = gwy_config.known_list
+
+    # Ensure the commands are stripped to prevent schema validation errors
+    assert "01:123456" in passed_known_list
+    assert CONF_COMMANDS not in passed_known_list["01:123456"]
+    assert passed_known_list["01:123456"]["class"] == "controller"
+
+    # Ensure other valid traits remain intact
+    assert "04:654321" in passed_known_list
+    assert passed_known_list["04:654321"]["faked"] is True
+
+
+@patch("custom_components.ramses_cc.coordinator.Gateway")
+async def test_known_list_mqtt_hgi_injection(
+    mock_gateway_class: MagicMock, hass: HomeAssistant
+) -> None:
+    """Test HGI details are injected into known_list when using MQTT.
+
+    :param mock_gateway_class: Mock for the ramses_rf Gateway class.
+    :type mock_gateway_class: MagicMock
+    :param hass: The Home Assistant instance fixture.
+    :type hass: HomeAssistant
+    """
+    # Arrange
+    mock_entry = MagicMock()
+    mock_entry.options = {
+        CONF_RAMSES_RF: {},
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt_ha"},
+        CONF_MQTT_USE_HA: True,
+        CONF_MQTT_HGI_ID: "18:111111",
+        SZ_KNOWN_LIST: {
+            "01:123456": {"class": "controller"},
+        },
+    }
+
+    with patch.object(
+        hass.config_entries, "async_entries", return_value=["mock_mqtt_entry"]
+    ):
+        coordinator = RamsesCoordinator(hass, mock_entry)
+
+        # Act
+        coordinator._create_client({})
+
+    # Assert
+    mock_gateway_class.assert_called_once()
+    call_kwargs = cast(dict[str, Any], mock_gateway_class.call_args.kwargs)
+    gwy_config = cast(GatewayConfig, call_kwargs["config"])
+
+    passed_known_list = gwy_config.known_list
+
+    # Verify original devices exist
+    assert "01:123456" in passed_known_list
+
+    # Verify the HGI has been correctly injected for MQTT operations
+    assert "18:111111" in passed_known_list
+    hgi_traits = passed_known_list["18:111111"]
+    assert hgi_traits["class"] == "HGI"
+    assert hgi_traits["alias"] == "ramses_esp"


### PR DESCRIPTION
### The Problem:

Following Phase 2.77 of the OSI Decoupling refactor in `ramses_rf`, the legacy `gwy.known_list` dictionary attribute was deprecated. L7 domain traits are now strictly housed within a `GatewayConfig` facade. Because the Home Assistant Gateway binary sensor was still attempting to parse the missing legacy data for its UI diagnostic attributes, an `IndexError` was triggered, causing immediate test failures (`test_gateway_binary_sensor_attrs`).

### Consequences:

If left unfixed, the integration will throw exceptions during entity state generation. Users will lose diagnostic visibility of the `known_list` and `block_list` within the Home Assistant frontend, and the test suite will remain broken. Furthermore, failing to strictly manage the configuration passed to the backend risks schema validation crashes during startup.

### The Fix:

Updated the Gateway binary sensor to point to the new OSI-compliant configuration facade. Additionally, introduced a robust end-to-end test suite to validate the lifecycle and sanitisation of the `known_list` payload prior to backend ingestion.

### Technical Implementation:
- Modified `RamsesGatewayBinarySensor.extra_state_attributes` to utilise a targeted `getattr` sequence (`getattr(gwy, "config", getattr(gwy, "_gwy_config", None))`) to safely extract the `known_list`, bypassing the deprecated property entirely.
- Refactored `test_binary_sensor.py` using the Arrange-Act-Assert (AAA) pattern to mock the modern `gwy.config.known_list` structure instead of relying on legacy duck-typing.
- Created a new, isolated test file (`test_known_list.py`) utilising the native `hass` fixture. This validates that `RamsesCoordinator._create_client()` correctly strips HA-specific keys (like `commands`) from the dictionary, and accurately injects the required virtual HGI (`18:xxx`) with its mandatory classes when operating over the MQTT transport layer.

### Testing Performed:
- **`test_binary_sensor.py`**: Validated that the Gateway diagnostic attributes format correctly using the new `gwy.config.known_list` data shape without triggering an `IndexError`.
- **`test_known_list.py`**:
    - `test_known_list_sanitised_for_serial`: Proved that custom Home Assistant parameters (e.g., `commands`) are successfully stripped to prevent `ramses_rf` schema validation failures.
    - `test_known_list_mqtt_hgi_injection`: Proved that the coordinator dynamically and correctly injects the virtual Gateway (`class: HGI`, `alias: ramses_esp`) into the data structure when the MQTT bridge is active.

### Risks of NOT Implementing:

The Gateway sensor will continuously throw indexing exceptions, breaking diagnostic views. Additionally, without strict sanitisation tests, future `ramses_rf` updates that tighten initialisation schemas could result in hard crashes if Home Assistant-specific dictionary keys leak into the backend.

### Risks of Implementing:

Users operating on heavily outdated firmwares or unsupported forks of `ramses_rf` that lack the `config` facade architecture may lose `known_list` visibility if the new attribute path cannot be resolved.

### Mitigation Steps:

The `getattr` extraction chain retains deep fallback support (checking `_gwy_config`, `engine._include`, and `gwy._include`) to gracefully handle edge cases and legacy environments without crashing the sensor. Strict static casting and Mypy compliance were applied to the new tests to prevent future type regressions.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.  