### PR TITLE
Fix REM gwy_status off in snapshot

### DIFF
--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -321,7 +321,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'on',
+      'state': 'off',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({


### PR DESCRIPTION
Repair after merge of #744 into master
