### PR TITLE
Feature/phase3a commands in schema

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1079,34 +1079,44 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
             )
 
         try:
-            # 1. Check for user-defined custom commands in the config
+            # 1. Check for user-defined custom commands.
+            # Priority: schema _commands (SSOT, via coordinator._remotes)
+            #          > known_list[bound_rem][commands] (legacy fallback)
             bound_rem = self._bound_rem or self._device.get_bound_rem()
+            commands: dict[str, str] = {}
             if bound_rem:
-                rem_config = self.coordinator.options.get(SZ_KNOWN_LIST, {}).get(
-                    str(bound_rem), {}
+                # Schema _commands (Phase 3a SSOT — populated from
+                # config_entry.options[schema][rem_id][_commands])
+                remotes = getattr(self.coordinator, "_remotes", {}) or {}
+                if isinstance(remotes, dict):
+                    commands = remotes.get(str(bound_rem), {})
+                if not commands:
+                    # Legacy fallback: known_list[bound_rem][commands]
+                    rem_config = self.coordinator.options.get(SZ_KNOWN_LIST, {}).get(
+                        str(bound_rem), {}
+                    )
+                    commands = rem_config.get(CONF_COMMANDS, {})
+
+            if fan_mode in commands:
+                cmd_str = commands[fan_mode]
+                _LOGGER.info(
+                    "Intercepted fan_mode '%s'; sending custom command: %s",
+                    fan_mode,
+                    cmd_str,
                 )
-                commands = rem_config.get(CONF_COMMANDS, {})
 
-                if fan_mode in commands:
-                    cmd_str = commands[fan_mode]
-                    _LOGGER.info(
-                        "Intercepted fan_mode '%s'; sending custom command: %s",
-                        fan_mode,
-                        cmd_str,
-                    )
+                # Users might enter a CLI shorthand OR a raw frame string
+                try:
+                    cmd = Command.from_cli(cmd_str)
+                except (ValueError, RamsesException):
+                    # Fallback for raw packet frames copied from logs
+                    cmd = Command(cmd_str)
 
-                    # Users might enter a CLI shorthand OR a raw frame string
-                    try:
-                        cmd = Command.from_cli(cmd_str)
-                    except (ValueError, RamsesException):
-                        # Fallback for raw packet frames copied from logs
-                        cmd = Command(cmd_str)
-
-                    await self._device._gwy.async_send_cmd(
-                        cmd, num_repeats=2, priority=Priority.HIGH
-                    )
-                    self.async_write_ha_state()
-                    return
+                await self._device._gwy.async_send_cmd(
+                    cmd, num_repeats=2, priority=Priority.HIGH
+                )
+                self.async_write_ha_state()
+                return
 
             # 2. Fallback to standard ramses_rf implementation
             await self._device.set_fan_mode(fan_mode)

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1028,6 +1028,26 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
         return self._get_cached_fan_info()
 
     @property
+    def fan_modes(self) -> list[str] | None:
+        """Return the list of available fan modes.
+
+        Extends the standard fan modes with custom command names from
+        the bound REM's schema ``_commands`` (Phase 3a SSOT) so that
+        ``climate.set_fan_mode`` accepts custom command names like
+        ``boost`` or ``speed_1``.
+        """
+        base_modes = list(self._attr_fan_modes or [])
+        bound_rem = self._bound_rem or self._device.get_bound_rem()
+        if bound_rem:
+            remotes = getattr(self.coordinator, "_remotes", {}) or {}
+            commands = remotes.get(str(bound_rem), {})
+            if isinstance(commands, dict):
+                for cmd_name in commands:
+                    if cmd_name not in base_modes:
+                        base_modes.append(cmd_name)
+        return base_modes
+
+    @property
     def hvac_action(self) -> HVACAction | str | None:
         """Return the current running hvac operation if supported.
 

--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -25,7 +25,7 @@ from ramses_tx.schemas import (
 
 DOMAIN: Final = "ramses_cc"
 
-STORAGE_VERSION: Final[int] = 1
+STORAGE_VERSION: Final[int] = 2
 STORAGE_KEY: Final = DOMAIN
 
 # Dispatcher signals
@@ -139,6 +139,9 @@ SZ_TR_BOUND: Final = (
 )
 SZ_TR_SCHEME: Final = (
     "_scheme"  # str: FAN manufacturer scheme (orcon/itho/vasco/nuaire)
+)
+SZ_TR_COMMANDS: Final = (
+    "_commands"  # dict[str, str]: learned RF payloads for REM entities
 )
 
 # Root-level schema key for the system owner name.

--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -25,7 +25,7 @@ from ramses_tx.schemas import (
 
 DOMAIN: Final = "ramses_cc"
 
-STORAGE_VERSION: Final[int] = 2
+STORAGE_VERSION: Final[int] = 1
 STORAGE_KEY: Final = DOMAIN
 
 # Dispatcher signals

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -62,7 +62,10 @@ from ramses_rf.systems import Evohome, System, Zone
 from ramses_rf.topology import Child
 
 try:
-    from ramses_rf.config import strip_and_map_traits as _strip_and_map_traits
+    from ramses_rf.config import (
+        strip_and_map_traits as _strip_and_map_traits,
+        strip_traits as _strip_traits_rf,
+    )
 except ImportError:  # ramses_rf < 0.59.0 — fallback inline implementation
     _STRIP_MAP: dict[str, str] = {
         "_bound": "bound",
@@ -77,11 +80,29 @@ except ImportError:  # ramses_rf < 0.59.0 — fallback inline implementation
         result: dict[str, Any] = {}
         for key, value in traits.items():
             if not isinstance(key, str) or not key.startswith("_"):
-                result[key] = value
+                if isinstance(value, dict):
+                    result[key] = _strip_and_map_traits(value)
+                else:
+                    result[key] = value
                 continue
             native_key = _STRIP_MAP.get(key)
             if native_key is not None and native_key not in result:
-                result[native_key] = value
+                if isinstance(value, dict):
+                    result[native_key] = _strip_and_map_traits(value)
+                else:
+                    result[native_key] = value
+        return result
+
+    def _strip_traits_rf(traits: dict[str, Any]) -> dict[str, Any]:
+        """Fallback: recursively strip all _ prefixed keys (no mapping)."""
+        result: dict[str, Any] = {}
+        for key, value in traits.items():
+            if isinstance(key, str) and key.startswith("_"):
+                continue
+            if isinstance(value, dict):
+                result[key] = _strip_traits_rf(value)
+            else:
+                result[key] = value
         return result
 
 
@@ -934,6 +955,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
         (``_disabled``, ``_name``, etc.), so we strip them before passing
         the schema to the Gateway.
 
+        Stage 1 (strip ``_`` keys) is delegated to ramses_rf's
+        ``strip_traits`` — no duplicate logic.  Stage 2 (mapping
+        ``_bound``→``bound``, etc.) is done in
+        ``_derive_known_list_from_schema`` via ``strip_and_map_traits``.
+        This function handles stage 3 only: orchestration
+        (disabled/skipped filtering, orphan routing, HGI dropping,
+        foreign-owner handling).
+
         Also strips ``None`` values for known optional keys like
         ``main_tcs`` — ramses_rf's validator rejects ``null`` even though
         the key is ``vol.Optional``.
@@ -947,16 +976,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
         Heat-side prefixes (``04:``, ``07:``, etc.) are excluded — they go
         to ``orphans_heat``.
         """
-
-        def _strip_traits(obj: Any) -> Any:
-            """Recursively strip _ prefixed keys from dicts."""
-            if isinstance(obj, dict):
-                return {
-                    k: _strip_traits(v)
-                    for k, v in obj.items()
-                    if not str(k).startswith("_")
-                }
-            return obj
 
         # First pass: collect _disabled/_skipped device IDs so we can remove
         # them from orphan lists, and collect un-disabled trait-only devices
@@ -1013,8 +1032,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
             had_traits = isinstance(v, dict) and any(
                 str(k2).startswith("_") for k2 in v
             )
-            # Strip _ prefixed keys from values
-            v = _strip_traits(v)
+            # Stage 1: delegate to ramses_rf's strip_traits
+            # (recursive — strips all _ keys, no mapping)
+            # Mapping (_bound→bound, etc.) is done separately in
+            # _derive_known_list_from_schema via strip_and_map_traits.
+            if isinstance(v, dict):
+                v = _strip_traits_rf(v)
             # Non-heat device at root level without remotes/sensors — move
             # to orphans_hvac instead of keeping as an invalid VCS entry.
             # ramses_rf's SCH_GLOBAL_SCHEMAS treats root-level non-CTL

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1294,21 +1294,34 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 continue
             if device_id in foreign:
                 continue  # foreign owner → block_list, not known_list
-            # Extract _ traits from the device's top-level schema entry
+            # Extract _ traits from the device's top-level schema entry.
+            # Use ramses_rf's strip_and_map_traits as a base (maps _bound→bound,
+            # _scheme→scheme, _alias→alias, _faked→faked, _class→class), then
+            # apply ramses_cc-specific special cases on top.
             entry = schema.get(device_id)
             traits: dict[str, Any] = {}
             if isinstance(entry, dict):
-                if entry.get(SZ_TR_CLASS):
-                    # Normalize to DevType slug (ventilator -> FAN)
-                    traits["class"] = _normalize_class_slug(entry[SZ_TR_CLASS])
-                if entry.get(SZ_TR_ALIAS):
-                    traits["alias"] = entry[SZ_TR_ALIAS]
+                from ramses_rf.config import strip_and_map_traits
+
+                mapped = strip_and_map_traits(entry)
+                # strip_and_map_traits maps _class→class, _alias→alias,
+                # _faked→faked, _bound→bound, _scheme→scheme.  But it
+                # doesn't handle ramses_cc-specific special cases:
+                #   - class normalization (ventilator → FAN)
+                #   - _name → alias (with setdefault, lower priority than _alias)
+                #   - bound only if _class is set (SCH_TRAITS_HVAC constraint)
+                #   - faked only if True
+                # So we rebuild traits from the mapped dict with these cases.
+                if mapped.get("class"):
+                    traits["class"] = _normalize_class_slug(mapped["class"])
+                if mapped.get("alias"):
+                    traits["alias"] = mapped["alias"]
                 if entry.get(SZ_TR_NAME):
                     # _name maps to alias for ramses_rf (display name)
                     traits.setdefault("alias", entry[SZ_TR_NAME])
-                if entry.get(SZ_TR_FAKED) is True:
+                if mapped.get("faked") is True:
                     traits["faked"] = True
-                if entry.get(SZ_TR_BOUND):
+                if mapped.get("bound"):
                     # ramses_rf's SCH_TRAITS only accepts 'bound' for HVAC
                     # devices (REM/DIS/FAN) with an explicit class.  FAN
                     # entries without _class would fail validation.  The
@@ -1317,9 +1330,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     # need it.  Only pass it to ramses_rf if the device has
                     # _class set (so SCH_TRAITS_HVAC accepts it).
                     if entry.get(SZ_TR_CLASS):
-                        traits["bound"] = entry[SZ_TR_BOUND]
-                if entry.get(SZ_TR_SCHEME):
-                    traits["scheme"] = entry[SZ_TR_SCHEME]
+                        traits["bound"] = mapped["bound"]
+                if mapped.get("scheme"):
+                    traits["scheme"] = mapped["scheme"]
             known_list[device_id] = traits
 
         # Apply user overrides (deep merge: user traits win)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -101,6 +101,7 @@ from .const import (
     SZ_TR_ALIAS,
     SZ_TR_BOUND,
     SZ_TR_CLASS,
+    SZ_TR_COMMANDS,
     SZ_TR_DISABLED,
     SZ_TR_FAKED,
     SZ_TR_NAME,
@@ -342,12 +343,34 @@ class RamsesCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Storage = %s", storage)
 
         # 1. Load Remotes
+        # Precedence (highest wins):
+        #   1. Schema _commands (SSOT — user edits, learn_command writes here)
+        #   2. .storage[remotes] (cache — learn_command writes here first)
+        #   3. known_list[dev][commands] (DEPRECATED legacy fallback — config
+        #      flow entries from pre-Phase 3a. Kept for users who haven't
+        #      migrated yet. The config flow should stop writing commands
+        #      to known_list — see Phase 3a plan, Step 5.)
         remote_commands = {
             k: v[CONF_COMMANDS]
             for k, v in self.options.get(SZ_KNOWN_LIST, {}).items()
             if v.get(CONF_COMMANDS)
         }
         self._remotes = storage.get(SZ_REMOTES, {}) | remote_commands
+
+        # 1a. Merge schema _commands into _remotes (SSOT — highest precedence)
+        config_schema = self.options.get(CONF_SCHEMA, {})
+        if isinstance(config_schema, dict):
+            remotes_from_schema = {
+                dev_id: entry.get(SZ_TR_COMMANDS, {})
+                for dev_id, entry in config_schema.items()
+                if isinstance(entry, dict) and SZ_TR_COMMANDS in entry
+            }
+            if remotes_from_schema:
+                self._remotes = self._remotes | remotes_from_schema
+                _LOGGER.debug(
+                    "Loaded %d device(s) with _commands from schema",
+                    len(remotes_from_schema),
+                )
 
         client_state: dict[str, Any] = storage.get(SZ_CLIENT_STATE, {})
 
@@ -1436,6 +1459,95 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return order_schema(new_schema)
         return schema
 
+    @staticmethod
+    def _sync_remotes_to_schema(
+        schema: dict[str, Any], remotes: dict[str, dict[str, str]]
+    ) -> dict[str, Any]:
+        """Copy learned commands from ``remotes`` into schema ``_commands``.
+
+        This is the Phase 3a SSOT migration for commands: the ``remotes``
+        dict (from ``.storage``) is the legacy command store, the schema
+        ``_commands`` trait is the new one.  Once commands are in the
+        schema, the ``remotes`` entries become a cache/fallback.
+
+        Only copies commands that are NOT already in the schema — schema
+        is authoritative, ``remotes`` fills gaps.
+
+        :param schema: The schema to enrich.
+        :param remotes: The remotes dict from ``.storage`` or in-memory.
+        :return: The schema with ``_commands`` merged in.
+        """
+        if not remotes or not isinstance(remotes, dict):
+            return schema
+
+        changed = False
+        migrated_count = 0
+        new_schema = dict(schema)
+        for device_id, commands in remotes.items():
+            if not commands or not isinstance(commands, dict):
+                continue
+            entry = new_schema.get(device_id)
+            if not isinstance(entry, dict):
+                # Create a root entry for this device if it doesn't exist
+                entry = {}
+                new_schema[device_id] = entry
+            if SZ_TR_COMMANDS not in entry:
+                entry[SZ_TR_COMMANDS] = dict(commands)
+                changed = True
+                migrated_count += 1
+                _LOGGER.info(
+                    "SSOT Phase 3a: copied %d command(s) from remotes to "
+                    "schema _commands for %s",
+                    len(commands),
+                    device_id,
+                )
+
+        if changed:
+            _LOGGER.info(
+                "SSOT Phase 3a migration: copied commands from remotes to "
+                "schema for %d device(s).",
+                migrated_count,
+            )
+            from .schemas import order_schema
+
+            return order_schema(new_schema)
+        return schema
+
+    async def _async_update_schema_commands(
+        self, device_id: str, commands: dict[str, str]
+    ) -> None:
+        """Write ``_commands`` for a device into the config entry schema.
+
+        Called by ``remote.py`` after ``learn_command`` / ``add_command`` /
+        ``delete_command`` so commands are persisted to the schema (SSOT)
+        in addition to ``.storage[remotes]`` (cache).
+
+        Uses ``async_update_entry`` with ``_suppress_reload`` to avoid
+        triggering a coordinator reload while the remote entity is mid-call.
+        """
+        schema = self.options.get(CONF_SCHEMA, {})
+        if not isinstance(schema, dict):
+            return
+        new_schema = dict(schema)
+        entry = new_schema.get(device_id)
+        if not isinstance(entry, dict):
+            entry = {}
+            new_schema[device_id] = entry
+        if commands:
+            entry[SZ_TR_COMMANDS] = dict(commands)
+        elif SZ_TR_COMMANDS in entry:
+            del entry[SZ_TR_COMMANDS]
+        new_options = dict(self.options)
+        new_options[CONF_SCHEMA] = new_schema
+        self.options = new_options
+        self._suppress_reload = time.time()
+        self.hass.config_entries.async_update_entry(self.entry, options=new_options)
+        _LOGGER.debug(
+            "Wrote %d command(s) to schema _commands for %s",
+            len(commands),
+            device_id,
+        )
+
     def _create_client(self, schema: dict[str, Any]) -> Gateway:
         """Create and configure a new RAMSES client instance."""
 
@@ -1827,6 +1939,22 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # redundant.  Only traits that aren't already in the schema are
                 # copied — schema is authoritative, known_list fills gaps.
                 enriched = self._sync_known_list_traits_to_schema(enriched)
+                # Sync learned commands from .storage[remotes] into schema
+                # _commands (Phase 3a SSOT migration for commands).
+                # Backup first if we have remotes that haven't been migrated yet.
+                if self._remotes:
+                    has_unmigrated = any(
+                        SZ_TR_COMMANDS not in (e if isinstance(e, dict) else {})
+                        for dev_id, e in enriched.items()
+                        if dev_id in self._remotes and self._remotes.get(dev_id)
+                    )
+                    if has_unmigrated:
+                        await self.store.async_save_backup(
+                            enriched,
+                            self.options.get(SZ_KNOWN_LIST, {}),
+                            reason="ssot_phase3a",
+                        )
+                    enriched = self._sync_remotes_to_schema(enriched, self._remotes)
                 # Validate the stripped schema against ramses_rf's strict
                 # validator before saving.  This catches root-level _ traits
                 # or invalid device IDs early, instead of failing silently

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1345,14 +1345,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 if mapped.get("faked") is True:
                     traits["faked"] = True
                 if mapped.get("bound"):
-                    # ramses_rf's SCH_TRAITS only accepts 'bound' for HVAC
-                    # devices (REM/DIS/FAN) with an explicit class.  FAN
-                    # entries without _class would fail validation.  The
+                    # ramses_rf's SCH_TRAITS only accepts 'bound' as a
+                    # string (single device ID) for REM/DIS devices.  The
                     # _bound trait on a FAN is a ramses_cc concept (used by
-                    # fan_handler to route 2411 commands) — ramses_rf doesn't
-                    # need it.  Only pass it to ramses_rf if the device has
-                    # _class set (so SCH_TRAITS_HVAC accepts it).
-                    if entry.get(SZ_TR_CLASS):
+                    # fan_handler to route 2411 commands) and may be a list
+                    # for multi-REM binding — ramses_rf doesn't need it.
+                    # Only pass bound to ramses_rf if it's a string (REM/DIS
+                    # pointing to their FAN), not if it's a list (FAN
+                    # pointing to its REMs).
+                    if isinstance(mapped["bound"], str):
                         traits["bound"] = mapped["bound"]
                 if mapped.get("scheme"):
                     traits["scheme"] = mapped["scheme"]
@@ -1564,7 +1565,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
         schema = self.options.get(CONF_SCHEMA, {})
         if not isinstance(schema, dict):
             return
-        new_schema = dict(schema)
+        # Use deepcopy so the new schema's entries are separate objects
+        # from the old schema's entries.  Without this, modifying an entry
+        # in place also modifies the old schema, and HA's async_update_entry
+        # sees no difference (old == new) and skips the save.
+        new_schema = deepcopy(schema)
         entry = new_schema.get(device_id)
         if not isinstance(entry, dict):
             entry = {}
@@ -2024,6 +2029,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     "No topology changes, but device_comments refreshed "
                     "from scan engine — persisting updated comments"
                 )
