### PR TITLE
Fix: persist device_comments when sync_learned_topology returns None

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1737,6 +1737,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # (where dst is --:------) that wasn't captured when the device was
             # first accepted.  This ensures sync_learned_topology has up-to-date
             # zone info in the comments.
+            comments_refreshed = False
             if self.discovery_manager and isinstance(config_schema, dict):
                 existing_comments = config_schema.get(SZ_DEVICE_COMMENTS, {})
                 if isinstance(existing_comments, dict):
@@ -1746,6 +1747,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     if refreshed is not existing_comments:
                         config_schema = dict(config_schema)
                         config_schema[SZ_DEVICE_COMMENTS] = refreshed
+                        comments_refreshed = True
             _LOGGER.debug("sync_learned_topology: config_schema=%s", config_schema)
             _LOGGER.debug("sync_learned_topology: learned_schema=%s", schema)
             # Build scan_codes map for DHW valve inference (13: devices
@@ -1791,6 +1793,23 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # checking it with a 5-second window in the update listener
                 # avoids the race condition where the flag is reset before the
                 # listener runs.
+                self._suppress_reload = time.time()
+                self.hass.config_entries.async_update_entry(
+                    self.entry, options=new_options
+                )
+            elif comments_refreshed:
+                # No topology changes (enriched is None), but the scan engine
+                # captured new zone bindings in device_comments.  Persist the
+                # updated comments so they survive to the next sync cycle —
+                # otherwise sync_learned_topology step 0b never sees the zone
+                # info and can't create zones from broadcast traffic.
+                _LOGGER.info(
+                    "No topology changes, but device_comments refreshed "
+                    "from scan engine — persisting updated comments"
+                )
+                new_options = dict(self.options)
+                new_options[CONF_SCHEMA] = config_schema
+                self.options = new_options
                 self._suppress_reload = time.time()
                 self.hass.config_entries.async_update_entry(
                     self.entry, options=new_options

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -583,7 +583,7 @@ class DiscoveryManager:
         if rssi is not None:
             parts.append(f"RSSI {rssi:.0f}")
 
-        return ". ".join(parts) + "."
+        return ". ".join(parts) + ". (auto-generated — do not edit)"
 
     @staticmethod
     def generate_schema_entry(

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -216,8 +216,12 @@ class DiscoveryManager:
             # HGI gateways (18:) are tracked but don't have zone bindings.
             # Still create comments for them (without zone/bound info).
             if dev_id.startswith("18:"):
-                if dev_id in result and result[dev_id]:
-                    continue  # already has a comment
+                if (
+                    dev_id in result
+                    and result[dev_id]
+                    and self._COMMENT_SUFFIX in result[dev_id]
+                ):
+                    continue  # already has a comment with suffix
                 likely_type = dev.likely_type or "HGI"
                 new_comment = self._build_comment(dev, likely_type, None, None)
                 if new_comment != result.get(dev_id, ""):
@@ -230,7 +234,8 @@ class DiscoveryManager:
             comment = result.get(dev_id, "")
             if not dev.zone_idx and not dev.bound_to:
                 # No binding info — still create a basic comment if missing
-                if comment:
+                # or if it lacks the auto-generated suffix.
+                if comment and self._COMMENT_SUFFIX in comment:
                     continue  # existing comment, no new info to add
                 likely_type = dev.likely_type or "unknown"
                 new_comment = self._build_comment(dev, likely_type, None, None)
@@ -241,7 +246,7 @@ class DiscoveryManager:
             # Check if comment already has the correct zone/bound info
             has_zone = dev.zone_idx and f"zone {dev.zone_idx}" in comment
             has_bound = dev.bound_to and f"bound to {dev.bound_to}" in comment
-            if has_zone and has_bound:
+            if has_zone and has_bound and self._COMMENT_SUFFIX in comment:
                 continue
             # Rebuild the comment from the scan engine data
             likely_type = dev.likely_type or "unknown"
@@ -529,6 +534,10 @@ class DiscoveryManager:
                 return entry
         return None
 
+    # Suffix appended to every auto-generated comment to warn users
+    # not to edit the structured portions (zone, bound_to, codes, RSSI).
+    _COMMENT_SUFFIX: str = "(auto-generated — do not edit)"
+
     # Types that the scan engine may confuse with each other.
     # 31DA (fan_status) is sent by both FANs and DIS devices.
     _AMBIGUOUS_TYPES: dict[str, str] = {
@@ -583,7 +592,7 @@ class DiscoveryManager:
         if rssi is not None:
             parts.append(f"RSSI {rssi:.0f}")
 
-        return ". ".join(parts) + ". (auto-generated — do not edit)"
+        return ". ".join(parts) + f". {DiscoveryManager._COMMENT_SUFFIX}"
 
     @staticmethod
     def generate_schema_entry(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -3457,6 +3457,9 @@ async def test_async_discovery_checkpoint_with_manager(hass: HomeAssistant) -> N
     coordinator.discovery_manager = MagicMock()
     coordinator.discovery_manager.check_for_new_devices = MagicMock()
     coordinator.discovery_manager.check_for_lost_devices = MagicMock()
+    # refresh_device_comments must return a real dict (not a MagicMock) so
+    # that HA's storage serializer doesn't choke on teardown.
+    coordinator.discovery_manager.refresh_device_comments = MagicMock(return_value={})
 
     await coordinator._async_discovery_checkpoint()
 

--- a/tests/tests_new/test_discovery_reset.py
+++ b/tests/tests_new/test_discovery_reset.py
@@ -514,6 +514,10 @@ class TestCoordinatorUnloadFilter:
         coordinator = coordinator_with_empty_schema
         coordinator.client = _make_mock_client()
 
+        # Mock async_update_entry — the coordinator calls it to persist
+        # comments, but the MagicMock entry isn't registered in HA.
+        coordinator.hass.config_entries.async_update_entry = MagicMock()
+
         # Mock discovery_manager with stale ACCEPTED metadata
         dm = MagicMock()
         dm.export_state.return_value = {
@@ -556,6 +560,10 @@ class TestCoordinatorUnloadFilter:
         coordinator = RamsesCoordinator(hass, entry)
         coordinator.client = _make_mock_client()
         cast(Any, coordinator.store).async_load = AsyncMock(return_value={})
+
+        # Mock async_update_entry — the coordinator calls it to persist
+        # comments, but the MagicMock entry isn't registered in HA.
+        hass.config_entries.async_update_entry = MagicMock()
 
         dm = MagicMock()
         dm.export_state.return_value = {
@@ -601,6 +609,10 @@ class TestCoordinatorUnloadFilter:
         coordinator = RamsesCoordinator(hass, entry)
         coordinator.client = _make_mock_client()
         cast(Any, coordinator.store).async_load = AsyncMock(return_value={})
+
+        # Mock async_update_entry — the coordinator calls it to persist
+        # comments, but the MagicMock entry isn't registered in HA.
+        hass.config_entries.async_update_entry = MagicMock()
 
         dm = MagicMock()
         dm.export_state.return_value = {


### PR DESCRIPTION
When the scan engine captures zone bindings from broadcast traffic (e.g. 3150 packets), refresh_device_comments updates the comments in a local config_schema variable.  However, when sync_learned_topology returns None (no topology changes), these updated comments were never persisted to self.options — they were silently lost.

This meant zone binding info from broadcast TRV traffic never survived to the next sync cycle, so step 0b/1g could never create zones from passive scan observations.

Fix: track a comments_refreshed flag and persist the config schema (with updated comments) even when sync_learned_topology returns None.

