### PR TITLE
Bump version

### DIFF
--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -14,9 +14,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.57.10",
+      "ramses-rf==0.57.11",
       "serialx>=1.6.0"
     ],
     "single_config_entry": true,
-    "version": "0.57.10"
+    "version": "0.57.11"
   }

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,13 +1,13 @@
 # Requirements to dev the source code
-# - last checked/updated: 2026-07-06 (c.f. HA 2026.7.1)
+# - last checked/updated: 2026-07-08 (c.f. HA 2026.7.1)
 
 # requirements (dependencies) are in manifest.json
 # - pip list | grep -E 'ramses|serial'
 
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
-  aioesphomeapi         >= 45.5.2               # required by config_flow > homeassistant.components.usb
+  aioesphomeapi         >= 45.5.2                # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.57.10                # as per: manifest.json latest:
+  ramses-rf             == 0.57.11               # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.8.2                 # required by config_flow > homeassistant.components.usb, see issue #623
@@ -17,10 +17,10 @@
 
 # used for development (linting)
     prek == 0.4.8                                # HA core 2026.6.2 uses ?
-    ruff >= 0.15.20                               # See also: pre-commit-config.yaml
+    ruff >= 0.15.20                              # See also: pre-commit-config.yaml
 
 # used for development (typing)
-    mypy >= 2.1.0                               # latest: 2.1.0
+    mypy >= 2.1.0                                # latest: 2.1.0
     voluptuous >= 0.15.2                         # latest: 0.16.0 = HA, ramses_rf 0.57.1: 0.15.2
 
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)


### PR DESCRIPTION
, _rf dependency to 0.57.11 for linked PRs