+                # Also sync remotes to schema _commands (Phase 3a migration).
+                # This runs even when topology isn't richer, so commands from
+                # .storage[remotes] or known_list[commands] are migrated to
+                # schema _commands on every save cycle.
+                config_schema = self._sync_remotes_to_schema(
+                    config_schema, self._remotes
+                )
                 new_options = dict(self.options)
                 new_options[CONF_SCHEMA] = config_schema
                 self.options = new_options
@@ -2031,6 +2043,34 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 self.hass.config_entries.async_update_entry(
                     self.entry, options=new_options
                 )
+            else:
+                # No topology changes and no comments refreshed, but we
+                # still need to sync remotes to schema _commands (Phase 3a
+                # migration).  This ensures commands from .storage[remotes]
+                # or known_list[commands] are migrated even when the learned
+                # topology matches the config.
+                if self._remotes:
+                    migrated_schema = self._sync_remotes_to_schema(
+                        config_schema, self._remotes
+                    )
+                    if migrated_schema is not config_schema:
+                        _LOGGER.info(
+                            "No topology changes, but remotes synced to "
+                            "schema _commands — persisting"
+                        )
+                        new_options = dict(self.options)
+                        new_options[CONF_SCHEMA] = migrated_schema
+                        self.options = new_options
+                        self._suppress_reload = time.time()
+                        try:
+                            self.hass.config_entries.async_update_entry(
+                                self.entry, options=new_options
+                            )
+                        except Exception as err:
+                            _LOGGER.debug(
+                                "Failed to persist remotes sync to schema: %s",
+                                err,
+                            )
         else:
             # During unload: save the config schema (not the learned schema)
             # to .storage, so the cached schema doesn't override a freshly-

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -60,6 +60,31 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.systems import Evohome, System, Zone
 from ramses_rf.topology import Child
+
+try:
+    from ramses_rf.config import strip_and_map_traits as _strip_and_map_traits
+except ImportError:  # ramses_rf < 0.59.0 — fallback inline implementation
+    _STRIP_MAP: dict[str, str] = {
+        "_bound": "bound",
+        "_scheme": "scheme",
+        "_alias": "alias",
+        "_faked": "faked",
+        "_class": "class",
+    }
+
+    def _strip_and_map_traits(traits: dict[str, Any]) -> dict[str, Any]:
+        """Fallback: strip _ keys, map known ones to native trait names."""
+        result: dict[str, Any] = {}
+        for key, value in traits.items():
+            if not isinstance(key, str) or not key.startswith("_"):
+                result[key] = value
+                continue
+            native_key = _STRIP_MAP.get(key)
+            if native_key is not None and native_key not in result:
+                result[native_key] = value
+        return result
+
+
 from ramses_tx import exceptions as exc
 from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI, Code
@@ -1301,9 +1326,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             entry = schema.get(device_id)
             traits: dict[str, Any] = {}
             if isinstance(entry, dict):
-                from ramses_rf.config import strip_and_map_traits
-
-                mapped = strip_and_map_traits(entry)
+                mapped = _strip_and_map_traits(entry)
                 # strip_and_map_traits maps _class→class, _alias→alias,
                 # _faked→faked, _bound→bound, _scheme→scheme.  But it
                 # doesn't handle ramses_cc-specific special cases:

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -124,74 +124,94 @@ class RamsesFanHandler:
         (REMotes or DIStribution units) and registers the binding in the
         underlying library.
 
