### PR TITLE
Any `SZ_HEAT_DEMAND` is diagnostic

### DIFF
--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -311,7 +311,6 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
         icon="mdi:radiator",
         ramses_cc_icon_off="mdi:radiator-off",
         native_unit_of_measurement=PERCENTAGE,
-        entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_RELAY_DEMAND,
@@ -566,6 +565,7 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
         ramses_rf_attr=SZ_SUPPLY_FAN_SPEED,
         name="Supply fan speed",
         native_unit_of_measurement=PERCENTAGE,
+        entity_category=None,
     ),
     RamsesSensorEntityDescription(
         key=SZ_SUPPLY_FLOW,


### PR DESCRIPTION
**PR Summary**

This PR fixes issue #712 for SUPPLY_FAN_SPEED as not diagnostic
But when that is logical, so is showing any HEAT_DEMAND under diagnose, OTB or not OTB

