### PR TITLE
fix(813): remove devices from orphans_heat in same pass as zone placement

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1666,10 +1666,18 @@ def sync_learned_topology(
 
     # 2. Sync top-level orphans_heat — remove devices now in zones or DHW
     config_heat_orphans = set(new_schema.get(SZ_ORPHANS_HEAT, []))
-    learned_heat_orphans = set((learned_schema or {}).get(SZ_ORPHANS_HEAT, []))
-    if config_heat_orphans and config_heat_orphans != learned_heat_orphans:
-        # Find devices that are in config orphans but in a zone or DHW in learned
+    # Always run this step when there are config orphans, even if they match
+    # learned orphans.  Devices may have been placed in zones via device
+    # comments (comment_device_zones) even when ramses_rf's learned schema
+    # still has them in orphans_heat (e.g. THM/RND zone binding from 000A
+    # packets — see issue 813: thermostats appeared in both orphans_heat
+    # AND the correct zone until HA restart).
+    if config_heat_orphans:
+        # Find devices that are in config orphans but in a zone or DHW in
+        # learned schema, in new_schema (already updated by steps 1b/1c),
+        # or in device comments.
         all_learned_zone_devices: set[str] = set()
+        # Scan learned schema
         for learned_entry in (learned_schema or {}).values():
             if not isinstance(learned_entry, dict):
                 continue
@@ -1689,6 +1697,30 @@ def sync_learned_topology(
                     all_learned_zone_devices.add(dhw_sensor)
                 for valve_key in ("hotwater_valve", "heating_valve"):
                     valve = learned_dhw.get(valve_key)
+                    if isinstance(valve, str):
+                        all_learned_zone_devices.add(valve)
+
+        # Scan new_schema (already updated by steps 1b/1c) — this catches
+        # devices placed in zones by comment-based sync even when the
+        # learned schema still has them in orphans_heat.
+        for ns_entry in new_schema.values():
+            if not isinstance(ns_entry, dict):
+                continue
+            for zone in ns_entry.get(SZ_ZONES, {}).values():
+                if isinstance(zone, dict):
+                    sensor = zone.get(SZ_SENSOR)
+                    if isinstance(sensor, str):
+                        all_learned_zone_devices.add(sensor)
+                    for a in zone.get("actuators", []):
+                        if isinstance(a, str):
+                            all_learned_zone_devices.add(a)
+            ns_dhw = ns_entry.get(SZ_DHW_SYSTEM, {})
+            if isinstance(ns_dhw, dict):
+                dhw_sensor = ns_dhw.get(SZ_SENSOR)
+                if isinstance(dhw_sensor, str):
+                    all_learned_zone_devices.add(dhw_sensor)
+                for valve_key in ("hotwater_valve", "heating_valve"):
+                    valve = ns_dhw.get(valve_key)
                     if isinstance(valve, str):
                         all_learned_zone_devices.add(valve)
 

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -871,6 +871,42 @@ def test_sync_learned_topology_heat_orphans_partial() -> None:
     assert result[SZ_ORPHANS_HEAT] == ["04:222222"]
 
 
+def test_sync_learned_topology_orphan_and_zone_same_pass() -> None:
+    """Device in both orphans_heat and a zone must be removed from orphans.
+
+    When a THM/RND is placed in a zone via device comments (000A zone
+    binding) but ramses_rf's learned schema still has it in orphans_heat,
+    the device appears in both places.  sync_learned_topology must remove
+    it from orphans_heat in the same pass (issue 813: thermostats showed
+    in both orphans_heat AND the correct zone until HA restart).
+    """
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {},
+        SZ_ORPHANS_HEAT: ["22:012299", "34:058721"],
+        SZ_DEVICE_COMMENTS: {
+            "22:012299": "Likely THM. bound to 01:216136. zone 01. codes: 000A, 30C9.",
+            "34:058721": "Likely RND. bound to 01:216136. zone 03. codes: 000A, 30C9.",
+        },
+    }
+    # Learned schema STILL has both in orphans_heat (ramses_rf hasn't
+    # placed them in zones yet — the 000C RP hasn't arrived)
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {SZ_ZONES: {}},
+        SZ_ORPHANS_HEAT: ["22:012299", "34:058721"],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    # Both should be in zones (from comments), NOT in orphans_heat
+    zones = result["01:216136"][SZ_ZONES]
+    assert zones["01"][SZ_SENSOR] == "22:012299"
+    assert zones["03"][SZ_SENSOR] == "34:058721"
+    # orphans_heat should be gone (both devices now in zones)
+    assert SZ_ORPHANS_HEAT not in result or result[SZ_ORPHANS_HEAT] == []
+
+
 def test_sync_learned_topology_hvac_non_dict_entry() -> None:
     """Non-dict HVAC entry in learned is skipped gracefully."""
     config: dict[str, Any] = {


### PR DESCRIPTION
When a device was placed in a zone via device comments (000A zone binding) but ramses_rf's learned schema still had it in orphans_heat, the device appeared in both places until HA restart.  Root cause: the orphan removal step was skipped when config orphans matched learned orphans, even though comment_device_zones had zone info.

Fix: always run the orphan removal step when there are config orphans. Also scan new_schema's own zones (updated by earlier steps) in addition to learned_schema and comment_device_zones.

see https://github.com/ramses-rf/ramses_cc/issues/813

AI used: GLM 5.2 high