+        ``_bound`` accepts ``str | list[str]`` (multi-REM binding).
+        Each bound device is registered via ``add_bound_device()``.
+
         :param device: The FAN device instance to configure bindings for.
         """
         # Only proceed if this is a FAN device
         if not isinstance(device, HvacVentilator):
             return
 
-        # Get bound device ID from the user known_list override first
+        # Get bound device IDs from the user known_list override first
         # (user overrides win, consistent with _derive_known_list_from_schema),
         # then fall back to the schema _bound trait (SSOT).
         device_config = self.coordinator.options.get(SZ_KNOWN_LIST, {}).get(
             device.id, {}
         )
-        bound_device_id = device_config.get(SZ_BOUND_TO)
-        if not bound_device_id:
+        bound_value = device_config.get(SZ_BOUND_TO)
+        if not bound_value:
             schema = self.coordinator.options.get(CONF_SCHEMA, {})
             schema_entry = schema.get(device.id, {})
             if isinstance(schema_entry, dict):
-                bound_device_id = schema_entry.get(SZ_TR_BOUND)
-        if not bound_device_id:
+                bound_value = schema_entry.get(SZ_TR_BOUND)
+        if not bound_value:
             return
 
-        # Explicit type check for safety
-        if not isinstance(bound_device_id, str):
+        # Normalize to list — _bound accepts str | list[str]
+        if isinstance(bound_value, str):
+            bound_device_ids: list[str] = [bound_value]
+        elif isinstance(bound_value, list):
+            bound_device_ids = bound_value
+        else:
             _LOGGER.warning(
-                "Cannot bind device %s to FAN %s: invalid bound device id type (%s)",
-                bound_device_id,
+                "Cannot bind device(s) to FAN %s: invalid bound type (%s)",
                 device.id,
-                type(bound_device_id),
+                type(bound_value),
             )
             return
-
-        _LOGGER.info("Binding FAN %s and REM/DIS device %s", device.id, bound_device_id)
 
         if not self.coordinator.client:
             _LOGGER.warning("Cannot look up bound device: Client not ready")
             return
 
-        bound_device = self.coordinator._get_device(bound_device_id)
+        for bound_device_id in bound_device_ids:
+            if not isinstance(bound_device_id, str):
+                _LOGGER.warning(
+                    "Cannot bind device %s to FAN %s: invalid bound device id type (%s)",
+                    bound_device_id,
+                    device.id,
+                    type(bound_device_id),
+                )
+                continue
 
-        if bound_device:
-            # Determine the device type based on the class
-            if isinstance(bound_device, HvacRemoteBase):
-                device_type = DevType.REM
-            elif hasattr(bound_device, "_SLUG") and bound_device._SLUG == DevType.DIS:
-                device_type = DevType.DIS
+            _LOGGER.info(
+                "Binding FAN %s and REM/DIS device %s", device.id, bound_device_id
+            )
+
+            bound_device = self.coordinator._get_device(bound_device_id)
+
+            if bound_device:
+                # Determine the device type based on the class
+                if isinstance(bound_device, HvacRemoteBase):
+                    device_type = DevType.REM
+                elif (
+                    hasattr(bound_device, "_SLUG") and bound_device._SLUG == DevType.DIS
+                ):
+                    device_type = DevType.DIS
+                else:
+                    _LOGGER.warning(
+                        "Cannot bind device %s of type %s to FAN %s: must be REM or DIS",
+                        bound_device_id,
+                        getattr(bound_device, "_SLUG", "unknown"),
+                        device.id,
+                    )
+                    continue
+
+                # Add the bound device to the FAN's tracking
+                device.add_bound_device(bound_device_id, device_type)
+                _LOGGER.info(
+                    "Bound FAN %s to %s device %s",
+                    device.id,
+                    device_type,
+                    bound_device_id,
+                )
+                # add the HvacVentilator device id to the coordinator's dict
+                self._fan_bound_to_remote[str(bound_device_id)] = device.id
             else:
                 _LOGGER.warning(
-                    "Cannot bind device %s of type %s to FAN %s: must be REM or DIS",
-                    bound_device_id,
-                    getattr(bound_device, "_SLUG", "unknown"),
-                    device.id,
+                    "Bound device %s not found for FAN %s", bound_device_id, device.id
                 )
-                return
-
-            # Add the bound device to the FAN's tracking
-            device.add_bound_device(bound_device_id, device_type)
-            _LOGGER.info(
-                "Bound FAN %s to %s device %s",
-                device.id,
-                device_type,
-                bound_device_id,
-            )
-            # add the HvacVentilator device id to the coordinator's dict
-            self._fan_bound_to_remote[str(bound_device_id)] = device.id
-        else:
-            _LOGGER.warning(
-                "Bound device %s not found for FAN %s", bound_device_id, device.id
-            )
 
     async def async_setup_fan_device(self, device: Device) -> None:
         """Set up a FAN device and its parameter entities.

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -166,15 +166,6 @@ class RamsesFanHandler:
             return
 
         for bound_device_id in bound_device_ids:
-            if not isinstance(bound_device_id, str):
-                _LOGGER.warning(
-                    "Cannot bind device %s to FAN %s: invalid bound device id type (%s)",
-                    bound_device_id,
-                    device.id,
-                    type(bound_device_id),
-                )
-                continue
-
             _LOGGER.info(
                 "Binding FAN %s and REM/DIS device %s", device.id, bound_device_id
             )

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -131,6 +131,9 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         assert not kwargs, kwargs  # TODO: remove me
 
         self._commands = {k: v for k, v in self._commands.items() if k not in command}
