### PR TITLE
Fix VirtualRf race condition, add async system_mode cooldown

### DIFF
--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import time
 from contextlib import suppress
 from datetime import datetime as dt
 from typing import Any, cast
@@ -112,6 +113,11 @@ def resolve_async_attr(
     """Safely get an attribute, resolving coroutines lazily.
 
     Bridges the gap between HA's synchronous properties and ramses_rf's async DTOs.
+
+    Includes a per-attribute cooldown (default 30s) to prevent command floods
+    when the async getter has side-effects (e.g. ramses_rf's ``system_mode()``
+    dispatches a 2E04 RQ when the state is unhydrated).  Without this, every
+    HA property access re-dispatches the same RQ in a tight loop.
     """
     val = getattr(obj, attr_name, default)
 
@@ -132,10 +138,21 @@ def resolve_async_attr(
 
         cache_key = f"_cached_{id(obj)}_{attr_name}"
         resolving_key = f"_resolving_{id(obj)}_{attr_name}"
+        cooldown_key = f"_cooldown_{id(obj)}_{attr_name}"
+
+        # Cooldown: don't re-dispatch the async getter within 30 seconds of
+        # the last dispatch.  This prevents command floods when the getter
+        # has side-effects (e.g. dispatching RQ commands) and the result is
+        # still None (unhydrated state).
+        COOLDOWN_SECS = 30
+        last_dispatch = getattr(entity, cooldown_key, 0)
+        now = time.monotonic()
+        within_cooldown = (now - last_dispatch) < COOLDOWN_SECS
 
         # Dispatch the background task to resolve the coroutine
-        if not getattr(entity, resolving_key, False):
+        if not getattr(entity, resolving_key, False) and not within_cooldown:
             setattr(entity, resolving_key, True)
+            setattr(entity, cooldown_key, now)
 
             async def _resolve() -> None:
                 try:

--- a/tests/tests_new/test_virtual_rf/test_virtual_rf.py
+++ b/tests/tests_new/test_virtual_rf/test_virtual_rf.py
@@ -264,13 +264,14 @@ async def test_read_ready_exception(caplog: pytest.LogCaptureFixture) -> None:
 
 
 async def test_read_ready_key_error(caplog: pytest.LogCaptureFixture) -> None:
-    """Test KeyError handling in _read_ready."""
+    """Test that _read_ready silently ignores unknown FDs (post-cleanup guard)."""
     rf = VirtualRf(1, start=True)
 
-    # Trigger the reader callback with an invalid FD
+    # Trigger the reader callback with an invalid FD (e.g. after cleanup)
     rf._read_ready(cast(Any, 99999))
 
-    assert "Error reading from port 99999" in caplog.text
+    # The guard should return silently — no error logged for stale FDs
+    assert "Error reading from port 99999" not in caplog.text
 
     await rf.stop()
 

--- a/tests/tests_old/test_init_data.py
+++ b/tests/tests_old/test_init_data.py
@@ -118,9 +118,10 @@ async def rf() -> AsyncGenerator[VirtualRf]:
         patch("ramses_tx.transport.port.comports", rf.comports, create=True),
         patch("ramses_tx.discovery.comports", rf.comports, create=True),
     ):
-        yield rf
-
-    await rf.stop()
+        try:
+            yield rf
+        finally:
+            await rf.stop()
 
 
 @patch("custom_components.ramses_cc.services._CALL_LATER_DELAY", _CALL_LATER_DELAY)

--- a/tests/virtual_rf/virtual_rf.py
+++ b/tests/virtual_rf/virtual_rf.py
@@ -87,6 +87,9 @@ class VirtualRfBase:
         self._port_to_object: dict[_PN, FileIO] = {}  # for I/O (read/write)
         self._port_to_slave_: dict[_PN, _FD] = {}  # #  for cleanup only
 
+        # Buffer for incoming data to handle fragmentation across reads
+        self._rx_buffer: dict[_PN, bytes] = {}
+
         for idx in range(num_ports):
             self._create_port(idx)
 
@@ -107,6 +110,7 @@ class VirtualRfBase:
         self._port_to_master[port_name] = _FD(master_fd)
         self._port_to_object[port_name] = open(master_fd, "rb+", buffering=0)  # noqa: SIM115
         self._port_to_slave_[port_name] = _FD(slave_fd)
+        self._rx_buffer[port_name] = b""  # Initialize buffer
 
         self._set_comport_info(port_name, dev_type=dev_type)
 
@@ -134,19 +138,48 @@ class VirtualRfBase:
         if not self._running:
             return
 
-        for master_fd in self._master_to_port:
+        # 1. Remove readers first to stop new events from being queued
+        for master_fd in list(self._master_to_port):
             self._loop.remove_reader(master_fd)
 
         self._running = False
+
+        # 2. Yield to the event loop so any already-queued reader callbacks
+        #    can drain before we destroy the FDs they reference.
+        await asyncio.sleep(0)
+
+        # 3. Perform the actual destruction of resources (FDs)
         self._cleanup()
 
     def _cleanup(self) -> None:
         """Destroy file objects and file descriptors."""
 
-        for fp in self._port_to_object.values():
-            fp.close()  # also closes corresponding master fd
-        for fd in self._port_to_slave_.values():
-            os.close(fd)  # else this slave fd will persist
+        # 1. Close master FileIO objects
+        for port_name, fp in self._port_to_object.items():
+            if fp.closed:
+                continue
+            try:
+                fp.flush()
+                fp.close()  # also closes corresponding master fd
+            except (OSError, ValueError) as err:
+                _LOGGER.debug(f"Note: Master FP for {port_name} closure: {err}")
+
+        # 2. Close slave FDs
+        for port_name, fd in self._port_to_slave_.items():
+            try:
+                os.close(fd)  # else this slave fd will persist
+            except OSError as err:
+                if err.errno != 9:  # EBADF — OS already reclaimed it
+                    _LOGGER.warning(
+                        f"Unexpected OSError closing slave FD for {port_name}: {err}"
+                    )
+
+        # 3. Clear maps so _read_ready safely exits if called after cleanup
+        self._master_to_port.clear()
+        self._port_to_master.clear()
+        self._port_to_object.clear()
+        self._port_to_slave_.clear()
+        self._rx_buffer.clear()
 
     def start(self) -> None:
         """Start polling ports and distributing data."""
@@ -160,6 +193,8 @@ class VirtualRfBase:
 
     def _read_ready(self, fd: _FD) -> None:
         """Callback for when data is ready to read from a port."""
+        if fd not in self._master_to_port:
+            return  # FD might have been closed/removed during cleanup
         try:
             self._pull_data_from_src_port(self._master_to_port[fd])
         except (OSError, KeyError) as err:
@@ -169,7 +204,7 @@ class VirtualRfBase:
         """Pull the data from the sending port and process any frames."""
 
         try:
-            data = self._port_to_object[src_port].read()  # read the Tx'd data
+            data = self._port_to_object[src_port].read(1024)  # read the Tx'd data
         except OSError:
             return
 
@@ -178,8 +213,14 @@ class VirtualRfBase:
 
         self._log.append(cast(tuple[_PN, str, bytes], (src_port, "SENT", data)))
 
-        # this assumes all .write(data) are 1+ whole frames terminated with \r\n
-        for frame in (d + b"\r\n" for d in data.split(b"\r\n") if d):  # ignore b""
+        # Append new data to buffer and process complete frames
+        self._rx_buffer[src_port] += data
+
+        while b"\r\n" in self._rx_buffer[src_port]:
+            line, remainder = self._rx_buffer[src_port].split(b"\r\n", 1)
+            self._rx_buffer[src_port] = remainder
+
+            frame = line + b"\r\n"
             if fr := self._proc_before_tx(src_port, frame):
                 self._cast_frame_to_all_ports(src_port, fr)  # is not echo only
 
@@ -219,7 +260,12 @@ class VirtualRfBase:
 
         if data := self._proc_after_rx(dst_port, frame):
             self._log.append((dst_port, "RCVD", data))
-            self._port_to_object[dst_port].write(data)
+            try:
+                self._port_to_object[dst_port].write(data)
+            except BlockingIOError:
+                _LOGGER.warning(f"Buffer full writing to {dst_port}, dropping packet")
+            except OSError as err:
+                _LOGGER.error(f"Write error to {dst_port}: {err}")
 
     def _proc_after_rx(self, rcv_port: _PN, frame: bytes) -> bytes | None:
         """Allow the device to modify the frame after receiving (e.g. adding RSSI)."""
@@ -289,18 +335,17 @@ class VirtualRf(VirtualRfBase):
     ) -> None:  # TODO: WIP
         """Dump frames as if from a sending port (for mocking)."""
 
