### PR TITLE
fix: use is_active attr and invert for PROBLEM device class

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -321,11 +321,16 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
     def is_on(self) -> bool | None:
         """Return True if the gateway has a problem (no recent messages).
 
+        `is_active` returns True when the gateway is healthy (recent
+        messages received).  Since this sensor uses
+        `BinarySensorDeviceClass.PROBLEM`, we invert so that `is_on=True`
+        means "problem" and `is_on=False` means "OK".
+
         :return: True if there is a problem, None if unknown.
         :rtype: bool | None
         """
         is_on = super().is_on
-        return None if is_on is None else is_on
+        return None if is_on is None else not is_on
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -346,7 +351,7 @@ class RamsesBinarySensorEntityDescription(
 BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
     RamsesBinarySensorEntityDescription(
         key="status",
-        ramses_rf_attr="status",  # "is_active",
+        ramses_rf_attr="is_active",
         name="Gateway status",
         ramses_rf_class=HgiGateway,
         ramses_cc_class=RamsesGatewayBinarySensor,

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -104,7 +104,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'off',
+      'state': 'on',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
@@ -228,7 +228,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'off',
+      'state': 'on',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
@@ -321,7 +321,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'off',
+      'state': 'on',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -401,15 +401,15 @@ async def test_gateway_binary_sensor_state(
     )
 
     # Act & Assert
-    # 1. Case A: Gateway active -> is_on True
+    # 1. Case A: Gateway active (OK) -> is_on False (no problem)
     mock_device.is_active = True
     is_on_check_a = sensor.is_on
-    assert is_on_check_a is True
+    assert is_on_check_a is False
 
-    # 2. Case B: Gateway inactive -> is_on False
+    # 2. Case B: Gateway inactive (dead) -> is_on True (problem)
     mock_device.is_active = False
     is_on_check_b = sensor.is_on
-    assert is_on_check_b is False
+    assert is_on_check_b is True
 
 
 @patch("custom_components.ramses_cc.binary_sensor.Command")


### PR DESCRIPTION
The gateway binary sensor used `ramses_rf_attr="status"` which returns an empty dict from `DeviceBase.status()`, not a boolean.  This caused the sensor to always show "OK" (False) regardless of gateway health.

Fix: change `ramses_rf_attr` back to `"is_active"` (the async property on `HgiGateway` that checks recent message timestamps) and invert the result so that `is_on=True` means "problem" (matching the `BinarySensorDeviceClass.PROBLEM` device class semantics).

Resolves #665.

depends on https://github.com/ramses-rf/ramses_rf/pull/736

@PWhite-Eng 