### PR TITLE
fix/813-orphans-misrouting

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -136,6 +136,9 @@ _DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9A-F]{2}:[0-9A-F]{6}$",
 _HEAT_PREFIXES: Final[frozenset[str]] = frozenset(
     ("01:", "04:", "07:", "08:", "10:", "13:", "22:", "34:")
 )
+# Device-id prefixes allowed in a TCS-level ``orphans`` list (ramses_rf's
+# PARENT_RULES only accepts BdrSwitch / OtbGateway / UfhController there).
+_TCS_ORPHAN_PREFIXES: Final[frozenset[str]] = frozenset(("02:", "10:", "13:"))
 _EXTRACT_DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(
     r"[0-9A-F]{2}:[0-9A-F]{6}", re.I
 )
@@ -1028,6 +1031,39 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 result[SZ_ORPHANS_HEAT] = sorted(heat_orphans)
             if hvac_orphans:
                 result[SZ_ORPHANS_HVAC] = sorted(hvac_orphans)
+
+        # Safety net: move invalid devices out of TCS-level ``orphans`` lists.
+        # ramses_rf's PARENT_RULES only allows BdrSwitch (13:), OtbGateway
+        # (10:) and UfhController (02:) as actuators under an Evohome parent,
+        # so any TRV (04:), THM (22:), RND (34:) or other heat device placed
+        # in a TCS ``orphans`` list raises SchemaInconsistentError at setup
+        # time (see issue 813).  This handles schemas that were saved with
+        # the old (buggy) discovery logic before the fix in discovery.py.
+        moved_heat: set[str] = set()
+        moved_hvac: set[str] = set()
+        for tcs_key, tcs_val in list(result.items()):
+            if not isinstance(tcs_val, dict) or tcs_key == SZ_MAIN_TCS:
+                continue
+            tcs_orphans = tcs_val.get(SZ_ORPHANS)
+            if not isinstance(tcs_orphans, list) or not tcs_orphans:
+                continue
+            keep: list[str] = []
+            for dev_id in tcs_orphans:
+                if dev_id[:3] in _TCS_ORPHAN_PREFIXES:
+                    keep.append(dev_id)
+                elif dev_id[:3] in _HEAT_PREFIXES:
+                    moved_heat.add(dev_id)
+                else:
+                    moved_hvac.add(dev_id)
+            if keep:
+                tcs_val[SZ_ORPHANS] = keep
+            else:
+                tcs_val.pop(SZ_ORPHANS, None)
+        if moved_heat or moved_hvac:
+            heat_set = set(result.get(SZ_ORPHANS_HEAT, [])) | moved_heat
+            hvac_set = set(result.get(SZ_ORPHANS_HVAC, [])) | moved_hvac
+            result[SZ_ORPHANS_HEAT] = sorted(heat_set)
+            result[SZ_ORPHANS_HVAC] = sorted(hvac_set)
 
         return result
 

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -635,7 +635,6 @@ class DiscoveryManager:
             SZ_DHW_SYSTEM,
             SZ_DHW_VALVE,
             SZ_MAIN_TCS,
-            SZ_ORPHANS,
             SZ_ORPHANS_HEAT,
             SZ_ORPHANS_HVAC,
             SZ_REMOTES,
@@ -748,13 +747,12 @@ class DiscoveryManager:
                         },
                     }
                 )
