### PR TITLE
fix(tests): stop test_services_entry_ hanging on perpetual QoS retransmit

### DIFF
--- a/tests/tests_old/test_init_data.py
+++ b/tests/tests_old/test_init_data.py
@@ -56,7 +56,11 @@ NUM_DEVS_SETUP = 13  # Updated from 1 due to better packet decoding
 
 # Clean config to prevent HA schema validation failures
 TEST_CONFIG = {
-    CONF_RAMSES_RF: {"disable_discovery": True},
+    # disable_qos: without it, the gateway perpetually retransmits any RQ that
+    # the virtual RF never replies to (e.g. discovery's RQ 2E04 to the CTL),
+    # which keeps scheduling new pending tasks and can prevent
+    # hass.async_block_till_done() below from ever settling (see #774).
+    CONF_RAMSES_RF: {"disable_discovery": True, "disable_qos": True},
     SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyACM0"},
 }
 
@@ -141,7 +145,9 @@ async def test_services_entry_(
     try:
         gwy = list(hass.data[DOMAIN].values())[0].client
         await cast_packets_to_rf(rf, f"{TEST_DIR}/system_1.log", gwy=gwy)
-        await hass.async_block_till_done()
+        # Bounded so an unexpected perpetual-transport stall fails fast and
+        # clearly instead of hanging for the full CI timeout (see #774).
+        await asyncio.wait_for(hass.async_block_till_done(), timeout=30)
 
         await _test_common(hass, entry, rf)
     finally:


### PR DESCRIPTION
Closes #774.

## Root cause

As diagnosed in the issue (thanks @wimpie70): the gateway's QoS layer keeps retransmitting any RQ the virtual RF never replies to (e.g. discovery's `RQ 2E04` to the CTL). Each retransmit schedules another pending task, so `hass.async_block_till_done()` can never fully settle — which is why the test occasionally hangs for 45+ minutes on CI instead of failing or passing quickly.

## Fix

- Set `disable_qos: True` in `TEST_CONFIG` — an existing `EngineConfig` field that already flows through the coordinator into the `Gateway`. With QoS disabled, sent commands aren't tracked or retried, removing the perpetual-retransmit source entirely.
- Wrapped the specific `hass.async_block_till_done()` call named in the issue in `asyncio.wait_for(..., timeout=30)`, so if anything else ever causes a similar stall, the test fails loudly within 30s instead of consuming the whole CI timeout budget.

## Testing

I set up the full dev/test environment locally and tried to reproduce the reported hang directly. I hit a different, 100%-reproducible failure in my environment (`assert 9 == 13`, fails in under a second, and the device count doesn't change even after several seconds of polling) — I confirmed this is a pre-existing, environment-specific issue unrelated to #774: it occurs identically with and without this fix, and it fails immediately rather than hanging, so it can't be the same mechanism. I did not attempt to fix that separate issue here to keep this PR scoped to what was actually reported.

I could not reproduce the actual 45-minute hang locally since it depends on CI-specific timing/load, so I can't personally confirm this resolves it end-to-end — but the fix directly targets the retransmit mechanism described in the issue via an existing, already-supported config option, and the change is a net-neutral no-op for every other assertion the test makes (verified identical pass/fail behavior on the unrelated local issue with and without this change).

ruff and mypy are clean on the changed file.