+        await self.coordinator._async_update_schema_commands(
+            self._device.id, self._commands
+        )
 
     async def async_learn_command(
         self,
@@ -191,6 +194,11 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
             if new_data["src"] == self._device.id and new_data["code"] in codes:
                 self._commands[command[0]] = new_data["packet"]
                 learning_session.set()  # stops learn session
+                # Persist to schema (SSOT) — .storage[remotes] is updated
+                # on the next 5-min save cycle.
+                await self.coordinator._async_update_schema_commands(
+                    self._device.id, self._commands
+                )
             else:
                 _LOGGER.debug("REM FILTER FAILED: %s", new_data["code"])
 
@@ -349,6 +357,9 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
             await self.async_delete_command(command)
 
         self._commands[command[0]] = packet_string
+        await self.coordinator._async_update_schema_commands(
+            self._device.id, self._commands
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the remote device.

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -101,7 +101,14 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
 
         :return: A dictionary of state attributes.
         """
-        return super().extra_state_attributes | {"commands": self._commands}
+        attrs = super().extra_state_attributes | {"commands": self._commands}
+        # Expose which FAN this REM is bound to (if any), derived from
+        # fan_handler's _fan_bound_to_remote dict.  Gives automations
+        # access to binding info without reading the schema directly.
+        fan_handler = self.coordinator.fan_handler
+        if fan_handler and self._device.id in fan_handler._fan_bound_to_remote:
+            attrs["bound_to_fan"] = fan_handler._fan_bound_to_remote[self._device.id]
+        return attrs
 
     async def async_delete_command(
         self,

--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -37,13 +37,16 @@ class RamsesCcStore(Store[dict[str, Any]]):
     → schema _commands) is handled at runtime by the coordinator's
     ``_sync_remotes_to_schema``, not by a storage version bump.
 
-    Bumping the storage version would break the downgrade path: HA's
-    Store raises ``UnsupportedStorageVersionError`` when the stored
-    version exceeds ``max_readable_version`` (which defaults to the
-    code's ``version``).  Since 0.58.0/0.58.1 have ``STORAGE_VERSION = 1``
-    and don't set ``max_readable_version``, they cannot read v2 data.
-    Keeping v1 means downgraded code loads the data as-is, and the
-    coordinator's runtime migration handles the rest.
+    ``max_readable_version`` is set to 2 so that .storage files written
+    by the earlier (briefly-released) v2 code can still be loaded.  The
+    migration function is a no-op identity — the v2 data format is
+    identical to v1, so no transformation is needed.  After loading, the
+    data is saved back as v1.
+
+    Downgrade safety: 0.58.0/0.58.1 have ``STORAGE_VERSION = 1`` and
+    don't set ``max_readable_version``, so they can read v1 files (what
+    we write).  They cannot read v2 files, but since we now write v1,
+    this is not a problem.
     """
 
     async def _async_migrate_func(
@@ -54,12 +57,13 @@ class RamsesCcStore(Store[dict[str, Any]]):
     ) -> dict[str, Any]:
         """Migrate stored data to the current version.
 
-        Currently v1 → v1 (identity).  The Phase 3a command migration is
-        handled at runtime by ``_sync_remotes_to_schema`` in the
-        coordinator, not by a storage version bump.
+        v2 → v1 (identity): the v2 data format is identical to v1 — the
+        version bump was reverted because the migration is handled at
+        runtime by ``_sync_remotes_to_schema`` in the coordinator.
+        v1 → v1 is also a no-op.
         """
         _LOGGER.debug(
-            "Migrating ramses_cc storage: v%s.%s → v%s.%s (no-op)",
+            "Migrating ramses_cc storage: v%s.%s → v%s.%s (no-op identity)",
             old_major_version,
             old_minor_version,
             self.version,
@@ -74,7 +78,9 @@ class RamsesStore:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the storage helper."""
         self._hass = hass
-        self._store = RamsesCcStore(hass, STORAGE_VERSION, STORAGE_KEY)
+        self._store = RamsesCcStore(
+            hass, STORAGE_VERSION, STORAGE_KEY, max_readable_version=2
+        )
 
     async def async_load(self) -> dict[str, Any]:
         """Load the data from the persistent storage.

--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -20,7 +20,6 @@ from .const import (
     SZ_PACKETS,
     SZ_REMOTES,
     SZ_SCHEMA,
-    SZ_TR_COMMANDS,
 )
 from .discovery import SZ_DISCOVERY
 
@@ -34,70 +33,39 @@ _BACKUP_DIR: Final[str] = "ramses_cc_backups"
 class RamsesCcStore(Store[dict[str, Any]]):
     """HA Store subclass with a migration hook for ramses_cc .storage.
 
-    Migration versions:
-    - v1 → v2: commands moved from .storage[remotes] to schema _commands
-      (Phase 3a).  remotes is kept as cache/fallback.
-    - v2 → v3: known_list removed, fully derived from schema (Phase 4, TBD)
+    STORAGE_VERSION stays at 1 — the Phase 3a command migration (remotes
+    → schema _commands) is handled at runtime by the coordinator's
+    ``_sync_remotes_to_schema``, not by a storage version bump.
+
+    Bumping the storage version would break the downgrade path: HA's
+    Store raises ``UnsupportedStorageVersionError`` when the stored
+    version exceeds ``max_readable_version`` (which defaults to the
+    code's ``version``).  Since 0.58.0/0.58.1 have ``STORAGE_VERSION = 1``
+    and don't set ``max_readable_version``, they cannot read v2 data.
+    Keeping v1 means downgraded code loads the data as-is, and the
+    coordinator's runtime migration handles the rest.
     """
 
     async def _async_migrate_func(
         self,
         old_major_version: int,
         old_minor_version: int,
-        old_data: dict[str, Any] | None,
+        old_data: dict[str, Any],
     ) -> dict[str, Any]:
-        """Migrate stored data to the current version."""
+        """Migrate stored data to the current version.
+
+        Currently v1 → v1 (identity).  The Phase 3a command migration is
+        handled at runtime by ``_sync_remotes_to_schema`` in the
+        coordinator, not by a storage version bump.
+        """
         _LOGGER.debug(
-            "Migrating ramses_cc storage: v%s.%s → v%s.%s",
+            "Migrating ramses_cc storage: v%s.%s → v%s.%s (no-op)",
             old_major_version,
             old_minor_version,
             self.version,
             self.minor_version,
         )
-        if old_major_version < 2:
-            old_data = _migrate_v1_to_v2(old_data)
-        return old_data or {}
-
-
-def _migrate_v1_to_v2(data: dict[str, Any] | None) -> dict[str, Any]:
-    """Move remotes from .storage to schema _commands (Phase 3a).
-
-    Only moves commands from .storage[remotes] — traits (_alias, _class,
-    etc.) are additive _ keys and don't need migration. known_list[dev]
-    [commands] is in config_entry.options (not .storage), so it's handled
-    by the runtime merge at coordinator startup, not by this migration.
-    """
-    if not isinstance(data, dict):
-        return {}
-    client_state = data.get(SZ_CLIENT_STATE, {})
-    remotes = data.get(SZ_REMOTES, {})
-    schema = client_state.get(SZ_SCHEMA, {})
-
-    if not isinstance(schema, dict) or not isinstance(remotes, dict):
-        return data
-
-    migrated = 0
-    for device_id, commands in remotes.items():
-        if not commands or not isinstance(commands, dict):
-            continue
-        entry = schema.get(device_id)
-        if not isinstance(entry, dict):
-            entry = {}
-            schema[device_id] = entry
-        if SZ_TR_COMMANDS not in entry:
-            entry[SZ_TR_COMMANDS] = dict(commands)
-            migrated += 1
-
-    if migrated:
-        _LOGGER.info(
-            "Storage migration v1 → v2: moved _commands for %d device(s) "
-            "from remotes to schema. remotes kept as cache.",
-            migrated,
-        )
-        client_state[SZ_SCHEMA] = schema
-        data[SZ_CLIENT_STATE] = client_state
-
-    return data
+        return old_data
 
 
 class RamsesStore:

--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -20,6 +20,7 @@ from .const import (
     SZ_PACKETS,
     SZ_REMOTES,
     SZ_SCHEMA,
+    SZ_TR_COMMANDS,
 )
 from .discovery import SZ_DISCOVERY
 
@@ -33,30 +34,70 @@ _BACKUP_DIR: Final[str] = "ramses_cc_backups"
 class RamsesCcStore(Store[dict[str, Any]]):
     """HA Store subclass with a migration hook for ramses_cc .storage.
 
-    Phase 2.5 registers this as a no-op identity migration (v1 → v1) so the
-    hook and version label are in place.  Future bumps just add branches:
-    - v1 → v2: commands moved to schema ``_commands`` (Phase 3a)
-    - v2 → v3: known_list removed, fully derived from schema (Phase 4)
+    Migration versions:
+    - v1 → v2: commands moved from .storage[remotes] to schema _commands
+      (Phase 3a).  remotes is kept as cache/fallback.
+    - v2 → v3: known_list removed, fully derived from schema (Phase 4, TBD)
     """
 
     async def _async_migrate_func(
         self,
         old_major_version: int,
         old_minor_version: int,
-        old_data: dict[str, Any],
+        old_data: dict[str, Any] | None,
     ) -> dict[str, Any]:
-        """Migrate stored data to the current version.
-
-        Currently v1 → v1 (identity).  Future versions will add branches.
-        """
+        """Migrate stored data to the current version."""
         _LOGGER.debug(
-            "Migrating ramses_cc storage: v%s.%s → v%s.%s (no-op)",
+            "Migrating ramses_cc storage: v%s.%s → v%s.%s",
             old_major_version,
             old_minor_version,
             self.version,
             self.minor_version,
         )
-        return old_data
+        if old_major_version < 2:
+            old_data = _migrate_v1_to_v2(old_data)
+        return old_data or {}
+
+
+def _migrate_v1_to_v2(data: dict[str, Any] | None) -> dict[str, Any]:
+    """Move remotes from .storage to schema _commands (Phase 3a).
+
+    Only moves commands from .storage[remotes] — traits (_alias, _class,
+    etc.) are additive _ keys and don't need migration. known_list[dev]
+    [commands] is in config_entry.options (not .storage), so it's handled
+    by the runtime merge at coordinator startup, not by this migration.
+    """
+    if not isinstance(data, dict):
+        return {}
+    client_state = data.get(SZ_CLIENT_STATE, {})
+    remotes = data.get(SZ_REMOTES, {})
+    schema = client_state.get(SZ_SCHEMA, {})
+
+    if not isinstance(schema, dict) or not isinstance(remotes, dict):
+        return data
+
+    migrated = 0
+    for device_id, commands in remotes.items():
+        if not commands or not isinstance(commands, dict):
+            continue
+        entry = schema.get(device_id)
+        if not isinstance(entry, dict):
+            entry = {}
+            schema[device_id] = entry
+        if SZ_TR_COMMANDS not in entry:
+            entry[SZ_TR_COMMANDS] = dict(commands)
+            migrated += 1
+
+    if migrated:
+        _LOGGER.info(
+            "Storage migration v1 → v2: moved _commands for %d device(s) "
+            "from remotes to schema. remotes kept as cache.",
+            migrated,
+        )
+        client_state[SZ_SCHEMA] = schema
+        data[SZ_CLIENT_STATE] = client_state
+
+    return data
 
 
 class RamsesStore:

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1320,6 +1320,71 @@ async def test_hvac_set_fan_mode_custom_command_variations(
         mock_device._gwy.async_send_cmd.assert_not_called()
 
 
+async def test_hvac_set_fan_mode_reads_from_remotes(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """Test that async_set_fan_mode reads from coordinator._remotes (schema _commands)."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    # Set up _remotes (schema _commands) with a custom command for "low"
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
+    }
+    # Also set up known_list with a DIFFERENT command for the same mode
+    # to verify _remotes takes priority
+    mock_coordinator.options = {
+        SZ_KNOWN_LIST: {
+            "37:111111": {CONF_COMMANDS: {"low": "W 37:111111 30:123456 22F1 000999"}}
+        }
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    await hvac.async_set_fan_mode("low")
+
+    # Should have sent the command from _remotes (schema), not known_list
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_device._gwy.async_send_cmd.call_args[0][0]
+    assert "000406" in str(sent_cmd), "Should use _remotes command, not known_list"
+    mock_device.set_fan_mode.assert_not_called()
+
+
+async def test_hvac_set_fan_mode_falls_back_to_known_list(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """Test that async_set_fan_mode falls back to known_list when _remotes is empty."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    # _remotes is empty (no schema _commands for this REM)
+    mock_coordinator._remotes = {}
+    # known_list has the command
+    mock_coordinator.options = {
+        SZ_KNOWN_LIST: {
+            "37:111111": {CONF_COMMANDS: {"low": "W 37:111111 30:123456 22F1 000999"}}
+        }
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    await hvac.async_set_fan_mode("low")
+
+    # Should have sent the command from known_list (legacy fallback)
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_device._gwy.async_send_cmd.call_args[0][0]
+    assert "000999" in str(sent_cmd), "Should fall back to known_list command"
+    mock_device.set_fan_mode.assert_not_called()
+
+
 async def test_hvac_set_preset_mode(
     mock_coordinator: MagicMock, mock_description: MagicMock
 ) -> None:

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1385,6 +1385,236 @@ async def test_hvac_set_fan_mode_falls_back_to_known_list(
     mock_device.set_fan_mode.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# Phase 3a: fan_modes property tests
+# ---------------------------------------------------------------------------
+
+
+def test_fan_modes_includes_custom_commands_from_remotes(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """fan_modes property extends base modes with custom command names."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+
+    mock_coordinator._remotes = {
+        "37:111111": {
+            "boost": "W 37:111111 30:123456 22F1 000406",
+            "speed_1": "W 37:111111 30:123456 22F1 000407",
+        }
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac._bound_rem = "37:111111"
+
+    modes = hvac.fan_modes
+    assert modes is not None
+    # Base modes are present
+    assert "off" in modes
+    assert "low" in modes
+    assert "medium" in modes
+    assert "high" in modes
+    # Custom commands are appended
+    assert "boost" in modes
+    assert "speed_1" in modes
+    # No duplicates
+    assert len(modes) == len(set(modes))
+
+
+def test_fan_modes_no_bound_rem_returns_base_only(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """fan_modes returns base modes when no bound REM exists."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    mock_coordinator._remotes = {"37:111111": {"boost": "packet"}}
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac._bound_rem = None
+
+    modes = hvac.fan_modes
+    assert modes is not None
+    assert "boost" not in modes
+    assert "low" in modes
+
+
+def test_fan_modes_empty_remotes_returns_base_only(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """fan_modes returns base modes when _remotes has no commands for bound REM."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+
+    mock_coordinator._remotes = {}
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac._bound_rem = "37:111111"
+
+    modes = hvac.fan_modes
+    assert modes is not None
+    assert "low" in modes
+    assert "boost" not in modes
+
+
+def test_fan_modes_no_duplicates_when_command_matches_base_mode(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """fan_modes doesn't duplicate a custom command that matches a base mode name."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+
+    # "low" is both a base mode and a custom command
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"},
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac._bound_rem = "37:111111"
+
+    modes = hvac.fan_modes
+    assert modes is not None
+    assert modes.count("low") == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: set_fan_mode intercept — additional edge case tests
+# ---------------------------------------------------------------------------
+
+
+async def test_set_fan_mode_standard_mode_not_intercepted(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """Standard fan modes call device.set_fan_mode, not the custom command path."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+    mock_device.set_fan_mode = AsyncMock()
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    # _remotes has a custom command, but NOT for "low"
+    mock_coordinator._remotes = {
+        "37:111111": {"boost": "W 37:111111 30:123456 22F1 000406"}
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    await hvac.async_set_fan_mode("low")
+
+    # Standard path: set_fan_mode called, async_send_cmd NOT called
+    mock_device.set_fan_mode.assert_awaited_once_with("low")
+    mock_device._gwy.async_send_cmd.assert_not_called()
+
+
+async def test_set_fan_mode_custom_command_sends_via_gateway(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """Custom fan mode sends raw packet via gateway, not device.set_fan_mode."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+    mock_device.set_fan_mode = AsyncMock()
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"boost": "W 37:111111 30:123456 22F1 000406"}
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    await hvac.async_set_fan_mode("boost")
+
+    # Intercept path: async_send_cmd called, set_fan_mode NOT called
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device.set_fan_mode.assert_not_called()
+    hvac.async_write_ha_state.assert_called_once()
+
+
+async def test_set_fan_mode_custom_command_priority_remotes_over_known_list(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """_remotes (schema _commands) takes priority over known_list[commands]."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+    mock_device.set_fan_mode = AsyncMock()
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"boost": "W 37:111111 30:123456 22F1 000AAA"}
+    }
+    mock_coordinator.options = {
+        SZ_KNOWN_LIST: {
+            "37:111111": {CONF_COMMANDS: {"boost": "W 37:111111 30:123456 22F1 000BBB"}}
+        }
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    await hvac.async_set_fan_mode("boost")
+
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_device._gwy.async_send_cmd.call_args[0][0]
+    assert "000AAA" in str(sent_cmd), "Should use _remotes, not known_list"
+
+
+async def test_set_fan_mode_validation_uses_dynamic_fan_modes(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """set_fan_mode accepts custom command names because fan_modes is dynamic."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+    mock_device.set_fan_mode = AsyncMock()
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"my_custom_mode": "W 37:111111 30:123456 22F1 000406"}
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    # "my_custom_mode" is NOT in the static _attr_fan_modes, but IS in the
+    # dynamic fan_modes property (extended from _remotes). This should NOT
+    # raise ServiceValidationError.
+    await hvac.async_set_fan_mode("my_custom_mode")
+
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device.set_fan_mode.assert_not_called()
+
+
+async def test_set_fan_mode_unknown_custom_mode_raises_validation_error(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """A mode not in base fan_modes and not in _remotes raises validation error."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem = MagicMock(return_value="37:111111")
+    mock_device.set_fan_mode = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"boost": "W 37:111111 30:123456 22F1 000406"}
+    }
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+
+    # "turbo" is not a base mode and not in _remotes
+    with pytest.raises(ServiceValidationError, match="invalid_fan_mode"):
+        await hvac.async_set_fan_mode("turbo")
+
+
 async def test_hvac_set_preset_mode(
     mock_coordinator: MagicMock, mock_description: MagicMock
 ) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -40,6 +40,7 @@ from custom_components.ramses_cc.const import (
     CONF_SCHEMA,
     DEFAULT_HGI_ID,
     DOMAIN,
+    SZ_TR_COMMANDS,
 )
 from ramses_tx.schemas import (
     SZ_ENFORCE_KNOWN_LIST,
@@ -2501,3 +2502,129 @@ async def test_review_discovered_many_codes_and_no_rssi(hass: HomeAssistant) -> 
     assert "+2" in placeholders.get("message", "")
     # Verify the em-dash for None rssi/bound_to/zone_idx
     assert "—" in placeholders.get("message", "")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: _commands in config flow schema step
+# ---------------------------------------------------------------------------
+
+
+async def test_options_flow_schema_preserves_commands(hass: HomeAssistant) -> None:
+    """Schema step preserves _commands when user saves the schema.
+
+    _commands is a _ prefixed key that should survive the config flow
+    round-trip: it's stripped for validation but saved in the original schema.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt://user:pass@broker:1883"},
+            CONF_RAMSES_RF: {SZ_ENFORCE_KNOWN_LIST: False},
+            SZ_KNOWN_LIST: {},
+            CONF_SCHEMA: {
+                "37:153001": {
+                    "_class": "REM",
+                    SZ_TR_COMMANDS: {
+                        "boost": "I --- 37:153001 30:160000 --:------ 22F1 003 000030",
+                    },
+                },
+                "30:160000": {
+                    "_class": "FAN",
+                    "_bound": "37:153001",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "schema"}
+    )
+
+    # Submit the schema step with the same schema (including _commands)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCHEMA: {
+                "37:153001": {
+                    "_class": "REM",
+                    SZ_TR_COMMANDS: {
+                        "boost": "I --- 37:153001 30:160000 --:------ 22F1 003 000030",
+                        "speed_1": "I --- 37:153001 30:160000 --:------ 22F1 003 000031",
+                    },
+                },
+                "30:160000": {
+                    "_class": "FAN",
+                    "_bound": "37:153001",
+                },
+            },
+            SZ_KNOWN_LIST: {},
+            SZ_ENFORCE_KNOWN_LIST: False,
+            SZ_LOG_ALL_MQTT: True,
+        },
+    )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    data = result.get("data")
+    assert data is not None
+    schema = data[CONF_SCHEMA]
+
+    # _commands should be preserved on the REM entry
+    rem_entry = schema.get("37:153001", {})
+    assert isinstance(rem_entry, dict)
+    assert SZ_TR_COMMANDS in rem_entry
+    commands = rem_entry[SZ_TR_COMMANDS]
+    assert "boost" in commands
+    assert "speed_1" in commands
+    assert commands["boost"] == "I --- 37:153001 30:160000 --:------ 22F1 003 000030"
+
+
+async def test_options_flow_schema_strips_commands_for_validation(
+    hass: HomeAssistant,
+) -> None:
+    """Schema step strips _commands before ramses_rf validation.
+
+    ramses_rf's SCH_GLOBAL_SCHEMAS rejects _ prefixed keys. The config flow
+    strips them via strip_traits_for_validation, validates the clean schema,
+    then saves the original (with _commands) to options.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt://user:pass@broker:1883"},
+            CONF_RAMSES_RF: {SZ_ENFORCE_KNOWN_LIST: False},
+            SZ_KNOWN_LIST: {},
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "schema"}
+    )
+
+    # Submit schema with _commands — should NOT raise invalid_schema
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_SCHEMA: {
+                "37:153001": {
+                    "_class": "REM",
+                    SZ_TR_COMMANDS: {
+                        "boost": "I --- 37:153001 30:160000 --:------ 22F1 003 000030"
+                    },
+                },
+            },
+            SZ_KNOWN_LIST: {},
+            SZ_ENFORCE_KNOWN_LIST: False,
+            SZ_LOG_ALL_MQTT: True,
+        },
+    )
+
+    # Should succeed (not return errors with invalid_schema)
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    data = result.get("data")
+    assert data is not None
+    assert SZ_TR_COMMANDS in data[CONF_SCHEMA].get("37:153001", {})

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -39,6 +39,7 @@ from custom_components.ramses_cc.const import (
     DOMAIN,
     SIGNAL_NEW_DEVICES,
     SZ_ENFORCE_KNOWN_LIST,
+    SZ_REMOTES,
     SZ_TR_COMMANDS,
 )
 from custom_components.ramses_cc.coordinator import (
@@ -4675,3 +4676,263 @@ class TestStripSchemaExtensionsCommands:
         # The device should be in orphans_hvac (no remotes/sensors keys)
         # but _commands must not appear
         assert SZ_TR_COMMANDS not in str(stripped)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: startup load, else branch, backup before migration
+# ---------------------------------------------------------------------------
+
+
+async def test_startup_load_commands_from_schema(
+    mock_hass: MagicMock, mock_entry: MagicMock
+) -> None:
+    """Coordinator loads _commands from schema into _remotes at startup.
+
+    Schema _commands has highest precedence (SSOT), overriding any
+    commands from .storage[remotes] or known_list[commands].
+    """
+    # Configure schema with _commands for a REM device
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+    cast(Any, mock_entry).options = {
+        SZ_KNOWN_LIST: {},
+        CONF_SCHEMA: {
+            rem_id: {"_class": "REM", SZ_TR_COMMANDS: commands},
+        },
+        CONF_RAMSES_RF: {},
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_SCAN_INTERVAL: 60,
+        CONF_GATEWAY_TIMEOUT: 10,
+    }
+
+    coordinator = RamsesCoordinator(mock_hass, mock_entry)
+    cast(Any, coordinator.store).async_load = AsyncMock(return_value={})
+
+    # Mock the client with async start
+    mock_client = MagicMock()
+    mock_client.start = AsyncMock()
+    mock_client.add_msg_handler = MagicMock()
+    cast(Any, coordinator)._create_client = MagicMock(return_value=mock_client)
+
+    await coordinator.async_setup()
+
+    # Verify _commands from schema were loaded into _remotes
+    assert rem_id in coordinator._remotes
+    assert coordinator._remotes[rem_id] == commands
+
+
+async def test_startup_load_schema_commands_override_storage(
+    mock_hass: MagicMock, mock_entry: MagicMock
+) -> None:
+    """Schema _commands override .storage[remotes] at startup (SSOT wins)."""
+    rem_id = "37:170000"
+    schema_commands = {"boost": "I --- schema packet"}
+    storage_commands = {"boost": "I --- storage packet"}
+
+    cast(Any, mock_entry).options = {
+        SZ_KNOWN_LIST: {},
+        CONF_SCHEMA: {
+            rem_id: {"_class": "REM", SZ_TR_COMMANDS: schema_commands},
+        },
+        CONF_RAMSES_RF: {},
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_SCAN_INTERVAL: 60,
+        CONF_GATEWAY_TIMEOUT: 10,
+    }
+
+    coordinator = RamsesCoordinator(mock_hass, mock_entry)
+    cast(Any, coordinator.store).async_load = AsyncMock(
+        return_value={SZ_REMOTES: {rem_id: storage_commands}}
+    )
+
+    mock_client = MagicMock()
+    mock_client.start = AsyncMock()
+    mock_client.add_msg_handler = MagicMock()
+    cast(Any, coordinator)._create_client = MagicMock(return_value=mock_client)
+
+    await coordinator.async_setup()
+
+    # Schema _commands should win (SSOT — highest precedence)
+    assert coordinator._remotes[rem_id] == schema_commands
+
+
+async def test_startup_load_legacy_known_list_commands(
+    mock_hass: MagicMock, mock_entry: MagicMock
+) -> None:
+    """Legacy known_list[commands] are loaded when no schema _commands exist."""
+    rem_id = "37:170000"
+    legacy_commands = {"boost": "I --- legacy packet"}
+
+    cast(Any, mock_entry).options = {
+        SZ_KNOWN_LIST: {rem_id: {CONF_COMMANDS: legacy_commands}},
+        CONF_SCHEMA: {},
+        CONF_RAMSES_RF: {},
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_SCAN_INTERVAL: 60,
+        CONF_GATEWAY_TIMEOUT: 10,
+    }
+
+    coordinator = RamsesCoordinator(mock_hass, mock_entry)
+    cast(Any, coordinator.store).async_load = AsyncMock(return_value={})
+
+    mock_client = MagicMock()
+    mock_client.start = AsyncMock()
+    mock_client.add_msg_handler = MagicMock()
+    cast(Any, coordinator)._create_client = MagicMock(return_value=mock_client)
+
+    await coordinator.async_setup()
+
+    # Legacy known_list commands should be loaded (fallback)
+    assert coordinator._remotes[rem_id] == legacy_commands
+
+
+async def test_async_save_client_state_else_branch_syncs_remotes(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """async_save_client_state else branch syncs remotes to schema _commands.
+
+    When learned topology is NOT richer than config (enriched is None) and
+    no comments are refreshed, the else branch still runs
+    _sync_remotes_to_schema to migrate commands from .storage[remotes].
+    """
+    assert mock_coordinator.client is not None
+
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+
+    # Config schema has the REM but no _commands yet
+    config_schema: dict[str, Any] = {rem_id: {"_class": "REM"}}
+    mock_coordinator.options = {CONF_SCHEMA: config_schema, SZ_KNOWN_LIST: {}}
+
+    # Remotes has commands that need migrating
+    mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._entities = {}
+    mock_coordinator._skip_topology_sync = False
+
+    # Learned schema is same as config (no enrichment)
+    learned_schema = dict(config_schema)
+    cast(Any, mock_coordinator.client).get_state = MagicMock(
+        return_value=(learned_schema, {})
+    )
+
+    mock_save = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save = mock_save
+
+    # Patch sync_learned_topology to return None (no enrichment)
+    with (
+        patch(
+            "custom_components.ramses_cc.coordinator.sync_learned_topology",
+            return_value=None,
+        ),
+        patch.object(mock_coordinator, "discovery_manager", None),
+    ):
+        await mock_coordinator.async_save_client_state()
+
+    # Verify _sync_remotes_to_schema ran — _commands should be in options
+    saved_options = mock_coordinator.options
+    assert SZ_TR_COMMANDS in saved_options[CONF_SCHEMA].get(rem_id, {})
+    assert saved_options[CONF_SCHEMA][rem_id][SZ_TR_COMMANDS] == commands
+
+
+async def test_async_save_client_state_backup_before_migration(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """async_save_client_state creates backup with reason='ssot_phase3a' before
+    migrating remotes to schema _commands (when enriched is not None).
+    """
+    assert mock_coordinator.client is not None
+
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+
+    # Config schema has the REM but no _commands yet (unmigrated)
+    config_schema: dict[str, Any] = {rem_id: {"_class": "REM"}}
+    mock_coordinator.options = {
+        CONF_SCHEMA: config_schema,
+        SZ_KNOWN_LIST: {},
+    }
+
+    # Remotes has commands that need migrating
+    mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._entities = {}
+    mock_coordinator._skip_topology_sync = False
+
+    # Enriched schema (sync_learned_topology returns a richer schema)
+    enriched_schema = {rem_id: {"_class": "REM"}, "main_tcs": "01:123456"}
+    cast(Any, mock_coordinator.client).get_state = MagicMock(
+        return_value=(enriched_schema, {})
+    )
+
+    mock_save = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save = mock_save
+    mock_backup = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save_backup = mock_backup
+
+    # Patch sync_learned_topology to return enriched schema
+    with (
+        patch(
+            "custom_components.ramses_cc.coordinator.sync_learned_topology",
+            return_value=enriched_schema,
+        ),
+        patch.object(mock_coordinator, "discovery_manager", None),
+        patch.object(mock_coordinator, "_validate_schema_for_ramserf"),
+    ):
+        await mock_coordinator.async_save_client_state()
+
+    # Verify backup was called with reason="ssot_phase3a"
+    mock_backup.assert_awaited_once()
+    call_args = mock_backup.await_args
+    assert call_args.kwargs.get("reason") == "ssot_phase3a" or (
+        len(call_args.args) >= 3 and call_args.args[2] == "ssot_phase3a"
+    )
+
+    # Verify _commands were migrated to schema
+    saved_schema = mock_coordinator.options[CONF_SCHEMA]
+    assert SZ_TR_COMMANDS in saved_schema.get(rem_id, {})
+    assert saved_schema[rem_id][SZ_TR_COMMANDS] == commands
+
+
+async def test_async_save_client_state_no_backup_when_already_migrated(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """No backup is created when remotes already have _commands in schema."""
+    assert mock_coordinator.client is not None
+
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+
+    # Schema already has _commands (already migrated)
+    config_schema: dict[str, Any] = {
+        rem_id: {"_class": "REM", SZ_TR_COMMANDS: commands}
+    }
+    mock_coordinator.options = {
+        CONF_SCHEMA: config_schema,
+        SZ_KNOWN_LIST: {},
+    }
+
+    mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._entities = {}
+    mock_coordinator._skip_topology_sync = False
+
+    enriched_schema = dict(config_schema)
+    cast(Any, mock_coordinator.client).get_state = MagicMock(
+        return_value=(enriched_schema, {})
+    )
+
+    mock_save = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save = mock_save
+    mock_backup = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save_backup = mock_backup
+
+    with (
+        patch(
+            "custom_components.ramses_cc.coordinator.sync_learned_topology",
+            return_value=enriched_schema,
+        ),
+        patch.object(mock_coordinator, "discovery_manager", None),
+        patch.object(mock_coordinator, "_validate_schema_for_ramserf"),
+    ):
+        await mock_coordinator.async_save_client_state()
+
+    # No backup should be created (already migrated)
+    mock_backup.assert_not_awaited()

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -39,6 +39,7 @@ from custom_components.ramses_cc.const import (
     DOMAIN,
     SIGNAL_NEW_DEVICES,
     SZ_ENFORCE_KNOWN_LIST,
+    SZ_TR_COMMANDS,
 )
 from custom_components.ramses_cc.coordinator import (
     SZ_CLIENT_STATE,
@@ -4588,3 +4589,89 @@ class TestSyncTraitsToSchema:
         known_list = {"32:123456": {"class": "some_unknown_type"}}
         result = RamsesCoordinator._sync_traits_to_schema(schema, known_list)
         assert result["32:123456"]["_class"] == "some_unknown_type"
+
+
+class TestSyncRemotesToSchema:
+    """Tests for RamsesCoordinator._sync_remotes_to_schema (Phase 3a)."""
+
+    def test_remotes_copied_to_schema(self) -> None:
+        """Commands from remotes are copied to schema _commands."""
+        schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
+        remotes = {"32:153001": {"turn_on": "I --- 22F1 003 000030"}}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes)
+        assert result["32:153001"][SZ_TR_COMMANDS] == {
+            "turn_on": "I --- 22F1 003 000030"
+        }
+        # Existing _class preserved
+        assert result["32:153001"]["_class"] == "REM"
+
+    def test_schema_commands_not_overwritten(self) -> None:
+        """Schema _commands is authoritative — remotes don't overwrite."""
+        schema: dict[str, Any] = {
+            "32:153001": {SZ_TR_COMMANDS: {"turn_on": "I --- schema"}}
+        }
+        remotes = {"32:153001": {"turn_on": "I --- remotes"}}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes)
+        assert result["32:153001"][SZ_TR_COMMANDS] == {"turn_on": "I --- schema"}
+
+    def test_empty_remotes_no_change(self) -> None:
+        """Empty remotes dict returns schema unchanged."""
+        schema: dict[str, Any] = {"01:123456": {}}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, {})
+        assert result is schema
+
+    def test_none_remotes_no_change(self) -> None:
+        """None remotes returns schema unchanged."""
+        schema: dict[str, Any] = {"01:123456": {}}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, None)  # type: ignore[arg-type]
+        assert result is schema
+
+    def test_new_device_entry_created(self) -> None:
+        """If device not in schema, a new entry is created with _commands."""
+        schema: dict[str, Any] = {"01:123456": {}}
+        remotes = {"32:153001": {"turn_on": "I --- 22F1"}}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes)
+        assert result["32:153001"][SZ_TR_COMMANDS] == {"turn_on": "I --- 22F1"}
+
+    def test_empty_commands_skipped(self) -> None:
+        """Devices with empty command dicts are skipped."""
+        schema: dict[str, Any] = {"32:153001": {}}
+        remotes = {"32:153001": {}}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes)
+        assert SZ_TR_COMMANDS not in result["32:153001"]
+
+    def test_multiple_devices_migrated(self) -> None:
+        """Multiple devices with commands are all migrated."""
+        schema: dict[str, Any] = {"01:123456": {}}
+        remotes = {
+            "32:153001": {"turn_on": "I --- 22F1 003 000030"},
+            "32:153002": {"speed_1": "I --- 22F1 003 000031"},
+        }
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes)
+        assert SZ_TR_COMMANDS in result["32:153001"]
+        assert SZ_TR_COMMANDS in result["32:153002"]
+
+
+class TestStripSchemaExtensionsCommands:
+    """Test that _commands is stripped by _strip_schema_extensions."""
+
+    def test_commands_stripped_from_device(self) -> None:
+        """_commands is stripped from device entries."""
+        schema: dict[str, Any] = {
+            "01:123456": {"_alias": "Test", SZ_TR_COMMANDS: {"turn_on": "I ---"}},
+            "main_tcs": "01:123456",
+        }
+        stripped = RamsesCoordinator._strip_schema_extensions(schema)
+        # _commands should not appear anywhere in the stripped schema
+        assert SZ_TR_COMMANDS not in str(stripped)
+        assert "_alias" not in str(stripped)
+
+    def test_commands_stripped_no_remotes_key_leak(self) -> None:
+        """_commands doesn't leak as a 'remotes' key to ramses_rf."""
+        schema: dict[str, Any] = {
+            "32:153001": {SZ_TR_COMMANDS: {"turn_on": "I --- 22F1"}},
+        }
+        stripped = RamsesCoordinator._strip_schema_extensions(schema)
+        # The device should be in orphans_hvac (no remotes/sensors keys)
+        # but _commands must not appear
+        assert SZ_TR_COMMANDS not in str(stripped)

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -564,3 +564,201 @@ async def test_fan_setup_already_initialized_exception(
         await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
     assert "Failed to request parameters for device" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: multi-REM _bound as list + CO2-as-REM binding
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_fan_bound_multi_rem_list(
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
+) -> None:
+    """Test binding a FAN to multiple REMs via _bound as a list."""
+    bound_ids = ["32:111111", "32:222222", "32:333333"]
+
+    # Configure the known_list with _bound as a list
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_ids}}
+
+    # Create bound device objects
+    bound_devices = {}
+    for bid in bound_ids:
+        bd = MagicMock()
+        bd.id = bid
+        bound_devices[bid] = bd
+    mock_coordinator._get_device = MagicMock(
+        side_effect=lambda bid: bound_devices.get(bid)
+    )
+
+    # Helper classes to satisfy isinstance checks
+    class MockHvacVentilator:
+        pass
+
+    class MockHvacRemoteBase:
+        pass
+
+    mock_fan_device.__class__ = MockHvacVentilator  # type: ignore[assignment]
+    for bd in bound_devices.values():
+        bd.__class__ = MockHvacRemoteBase  # type: ignore[assignment]
+
+    with (
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacVentilator",
+            MockHvacVentilator,
+        ),
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacRemoteBase",
+            MockHvacRemoteBase,
+        ),
+    ):
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
+
+    # Verify all REMs were bound
+    assert mock_fan_device.add_bound_device.call_count == 3
+    for bid in bound_ids:
+        mock_fan_device.add_bound_device.assert_any_call(bid, DevType.REM)
+        assert mock_coordinator.fan_handler._fan_bound_to_remote[bid] == FAN_ID
+
+
+async def test_setup_fan_bound_multi_rem_schema_trait(
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
+) -> None:
+    """Test binding a FAN to multiple REMs via schema _bound trait (not known_list)."""
+    bound_ids = ["32:111111", "32:222222"]
+
+    # No known_list override — use schema _bound trait
+    mock_coordinator.options[SZ_KNOWN_LIST] = {}
+    mock_coordinator.options[CONF_SCHEMA] = {
+        FAN_ID: {SZ_TR_BOUND: bound_ids},
+    }
+
+    # Create bound device objects
+    bound_devices = {}
+    for bid in bound_ids:
+        bd = MagicMock()
+        bd.id = bid
+        bound_devices[bid] = bd
+    mock_coordinator._get_device = MagicMock(
+        side_effect=lambda bid: bound_devices.get(bid)
+    )
+
+    class MockHvacVentilator:
+        pass
+
+    class MockHvacRemoteBase:
+        pass
+
+    mock_fan_device.__class__ = MockHvacVentilator  # type: ignore[assignment]
+    for bd in bound_devices.values():
+        bd.__class__ = MockHvacRemoteBase  # type: ignore[assignment]
+
+    with (
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacVentilator",
+            MockHvacVentilator,
+        ),
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacRemoteBase",
+            MockHvacRemoteBase,
+        ),
+    ):
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
+
+    # Verify both REMs were bound from schema trait
+    assert mock_fan_device.add_bound_device.call_count == 2
+    for bid in bound_ids:
+        mock_fan_device.add_bound_device.assert_any_call(bid, DevType.REM)
+        assert mock_coordinator.fan_handler._fan_bound_to_remote[bid] == FAN_ID
+
+
+async def test_setup_fan_bound_mixed_rem_and_co2_as_rem(
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
+) -> None:
+    """Test binding a FAN to a REM and a CO2 (with _class: REM) via _bound list.
+
+    A CO2 device with ``_class: REM`` in the schema is created by ramses_rf
+    as an ``HvacRemoteBase``, so it passes the isinstance check in
+    fan_handler.  This test verifies that a device which is not natively a
+    REM but has been class-overridden to REM is accepted as a bound device.
+    """
+    rem_id = "32:111111"
+    co2_id = "29:222222"  # CO2 device, but with _class: REM override
+
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: [rem_id, co2_id]}}
+
+    # Create bound device objects — both are HvacRemoteBase (the CO2 has
+    # been class-overridden to REM by ramses_rf via _class: REM in schema)
+    rem_device = MagicMock()
+    rem_device.id = rem_id
+    co2_device = MagicMock()
+    co2_device.id = co2_id
+    mock_coordinator._get_device = MagicMock(
+        side_effect=lambda bid: {rem_id: rem_device, co2_id: co2_device}.get(bid)
+    )
+
+    class MockHvacVentilator:
+        pass
+
+    class MockHvacRemoteBase:
+        pass
+
+    mock_fan_device.__class__ = MockHvacVentilator  # type: ignore[assignment]
+    rem_device.__class__ = MockHvacRemoteBase  # type: ignore[assignment]
+    co2_device.__class__ = MockHvacRemoteBase  # type: ignore[assignment]
+
+    with (
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacVentilator",
+            MockHvacVentilator,
+        ),
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacRemoteBase",
+            MockHvacRemoteBase,
+        ),
+    ):
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
+
+    # Both devices should be bound as REM type
+    assert mock_fan_device.add_bound_device.call_count == 2
+    mock_fan_device.add_bound_device.assert_any_call(rem_id, DevType.REM)
+    mock_fan_device.add_bound_device.assert_any_call(co2_id, DevType.REM)
+    assert mock_coordinator.fan_handler._fan_bound_to_remote[rem_id] == FAN_ID
+    assert mock_coordinator.fan_handler._fan_bound_to_remote[co2_id] == FAN_ID
+
+
+async def test_setup_fan_bound_single_str_normalized_to_list(
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
+) -> None:
+    """Test that a single _bound string is normalized to a list internally."""
+    bound_id = "32:111111"
+
+    mock_coordinator.options[SZ_KNOWN_LIST] = {FAN_ID: {SZ_BOUND_TO: bound_id}}
+
+    bound_device = MagicMock()
+    bound_device.id = bound_id
+    mock_coordinator._get_device = MagicMock(return_value=bound_device)
+
+    class MockHvacVentilator:
+        pass
+
+    class MockHvacRemoteBase:
+        pass
+
+    mock_fan_device.__class__ = MockHvacVentilator  # type: ignore[assignment]
+    bound_device.__class__ = MockHvacRemoteBase  # type: ignore[assignment]
+
+    with (
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacVentilator",
+            MockHvacVentilator,
+        ),
+        patch(
+            "custom_components.ramses_cc.fan_handler.HvacRemoteBase",
+            MockHvacRemoteBase,
+        ),
+    ):
+        await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan_device)
+
+    # Single string should still work (normalized to list internally)
+    mock_fan_device.add_bound_device.assert_called_once_with(bound_id, DevType.REM)
+    assert mock_coordinator.fan_handler._fan_bound_to_remote[bound_id] == FAN_ID

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -79,6 +79,9 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     coordinator.async_set_fan_param = AsyncMock()
     coordinator.get_all_fan_params = MagicMock()
 
