### PR TITLE
New cov-report-comment action

### DIFF
--- a/.github/workflows/check-cov.yml
+++ b/.github/workflows/check-cov.yml
@@ -104,35 +104,9 @@ jobs:
           output: both
           thresholds: '90 97'
 
-      - name: Add Coverage PR Comment
-        # from: https://github.com/marketplace/actions/comment-pull-request
-        if: github.event_name == 'pull_request_target'
-        uses: thollander/actions-comment-pull-request@v3
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@v1
         with:
-          file-path: code-coverage-results.md
-          comment-tag: code-coverage-results.md  # replaces existing by this name
-          mode: recreate
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-# or:
-#      - name: Create Coverage Badge
-#        # from: https://github.com/marketplace/actions/coverage-py-badge
-#        uses: tj-actions/coverage-badge-py@v2
-#        id: coverage-badge-py
-#        with:
-#            # Output path to write the
-#            # coverage badge.
-#            # Type: string
-#            # Default: "coverage.svg"
-#            output: 'misc/coverage-badge.svg'
-#
-#            # Overwrite an existing coverage badge.
-#            # Type: boolean
-#            # Default: "true"
-#            overwrite: ''
-#
-#            # Current working directory
-#            # Type: string
-#            # Default: "."
-#            working-directory: ''
+          pytest-xml-coverage-path: ./coverage.xml
 
       - run: echo "🍏 This job's status is ${{ job.status }}."


### PR DESCRIPTION
**PR Summary**

Use new GitHub Action to add coverage report as comment to every PR.
Previous action is not maintained and will be rejected by HA on ramses_cc. Same action used on ramses_rf PRs.
Fixes #606 