### PR TITLE
test: add deterministic queue flushing to prevent test teardown race conditions

### DIFF
--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
@@ -32,6 +34,53 @@ from .const import TEST_SYSTEMS
 
 # Constants
 DEVICE_ID = "32:123456"
+
+
+async def async_flush_queues(gwy: Any) -> None:
+    """Deterministically drain specific backend CQRS queues.
+
+    Hardcoded references are used to avoid introspection side-effects
+    (e.g., prematurely joining transport queues causing test teardown
+    drops and lost connections).
+    """
+    queues: list[asyncio.Queue[Any]] = []
+
+    # 1. Legacy / Top-level Gateway Queues
+    if hasattr(gwy, "msg_queue") and isinstance(gwy.msg_queue, asyncio.Queue):
+        queues.append(gwy.msg_queue)
+
+    # 2. Engine Layer Queues
+    engine = getattr(gwy, "_engine", None)
+    if engine and hasattr(engine, "_msg_queue"):
+        if isinstance(engine._msg_queue, asyncio.Queue):
+            queues.append(engine._msg_queue)
+
+    # 3. Phase 2.95+ Central Dispatcher Queues
+    dispatcher = getattr(gwy, "dispatcher", None) or getattr(
+        gwy, "central_dispatcher", None
+    )
+    if dispatcher:
+        for q_name in (
+            "_in_queue",
+            "ssot_queue",
+            "discovery_queue",
+            "binding_queue",
+            "faked_queue",
+        ):
+            if hasattr(dispatcher, q_name):
+                q = getattr(dispatcher, q_name)
+                if isinstance(q, asyncio.Queue):
+                    queues.append(q)
+
+    # Await specifically targeted queues
+    for q in queues:
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(q.join(), timeout=5.0)
+
+    # Ensure the event loop has ticked enough to process immediate task
+    # results from synchronous TopologyBuilder iterations.
+    for _ in range(50):
+        await asyncio.sleep(0)
 
 
 @pytest.fixture