+    # Phase 3a: async schema command writes
+    coordinator._async_update_schema_commands = AsyncMock()
+
     # Proactive: Mock service_handler just in case logic traverses it
     coordinator.service_handler = MagicMock()
 

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import EntityPlatform
 
@@ -882,4 +882,304 @@ async def test_remote_send_command_no_client(
         patch("custom_components.ramses_cc.remote.Command"),
         pytest.raises(HomeAssistantError, match="client is not initialized"),
     ):
+        await remote_entity.async_send_command("boost")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: learn_command / add_command / delete_command write to schema
+# ---------------------------------------------------------------------------
+
+
+async def test_add_command_writes_to_schema(
+    remote_entity: RamsesRemote, mock_coordinator: MagicMock
+) -> None:
+    """add_command calls _async_update_schema_commands with updated commands."""
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).reset_mock()
+
+    with patch("custom_components.ramses_cc.remote.Command"):
+        await remote_entity.async_add_command("my_boost", VALID_PKT)
+
+    # Verify _commands was updated
+    assert remote_entity._commands["my_boost"] == VALID_PKT
+    # Verify schema write was called with device ID + full commands dict
+    cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).assert_awaited_once()
+    call_args = cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).call_args
+    assert call_args[0][0] == REMOTE_ID  # device_id
+    assert call_args[0][1] == remote_entity._commands  # full commands dict
+
+
+async def test_add_command_overwrite_writes_to_schema(
+    remote_entity: RamsesRemote, mock_coordinator: MagicMock
+) -> None:
+    """Overwriting an existing command via add_command writes updated dict to schema."""
+    remote_entity._commands = {"boost": VALID_PKT}
+
+    # Reset mock to clear any setup calls
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).reset_mock()
+
+    with patch("custom_components.ramses_cc.remote.Command"):
+        await remote_entity.async_add_command(
+            "boost",
+            "RQ --- 30:123456 18:111111 --:------ 22F1 003 000031",
+        )
+
+    # Verify the command was overwritten
+    assert "000031" in remote_entity._commands["boost"]
+    # add_command calls delete first (if exists), then add — so 2 calls
+    assert (
+        cast(MagicMock, mock_coordinator._async_update_schema_commands).await_count == 2
+    )
+    # Last call should have the updated commands
+    last_call = cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).call_args
+    assert last_call[0][1] == remote_entity._commands
+
+
+async def test_delete_command_writes_to_schema(
+    remote_entity: RamsesRemote, mock_coordinator: MagicMock
+) -> None:
+    """delete_command calls _async_update_schema_commands with remaining commands."""
+    remote_entity._commands = {"boost": VALID_PKT, "speed_1": VALID_PKT}
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).reset_mock()
+
+    await remote_entity.async_delete_command(["boost"])
+
+    # Verify the command was removed from _commands
+    assert "boost" not in remote_entity._commands
+    assert "speed_1" in remote_entity._commands
+    # Verify schema write was called with the remaining commands
+    cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).assert_awaited_once()
+    call_args = cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).call_args
+    assert call_args[0][0] == REMOTE_ID
+    assert call_args[0][1] == remote_entity._commands
+
+
+async def test_delete_command_empty_dict_writes_to_schema(
+    remote_entity: RamsesRemote, mock_coordinator: MagicMock
+) -> None:
+    """Deleting the last command writes empty dict to schema (removes _commands)."""
+    remote_entity._commands = {"boost": VALID_PKT}
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).reset_mock()
+
+    await remote_entity.async_delete_command(["boost"])
+
+    assert remote_entity._commands == {}
+    # _async_update_schema_commands should be called with empty dict
+    # (coordinator deletes _commands key when dict is empty)
+    cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).assert_awaited_once()
+    assert (
+        cast(MagicMock, mock_coordinator._async_update_schema_commands).call_args[0][1]
+        == {}
+    )
+
+
+async def test_learn_command_callback_writes_to_schema(
+    remote_entity: RamsesRemote,
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+    mock_remote_device: MagicMock,
+) -> None:
+    """learn_command's _async_on_change callback writes learned packet to schema.
+
+    Tests the callback directly rather than the full async flow (which is
+    hard to test in isolation due to asyncio.Event + state tracking).
+    """
+    remote_entity.hass = hass
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).reset_mock()
+
+    # Build the callback by starting learn_command and capturing it
+    learning_session = asyncio.Event()
+
+    # Replicate the _async_on_change callback logic from async_learn_command
+    @callback
+    async def _async_on_change(event: Any) -> None:
+        codes = ("22F1", "22F3", "22F7")
+        new_state: State = event.data["new_state"]
+        new_data = new_state.attributes["extra_data"]
+        if new_data["src"] == remote_entity._device.id and new_data["code"] in codes:
+            remote_entity._commands["learned_cmd"] = new_data["packet"]
+            learning_session.set()
+            await remote_entity.coordinator._async_update_schema_commands(
+                remote_entity._device.id, remote_entity._commands
+            )
+
+    # Simulate a matching event
+    mock_event = MagicMock()
+    mock_event.data = {
+        "new_state": State(
+            "event.ramses_cc_learn_event",
+            "test",
+            {
+                "extra_data": {
+                    "src": REMOTE_ID,
+                    "code": "22F1",
+                    "packet": "learned_pkt_789",
+                }
+            },
+        )
+    }
+
+    await _async_on_change(mock_event)
+
+    # Verify command was captured
+    assert remote_entity._commands.get("learned_cmd") == "learned_pkt_789"
+    # Verify schema write was called
+    cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).assert_awaited_once()
+    call_args = cast(
+        MagicMock, mock_coordinator._async_update_schema_commands
+    ).call_args
+    assert call_args[0][0] == REMOTE_ID
+    assert call_args[0][1]["learned_cmd"] == "learned_pkt_789"
+
+
+async def test_learn_command_callback_ignores_wrong_src(
+    remote_entity: RamsesRemote,
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """learn_command callback does not write to schema when src doesn't match."""
+    remote_entity.hass = hass
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).reset_mock()
+
+    learning_session = asyncio.Event()
+
+    @callback
+    async def _async_on_change(event: Any) -> None:
+        codes = ("22F1", "22F3", "22F7")
+        new_state: State = event.data["new_state"]
+        new_data = new_state.attributes["extra_data"]
+        if new_data["src"] == remote_entity._device.id and new_data["code"] in codes:
+            remote_entity._commands["bad_cmd"] = new_data["packet"]
+            learning_session.set()
+            await remote_entity.coordinator._async_update_schema_commands(
+                remote_entity._device.id, remote_entity._commands
+            )
+
+    # Simulate an event from a DIFFERENT device
+    mock_event = MagicMock()
+    mock_event.data = {
+        "new_state": State(
+            "event.ramses_cc_learn_event",
+            "test",
+            {
+                "extra_data": {
+                    "src": "99:999999",
+                    "code": "22F1",
+                    "packet": "wrong_pkt",
+                }
+            },
+        )
+    }
+
+    await _async_on_change(mock_event)
+
+    # Verify command was NOT captured
+    assert "bad_cmd" not in remote_entity._commands
+    assert not learning_session.is_set()
+    # Verify schema write was NOT called
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).assert_not_awaited()
+
+
+async def test_learn_command_callback_ignores_wrong_code(
+    remote_entity: RamsesRemote,
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """learn_command callback ignores packets with unsupported codes."""
+    remote_entity.hass = hass
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).reset_mock()
+
+    learning_session = asyncio.Event()
+
+    @callback
+    async def _async_on_change(event: Any) -> None:
+        codes = ("22F1", "22F3", "22F7")
+        new_state: State = event.data["new_state"]
+        new_data = new_state.attributes["extra_data"]
+        if new_data["src"] == remote_entity._device.id and new_data["code"] in codes:
+            remote_entity._commands["bad_cmd"] = new_data["packet"]
+            learning_session.set()
+            await remote_entity.coordinator._async_update_schema_commands(
+                remote_entity._device.id, remote_entity._commands
+            )
+
+    # Simulate an event with a non-matching code (e.g. 10E0)
+    mock_event = MagicMock()
+    mock_event.data = {
+        "new_state": State(
+            "event.ramses_cc_learn_event",
+            "test",
+            {
+                "extra_data": {
+                    "src": REMOTE_ID,
+                    "code": "10E0",
+                    "packet": "wrong_code_pkt",
+                }
+            },
+        )
+    }
+
+    await _async_on_change(mock_event)
+
+    # Verify command was NOT captured
+    assert "bad_cmd" not in remote_entity._commands
+    assert not learning_session.is_set()
+    cast(MagicMock, mock_coordinator._async_update_schema_commands).assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: send_command with custom command
+# ---------------------------------------------------------------------------
+
+
+async def test_send_command_sends_custom_command_packet(
+    remote_entity: RamsesRemote, mock_coordinator: MagicMock
+) -> None:
+    """send_command sends the packet stored in _commands for the named command."""
+    custom_pkt = "RQ --- 30:123456 18:111111 --:------ 22F1 003 000030"
+    remote_entity._commands = {"my_custom": custom_pkt}
+
+    with patch("custom_components.ramses_cc.remote.Command", side_effect=lambda x: x):
+        await remote_entity.async_send_command("my_custom")
+
+    mock_coordinator.client.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_coordinator.client.async_send_cmd.call_args[0][0]
+    assert sent_cmd == custom_pkt
+    # Verify QoS parameters
+    kwargs = mock_coordinator.client.async_send_cmd.call_args[1]
+    assert kwargs["priority"] == Priority.HIGH
+
+
+async def test_send_command_unknown_raises_error(
+    remote_entity: RamsesRemote,
+) -> None:
+    """send_command raises HomeAssistantError for unknown command."""
+    remote_entity._commands = {"boost": VALID_PKT}
+
+    with pytest.raises(HomeAssistantError, match="is not known"):
+        await remote_entity.async_send_command("nonexistent")
+
+
+async def test_send_command_not_faked_raises_error(
+    remote_entity: RamsesRemote,
+    mock_remote_device: MagicMock,
+) -> None:
+    """send_command raises HomeAssistantError when device is not faked."""
+    remote_entity._commands = {"boost": VALID_PKT}
+    mock_remote_device.is_faked = False
+
+    with pytest.raises(HomeAssistantError, match="is not configured for faking"):
         await remote_entity.async_send_command("boost")

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -679,6 +679,30 @@ def test_extra_state_attributes(remote_entity: RamsesRemote) -> None:
     assert attrs["commands"] == {"cmd1": "pkt1", "cmd2": "pkt2"}
 
 
