### PR TITLE
fix: find_param_entity unique_id mismatch with number platform

### DIFF
--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -40,16 +40,45 @@ class RamsesFanHandler:
         Helper Method that searches for a number entity corresponding to a specific
         parameter on a device.
 
-        :param device_id: The ID of the device (e.g., '30:123456').
-        :param param_id: The 2-character hex ID of the parameter.
+        The callers pass a *normalized* device_id (colons replaced with
+        underscores, e.g. ``32_153289``) and an *uppercased* param_id
+        (e.g. ``3D``).  The number platform, however, stores entities with
+        the following unique_id formats:
+
+        * **New** (since PR 581): ``"{device.id}-param_{key}"`` where
+          ``device.id`` keeps its colons and ``key`` preserves the schema
+          case — e.g. ``32:153289-param_3D``.
+        * **Old** (pre-migration): ``"{normalized_id}_param_{param.lower()}"``
+          — e.g. ``32_153289_param_3d``.
+
+        We try the new format first and fall back to the old one so that
+        entities that have not yet been migrated are still found.
+
+        :param device_id: The ID of the device (normalized or raw,
+            e.g. ``32_153289`` or ``32:153289``).
+        :param param_id: The 2-character hex ID of the parameter (uppercased,
+            e.g. ``3D``).
         :return: The found entity or None if not found in the registry/platform.
         """
-        safe_device_id = str(device_id).replace(":", "_").lower()
-        unique_id = f"{safe_device_id}_param_{param_id.lower()}"
+        # Restore colons for the new unique_id format (device.id keeps colons)
+        colon_device_id = str(device_id).replace("_", ":")
+        normalized_device_id = str(device_id).replace(":", "_").lower()
+
+        # New format: "32:153289-param_3D" (colons, schema case)
+        new_unique_id = f"{colon_device_id}-param_{param_id}"
+        # Old format: "32_153289_param_3d" (underscores, lowercase)
+        old_unique_id = f"{normalized_device_id}_param_{param_id.lower()}"
+
         ent_reg = er.async_get(self.hass)
-        entity_id = ent_reg.async_get_entity_id("number", DOMAIN, unique_id)
+        entity_id = ent_reg.async_get_entity_id("number", DOMAIN, new_unique_id)
         if entity_id is None:
-            _LOGGER.debug("Entity (unique_id=%s) not found in registry.", unique_id)
+            entity_id = ent_reg.async_get_entity_id("number", DOMAIN, old_unique_id)
+        if entity_id is None:
+            _LOGGER.debug(
+                "Entity (unique_id=%s or %s) not found in registry.",
+                new_unique_id,
+                old_unique_id,
+            )
             return None
 
         _LOGGER.debug("Found entity %s in entity registry", entity_id)

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -366,7 +366,7 @@ async def test_find_param_entity_logic(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
     """Test find_param_entity logic (registry lookup and platform entity retrieval)."""
-    # Test 1: Entity not in registry
+    # Test 1: Entity not in registry — verify both new and old formats are tried
     with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
         mock_registry = MagicMock()
         mock_er_get.return_value = mock_registry
@@ -374,6 +374,12 @@ async def test_find_param_entity_logic(
 
         res = mock_coordinator.fan_handler.find_param_entity(FAN_ID, "10")
         assert res is None
+
+        # Verify the new unique_id format (with colons) was queried first
+        call_args = mock_registry.async_get_entity_id.call_args_list
+        queried_unique_ids = [c.args[2] for c in call_args]
+        assert "30:123456-param_10" in queried_unique_ids  # new format
+        assert "30_123456_param_10" in queried_unique_ids  # old format fallback
 
     # Test 2: Entity in registry, but platform not loaded or entity not in platform
     with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
@@ -403,6 +409,24 @@ async def test_find_param_entity_logic(
 
         res = mock_coordinator.fan_handler.find_param_entity(FAN_ID, "10")
         assert res == mock_entity
+
+    # Test 4: Normalized device_id (underscores) — as passed by services.py
+    with patch("homeassistant.helpers.entity_registry.async_get") as mock_er_get:
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get_entity_id.return_value = None
+
+        # services.py passes normalized_device_id (colons → underscores)
+        res = mock_coordinator.fan_handler.find_param_entity("30_123456", "0A")
+        assert res is None
+
+        # Verify the new format with colons was reconstructed correctly
+        call_args = mock_registry.async_get_entity_id.call_args_list
+        queried_unique_ids = [c.args[2] for c in call_args]
+        assert (
+            "30:123456-param_0A" in queried_unique_ids
+        )  # new format (colons restored)
+        assert "30_123456_param_0a" in queried_unique_ids  # old format (lowercase)
 
 
 async def test_fan_setup_callbacks_exception(


### PR DESCRIPTION
The number platform creates parameter entities with unique_id format "{device.id}-param_{id}" (e.g., "32:153289-param_01"), but find_param_entity in fan_handler.py was looking for the old format "{device_id}_param_{id}" with underscores (e.g., "32_153289_param_01").

This mismatch meant find_param_entity never found the entities, so:
- The hourglass/pending state was never set when requesting parameters
- The refresh-all-parameters button appeared not to work (the backend was fetching values, but the UI entities never showed pending state or visually updated)

Fix: try the new unique_id format first, fall back to the old format for any entities that haven't been migrated yet.


I did have a lookup on what happened on changing to the new format:

The naming convention change history (all in number.py):

PR 581 (Apr 3, merged) — introduced new format {device.id}-{key} = 32:153289-param_01, with a migration step that converts old → new via ent_reg.async_update_entity(existing_entity_id, new_unique_id=new_unique_id). Resolves issue 516.
Commits 8a75a15 / 79a0b6e — temporarily reverted to underscore, then 2fc8b9c / ae168c5 — changed back to dash. Final state: dash format is mandatory.
The migration code at number.py:1148-1170 handles converting old unique_ids to new ones on startup.
Your prod entity registry confirms: all 16 param entities are already migrated to the new format (32:153289-param_01), zero old-format entries remain.

Why hourglasses show on startup but not on refresh button:

Startup: The number platform calls entity._request_parameter_value() directly on each entity object (number.py:268-274), which calls self.set_pending() directly — no registry lookup needed.
Refresh button: Goes through services.py → fan_handler.find_param_entity() which does a registry lookup by unique_id (fan_handler.py:47-66). This was using the old format 32_153289_param_01 — never found, so set_pending() was never called.
My fix is correct: tries the new format (32:153289-param_01) first, falls back to the old format (32_153289_param_01) for any entities that haven't been migrated yet. This matches exactly what _has_existing_param_entities in number.py already does (lines 94-111) — it checks both legacy_prefix and new_prefix.