### PR TITLE
Add sensor `async_update()` to allow polling by code

### DIFF
--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from ramses_rf.devices import Device, HvacRemoteBase, HvacVentilator
 from ramses_rf.entity import Entity as RamsesRFEntity
-from ramses_tx import Command
 from ramses_tx.const import DevType
 from ramses_tx.typing import DeviceIdT
 
@@ -261,17 +260,4 @@ class RamsesFanHandler:
                     "Entities will still work for received parameter updates.",
                     device.id,
                     err,
-                )
-
-            # HACK: Force one time RQ of 10D0 - TODO(eb): remove when PR #632 is working
-            try:
-                cmd = Command.from_cli(f"RQ {device.id} 10D0 00")
-                _LOGGER.debug("Poll 10D0 filter_remaining for %s", device.id)
-                await device._gwy.async_send_cmd(cmd)
-            except Exception as err:
-                _LOGGER.debug(
-                    "Failed to poll filter_remaining for %s: %s",
-                    device.id,
-                    err,
-                    exc_info=True,
                 )

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import timedelta as td
 from types import UnionType
 from typing import Any, cast
 
@@ -98,6 +99,7 @@ from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import resolve_async_attr
 
 _LOGGER = logging.getLogger(__name__)
+SCAN_INTERVAL = td(minutes=10)
 
 
 async def async_setup_entry(
@@ -162,6 +164,11 @@ class RamsesSensor(RamsesEntity, SensorEntity):
                     _LOGGER.debug(
                         "Poll %s for %s failed: %s", code, self._device.id, err
                     )
+
+    @property
+    def should_poll(self) -> bool:
+        """Return whether HA should periodically poll for updates"""
+        return self._attr_should_poll
 
     @property
     def native_value(self) -> Any | None:

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -91,6 +91,7 @@ from ramses_tx.const import (
     SZ_OEM_CODE,
     SZ_OUTSIDE_TEMP,
     SZ_REL_MODULATION_LEVEL,
+    Code,
 )
 
 from .const import ATTR_SETPOINT, ATTR_WORKING_SCHEMA, DOMAIN, UnitOfVolumeFlowRate
@@ -99,7 +100,7 @@ from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import resolve_async_attr
 
 _LOGGER = logging.getLogger(__name__)
-SCAN_INTERVAL = td(minutes=10)
+SCAN_INTERVAL = td(minutes=20)  # only used for polling 10D0 filter_remaining
 
 
 async def async_setup_entry(
@@ -287,7 +288,7 @@ class RamsesSensorEntityDescription(RamsesEntityDescription, SensorEntityDescrip
     ramses_rf_class: type[RamsesRFEntity] | UnionType = RamsesRFEntity
     # key is used to create HA unique_id
     # ramses_rf_attr must match ramses_rf device method
-    poll_codes: list[str] | None = None  # opt-in for fetch-driven entities
+    poll_codes: list[Code] | None = None  # opt-in for fetch-driven entities
 
 
 SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
@@ -532,14 +533,14 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
         ramses_rf_attr=SZ_FILTER_REMAINING,
         name="Filter remaining",
         native_unit_of_measurement=UnitOfTime.DAYS,
-        poll_codes=["10D0"],
+        poll_codes=[Code._10D0],
     ),
     RamsesSensorEntityDescription(
         key=SZ_FILTER_REMAINING_PERCENT,
         ramses_rf_attr=SZ_FILTER_REMAINING_PERCENT,
         name="Filter remaining (%)",
         native_unit_of_measurement=PERCENTAGE,
-        poll_codes=["10D0"],
+        poll_codes=[Code._10D0],
     ),
     RamsesSensorEntityDescription(
         key=SZ_INDOOR_HUMIDITY,

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -75,6 +75,7 @@ from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.schemas import SZ_SCHEMA
 from ramses_rf.systems.tcs import System
 from ramses_rf.systems.zones import ZoneBase
+from ramses_tx.command import Command
 from ramses_tx.const import (
     SZ_BOILER_OUTPUT_TEMP,
     SZ_BOILER_RETURN_TEMP,
@@ -134,14 +135,33 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         self,
         coordinator: RamsesCoordinator,
         device: RamsesRFEntity,
-        entity_description: RamsesEntityDescription,
+        entity_description: RamsesSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
         _LOGGER.info("Initializing %s: %s", device.id, entity_description.key)
         super().__init__(coordinator, device, entity_description)
 
         self._attr_unique_id = f"{device.id}-{entity_description.key}"
+        self._attr_should_poll = not entity_description.poll_codes
+
+        # Disable polling by default, override by setting poll_codes
         self._last_known_value: Any | None = None
+
+    async def async_update(self) -> None:
+        """Send RQ to refresh the value from the device (for poll-driven entities)."""
+        if not self._attr_should_poll:
+            return  # push-driven entities: no-op, signal handles updates
+        _poll_cd = self.entity_description.poll_codes
+        if _poll_cd:
+            for code in _poll_cd:
+                cmd = Command.from_cli(f"RQ {self._device.id} {code} 00")
+                try:
+                    await self._device._gwy.async_send_cmd(cmd)
+                    _LOGGER.debug("Polled %s for %s", code, self._device.id)
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Poll %s for %s failed: %s", code, self._device.id, err
+                    )
 
     @property
     def native_value(self) -> Any | None:
@@ -260,6 +280,7 @@ class RamsesSensorEntityDescription(RamsesEntityDescription, SensorEntityDescrip
     ramses_rf_class: type[RamsesRFEntity] | UnionType = RamsesRFEntity
     # key is used to create HA unique_id
     # ramses_rf_attr must match ramses_rf device method
+    poll_codes: list[str] | None = None  # opt-in for fetch-driven entities
 
 
 SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
@@ -504,12 +525,14 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
         ramses_rf_attr=SZ_FILTER_REMAINING,
         name="Filter remaining",
         native_unit_of_measurement=UnitOfTime.DAYS,
+        poll_codes=["10D0"],
     ),
     RamsesSensorEntityDescription(
         key=SZ_FILTER_REMAINING_PERCENT,
         ramses_rf_attr=SZ_FILTER_REMAINING_PERCENT,
         name="Filter remaining (%)",
         native_unit_of_measurement=PERCENTAGE,
+        poll_codes=["10D0"],
     ),
     RamsesSensorEntityDescription(
         key=SZ_INDOOR_HUMIDITY,

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -145,7 +145,7 @@ def mock_device_gwy():
 
 
 @pytest.fixture
-def mock_entity_description():
+def mock_entity_description_codes():
     """Fixture for a mocked entity description."""
     description = MagicMock()
     description.key = "test_key"
@@ -163,7 +163,7 @@ def mock_entity_description_no_codes():
 
 @pytest.fixture
 def entity_push_driven(
-    mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description
+    mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description_codes
 ):
     """Entity for push-driven scenario (should_poll=False)."""
     desc = MagicMock(spec=RamsesSensorEntityDescription)
@@ -171,16 +171,18 @@ def entity_push_driven(
     desc.ramses_rf_attr = "test_attr"
     sensor = RamsesSensor(mock_coordinator, mock_device_gwy, desc)
     sensor._attr_should_poll = False
-    sensor.entity_description = mock_entity_description
+    sensor.entity_description = mock_entity_description_codes
     return sensor
 
 
 @pytest.fixture
 def entity_poll_driven(
-    mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description
+    mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description_codes
 ):
     """Entity for poll-driven scenario (should_poll=True)."""
-    sensor = RamsesSensor(mock_coordinator, mock_device_gwy, mock_entity_description)
+    sensor = RamsesSensor(
+        mock_coordinator, mock_device_gwy, mock_entity_description_codes
+    )
     sensor._attr_should_poll = True
     return sensor
 
@@ -193,7 +195,7 @@ def entity_poll_driven_no_codes(
     sensor = RamsesSensor(
         mock_coordinator, mock_device_gwy, mock_entity_description_no_codes
     )
-    sensor._attr_should_poll = True
+    sensor._attr_should_poll = True  # override init
     return sensor
 
 
@@ -202,6 +204,8 @@ async def test_async_update_push_driven(
     entity_push_driven, caplog: pytest.LogCaptureFixture
 ):
     """Test that async_update does nothing for push-driven entities."""
+    assert entity_push_driven.should_poll is False
+
     with caplog.at_level(logging.DEBUG):
         await entity_push_driven.async_update()
         # No commands sent
@@ -215,6 +219,8 @@ async def test_async_update_poll_driven_success(
     entity_poll_driven, caplog: pytest.LogCaptureFixture
 ):
     """Test that async_update sends commands for poll-driven entities (success)."""
+    assert entity_poll_driven.should_poll is True
+
     with caplog.at_level(logging.DEBUG):
         await entity_poll_driven.async_update()
 
@@ -234,6 +240,8 @@ async def test_async_update_poll_driven_failure(
     entity_poll_driven, caplog: pytest.LogCaptureFixture
 ):
     """Test that async_update handles and logs errors for poll-driven entities."""
+    assert entity_poll_driven.should_poll is True
+
     # Force an error in async_send_cmd
     entity_poll_driven._device._gwy.async_send_cmd = AsyncMock(
         side_effect=Exception("Connection error")
@@ -255,6 +263,8 @@ async def test_async_update_no_poll_codes(
     entity_poll_driven_no_codes, caplog: pytest.LogCaptureFixture
 ):
     """Test that async_update does nothing if there are no poll_codes."""
+    assert entity_poll_driven_no_codes.should_poll is True
+
     with caplog.at_level(logging.DEBUG):
         await entity_poll_driven_no_codes.async_update()
         entity_poll_driven_no_codes._device._gwy.async_send_cmd.assert_not_called()

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import get_args
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
@@ -18,6 +19,7 @@ from custom_components.ramses_cc.const import DOMAIN
 from custom_components.ramses_cc.sensor import (
     SENSOR_DESCRIPTIONS,
     RamsesSensor,
+    RamsesSensorEntityDescription,
     async_setup_entry,
 )
 from ramses_rf.const import SZ_TEMPERATURE
@@ -29,6 +31,7 @@ from ramses_rf.devices import (
     Thermostat,
 )
 from ramses_rf.entity import Entity as RamsesRFEntity
+from ramses_tx.command import Command
 
 
 @pytest.fixture
@@ -119,7 +122,7 @@ def test_sensor_init_and_properties(
 ) -> None:
     """Test initialization and basic properties of RamsesSensor."""
     # Create a description
-    desc = MagicMock(spec=SensorEntityDescription)
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "test_key"
     desc.ramses_rf_attr = "temperature"
     desc.ramses_cc_icon_off = "mdi:thermometer-off"
@@ -131,11 +134,138 @@ def test_sensor_init_and_properties(
     assert sensor.unique_id == "01:123456-test_key"
 
 
+@pytest.fixture
+def mock_device_gwy():
+    """Fixture for a mocked device."""
+    device = MagicMock()
+    device.id = "01:123455"
+    device._gwy = MagicMock()
+    device._gwy.async_send_cmd = AsyncMock()
+    return device
+
+
+@pytest.fixture
+def mock_entity_description():
+    """Fixture for a mocked entity description."""
+    description = MagicMock()
+    description.key = "test_key"
+    description.poll_codes = ["0001", "0002"]  # For poll-driven test
+    return description
+
+
+@pytest.fixture
+def mock_entity_description_no_codes():
+    """Fixture for a mocked entity description."""
+    description = MagicMock()
+    description.key = "test_key_no_codes"
+    return description
+
+
+@pytest.fixture
+def entity_push_driven(
+    mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description
+):
+    """Entity for push-driven scenario (should_poll=False)."""
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
+    desc.key = "test_key"
+    desc.ramses_rf_attr = "test_attr"
+    sensor = RamsesSensor(mock_coordinator, mock_device_gwy, desc)
+    sensor._attr_should_poll = False
+    sensor.entity_description = mock_entity_description
+    return sensor
+
+
+@pytest.fixture
+def entity_poll_driven(
+    mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description
+):
+    """Entity for poll-driven scenario (should_poll=True)."""
+    sensor = RamsesSensor(mock_coordinator, mock_device_gwy, mock_entity_description)
+    sensor._attr_should_poll = True
+    return sensor
+
+
+@pytest.fixture
+def entity_poll_driven_no_codes(
+    mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description_no_codes
+):
+    """Entity for poll-driven scenario (should_poll=True)."""
+    sensor = RamsesSensor(
+        mock_coordinator, mock_device_gwy, mock_entity_description_no_codes
+    )
+    sensor._attr_should_poll = True
+    return sensor
+
+
+@pytest.mark.asyncio
+async def test_async_update_push_driven(
+    entity_push_driven, caplog: pytest.LogCaptureFixture
+):
+    """Test that async_update does nothing for push-driven entities."""
+    with caplog.at_level(logging.DEBUG):
+        await entity_push_driven.async_update()
+        # No commands sent
+        entity_push_driven._device._gwy.async_send_cmd.assert_not_called()
+        # No polling logs
+        assert "Polled" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_update_poll_driven_success(
+    entity_poll_driven, caplog: pytest.LogCaptureFixture
+):
+    """Test that async_update sends commands for poll-driven entities (success)."""
+    with caplog.at_level(logging.DEBUG):
+        await entity_poll_driven.async_update()
+
+        # Check that commands were sent for each poll_code
+        assert entity_poll_driven._device._gwy.async_send_cmd.call_count == 2
+        calls = entity_poll_driven._device._gwy.async_send_cmd.call_args_list
+        assert calls[0][0][0] == Command.from_cli("RQ 01:123455 0001 00")
+        assert calls[1][0][0] == Command.from_cli("RQ 01:123455 0002 00")
+
+        # Check logs
+        assert "Polled 0001 for 01:123455" in caplog.text
+        assert "Polled 0002 for 01:123455" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_update_poll_driven_failure(
+    entity_poll_driven, caplog: pytest.LogCaptureFixture
+):
+    """Test that async_update handles and logs errors for poll-driven entities."""
+    # Force an error in async_send_cmd
+    entity_poll_driven._device._gwy.async_send_cmd = AsyncMock(
+        side_effect=Exception("Connection error")
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        await entity_poll_driven.async_update()
+
+        # Commands were attempted
+        assert entity_poll_driven._device._gwy.async_send_cmd.call_count == 2
+
+        # Errors were logged
+        assert "Poll 0001 for 01:123455 failed: Connection error" in caplog.text
+        assert "Poll 0002 for 01:123455 failed: Connection error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_update_no_poll_codes(
+    entity_poll_driven_no_codes, caplog: pytest.LogCaptureFixture
+):
+    """Test that async_update does nothing if there are no poll_codes."""
+    with caplog.at_level(logging.DEBUG):
+        await entity_poll_driven_no_codes.async_update()
+        entity_poll_driven_no_codes._device._gwy.async_send_cmd.assert_not_called()
+        assert "Polled" not in caplog.text
+
+
 def test_sensor_native_value(
     mock_coordinator: MagicMock, mock_device: MagicMock
 ) -> None:
     """Test native_value logic including percentage handling and caching."""
-    desc = MagicMock(spec=SensorEntityDescription)
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "test_key"
     desc.ramses_rf_attr = "test_attr"
 
@@ -162,7 +292,7 @@ def test_sensor_native_value(
 
 def test_sensor_icon(mock_coordinator: MagicMock, mock_device: MagicMock) -> None:
     """Test icon property logic."""
-    desc = MagicMock(spec=SensorEntityDescription)
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "test_key"
     desc.ramses_rf_attr = "val"
     desc.icon = "mdi:on"
@@ -189,7 +319,7 @@ def test_async_put_co2_level(mock_coordinator: MagicMock) -> None:
     """Test async_put_co2_level."""
     device = MagicMock(spec=HvacCarbonDioxideSensor)
     device.id = "30:111111"
-    desc = MagicMock(spec=SensorEntityDescription)
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "co2"
     desc.ramses_rf_attr = "co2_level"
 
@@ -222,7 +352,7 @@ def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:
     """Test async_put_dhw_temp."""
     device = MagicMock(spec=DhwSensor)
     device.id = "07:111111"
-    desc = MagicMock(spec=SensorEntityDescription)
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "dhw"
     desc.ramses_rf_attr = "temperature"
 
@@ -249,7 +379,7 @@ def test_async_put_indoor_humidity(mock_coordinator: MagicMock) -> None:
     """Test async_put_indoor_humidity."""
     device = MagicMock(spec=HvacHumiditySensor)
     device.id = "30:222222"
-    desc = MagicMock(spec=SensorEntityDescription)
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "hum"
     desc.ramses_rf_attr = "indoor_humidity"
 
@@ -276,7 +406,7 @@ def test_async_put_room_temp(mock_coordinator: MagicMock) -> None:
     """Test async_put_room_temp."""
     device = MagicMock(spec=Thermostat)
     device.id = "03:111111"
-    desc = MagicMock(spec=SensorEntityDescription)
+    desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "temp"
     desc.ramses_rf_attr = "temperature"
 


### PR DESCRIPTION
This PR fixes issue #794 PR 2

- add `poll_code` to sensor_description
- add `should_poll` property for HA to pick up, SCAN_INTERVAL const
- add tests
- remove fan_handler RQ 10D0 hack

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: Initial suggestions #794 by GLM 5.2-High, Mistral Vibe used to draft tests.

SCAN_INTERVAL set a fixed 20 mins polling interval in sensor.py, because we only RQ the `10DO` `filter_remaining`. Schedules via HA. Tested with 10 mins shows it works:

<img width="1074" height="159" alt="RP-10DO-PR797" src="https://github.com/user-attachments/assets/1a76af7a-9883-47b7-923b-588f6d83396d" />