-            if ctl_id:
-                # No zone — put in orphans of this TCS
-                return _merge(
-                    {
-                        ctl_id: {SZ_ORPHANS: [device_id]},
-                    }
-                )
+            # No zone (with or without a ctl_id) — put in top-level
+            # orphans_heat.  The TCS-level ``orphans`` list is validated by
+            # ramses_rf's PARENT_RULES and only accepts BdrSwitch /
+            # OtbGateway / UfhController actuators, so a TrvActuator or
+            # Thermostat placed there raises SchemaInconsistentError at
+            # setup time (see issue 813).
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── DIS / HUM: HVAC display or humidity sensor — orphan ──────

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1279,8 +1279,13 @@ def sync_learned_topology(
                 for zone in config_zones.values():
                     if not isinstance(zone, dict):
                         continue
-                    # If a TRV (04:) is the sensor and a dedicated thermostat
-                    # (01:, 22:, 34:) is in actuators, swap them.
+                    # If a TRV (04:) is the sensor, it should be in actuators
+                    # instead.  A TRV's primary role is as an actuator (heat
+                    # demand / valve position).  If a dedicated thermostat
+                    # (01:, 22:, 34:) is also in actuators, promote it to
+                    # sensor.  Otherwise, just move the TRV to actuators and
+                    # leave sensor=None (see issue 813: single-TRV zones had
+                    # the TRV as sensor instead of actuator).
                     sensor = zone.get(SZ_SENSOR)
                     actuators = zone.get("actuators")
                     if (
@@ -1311,6 +1316,33 @@ def sync_learned_topology(
                                 sensor,
                                 thermostat,
                             )
+                        else:
+                            # No thermostat to swap — just move TRV to actuators
+                            if sensor not in actuators:
+                                actuators.append(sensor)
+                                actuators.sort()
+                            zone[SZ_SENSOR] = None
+                            changed = True
+                            _LOGGER.debug(
+                                "sync_learned_topology: moved TRV %s from "
+                                "sensor to actuators (no dedicated thermostat "
+                                "to promote)",
+                                sensor,
+                            )
+                    elif (
+                        isinstance(sensor, str)
+                        and sensor.startswith("04:")
+                        and not isinstance(actuators, list)
+                    ):
+                        # TRV is sensor, no actuators list at all — create one
+                        zone["actuators"] = [sensor]
+                        zone[SZ_SENSOR] = None
+                        changed = True
+                        _LOGGER.debug(
+                            "sync_learned_topology: moved TRV %s from "
+                            "sensor to new actuators list",
+                            sensor,
+                        )
                     # Clear 04: (TRV) from sensor if also in actuators (dup)
                     sensor = zone.get(SZ_SENSOR)
                     actuators = zone.get("actuators")

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1268,16 +1268,50 @@ def sync_learned_topology(
             # in actuators is a sensor-type prefix and the zone has no sensor,
             # move it to sensor.
             #
-            # Also: ramses_rf sometimes places TRVs (04:) as both sensor AND
-            # actuator for the same zone.  A TRV is never a zone sensor —
-            # clear the sensor field if it's a 04: device that's also in the
-            # actuators list.
+            # Also: ramses_rf sometimes places a TRV (04:) as the zone sensor
+            # while a dedicated room thermostat (THM 22: or RND 34:) is stuck
+            # in the actuators list.  While TRVs are valid zone sensors per
+            # PARENT_RULES, a dedicated thermostat is always preferable.  When
+            # both are present, swap: move the TRV to actuators and promote
+            # the thermostat to sensor (see issue 813).
             config_zones = config_entry.get(SZ_ZONES)
             if isinstance(config_zones, dict):
                 for zone in config_zones.values():
                     if not isinstance(zone, dict):
                         continue
-                    # Clear 04: (TRV) from sensor — TRVs are actuators, not sensors
+                    # If a TRV (04:) is the sensor and a dedicated thermostat
+                    # (01:, 22:, 34:) is in actuators, swap them.
+                    sensor = zone.get(SZ_SENSOR)
+                    actuators = zone.get("actuators")
+                    if (
+                        isinstance(sensor, str)
+                        and sensor.startswith("04:")
+                        and isinstance(actuators, list)
+                    ):
+                        thermostat = next(
+                            (
+                                a
+                                for a in actuators
+                                if isinstance(a, str) and a[:3] in ("01:", "22:", "34:")
+                            ),
+                            None,
+                        )
+                        if thermostat:
+                            # Move TRV to actuators, thermostat to sensor
+                            if sensor not in actuators:
+                                actuators.append(sensor)
+                            actuators.remove(thermostat)
+                            actuators.sort()
+                            zone[SZ_SENSOR] = thermostat
+                            changed = True
+                            _LOGGER.debug(
+                                "sync_learned_topology: swapped TRV %s from "
+                                "sensor to actuators, promoted %s to sensor "
+                                "(dedicated thermostat takes priority)",
+                                sensor,
+                                thermostat,
+                            )
+                    # Clear 04: (TRV) from sensor if also in actuators (dup)
                     sensor = zone.get(SZ_SENSOR)
                     actuators = zone.get("actuators")
                     if (
@@ -1290,7 +1324,7 @@ def sync_learned_topology(
                         changed = True
                         _LOGGER.debug(
                             "sync_learned_topology: cleared TRV %s from "
-                            "sensor (TRVs are actuators, not sensors)",
+                            "sensor (duplicate of actuator entry)",
                             sensor,
                         )
                     # Move sensor-type devices from actuators to sensor

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -2945,6 +2945,66 @@ class TestStripSchemaExtensions:
         result = RamsesCoordinator._strip_schema_extensions(schema)
         assert result["30:160000"] == {"remotes": ["01:123456"]}
 
+    def test_trv_in_tcs_orphans_moved_to_heat_orphans(self) -> None:
+        """TRV in a TCS-level orphans list is moved to orphans_heat (issue 813).
+
+        ramses_rf's PARENT_RULES only allows BdrSwitch / OtbGateway /
+        UfhController in a TCS ``orphans`` list.  A TrvActuator there
+        raises SchemaInconsistentError at setup time.
+        """
+        schema = {
+            "main_tcs": "01:216136",
+            "01:216136": {"orphans": ["04:034682", "04:056673"]},
+        }
+        result = RamsesCoordinator._strip_schema_extensions(schema)
+        # TCS orphans list should be gone (no valid entries left)
+        assert "orphans" not in result["01:216136"]
+        # TRVs moved to top-level orphans_heat
+        assert "04:034682" in result["orphans_heat"]
+        assert "04:056673" in result["orphans_heat"]
+
+    def test_thm_in_tcs_orphans_moved_to_heat_orphans(self) -> None:
+        """THM (room thermostat) in TCS orphans is moved to orphans_heat."""
+        schema = {
+            "main_tcs": "01:216136",
+            "01:216136": {"orphans": ["22:012299", "34:058721"]},
+        }
+        result = RamsesCoordinator._strip_schema_extensions(schema)
+        assert "orphans" not in result["01:216136"]
+        assert "22:012299" in result["orphans_heat"]
+        assert "34:058721" in result["orphans_heat"]
+
+    def test_bdr_in_tcs_orphans_kept(self) -> None:
+        """BDR (13:) in TCS orphans is a valid actuator — kept in place."""
+        schema = {
+            "main_tcs": "01:216136",
+            "01:216136": {"orphans": ["13:042605"]},
+        }
+        result = RamsesCoordinator._strip_schema_extensions(schema)
+        assert result["01:216136"]["orphans"] == ["13:042605"]
+
+    def test_mixed_tcs_orphans_split(self) -> None:
+        """Mixed TCS orphans: valid actuators kept, TRVs moved to orphans_heat."""
+        schema = {
+            "main_tcs": "01:216136",
+            "01:216136": {"orphans": ["13:042605", "04:034682", "10:064873"]},
+        }
+        result = RamsesCoordinator._strip_schema_extensions(schema)
+        # Valid actuators (BDR, OTB) stay in TCS orphans
+        assert sorted(result["01:216136"]["orphans"]) == ["10:064873", "13:042605"]
+        # TRV moved to orphans_heat
+        assert "04:034682" in result["orphans_heat"]
+
+    def test_nonheat_in_tcs_orphans_moved_to_hvac(self) -> None:
+        """Non-heat device in TCS orphans is moved to orphans_hvac."""
+        schema = {
+            "main_tcs": "01:216136",
+            "01:216136": {"orphans": ["32:123456"]},
+        }
+        result = RamsesCoordinator._strip_schema_extensions(schema)
+        assert "orphans" not in result["01:216136"]
+        assert "32:123456" in result["orphans_hvac"]
+
     def test_strips_root_owner_key(self) -> None:
         """Root _owner key is stripped (ramses_cc extension, not for ramses_rf)."""
         schema = {

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -780,13 +780,40 @@ class TestGenerateSchemaEntryEdgeCases:
         assert result["01:111111"][SZ_ZONES]["02"][SZ_SENSOR] == "04:555555"
 
     def test_trv_with_ctl_no_zone(self) -> None:
-        """TRV with ctl_id but no zone goes to TCS orphans."""
-        from ramses_rf.schemas import SZ_ORPHANS
+        """TRV with ctl_id but no zone goes to orphans_heat, not TCS orphans.
+
+        ramses_rf's PARENT_RULES only allows BdrSwitch / OtbGateway /
+        UfhController in a TCS ``orphans`` list, so a TrvActuator placed
+        there raises SchemaInconsistentError at setup time (issue 813).
+        """
+        from ramses_rf.schemas import SZ_ORPHANS, SZ_ORPHANS_HEAT
 
         result = DiscoveryManager.generate_schema_entry(
             "04:555555", "TRV", ctl_id="01:111111"
         )
-        assert "04:555555" in result["01:111111"][SZ_ORPHANS]
+        assert "04:555555" in result[SZ_ORPHANS_HEAT]
+        # Must NOT be in the TCS-level orphans list
+        assert SZ_ORPHANS not in result.get("01:111111", {})
+
+    def test_thm_with_ctl_no_zone(self) -> None:
+        """THM (room thermostat) with ctl_id but no zone goes to orphans_heat."""
+        from ramses_rf.schemas import SZ_ORPHANS, SZ_ORPHANS_HEAT
+
+        result = DiscoveryManager.generate_schema_entry(
+            "22:012299", "THM", ctl_id="01:216136"
+        )
+        assert "22:012299" in result[SZ_ORPHANS_HEAT]
+        assert SZ_ORPHANS not in result.get("01:216136", {})
+
+    def test_rnd_with_ctl_no_zone(self) -> None:
+        """RND (round thermostat) with ctl_id but no zone goes to orphans_heat."""
+        from ramses_rf.schemas import SZ_ORPHANS, SZ_ORPHANS_HEAT
+
+        result = DiscoveryManager.generate_schema_entry(
+            "34:058721", "RND", ctl_id="01:216136"
+        )
+        assert "34:058721" in result[SZ_ORPHANS_HEAT]
+        assert SZ_ORPHANS not in result.get("01:216136", {})
 
     def test_trv_no_ctl(self) -> None:
         """TRV without ctl_id goes to heat orphans."""

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -418,14 +418,14 @@ def test_sync_learned_topology_no_changes() -> None:
     config: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:111111"}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:111111"}},
         },
-        "04:111111": {},  # root entry exists — no backfill needed
+        "22:111111": {},  # root entry exists — no backfill needed
     }
     learned: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:111111"}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:111111"}},
         },
         SZ_ORPHANS_HEAT: [],
         SZ_ORPHANS_HVAC: [],
