### PR TITLE
Remove Not Minimal startup check and warning

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -66,7 +66,7 @@ from .const import (
 )
 from .fan_handler import RamsesFanHandler
 from .mqtt_bridge import RamsesMqttBridge
-from .schemas import merge_schemas, schema_is_minimal
+from .schemas import merge_schemas
 from .services import RamsesServiceHandler
 from .store import RamsesStore
 
@@ -248,8 +248,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # 2. Schema Handling
         config_schema = self.options.get(CONF_SCHEMA, {})
         _LOGGER.debug("CONFIG_SCHEMA: %s", config_schema)
-        if not schema_is_minimal(config_schema):
-            _LOGGER.warning("The config schema is not minimal (consider minimising it)")
 
         cached_schema = client_state.get(SZ_SCHEMA, {})
         _LOGGER.debug("CACHED_SCHEMA: %s", cached_schema)

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -20,8 +20,6 @@ from ramses_rf.schemas import (
     SZ_APPLIANCE_CONTROL,
     SZ_BOUND_TO,
     SZ_CONFIG,
-    SZ_ORPHANS_HEAT,
-    SZ_ORPHANS_HVAC,
     SZ_RESTORE_CACHE,
     SZ_SENSOR,
     SZ_SYSTEM,
@@ -38,7 +36,6 @@ from ramses_tx.const import (
 )
 from ramses_tx.schemas import (
     SCH_ENGINE_DICT,
-    SZ_BLOCK_LIST,
     SZ_KNOWN_LIST,
     SZ_PORT_CONFIG,
     SZ_SERIAL_PORT,
@@ -224,35 +221,6 @@ def merge_schemas(config_schema: _SchemaT, cached_schema: _SchemaT) -> _SchemaT 
 
     _LOGGER.info("Cached schema is a subset of config schema. Skipping cached.")
     return None
-
-
-def schema_is_minimal(schema: _SchemaT) -> bool:
-    """Return True if the schema is minimal (i.e. no optional keys).
-
-    Validates if the provided schema meets the minimum structural requirements
-    for a Temperature Control System (TCS) without containing unnecessary
-    or optional definition keys.
-
-    :param schema: The schema dictionary to validate.
-    :return: True if the schema is a valid minimal TCS schema, False otherwise.
-    """
-
-    key: str
-    sch: _SchemaT
-
-    for key, sch in schema.items():
-        if key in (SZ_BLOCK_LIST, SZ_KNOWN_LIST, SZ_ORPHANS_HEAT, SZ_ORPHANS_HVAC):
-            continue
-
-        try:
-            _ = SCH_MINIMUM_TCS(shrink(sch))
-        except vol.Invalid:
-            return False
-
-        if SZ_ZONES in sch and list(sch[SZ_ZONES].values())[0][SZ_SENSOR] != key:
-            return False
-
-    return True
 
 
 SCH_NO_SVC_PARAMS = vol.Schema({}, extra=vol.PREVENT_EXTRA)

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -74,7 +74,7 @@
                     "log_all_mqtt": "Log Tx + all MQTT traffic"
                 },
                 "data_description": {
-                    "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
+                    "schema": "A mapping of system device IDs to their respective schemas. This should describe your complete system(s), including zones with sensors, as YAML.",
                     "known_list": "A mapping of known device IDs and optionally their traits.",
                     "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. HA Restart required.",
                     "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console."
@@ -184,7 +184,7 @@
                     "log_all_mqtt": "Log Tx + all MQTT traffic"
                 },
                 "data_description": {
-                  "schema": "A mapping of system device IDs to their respective schemas. This should be kept minimal and only contain devices that are not automatically discovered.",
+                  "schema": "A mapping of system device IDs to their respective schemas. This should describe your complete system(s), including zones with sensors, as YAML.",
                   "known_list": "A mapping of known device IDs and optionally their traits.",
                   "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. After activating, clear the discovered system schemas cache before restarting.",
                   "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console."

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -74,7 +74,7 @@
                     "log_all_mqtt": "Log Tx + alle MQTT-topics"
                 },
                 "data_description": {
-                    "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
+                    "schema": "Een mapping van systeem device-ID's naar hun schema's inclusief Zones met Sensors, als YAML.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
                     "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor. Wis wel 1x de systeem-cache nadat je deze optie activeert.",
                     "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole."
@@ -184,7 +184,7 @@
                     "log_all_mqtt": "Log Tx + alle MQTT-topics"
                 },
                 "data_description": {
-                    "schema": "Een mapping van systeem device-ID's naar hun schema's. Houd dit eenvoudig en vermeld alleen devices die niet automatisch verschijnen.",
+                    "schema": "Een mapping van systeem device-ID's naar hun schema's inclusief Zones met hun Sensors, als YAML.",
                     "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
                     "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen. Vereist HA herstart!",
                     "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole."

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -589,7 +589,7 @@ async def test_setup_uses_merged_schema_on_success(
         return_value={SZ_CLIENT_STATE: {SZ_SCHEMA: cached_schema}}
     )
 
-    # 2. Setup a mock config schema in options
+    # 2. Set up a mock config schema in options
     coordinator.options[CONF_SCHEMA] = config_schema
 
     # 3. Mock _create_client to return a valid client object (Success case)
@@ -597,16 +597,11 @@ async def test_setup_uses_merged_schema_on_success(
     cast(Any, mock_client).start = AsyncMock()
     cast(Any, coordinator)._create_client = MagicMock(return_value=mock_client)
 
-    # Patch mock schema_is_minimal to prevent TypeError
     with (
         patch(
             "custom_components.ramses_cc.coordinator.merge_schemas",
             return_value=merged_result,
         ) as mock_merge,
-        patch(
-            "custom_components.ramses_cc.coordinator.schema_is_minimal",
-            return_value=True,
-        ),
     ):
         # 5. Execute async_setup
         await coordinator.async_setup()

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -623,36 +623,6 @@ async def test_setup_uses_merged_schema_on_success(
         assert coordinator.client is mock_client
 
 
-async def test_setup_logs_warning_on_non_minimal_schema(
-    mock_hass: MagicMock, mock_entry: MagicMock
-) -> None:
-    """Test that a warning is logged when the schema is not minimal.
-
-    (Line 155).
-    """
-    coordinator = RamsesCoordinator(mock_hass, mock_entry)
-    cast(Any, coordinator.store).async_load = AsyncMock(return_value={})
-
-    # Mock success path for client creation so setup completes
-    mock_client = MagicMock()
-    cast(Any, mock_client).start = AsyncMock()
-    cast(Any, coordinator)._create_client = MagicMock(return_value=mock_client)
-
-    # Patch schema_is_minimal to return False -> triggers the warning
-    with (
-        patch(
-            "custom_components.ramses_cc.coordinator.schema_is_minimal",
-            return_value=False,
-        ),
-        patch("custom_components.ramses_cc.coordinator._LOGGER") as mock_log,
-    ):
-        await coordinator.async_setup()
-
-        cast(Any, mock_log.warning).assert_any_call(
-            "The config schema is not minimal (consider minimising it)"
-        )
-
-
 async def test_update_device_name_fallback_to_id(
     mock_coordinator: RamsesCoordinator,
 ) -> None:

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -13,20 +13,9 @@ from custom_components.ramses_cc.const import (
     CONF_COMMANDS,
     CONF_RAMSES_RF,
 )
-from custom_components.ramses_cc.schemas import (
-    merge_schemas,
-    normalise_config,
-    schema_is_minimal,
-)
-from ramses_rf.schemas import (
-    SZ_APPLIANCE_CONTROL,
-    SZ_CLASS,
-    SZ_KNOWN_LIST,
-    SZ_SENSOR,
-    SZ_SYSTEM,
-)
-from ramses_tx.const import SZ_ZONES
-from ramses_tx.schemas import SZ_BLOCK_LIST, SZ_PORT_NAME, SZ_SERIAL_PORT
+from custom_components.ramses_cc.schemas import merge_schemas, normalise_config
+from ramses_rf.schemas import SZ_CLASS, SZ_KNOWN_LIST
+from ramses_tx.schemas import SZ_PORT_NAME, SZ_SERIAL_PORT
 
 
 def test_normalise_config() -> None:
@@ -75,40 +64,3 @@ def test_merge_schemas_logic(caplog: pytest.LogCaptureFixture) -> None:
     ):
         assert merge_schemas({"a": 1}, {"b": 2}) is None
         assert "Cached schema is a subset of config schema" in caplog.text
-
-
-def test_schema_is_minimal_logic() -> None:
-    """Test minimal schema validation branches (Lines 203-214)."""
-    # Case 1: Valid minimal schema (Line 203 & 214)
-    # Note: To pass line 211, the top-level key must match the zone sensor ID
-    minimal_schema: dict[str, Any] = {
-        "01:123456": {
-            SZ_ZONES: {"01": {SZ_SENSOR: "01:123456"}},
-        }
-    }
-    assert schema_is_minimal(minimal_schema) is True
-
-    # Case 2: Excluded keys branch (Line 204)
-    excluded_keys: dict[str, Any] = {
-        SZ_BLOCK_LIST: ["01:111111"],
-        SZ_KNOWN_LIST: {"18:111111": {SZ_CLASS: "HGI"}},
-        "01:123456": {SZ_ZONES: {"01": {SZ_SENSOR: "01:123456"}}},
-    }
-    assert schema_is_minimal(excluded_keys) is True
-
-    # Case 3: Invalid content for SCH_MINIMUM_TCS (Line 208)
-    not_minimal: dict[str, Any] = {
-        "10:123456": {
-            SZ_SYSTEM: {SZ_APPLIANCE_CONTROL: "10:123456"},
-            "extra_key": "not_allowed",
-        }
-    }
-    assert schema_is_minimal(not_minimal) is False
-
-    # Case 4: Mismatched zone sensor (Line 211)
-    mismatched: dict[str, Any] = {
-        "01:111111": {
-            SZ_ZONES: {"01": {SZ_SENSOR: "01:222222"}},
-        }
-    }
-    assert schema_is_minimal(mismatched) is False

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -1251,10 +1251,6 @@ async def test_setup_schema_merge_failure(hass: HomeAssistant) -> None:
             "custom_components.ramses_cc.coordinator.merge_schemas",
             return_value={"merged": "schema"},
         ),
-        patch(
-            "custom_components.ramses_cc.coordinator.schema_is_minimal",
-            return_value=True,
-        ),
         patch.object(coordinator, "_create_client") as mock_create_client,
         patch(
             "custom_components.ramses_cc.coordinator.extract_serial_port",


### PR DESCRIPTION
This PR fixes issue #785 

- Reword Schema config pane description (help) en/nl
- Leave `is_minimal()` method in place, plus tests except the log warning.