@@ -73,7 +122,8 @@ async def test_entities(
     config = configuration_fixture(instance)
     config[DOMAIN]["serial_port"] = rf.ports[0]
 
-    # Convert legacy packet_log keys from fixtures to the new schema dynamically
+    # Convert legacy packet_log keys from fixtures to the new schema
+    # dynamically
     if "packet_log" in config.get(DOMAIN, {}) and isinstance(
         config[DOMAIN]["packet_log"], dict
     ):
@@ -84,11 +134,13 @@ async def test_entities(
         if "rotate_backups" in pkt_log:
             pkt_log["packet_log_retention_days"] = pkt_log.pop("rotate_backups")
 
-    # Ensure VirtualRf gateway is in known_list to prevent strict filtering drops
+    # Ensure VirtualRf gateway is in known_list to prevent strict filtering
+    # drops
     config[DOMAIN].setdefault("known_list", {})["18:006402"] = {"class": "HGI"}
 
-    # Patch 'available' to always be True during setup so historical packet logs
-    # render fully populated states in the snapshot, bypassing 60-min timeout.
+    # Patch 'available' to always be True during setup so historical packet
+    # logs render fully populated states in the snapshot, bypassing 60-min
+    # timeout.
     with (
         patch(
             "custom_components.ramses_cc.entity.RamsesEntity.available",
@@ -107,6 +159,13 @@ async def test_entities(
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+        # Deterministically flush all background queues via hardcoded paths
+        if DOMAIN in hass.data:
+            for coordinator in hass.data[DOMAIN].values():
+                if getattr(coordinator, "client", None):
+                    await async_flush_queues(coordinator.client)
         await hass.async_block_till_done()
 
     entry = None

--- a/tests/tests_old/test_evo_control.py
+++ b/tests/tests_old/test_evo_control.py
@@ -17,6 +17,8 @@ This does not test any service calls, or any other endpoints.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 from typing import Any, cast
 
@@ -42,6 +44,53 @@ from .helpers import TEST_DIR
 
 INPUT_FILE = "/system_1.log"
 SCHEMA_FILE = "/system_1.json"
+
+
+async def async_flush_queues(gwy: Any) -> None:
+    """Deterministically drain specific backend CQRS queues.
+
+    Hardcoded references are used to avoid introspection side-effects
+    (e.g., prematurely joining transport queues causing test teardown
+    drops and lost connections).
+    """
+    queues: list[asyncio.Queue[Any]] = []
+
+    # 1. Legacy / Top-level Gateway Queues
+    if hasattr(gwy, "msg_queue") and isinstance(gwy.msg_queue, asyncio.Queue):
+        queues.append(gwy.msg_queue)
+
+    # 2. Engine Layer Queues
+    engine = getattr(gwy, "_engine", None)
+    if engine and hasattr(engine, "_msg_queue"):
+        if isinstance(engine._msg_queue, asyncio.Queue):
+            queues.append(engine._msg_queue)
+
+    # 3. Phase 2.95+ Central Dispatcher Queues
+    dispatcher = getattr(gwy, "dispatcher", None) or getattr(
+        gwy, "central_dispatcher", None
+    )
+    if dispatcher:
+        for q_name in (
+            "_in_queue",
+            "ssot_queue",
+            "discovery_queue",
+            "binding_queue",
+            "faked_queue",
+        ):
+            if hasattr(dispatcher, q_name):
+                q = getattr(dispatcher, q_name)
+                if isinstance(q, asyncio.Queue):
+                    queues.append(q)
+
+    # Await specifically targeted queues
+    for q in queues:
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(q.join(), timeout=5.0)
+
+    # Ensure the event loop has ticked enough to process immediate task
+    # results from synchronous TopologyBuilder iterations.
+    for _ in range(50):
+        await asyncio.sleep(0)
 
 
 class MockRamsesCoordinator:
@@ -72,10 +121,15 @@ async def instantiate_entities(
         engine=engine_config,
     )
 
-    # Explicitly set port_name to None to bypass hardware serial initialization
+    # Explicitly set port_name to None to bypass hardware serial
+    # initialisation
     gwy: Gateway = Gateway(port_name=None, config=gwy_config)
 
     await gwy.start()
+
+    # Deterministically flush CQRS background queues
+    await async_flush_queues(gwy)
+
     # have to stop MessageIndex thread, aka: gwy.msg_db.stop()
     await gwy.stop()
 
@@ -170,7 +224,12 @@ async def test_namespace(hass: HomeAssistant) -> None:
         SCHEMA = list(_SCHEMA.values())[0]
 
     # The intention here is check the namespace used by EvoControl
-    climates, water_heaters, binary_sensors, sensors = await instantiate_entities(hass)
+    (
+        climates,
+        water_heaters,
+        binary_sensors,
+        sensors,
+    ) = await instantiate_entities(hass)
 
     #
     # evo_control uses: binary_sensor.${cid}_status


### PR DESCRIPTION
### The Problem:

Tests in both the legacy (`tests_old`) and new (`tests_new`) suites occasionally suffer from intermittent failures and dropped connections during teardown. This happens because background Command-Query Responsibility Segregation (CQRS) queues—such as the gateway message queue, the engine message queue, and various Phase 2.95+ central dispatcher queues—are not cleanly or completely drained before the test environment is destroyed.

### Consequences:

If this isn't fixed, it results in flaky CI/CD test runs, lost packets, and noise in test logs due to connection teardown drops. These silent failures hide legitimate regressions and reduce developer confidence in the test suite.

### The Fix:

Introduced a hardcoded async helper function (`async_flush_queues`) to both test modules to explicitly and deterministically drain backend CQRS queues before the gateway is stopped or the Home Assistant components wrap up. Long comment blocks and tuple unpacking lines were also wrapped to comply with project linting guidelines.

### Technical Implementation:
- **Targeted Queue Identification:** The `async_flush_queues` function safely inspects the gateway object via `hasattr` and `getattr` to find `asyncio.Queue` instances across three layers: Legacy/Top-level Gateway (`msg_queue`), Engine Layer (`_msg_queue`), and Central Dispatcher (`_in_queue`, `ssot_queue`, `discovery_queue`, `binding_queue`, `faked_queue`).
- **Safe Awaiting:** Every isolated queue is joined using `asyncio.wait_for(q.join(), timeout=5.0)` wrapped in a `contextlib.suppress(asyncio.TimeoutError)` block to ensure the test suite never hangs indefinitely.
- **Event Loop Micro-ticks:** Added a sequence of 50 `await asyncio.sleep(0)` iterations at the end of the helper to ensure the event loop processes any lingering immediate tasks produced by synchronous `TopologyBuilder` iterations.
- **Hooks Added:** Called the helper inside `test_entities` immediately after `async_setup_component` and inside `instantiate_entities` right before `gwy.stop()`.

### Testing Performed:

Manually verified that running `pytest tests/tests_new/test_init.py` and `pytest tests/tests_old/test_evo_control.py` execute successfully. The added timeout suppression guarantees that even if a queue fails to join within 5 seconds, the tests will gracefully fall back rather than hanging the test process.

### Risks of NOT Implementing:

Continued intermittent test flakiness, particularly in local environments and automated CI pipelines, causing developer friction and unreliable merge signals.

### Risks of Implementing:
- Minor performance overhead added to test run execution times due to the intentional 50-tick loop sleep and queue waits.
- Since the helper uses hardcoded internal string paths (e.g., `_msg_queue`, `ssot_queue`), future refactoring of the core gateway queue names could silently render this cleanup helper ineffective until updated.

### Mitigation Steps:
- Addressed the test hang risk by wrapping the queue joins inside an explicit `asyncio.wait_for` timeout block alongside `contextlib.suppress`.
- Used defensive `hasattr`, `getattr`, and `isinstance(..., asyncio.Queue)` checks to prevent the helper from throwing `AttributeError` or crashing if core internals change.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.