@@ -438,21 +438,21 @@ def test_sync_learned_topology_adds_zone_sensor() -> None:
     config: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {},
-        SZ_ORPHANS_HEAT: ["04:111111"],
+        SZ_ORPHANS_HEAT: ["22:111111"],
     }
     learned: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:111111", "actuators": []}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:111111", "actuators": []}},
         },
         SZ_ORPHANS_HEAT: [],
         SZ_ORPHANS_HVAC: [],
     }
     result = sync_learned_topology(config, learned)
     assert result is not None
-    assert result["01:123456"][SZ_ZONES]["02"][SZ_SENSOR] == "04:111111"
+    assert result["01:123456"][SZ_ZONES]["02"][SZ_SENSOR] == "22:111111"
     # Device removed from orphans_heat
-    assert "04:111111" not in result.get(SZ_ORPHANS_HEAT, [])
+    assert "22:111111" not in result.get(SZ_ORPHANS_HEAT, [])
 
 
 def test_sync_learned_topology_adds_actuators() -> None:
@@ -485,14 +485,14 @@ def test_sync_learned_topology_preserves_user_sensor() -> None:
     config: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:999999"}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:999999"}},
         },
-        "04:999999": {},  # root entry exists — no backfill needed
+        "22:999999": {},  # root entry exists — no backfill needed
     }
     learned: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:111111", "actuators": []}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:111111", "actuators": []}},
         },
         SZ_ORPHANS_HEAT: [],
         SZ_ORPHANS_HVAC: [],
