### PR TITLE
ci: Implement dual-workflow architecture for safe PR coverage comments (#726)

### DIFF
--- a/.github/workflows/check-cov.yml
+++ b/.github/workflows/check-cov.yml
@@ -12,7 +12,7 @@ on:
       "tests/**",
     ]
 
-  pull_request_target:
+  pull_request:
     branches: [ "master" ]
     paths: [
       ".github/workflows/check-cov.yml",
@@ -28,7 +28,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
 
@@ -104,14 +104,18 @@ jobs:
           output: both
           thresholds: '90 97'
 
-      - name: Add Pytest Coverage comment
-        # can only run on pr_target repository
-        if: github.event_name == 'pull_request_target'
-        uses: MishaKav/pytest-coverage-comment@v1
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo ${{ github.event.pull_request.number }} > pr-number.txt
+
+      - name: Upload coverage artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
         with:
-          pytest-xml-coverage-path: ./coverage.xml
-          # custom settings
-          report-only-changed-files: true
-          remove-links-to-files: true
+          name: coverage-artifact
+          path: |
+            coverage.xml
+            pr-number.txt
+          overwrite: true
 
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/post-cov.yml
+++ b/.github/workflows/post-cov.yml
@@ -1,0 +1,47 @@
+name: Post Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["Coverage"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  post-comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download coverage artifact
+        id: download
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: coverage-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        if: steps.download.outcome == 'success'
+        id: pr-number
+        run: echo "PR_NUMBER=$(cat pr-number.txt)" >> $GITHUB_ENV
+
+      - name: Add Pytest Coverage comment
+        if: steps.download.outcome == 'success'
+        # can only run on pr_target repository originally, now runs
+        # safely via artifact decoupling
+        uses: MishaKav/pytest-coverage-comment@v1
+        with:
+          pytest-xml-coverage-path: ./coverage.xml
+          issue-number: ${{ env.PR_NUMBER }}
+          # custom settings
+          report-only-changed-files: true
+          remove-links-to-files: true
+
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -16,6 +16,8 @@ import sys
 from types import ModuleType
 from typing import Any
 
+# TEST: Triggering CI workflow
+
 # from collections.abc import Callable
 #
 # from homeassistant.components.event import EventEntity

--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -16,8 +16,6 @@ import sys
 from types import ModuleType
 from typing import Any
 
-# TEST: Triggering CI workflow
-
 # from collections.abc import Callable
 #
 # from homeassistant.components.event import EventEntity

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -3,8 +3,8 @@
   list([
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'device_class': 'problem',
-        'friendly_name': 'CTL 01:145038 System status',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 System status',
         'id': '01:145038',
         'working_schema': dict({
           'orphans': list([
@@ -30,8 +30,8 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'active_faults': None,
-        'device_class': 'problem',
-        'friendly_name': 'CTL 01:145038 Active fault',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 Active fault',
         'id': '01:145038',
         'latest_event': None,
         'latest_fault': None,
@@ -46,8 +46,8 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'battery_level': None,
-        'device_class': 'battery',
-        'friendly_name': 'THM 03:123456 Battery',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'THM 03:123456 Battery',
         'id': '03:123456',
       }),
       'context': <ANY>,
@@ -64,8 +64,8 @@
         'config': dict({
           'enforce_known_list': True,
         }),
-        'device_class': 'problem',
-        'friendly_name': 'HGI 18:006402 Gateway status',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'HGI 18:006402 Gateway status',
         'id': '18:006402',
         'is_evofw3': True,
         'known_list': list([
@@ -108,7 +108,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'CTL 01:145038 System info',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 System info',
         'id': '01:145038',
         'working_schema': dict({
           'orphans': list([
@@ -133,11 +133,11 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'CTL 01:145038 Heat demand',
-        'icon': 'mdi:radiator-off',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 Heat demand',
+        <EntityStateAttribute.ICON: 'icon'>: 'mdi:radiator-off',
         'id': '01:145038',
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': '%',
+        <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+        <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
       }),
       'context': <ANY>,
       'entity_id': 'sensor.ctl_01_145038_heat_demand',
@@ -148,12 +148,12 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'device_class': 'temperature',
-        'friendly_name': 'THM 03:123456 Temperature',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'THM 03:123456 Temperature',
         'id': '03:123456',
         'setpoint': None,
-        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+        <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+        <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
       }),
       'context': <ANY>,
       'entity_id': 'sensor.thm_03_123456_temperature',
@@ -167,8 +167,8 @@
         'data': dict({
           'type': <RamsesEventType.LEARN: 'ramses_cc_learn'>,
         }),
-        'event_type': None,
-        'event_types': list([
+        <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+        <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
           <RamsesEventType.LEARN: 'ramses_cc_learn'>,
         ]),
         'type': <RamsesEventType.LEARN: 'ramses_cc_learn'>,
@@ -185,8 +185,8 @@
         'data': dict({
           'type': <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
         }),
-        'event_type': None,
-        'event_types': list([
+        <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+        <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
           <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
         ]),
         'type': <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
@@ -209,8 +209,8 @@
         'config': dict({
           'enforce_known_list': True,
         }),
-        'device_class': 'problem',
-        'friendly_name': 'HGI 18:006402 Gateway status',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'HGI 18:006402 Gateway status',
         'id': '18:006402',
         'is_evofw3': True,
         'known_list': list([
@@ -235,8 +235,8 @@
         'data': dict({
           'type': <RamsesEventType.LEARN: 'ramses_cc_learn'>,
         }),
-        'event_type': None,
-        'event_types': list([
+        <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+        <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
           <RamsesEventType.LEARN: 'ramses_cc_learn'>,
         ]),
         'type': <RamsesEventType.LEARN: 'ramses_cc_learn'>,
@@ -253,8 +253,8 @@
         'data': dict({
           'type': <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
         }),
-        'event_type': None,
-        'event_types': list([
+        <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+        <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
           <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
         ]),
         'type': <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
@@ -273,8 +273,8 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'battery_level': None,
-        'device_class': 'battery',
-        'friendly_name': 'REM 29:179540 Battery',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'REM 29:179540 Battery',
         'id': '29:179540',
       }),
       'context': <ANY>,
@@ -291,8 +291,8 @@
         'config': dict({
           'enforce_known_list': True,
         }),
-        'device_class': 'problem',
-        'friendly_name': 'HGI 18:006402 Gateway status',
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'HGI 18:006402 Gateway status',
         'id': '18:006402',
         'is_evofw3': True,
         'known_list': list([
@@ -325,7 +325,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'REM 29:179540 Fan mode',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'REM 29:179540 Fan mode',
         'id': '29:179540',
       }),
       'context': <ANY>,
@@ -337,7 +337,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': 'REM 29:179540 Fan rate',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'REM 29:179540 Fan rate',
         'id': '29:179540',
       }),
       'context': <ANY>,
@@ -349,15 +349,15 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'assumed_state': True,
+        <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
         'commands': NodeDictClass({
           'auto': ' I --- 29:179540 32:157747 --:------ 22F1 003 000404',
           'away': ' I --- 29:179540 32:157747 --:------ 22F1 003 000004',
           'high': ' I --- 29:179540 32:157747 --:------ 22F1 003 000304',
         }),
-        'friendly_name': 'REM 29:179540',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'REM 29:179540',
         'id': '29:179540',
-        'supported_features': <RemoteEntityFeature: 3>,
+        <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <RemoteEntityFeature: 3>,
       }),
       'context': <ANY>,
       'entity_id': 'remote.rem_29_179540',
@@ -371,8 +371,8 @@
         'data': dict({
           'type': <RamsesEventType.LEARN: 'ramses_cc_learn'>,
         }),
-        'event_type': None,
-        'event_types': list([
+        <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+        <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
           <RamsesEventType.LEARN: 'ramses_cc_learn'>,
         ]),
         'type': <RamsesEventType.LEARN: 'ramses_cc_learn'>,
@@ -389,8 +389,8 @@
         'data': dict({
           'type': <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
         }),
-        'event_type': None,
-        'event_types': list([
+        <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+        <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
           <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,
         ]),
         'type': <RamsesEventType.REGEX: 'ramses_cc_regex_match'>,


### PR DESCRIPTION
### The Problem:

Currently, the `check-cov.yml` workflow relies on the `pull_request_target` trigger to secure permissions for posting coverage comments. However, this intentionally forces GitHub to check out and test the `master` branch instead of the incoming PR branch. If underlying dependencies (like Home Assistant core or `ramses_rf`) update, the old `master` code fails against the new requirements, causing false CI failures and completely ignoring the actual PR code (Resolves #726).

### Consequences:

If left unaddressed, the CI pipeline will continuously suffer from false failures due to dependency mismatches. Furthermore, any coverage reports that do successfully post are actually reporting the metrics of the `master` branch, providing entirely inaccurate feedback for the developer's PR.

### The Fix:

Split the coverage reporting process into a secure, decoupled dual-workflow architecture using GitHub Actions' upload/download artifact pattern.

### Technical Implementation:
- **Workflow A (Generator):** Modified `check-cov.yml` to use standard `pull_request` triggers with strict `contents: read` permissions. This securely tests the actual incoming PR code.
- **Artifact Bridge:** Configured `actions/upload-artifact@v7` to export the resulting `coverage.xml` alongside a newly generated `pr-number.txt` file to establish context.
- **Workflow B (Consumer):** Introduced a new `post-cov.yml` workflow, triggered by `workflow_run`. This runs in the trusted base repository context, downloads the data via `actions/download-artifact@v8`, reads the PR number, and securely posts the comment using elevated `pull-requests: write` permissions.
- **Bundled Fix:** Aligned `test_init.ambr` Syrupy snapshots with Home Assistant 2026.7 Enum attributes to restore a green test matrix.

### Testing Performed:

Verified the generation of the `coverage-artifact.zip` containing the exact target PR number and correct XML schema. Executed local Pytest matrix following a dependency upgrade to validate the snapshot fixes.

### Risks of NOT Implementing:

Persistently broken continuous integration pipelines, lack of accurate code coverage metrics on new features, and the continued use of `pull_request_target`, which is flagged by GitHub as a potential security risk when handling fork code.

### Risks of Implementing:

The decoupled nature of `workflow_run` means failures in the bot commenting step will occur asynchronously, making it slightly harder to debug at a glance compared to a single unified workflow.

### Mitigation Steps:

Explicitly pinned the major versions of the artifact actions (`v7` and `v8`) to ensure API compatibility across the boundary. Added a `continue-on-error` outcome check to gracefully handle skipped paths if no Python files are altered in a PR.

### AI Assistance Disclosure:

This contribution was developed with the assistance of Google Gemini 3.1 Pro for code generation and documentation. No Agentic AI systems were employed; all logic and implementations were reviewed, verified, and manually committed by the author.

---

  