### PR TITLE
fix(802): cancel _pending_timer tasks on HA stop event

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Final, TypeVar, cast
 import serial  # type: ignore[import-untyped]
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -556,6 +556,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         await self.client.start(**start_kwargs)
         self.entry.async_on_unload(self._async_stop_client)
+
+        # Cancel non-critical tasks (pending timers) on HA stop to avoid
+        # "still running after final writes shutdown stage" warnings (issue 802)
+        unsub_stop = self.hass.bus.async_listen(
+            EVENT_HOMEASSISTANT_STOP, self._async_on_ha_stop
+        )
+        self.entry.async_on_unload(unsub_stop)
 
         # Reset _suppress_reload — it may have been set by
         # _async_mark_ssot_migrated above to prevent the update listener
@@ -1690,6 +1697,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             )
         except Exception as err:
             _LOGGER.warning("Unexpected error while stopping RAMSES client: %s", err)
+
+    async def _async_on_ha_stop(self, _event: Any) -> None:
+        """Cancel non-critical tasks when HA stops (issue 802).
+
+        This runs on EVENT_HOMEASSISTANT_STOP, before the 'final writes'
+        stage, to cancel lingering _pending_timer tasks that would
+        otherwise delay shutdown.
+        """
+        _LOGGER.debug("Coordinator: HA stop event, cancelling pending tasks")
+        await self.service_handler.async_cleanup()
 
     async def _async_save_on_unload(self) -> None:
         """Save client state during unload, skipping topology sync.

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -862,6 +862,8 @@ class RamsesNumberParam(RamsesNumberBase):
         self._pending_timer = self.hass.async_create_task(
             self._clear_pending_after_timeout(30)
         )
+        # Track for central cleanup on HA shutdown (issue 802)
+        self.coordinator.service_handler.register_pending_timer(self._pending_timer)
 
     def _is_boost_mode_param(self) -> bool:
         """Check if this is a boost mode parameter (ID 95).

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -92,6 +92,7 @@ class RamsesServiceHandler:
         self._fan_param_sequences: dict[str, asyncio.Task[Any]] = {}
         self._probe_task: asyncio.Task[Any] | None = None
         self._call_later_handles: list[Any] = []
+        self._pending_timers: list[asyncio.Task[Any]] = []
 
     @callback
     def _schedule_refresh(self, _: Any) -> None:
@@ -122,9 +123,18 @@ class RamsesServiceHandler:
         prev = getattr(entity, "_pending_timer", None)
         if prev and not prev.done():
             prev.cancel()
-        entity._pending_timer = self.hass.async_create_task(
+        task = self.hass.async_create_task(
             cast(Any, entity)._clear_pending_after_timeout(timeout)
         )
+        entity._pending_timer = task
+        self._pending_timers.append(task)
+
+    def register_pending_timer(self, task: asyncio.Task[Any]) -> None:
+        """Register a pending timer task for central cleanup on shutdown.
+
+        :param task: The asyncio task to track.
+        """
+        self._pending_timers.append(task)
 
     async def async_cleanup(self) -> None:
         """Cancel pending tasks and scheduled callbacks during unload."""
@@ -140,6 +150,13 @@ class RamsesServiceHandler:
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
         self._fan_param_sequences.clear()
+
+        for task in list(self._pending_timers):
+            if not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        self._pending_timers.clear()
 
         for handle in self._call_later_handles:
             handle()

--- a/tests/tests_new/test_task_cleanup.py
+++ b/tests/tests_new/test_task_cleanup.py
@@ -304,3 +304,95 @@ async def test_service_handler_cleanup_no_op_when_idle(
     assert handler._probe_task is None
     assert handler._call_later_handles == []
     assert handler._fan_param_sequences == {}
+
+
+async def test_schedule_clear_pending_tracks_task_in_handler(
+    mock_coordinator: MagicMock,
+) -> None:
+    """_schedule_clear_pending also tracks the task in the handler's _pending_timers.
+
+    This proves the fix for issue 802: pending timers must be centrally
+    tracked so they can be cancelled on HA shutdown.
+    """
+    handler = RamsesServiceHandler(mock_coordinator)
+
+    entity = MagicMock()
+    entity._pending_timer = None
+
+    async def _clear_pending(timeout: int) -> None:
+        await asyncio.sleep(timeout)
+
+    entity._clear_pending_after_timeout = _clear_pending
+
+    handler._schedule_clear_pending(entity, 30)
+
+    # Task should be tracked in the handler
+    assert len(handler._pending_timers) == 1
+    assert handler._pending_timers[0] is entity._pending_timer
+
+    # Cleanup
+    entity._pending_timer.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await entity._pending_timer
+
+
+async def test_register_pending_timer_tracks_task(
+    mock_coordinator: MagicMock,
+) -> None:
+    """register_pending_timer adds a task to the central tracking list."""
+    handler = RamsesServiceHandler(mock_coordinator)
+
+    task = asyncio.create_task(asyncio.sleep(100))
+    handler.register_pending_timer(task)
+
+    assert task in handler._pending_timers
+
+    # Cleanup
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+async def test_async_cleanup_cancels_pending_timers(
+    mock_coordinator: MagicMock,
+) -> None:
+    """async_cleanup cancels all tracked pending timers (issue 802).
+
+    This proves that pending timers registered via _schedule_clear_pending
+    or register_pending_timer are cancelled on cleanup, preventing
+    'still running after final writes shutdown stage' warnings.
+    """
+    handler = RamsesServiceHandler(mock_coordinator)
+
+    async def _long_pending() -> None:
+        await asyncio.sleep(100)
+
+    task1 = asyncio.create_task(_long_pending())
+    task2 = asyncio.create_task(_long_pending())
+    handler.register_pending_timer(task1)
+    handler.register_pending_timer(task2)
+
+    assert len(handler._pending_timers) == 2
+
+    await handler.async_cleanup()
+
+    assert task1.cancelled() or task1.done()
+    assert task2.cancelled() or task2.done()
+    assert handler._pending_timers == []
+
+
+async def test_async_cleanup_is_idempotent_for_pending_timers(
+    mock_coordinator: MagicMock,
+) -> None:
+    """async_cleanup can be called twice without error (stop event + unload)."""
+    handler = RamsesServiceHandler(mock_coordinator)
+
+    task = asyncio.create_task(asyncio.sleep(100))
+    handler.register_pending_timer(task)
+
+    await handler.async_cleanup()
+    assert task.cancelled() or task.done()
+
+    # Second call should not raise
+    await handler.async_cleanup()
+    assert handler._pending_timers == []


### PR DESCRIPTION
Register EVENT_HOMEASSISTANT_STOP listener in coordinator to cancel lingering _pending_timer tasks before the 'final writes' shutdown stage. Track all pending timers centrally in RamsesServiceHandler via _pending_timers list, and extend async_cleanup() to cancel them.

- services.py: add _pending_timers tracking, register_pending_timer(), extend async_cleanup() to cancel pending timers
- number.py: register entity-created _pending_timer with service_handler
- coordinator.py: add _async_on_ha_stop() listener for stop event
- test_task_cleanup.py: 4 new tests for tracking and cleanup

fix for https://github.com/ramses-rf/ramses_cc/issues/802
the other _rf part of the fix is on its way

AI used: GLM 5.2 high