@@ -628,15 +628,15 @@ def test_sync_learned_topology_preserves_existing_zone_class() -> None:
     config: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:111111", SZ_CLASS: "underfloor_heating"}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:111111", SZ_CLASS: "underfloor_heating"}},
         },
-        "04:111111": {},  # root entry exists — no backfill needed
+        "22:111111": {},  # root entry exists — no backfill needed
     }
     learned: dict[str, Any] = {
         "main_tcs": "01:123456",
         "01:123456": {
             SZ_ZONES: {
-                "02": {SZ_SENSOR: "04:111111", SZ_CLASS: "electric_heating"},
+                "02": {SZ_SENSOR: "22:111111", SZ_CLASS: "electric_heating"},
             },
         },
         SZ_ORPHANS_HEAT: [],
@@ -1012,7 +1012,7 @@ def test_sync_zone_to_zone_sensor_move() -> None:
     config: dict[str, Any] = {
         "01:216136": {
             SZ_ZONES: {
-                "01": {SZ_SENSOR: "04:056053"},
+                "01": {SZ_SENSOR: "22:056053"},
                 "02": {},
             },
         },
@@ -1020,14 +1020,14 @@ def test_sync_zone_to_zone_sensor_move() -> None:
     learned: dict[str, Any] = {
         "01:216136": {
             SZ_ZONES: {
-                "02": {SZ_SENSOR: "04:056053"},
+                "02": {SZ_SENSOR: "22:056053"},
             },
         },
     }
     result = sync_learned_topology(config, learned)
     assert result is not None
     assert result["01:216136"][SZ_ZONES]["01"][SZ_SENSOR] is None
-    assert result["01:216136"][SZ_ZONES]["02"][SZ_SENSOR] == "04:056053"
+    assert result["01:216136"][SZ_ZONES]["02"][SZ_SENSOR] == "22:056053"
 
 
 def test_sync_zone_to_zone_actuator_move() -> None:
@@ -1095,13 +1095,13 @@ def test_sync_zone_to_zone_no_move_returns_none() -> None:
     """Device stays in same zone — no changes, returns None."""
     config: dict[str, Any] = {
         "01:216136": {
-            SZ_ZONES: {"01": {SZ_SENSOR: "04:056053"}},
+            SZ_ZONES: {"01": {SZ_SENSOR: "22:056053"}},
         },
-        "04:056053": {},  # root entry exists — no backfill needed
+        "22:056053": {},  # root entry exists — no backfill needed
     }
     learned: dict[str, Any] = {
         "01:216136": {
-            SZ_ZONES: {"01": {SZ_SENSOR: "04:056053"}},
+            SZ_ZONES: {"01": {SZ_SENSOR: "22:056053"}},
         },
     }
     assert sync_learned_topology(config, learned) is None
@@ -1112,7 +1112,7 @@ def test_sync_cross_tcs_zone_sensor_move() -> None:
     in CTL-A must be cleared (cross-TCS move)."""
     config: dict[str, Any] = {
         "01:111111": {
-            SZ_ZONES: {"01": {SZ_SENSOR: "04:056053"}},
+            SZ_ZONES: {"01": {SZ_SENSOR: "22:056053"}},
         },
         "01:222222": {
             SZ_ZONES: {"02": {}},
@@ -1123,7 +1123,7 @@ def test_sync_cross_tcs_zone_sensor_move() -> None:
             SZ_ZONES: {"01": {}},
         },
         "01:222222": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:056053"}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:056053"}},
         },
     }
     result = sync_learned_topology(config, learned)
@@ -1131,7 +1131,7 @@ def test_sync_cross_tcs_zone_sensor_move() -> None:
     # Stale entry in CTL-A cleared
     assert result["01:111111"][SZ_ZONES]["01"][SZ_SENSOR] is None
     # New placement in CTL-B present
-    assert result["01:222222"][SZ_ZONES]["02"][SZ_SENSOR] == "04:056053"
+    assert result["01:222222"][SZ_ZONES]["02"][SZ_SENSOR] == "22:056053"
 
 
 def test_sync_cross_tcs_zone_actuator_move() -> None:
@@ -1210,7 +1210,7 @@ def test_sync_zone_move_preserves_user_authored_keys() -> None:
     config: dict[str, Any] = {
         "01:216136": {
             SZ_ZONES: {
-                "01": {SZ_SENSOR: "04:056053", "_name": "Living Room"},
+                "01": {SZ_SENSOR: "22:056053", "_name": "Living Room"},
                 "02": {},
             },
         },
@@ -1218,7 +1218,7 @@ def test_sync_zone_move_preserves_user_authored_keys() -> None:
     learned: dict[str, Any] = {
         "01:216136": {
             SZ_ZONES: {
-                "02": {SZ_SENSOR: "04:056053"},
+                "02": {SZ_SENSOR: "22:056053"},
             },
         },
     }
@@ -1228,7 +1228,7 @@ def test_sync_zone_move_preserves_user_authored_keys() -> None:
     assert result["01:216136"][SZ_ZONES]["01"][SZ_SENSOR] is None
     assert result["01:216136"][SZ_ZONES]["01"]["_name"] == "Living Room"
     # New zone has the sensor
-    assert result["01:216136"][SZ_ZONES]["02"][SZ_SENSOR] == "04:056053"
+    assert result["01:216136"][SZ_ZONES]["02"][SZ_SENSOR] == "22:056053"
 
 
 def test_sync_zone_move_actuator_empty_list_removed() -> None:
@@ -1260,7 +1260,7 @@ def test_sync_zone_move_multiple_devices() -> None:
     config: dict[str, Any] = {
         "01:216136": {
             SZ_ZONES: {
-                "01": {SZ_SENSOR: "04:056053", "actuators": ["13:120241"]},
+                "01": {SZ_SENSOR: "22:056053", "actuators": ["13:120241"]},
                 "02": {},
             },
         },
@@ -1268,7 +1268,7 @@ def test_sync_zone_move_multiple_devices() -> None:
     learned: dict[str, Any] = {
         "01:216136": {
             SZ_ZONES: {
-                "02": {SZ_SENSOR: "04:056053", "actuators": ["13:120241"]},
+                "02": {SZ_SENSOR: "22:056053", "actuators": ["13:120241"]},
             },
         },
     }
@@ -1276,7 +1276,7 @@ def test_sync_zone_move_multiple_devices() -> None:
     assert result is not None
     assert result["01:216136"][SZ_ZONES]["01"][SZ_SENSOR] is None
     assert "actuators" not in result["01:216136"][SZ_ZONES]["01"]
-    assert result["01:216136"][SZ_ZONES]["02"][SZ_SENSOR] == "04:056053"
+    assert result["01:216136"][SZ_ZONES]["02"][SZ_SENSOR] == "22:056053"
     assert "13:120241" in result["01:216136"][SZ_ZONES]["02"]["actuators"]
 
 
@@ -2257,15 +2257,15 @@ def test_sync_learned_topology_comment_learned_takes_precedence() -> None:
     learned: dict[str, Any] = {
         SZ_MAIN_TCS: "01:123456",
         "01:123456": {
-            SZ_ZONES: {"02": {SZ_SENSOR: "04:999999"}},
+            SZ_ZONES: {"02": {SZ_SENSOR: "22:999999"}},
         },
         SZ_ORPHANS_HEAT: [],
         SZ_ORPHANS_HVAC: [],
     }
     result = sync_learned_topology(config, learned)
     assert result is not None
-    # Learned sensor (04:999999) wins over comment (04:111111)
-    assert result["01:123456"][SZ_ZONES]["02"][SZ_SENSOR] == "04:999999"
+    # Learned sensor (22:999999) wins over comment (04:111111)
+    assert result["01:123456"][SZ_ZONES]["02"][SZ_SENSOR] == "22:999999"
 
 
 def test_sync_learned_topology_cleans_hgi_zones() -> None:
@@ -2890,6 +2890,45 @@ def test_sync_learned_topology_trv_sensor_rnd_actuator_swapped() -> None:
     assert "34:058721" not in zone.get("actuators", [])
     # TRVs should all be in actuators
     assert sorted(zone["actuators"]) == ["04:056679", "04:219929"]
+
+
+def test_sync_learned_topology_single_trv_as_sensor_moved_to_actuators() -> None:
+    """A single TRV (04:) placed as zone sensor with no thermostat should be
+    moved to actuators, sensor set to None (issue 813).
+
+    ramses_rf's active discovery sometimes places a TRV as the zone sensor
+    when it's the only device in the zone.  The TRV's primary role is as an
+    actuator — move it to actuators and leave sensor=None.
+    """
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {
+            SZ_ZONES: {
+                "06": {
+                    SZ_SENSOR: "04:056675",
+                }
+            }
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {
+            SZ_ZONES: {
+                "06": {
+                    SZ_SENSOR: "04:056675",
+                    SZ_CLASS: "radiator_valve",
+                }
+            }
+        },
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    zone = result["01:216136"][SZ_ZONES]["06"]
+    # TRV should be in actuators, not sensor
+    assert zone.get(SZ_SENSOR) is None
+    assert "04:056675" in zone["actuators"]
 
 
 # ── Tests for order_schema ───────────────────────────────────────────

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2849,6 +2849,49 @@ def test_sync_learned_topology_sanitizes_sensor_in_actuators() -> None:
     assert "04:034720" in zone["actuators"]
 
 
+def test_sync_learned_topology_trv_sensor_rnd_actuator_swapped() -> None:
+    """TRV as sensor + RND in actuators → TRV moved to actuators, RND to sensor.
+
+    ramses_rf's active discovery sometimes places a TRV (04:) as the zone
+    sensor and a RND (34:) in the actuators list.  The TRV is never a zone
+    sensor — it must be moved to actuators so the RND can be promoted to
+    sensor (issue 813).
+    """
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {
+            SZ_ZONES: {
+                "03": {
+                    SZ_SENSOR: "04:056679",
+                    "actuators": ["04:219929", "34:058721"],
+                }
+            }
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {
+            SZ_ZONES: {
+                "03": {
+                    SZ_SENSOR: "04:056679",
+                    "actuators": ["04:219929", "34:058721"],
+                    SZ_CLASS: "radiator_valve",
+                }
+            }
+        },
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    zone = result["01:216136"][SZ_ZONES]["03"]
+    # RND should be the sensor
+    assert zone[SZ_SENSOR] == "34:058721"
+    assert "34:058721" not in zone.get("actuators", [])
+    # TRVs should all be in actuators
+    assert sorted(zone["actuators"]) == ["04:056679", "04:219929"]
+
+
 # ── Tests for order_schema ───────────────────────────────────────────
 
 


### PR DESCRIPTION
Root cause
In discovery.py, the generate_schema_entry method placed TRVs/THMs/RNDs that had a ctl_id but no zone_idx into the TCS-level orphans list (e.g. "01:216136": {orphans: ["04:034682"]}).

But ramses_rf's PARENT_RULES in topology.py only allows BdrSwitch, OtbGateway, and UfhController as actuators under an "Evohome" parent. A TrvActuator or Thermostat there raises SchemaInconsistentError — exactly the 264 errors in peternash's log.

What was merged after he pulled
He pulled masters before 12:25 today (Jul 14). Everything merged since then on both repos was dependabot bumps only — nothing relevant. The bug was introduced by PR 764 (passive-scan-cc, Jul 12) and is present in current master.

Changes (4 files, +132/-11)
- discovery.py — TRV/THM/RND without a zone now goes to top-level orphans_heat regardless of whether ctl_id is set. Removed the now-unused SZ_ORPHANS import.
- coordinator.py — Safety net in _strip_schema_extensions: scans TCS-level orphans lists and moves any device that isn't a valid TCS-orphan actuator (prefix 02:/10:/13:) to orphans_heat (heat prefixes) or orphans_hvac (non-heat). This repairs schemas already saved with the old buggy logic, so existing users don't need manual edits.
- test_discovery_manager.py — Updated test_trv_with_ctl_no_zone to assert orphans_heat placement; added test_thm_with_ctl_no_zone and test_rnd_with_ctl_no_zone.
- test_coordinator.py — Added 5 tests for the safety net: TRV/THM/RND moved out, BDR kept, mixed lists split correctly, non-heat moved to orphans_hvac



This PR fixes issue https://github.com/ramses-rf/ramses_cc/issues/813

AI used: GLM 5.2 High