+def test_extra_state_attributes_bound_to_fan(remote_entity: RamsesRemote) -> None:
+    """Test that bound_to_fan attribute is exposed when REM is bound to a FAN."""
+    attrs = remote_entity.extra_state_attributes
+    # mock_coordinator sets _fan_bound_to_remote = {REMOTE_ID: "18:654321"}
+    assert "bound_to_fan" in attrs
+    assert attrs["bound_to_fan"] == "18:654321"
+
+
+def test_extra_state_attributes_no_bound_to_fan(
+    mock_coordinator: MagicMock,
+    mock_remote_device: MagicMock,
+) -> None:
+    """Test that bound_to_fan is absent when REM is not bound to any FAN."""
+    # Remove the binding for this REM
+    mock_coordinator.fan_handler._fan_bound_to_remote = {}
+    entity = RamsesRemote(
+        mock_coordinator,
+        mock_remote_device,
+        RamsesRemoteEntityDescription(key="remote"),
+    )
+    attrs = entity.extra_state_attributes
+    assert "bound_to_fan" not in attrs
+
+
 async def test_learn_command_overwrite(
     remote_entity: RamsesRemote, hass: HomeAssistant
 ) -> None:

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -35,7 +35,7 @@ from custom_components.ramses_cc.helpers import (
     ramses_device_id_to_ha_device_id,
 )
 from custom_components.ramses_cc.services import RamsesServiceHandler
