### PR TITLE
Add Phase 2.5 migration scaffolding: RamsesCcStore subclass

### DIFF
--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -30,13 +30,42 @@ _MAX_BACKUPS: Final[int] = 5
 _BACKUP_DIR: Final[str] = "ramses_cc_backups"
 
 
+class RamsesCcStore(Store[dict[str, Any]]):
+    """HA Store subclass with a migration hook for ramses_cc .storage.
+
+    Phase 2.5 registers this as a no-op identity migration (v1 → v1) so the
+    hook and version label are in place.  Future bumps just add branches:
+    - v1 → v2: commands moved to schema ``_commands`` (Phase 3a)
+    - v2 → v3: known_list removed, fully derived from schema (Phase 4)
+    """
+
+    async def _async_migrate_func(
+        self,
+        old_major_version: int,
+        old_minor_version: int,
+        old_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Migrate stored data to the current version.
+
+        Currently v1 → v1 (identity).  Future versions will add branches.
+        """
+        _LOGGER.debug(
+            "Migrating ramses_cc storage: v%s.%s → v%s.%s (no-op)",
+            old_major_version,
+            old_minor_version,
+            self.version,
+            self.minor_version,
+        )
+        return old_data
+
+
 class RamsesStore:
     """Class to handle persistence of RAMSES configuration and state."""
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the storage helper."""
         self._hass = hass
-        self._store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._store = RamsesCcStore(hass, STORAGE_VERSION, STORAGE_KEY)
 
     async def async_load(self) -> dict[str, Any]:
         """Load the data from the persistent storage.

--- a/tests/tests_new/test_store.py
+++ b/tests/tests_new/test_store.py
@@ -21,7 +21,7 @@ from custom_components.ramses_cc.const import (
 )
 from custom_components.ramses_cc.coordinator import RamsesCoordinator
 from custom_components.ramses_cc.discovery import SZ_DISCOVERY
-from custom_components.ramses_cc.store import RamsesStore
+from custom_components.ramses_cc.store import RamsesCcStore, RamsesStore
 from ramses_rf.gateway import Gateway
 
 REM_ID = "32:111111"
@@ -32,10 +32,52 @@ REM_ID = "32:111111"
 
 async def test_store_init(hass: HomeAssistant) -> None:
     """Test the initialization of the store."""
-    with patch("custom_components.ramses_cc.store.Store") as mock_store_cls:
+    with patch("custom_components.ramses_cc.store.RamsesCcStore") as mock_store_cls:
         store = RamsesStore(hass)
         mock_store_cls.assert_called_once()
         assert store._store is not None
+
+
+async def test_store_uses_ramses_cc_store_subclass(hass: HomeAssistant) -> None:
+    """Test that RamsesStore uses the RamsesCcStore subclass (migration hook)."""
+    store = RamsesStore(hass)
+    assert isinstance(store._store, RamsesCcStore)
+
+
+async def test_store_migration_noop_identity(hass: HomeAssistant) -> None:
+    """Test that the no-op migration (v1 → v1) returns data unchanged.
+
+    Phase 2.5 registers the migration hook as an identity migration so the
+    scaffolding is in place for future version bumps (v1 → v2, etc.).
+    """
+    store = RamsesStore(hass)
+    assert isinstance(store._store, RamsesCcStore)
+
+    # Simulate a v1 data payload (the real .storage format)
+    v1_data: dict[str, Any] = {
+        SZ_CLIENT_STATE: {SZ_SCHEMA: {"01:123456": {}}, SZ_PACKETS: {}},
+        SZ_REMOTES: {
+            "32:153001": {
+                "turn_on": "I --- 32:153001 18:006402 --:------ 22F1 003 000030"
+            }
+        },
+    }
+
+    # The migrate func should return the data unchanged (identity)
+    result = await store._store._async_migrate_func(1, 1, v1_data)
+    assert result is v1_data
+
+
+async def test_store_migration_future_version_unchanged(hass: HomeAssistant) -> None:
+    """Test that the no-op migration also returns data unchanged for any version.
+
+    Currently the migration is identity for all versions — future branches
+    will be added in Phase 3a (v1 → v2) and Phase 4 (v2 → v3).
+    """
+    store = RamsesStore(hass)
+    data: dict[str, Any] = {"some_key": "some_value"}
+    result = await store._store._async_migrate_func(99, 1, data)
+    assert result is data
 
 
 async def test_store_async_load(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Register a no-op identity migration (v1 → v1) by subclassing HA's Store as RamsesCcStore and overriding _async_migrate_func. This puts the migration hook and version label in place so future format bumps (v1 → v2 for commands, v2 → v3 for known_list removal) just add branches to an existing function.

HA's Store class has no migrate_func constructor parameter in the current version — subclass+override is the pattern HA's own components use (tag, energy, knx).

Tests verify the subclass is wired up and the migration returns data unchanged.

AI used: GLM-5.2 High

see https://github.com/ramses-rf/ramses_cc/issues/809