-        async def no_data_left_to_send() -> None:
-            """Wait until all pending data is read."""
-            # With add_reader, we don't have a selector to query like this.
-            # We just wait a short moment for callbacks to process.
-            await asyncio.sleep(0.001)
-
         for data in pkts:
             self._log.append(cast(tuple[_PN, str, bytes], ("/dev/mock", "SENT", data)))
             self._cast_frame_to_all_ports(_PN("/dev/mock"), data)  # is not echo only
 
+        # Yield control repeatedly to ensure all micro-tasks generated by the
+        # writes have a chance to run before the caller proceeds.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
         if timeout:
-            await asyncio.wait_for(no_data_left_to_send(), timeout)
+            await asyncio.wait_for(asyncio.sleep(0.001), timeout)
 
     def _proc_after_rx(self, rcv_port: _PN, frame: bytes) -> bytes | None:
         """Return the frame as it would have been modified by a gateway after Rx.


### PR DESCRIPTION
The ramses_rf system_mode getter (PR 769) was changed from a sync property to an async method that dispatches a 2E04 RQ command when unpopulated. This caused ramses_cc to call it as a sync property, getting back a coroutine and retrying in an infinite loop, plus unbounded task creation from the RQ dispatch side-effect.

Fixes:
- virtual_rf.py: yield to event loop before cleanup, make _cleanup() robust (check closed, handle errors, clear maps), add FD guard in _read_ready, add _rx_buffer for frame fragmentation, handle BlockingIOError in _push_frame_to_dst_port
- helpers.py: add cooldown to resolve_async_attr to prevent tight retry loops when an async attribute returns None/unpopulated
- test_init_data.py: move rf.stop() into finally block for guaranteed cleanup
- test_virtual_rf.py: updated for VirtualRf changes

created with AI, not tested (yet)