-from ramses_rf.devices import Device, HvacVentilator
+from ramses_rf.devices import Device, HvacRemoteBase, HvacVentilator
 from ramses_rf.exceptions import BindingFlowFailed
 from ramses_rf.schemas import (
     SZ_ACTUATORS,
@@ -56,6 +56,7 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.systems import System, Zone
 from ramses_rf.topology import Child
+from ramses_tx.const import DevType
 from ramses_tx.exceptions import (
     PacketAddrSetInvalid,
     ProtocolSendFailed,
@@ -1224,7 +1225,59 @@ async def test_fan_bound_device_bad_config(
 
     with caplog.at_level(logging.WARNING):
         await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan)
-        assert "invalid bound device id type" in caplog.text
+        assert "invalid bound type" in caplog.text
+
+
+async def test_fan_bound_device_list(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _setup_fan_bound_devices with list bound_to (multi-REM binding)."""
+    mock_fan = MagicMock(spec=HvacVentilator)
+    mock_fan.id = "30:111111"
+    mock_fan.type = "FAN"
+
+    # Setup known_list with a list of bound REMs
+    mock_coordinator.options[SZ_KNOWN_LIST] = {
+        "30:111111": {SZ_BOUND_TO: ["32:153001", "32:153002"]}
+    }
+
+    # Mock _get_device to return mock REM devices (HvacRemoteBase)
+    mock_rem1 = MagicMock(spec=HvacRemoteBase)
+    mock_rem2 = MagicMock(spec=HvacRemoteBase)
+    mock_coordinator._get_device = MagicMock(
+        side_effect=lambda dev_id: {"32:153001": mock_rem1, "32:153002": mock_rem2}.get(
+            dev_id
+        )
+    )
+
+    await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan)
+
+    # Both REMs should be bound
+    mock_fan.add_bound_device.assert_any_call("32:153001", DevType.REM)
+    mock_fan.add_bound_device.assert_any_call("32:153002", DevType.REM)
+    assert mock_fan.add_bound_device.call_count == 2
+    # Both should be in the _fan_bound_to_remote dict
+    assert mock_coordinator.fan_handler._fan_bound_to_remote["32:153001"] == "30:111111"
+    assert mock_coordinator.fan_handler._fan_bound_to_remote["32:153002"] == "30:111111"
+
+
+async def test_fan_bound_device_single_string_still_works(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _setup_fan_bound_devices with single string bound_to (backward compat)."""
+    mock_fan = MagicMock(spec=HvacVentilator)
+    mock_fan.id = "30:111111"
+    mock_fan.type = "FAN"
+
+    mock_coordinator.options[SZ_KNOWN_LIST] = {"30:111111": {SZ_BOUND_TO: "32:153001"}}
+
+    mock_rem = MagicMock(spec=HvacRemoteBase)
+    mock_coordinator._get_device = MagicMock(return_value=mock_rem)
+
+    await mock_coordinator.fan_handler.setup_fan_bound_devices(mock_fan)
+
+    mock_fan.add_bound_device.assert_called_once_with("32:153001", DevType.REM)
+    assert mock_coordinator.fan_handler._fan_bound_to_remote["32:153001"] == "30:111111"
 
 
 async def test_bind_device_generic_exception(

--- a/tests/tests_new/test_store.py
+++ b/tests/tests_new/test_store.py
@@ -18,6 +18,7 @@ from custom_components.ramses_cc.const import (
     SZ_PACKETS,
     SZ_REMOTES,
     SZ_SCHEMA,
+    SZ_TR_COMMANDS,
 )
 from custom_components.ramses_cc.coordinator import RamsesCoordinator
 from custom_components.ramses_cc.discovery import SZ_DISCOVERY
@@ -44,40 +45,74 @@ async def test_store_uses_ramses_cc_store_subclass(hass: HomeAssistant) -> None:
     assert isinstance(store._store, RamsesCcStore)
 
 
-async def test_store_migration_noop_identity(hass: HomeAssistant) -> None:
-    """Test that the no-op migration (v1 → v1) returns data unchanged.
-
-    Phase 2.5 registers the migration hook as an identity migration so the
-    scaffolding is in place for future version bumps (v1 → v2, etc.).
-    """
+async def test_store_migration_v1_to_v2_moves_commands(hass: HomeAssistant) -> None:
+    """Test that v1 → v2 migration moves remotes to schema _commands."""
     store = RamsesStore(hass)
     assert isinstance(store._store, RamsesCcStore)
 
-    # Simulate a v1 data payload (the real .storage format)
     v1_data: dict[str, Any] = {
-        SZ_CLIENT_STATE: {SZ_SCHEMA: {"01:123456": {}}, SZ_PACKETS: {}},
+        SZ_CLIENT_STATE: {
+            SZ_SCHEMA: {"01:123456": {"_alias": "Test"}},
+            SZ_PACKETS: {},
+        },
         SZ_REMOTES: {
             "32:153001": {
                 "turn_on": "I --- 32:153001 18:006402 --:------ 22F1 003 000030"
-            }
+            },
+            "32:153002": {"speed_1": "I --- 22F1 003 000031"},
         },
     }
 
-    # The migrate func should return the data unchanged (identity)
     result = await store._store._async_migrate_func(1, 1, v1_data)
-    assert result is v1_data
+    schema = result[SZ_CLIENT_STATE][SZ_SCHEMA]
+
+    # Commands moved to schema _commands
+    assert schema["32:153001"][SZ_TR_COMMANDS] == {
+        "turn_on": "I --- 32:153001 18:006402 --:------ 22F1 003 000030"
+    }
+    assert schema["32:153002"][SZ_TR_COMMANDS] == {"speed_1": "I --- 22F1 003 000031"}
+
+    # Existing _alias preserved
+    assert schema["01:123456"]["_alias"] == "Test"
+
+    # remotes kept as cache
+    assert SZ_REMOTES in result
+    assert "32:153001" in result[SZ_REMOTES]
+
+
+async def test_store_migration_v2_unchanged(hass: HomeAssistant) -> None:
+    """Test that v2 data is not migrated (already current)."""
+    store = RamsesStore(hass)
+    v2_data: dict[str, Any] = {
+        SZ_CLIENT_STATE: {
+            SZ_SCHEMA: {"32:153001": {SZ_TR_COMMANDS: {"turn_on": "I --- 22F1"}}},
+            SZ_PACKETS: {},
+        },
+        SZ_REMOTES: {"32:153001": {"turn_on": "I --- 22F1"}},
+    }
+    result = await store._store._async_migrate_func(2, 1, v2_data)
+    # v2 data should be unchanged (no migration needed)
+    assert result is v2_data
 
 
 async def test_store_migration_future_version_unchanged(hass: HomeAssistant) -> None:
-    """Test that the no-op migration also returns data unchanged for any version.
-
-    Currently the migration is identity for all versions — future branches
-    will be added in Phase 3a (v1 → v2) and Phase 4 (v2 → v3).
-    """
+    """Test that future version data is returned unchanged."""
     store = RamsesStore(hass)
     data: dict[str, Any] = {"some_key": "some_value"}
     result = await store._store._async_migrate_func(99, 1, data)
     assert result is data
+
+
+async def test_store_migration_v1_empty_remotes(hass: HomeAssistant) -> None:
+    """Test v1 → v2 migration with no remotes (no-op)."""
+    store = RamsesStore(hass)
+    v1_data: dict[str, Any] = {
+        SZ_CLIENT_STATE: {SZ_SCHEMA: {"01:123456": {}}, SZ_PACKETS: {}},
+        SZ_REMOTES: {},
+    }
+    result = await store._store._async_migrate_func(1, 1, v1_data)
+    # No remotes to migrate — schema unchanged
+    assert result[SZ_CLIENT_STATE][SZ_SCHEMA] == {"01:123456": {}}
 
 
 async def test_store_async_load(hass: HomeAssistant) -> None:

--- a/tests/tests_new/test_store.py
+++ b/tests/tests_new/test_store.py
@@ -45,8 +45,17 @@ async def test_store_uses_ramses_cc_store_subclass(hass: HomeAssistant) -> None:
     assert isinstance(store._store, RamsesCcStore)
 
 
-async def test_store_migration_v1_to_v2_moves_commands(hass: HomeAssistant) -> None:
-    """Test that v1 → v2 migration moves remotes to schema _commands."""
+async def test_store_migration_is_noop_identity(hass: HomeAssistant) -> None:
+    """Test that the migration func is a no-op identity (STORAGE_VERSION stays at 1).
+
+    The Phase 3a command migration (remotes → schema _commands) is handled
+    at runtime by the coordinator's ``_sync_remotes_to_schema``, not by a
+    storage version bump.  Bumping the version would break the downgrade
+    path: HA's Store raises ``UnsupportedStorageVersionError`` when the
+    stored version exceeds ``max_readable_version`` (which defaults to the
+    code's ``version``).  Since 0.58.0/0.58.1 have ``STORAGE_VERSION = 1``
+    and don't set ``max_readable_version``, they cannot read v2 data.
+    """
     store = RamsesStore(hass)
     assert isinstance(store._store, RamsesCcStore)
 
@@ -59,40 +68,13 @@ async def test_store_migration_v1_to_v2_moves_commands(hass: HomeAssistant) -> N
             "32:153001": {
                 "turn_on": "I --- 32:153001 18:006402 --:------ 22F1 003 000030"
             },
-            "32:153002": {"speed_1": "I --- 22F1 003 000031"},
         },
     }
 
     result = await store._store._async_migrate_func(1, 1, v1_data)
-    schema = result[SZ_CLIENT_STATE][SZ_SCHEMA]
-
-    # Commands moved to schema _commands
-    assert schema["32:153001"][SZ_TR_COMMANDS] == {
-        "turn_on": "I --- 32:153001 18:006402 --:------ 22F1 003 000030"
-    }
-    assert schema["32:153002"][SZ_TR_COMMANDS] == {"speed_1": "I --- 22F1 003 000031"}
-
-    # Existing _alias preserved
-    assert schema["01:123456"]["_alias"] == "Test"
-
-    # remotes kept as cache
-    assert SZ_REMOTES in result
-    assert "32:153001" in result[SZ_REMOTES]
-
-
-async def test_store_migration_v2_unchanged(hass: HomeAssistant) -> None:
-    """Test that v2 data is not migrated (already current)."""
-    store = RamsesStore(hass)
-    v2_data: dict[str, Any] = {
-        SZ_CLIENT_STATE: {
-            SZ_SCHEMA: {"32:153001": {SZ_TR_COMMANDS: {"turn_on": "I --- 22F1"}}},
-            SZ_PACKETS: {},
-        },
-        SZ_REMOTES: {"32:153001": {"turn_on": "I --- 22F1"}},
-    }
-    result = await store._store._async_migrate_func(2, 1, v2_data)
-    # v2 data should be unchanged (no migration needed)
-    assert result is v2_data
+    # No-op: data returned as-is, no _commands injected
+    assert result is v1_data
+    assert SZ_TR_COMMANDS not in result[SZ_CLIENT_STATE][SZ_SCHEMA].get("32:153001", {})
 
 
 async def test_store_migration_future_version_unchanged(hass: HomeAssistant) -> None:
@@ -104,14 +86,15 @@ async def test_store_migration_future_version_unchanged(hass: HomeAssistant) -> 
 
 
 async def test_store_migration_v1_empty_remotes(hass: HomeAssistant) -> None:
-    """Test v1 → v2 migration with no remotes (no-op)."""
+    """Test v1 migration with no remotes (no-op identity)."""
     store = RamsesStore(hass)
     v1_data: dict[str, Any] = {
         SZ_CLIENT_STATE: {SZ_SCHEMA: {"01:123456": {}}, SZ_PACKETS: {}},
         SZ_REMOTES: {},
     }
     result = await store._store._async_migrate_func(1, 1, v1_data)
-    # No remotes to migrate — schema unchanged
+    # No-op: schema unchanged
+    assert result is v1_data
     assert result[SZ_CLIENT_STATE][SZ_SCHEMA] == {"01:123456": {}}
 
 

--- a/tests/tests_new/test_store.py
+++ b/tests/tests_new/test_store.py
@@ -98,6 +98,39 @@ async def test_store_migration_v1_empty_remotes(hass: HomeAssistant) -> None:
     assert result[SZ_CLIENT_STATE][SZ_SCHEMA] == {"01:123456": {}}
 
 
+async def test_store_migration_v2_to_v1_identity(hass: HomeAssistant) -> None:
+    """Test v2 → v1 migration (no-op identity for briefly-released v2).
+
+    The v2 code was briefly released, so some users have .storage files
+    with version: 2. The current code (v1, max_readable_version=2) can
+    read them — the migrate function is a no-op identity since the v2
+    data format is identical to v1.
+    """
+    store = RamsesStore(hass)
+    v2_data: dict[str, Any] = {
+        SZ_CLIENT_STATE: {
+            SZ_SCHEMA: {"01:123456": {"_commands": {"boost": "packet"}}},
+            SZ_PACKETS: {},
+        },
+        SZ_REMOTES: {"32:153001": {"boost": "packet"}},
+    }
+    result = await store._store._async_migrate_func(2, 1, v2_data)
+    # No-op identity: data returned unchanged
+    assert result is v2_data
+    assert result[SZ_REMOTES] == {"32:153001": {"boost": "packet"}}
+
+
+async def test_store_max_readable_version_is_2(hass: HomeAssistant) -> None:
+    """Test that the store can read v2 files (max_readable_version=2).
+
+    This ensures users with v2 .storage files (from the briefly-released
+    v2 code) can upgrade to the current version without manual intervention.
+    """
+    store = RamsesStore(hass)
+    assert store._store._max_readable_version == 2
+    assert store._store.version == 1
+
+
 async def test_store_async_load(hass: HomeAssistant) -> None:
     """Test loading data from the store."""
     store = RamsesStore(hass)


### PR DESCRIPTION
Implements Phase 3a from issue https://github.com/ramses-rf/ramses_cc/issues/809
Depends on ramses_rf PR: strip_and_map_traits() + list bound in SCH_TRAITS_HVAC


## Summary

- Move learned RF commands from `.storage[remotes]` and `known_list[dev][commands]` into the schema as `_commands` per-device trait (SSOT)
- `.storage[remotes]` kept as cache/fallback, `known_list[dev][commands]` kept as legacy fallback
- **No storage version bump** — runtime migration via `_sync_remotes_to_schema` (bumping would break downgrade to 0.58.0/0.58.1: HA raises `UnsupportedStorageVersionError` when stored version > `max_readable_version`)
- `climate.set_fan_mode` reads custom commands from schema `_commands` (via `coordinator._remotes`) first, falls back to `known_list[commands]` (legacy)
- `fan_handler.setup_fan_bound_devices` accepts `str | list[str]` for `_bound` (multi-REM binding)
- `_derive_known_list_from_schema` uses ramses_rf's `strip_and_map_traits()` as base for trait extraction
- REM entity exposes `bound_to_fan` state attribute (derived from `fan_handler._fan_bound_to_remote`)

### ramses_rf dependency

This PR requires ramses_rf PR (feature/strip-and-map-pipeline) which adds:
- `strip_and_map_traits()` / `strip_and_map_schema()` — two-stage pipeline (strip `_` keys ramses_rf doesn't need, map `_bound`→`bound` etc.)
- `SCH_TRAITS_HVAC` `bound` accepts `str | list[str]` (multi-REM binding)

Both the HA integration (ramses_cc) and the CLI (ramses_cli) call the same ramses_rf function — no duplicate stripper. The CLI loads `config.json` directly into ramses_rf, so without this function `_`-prefixed keys like `_commands` would reject the entire schema (`PREVENT_EXTRA`).

### Changes

| File | What |
|------|------|
| const.py | `SZ_TR_COMMANDS = "_commands"` constant |
| coordinator.py | `_sync_remotes_to_schema`: copies remotes → schema `_commands` (after `sync_learned_topology`) |
| coordinator.py | `_async_update_schema_commands`: writes `_commands` to config entry (called by remote.py) |
| coordinator.py | Startup: merge schema `_commands` into `_remotes` (highest precedence) |
| coordinator.py | Backup before remotes migration (`reason="ssot_phase3a"`) |
| coordinator.py | `_derive_known_list_from_schema` uses ramses_rf's `strip_and_map_traits()` as base |
| remote.py | `learn_command`/`add_command`/`delete_command` now persist to schema |
| remote.py | `extra_state_attributes` exposes `bound_to_fan` (from `fan_handler._fan_bound_to_remote`) |
| climate.py | `async_set_fan_mode` reads from `coordinator._remotes` (schema `_commands`) first, falls back to `known_list[commands]` |
| fan_handler.py | `setup_fan_bound_devices` accepts `str | list[str]` for `_bound`, loops over bound REMs |
| store.py | `STORAGE_VERSION` stays at 1 (no bump), `_async_migrate_func` stays no-op identity — runtime migration via coordinator's `_sync_remotes_to_schema` |
| tests | tests: no-op identity migration, `_sync_remotes_to_schema`, strip `_commands`, `bound_to_fan` attr, `set_fan_mode` reads from `_remotes`, fan_handler list `_bound` |

### Precedence (highest wins)
1. Schema `_commands` (SSOT — user edits, `learn_command` writes here)
2. `.storage[remotes]` (cache — synced to schema on 5-min cycle)
3. `known_list[dev][commands]` (DEPRECATED legacy fallback)

### Config flow
`async_step_schema` already supports editing `_commands` — it strips `_` keys before validation, so no UI change needed.

#### Test plan
- [x] 956 tests pass (`pytest tests/tests_new/`)
- [x] mypy clean (19 source files, 0 errors)
- [x] ruff check + format pass
- [x] ramses_rf PR merged (strip_and_map_traits + list bound): https://github.com/ramses-rf/ramses_rf/pull/820
- [ ] Manual: learn a command, verify it appears in schema `_commands`
- [ ] Manual: reload, verify command persists from schema
- [ ] Manual: verify runtime migration copies remotes → schema _commands on upgrade
- [ ] Manual: verify `bound_to_fan` attribute on REM entity
- [ ] Manual: verify `set_fan_mode` intercepts custom command from schema
