### PR TITLE
fix(608): use `await set_temperature()` instead of sync property setter

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as dc_replace
 from datetime import datetime as dt, timedelta as td
 from typing import Any, Final, cast
 
@@ -765,8 +765,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
 
     # the following are integration-specific method service calls
 
-    @callback
-    def async_fake_zone_temp(self, temperature: float) -> None:
+    async def async_fake_zone_temp(self, temperature: float) -> None:
         """Cast the room temperature of this zone (if faked).
 
         :param temperature: The temperature to fake.
@@ -778,7 +777,15 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             )
 
         sensor = cast(Any, self._device.sensor)
-        sensor.temperature = temperature
+        await sensor.set_temperature(temperature)
+
+        # Also update the zone's temp_state so that current_temperature
+        # reflects the faked value immediately (the zone's temp_state is
+        # separate from the sensor's temp_state in ramses_rf's CQRS model)
+        zone = cast(Any, self._device)
+        if hasattr(zone, "temp_state"):
+            zone.temp_state = dc_replace(zone.temp_state, temperature=temperature)
+        self.async_write_ha_state()
 
     async def async_reset_zone_config(self) -> None:
         """Reset the configuration of the Zone.

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -214,8 +214,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         # setter will raise an exception if device is not faked
         cast(Any, self._device).co2_level = co2_level  # would accept None
 
-    @callback
-    def async_put_dhw_temp(self, temperature: float) -> None:
+    async def async_put_dhw_temp(self, temperature: float) -> None:
         """Cast the DHW cylinder temperature (if faked).
 
         :param temperature: The temperature in degrees Celsius.
@@ -230,8 +229,9 @@ class RamsesSensor(RamsesEntity, SensorEntity):
             raise TypeError(f"Cannot set DHW temperature on {self._device}")
         # TODO: Until here
 
-        # setter will raise an exception if device is not faked
-        cast(Any, self._device).temperature = temperature  # would accept None
+        # set_temperature will raise DeviceNotFaked if device is not faked
+        await cast(Any, self._device).set_temperature(temperature)
+        self.async_write_ha_state()
 
     @callback
     def async_put_indoor_humidity(self, indoor_humidity: float) -> None:
@@ -254,8 +254,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
             indoor_humidity / 100
         )  # would accept None
 
-    @callback
-    def async_put_room_temp(self, temperature: float) -> None:
+    async def async_put_room_temp(self, temperature: float) -> None:
         """Cast the room temperature (if faked).
 
         :param temperature: The temperature in degrees Celsius.
@@ -270,8 +269,9 @@ class RamsesSensor(RamsesEntity, SensorEntity):
             raise TypeError(f"Cannot set room temperature on {self._device}")
         # TODO: Until here
 
-        # setter will raise an exception if device is not faked
-        cast(Any, self._device).temperature = temperature  # would accept None
+        # set_temperature will raise DeviceNotFaked if device is not faked
+        await cast(Any, self._device).set_temperature(temperature)
+        self.async_write_ha_state()
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace as dc_replace
 from datetime import datetime as dt, timedelta as td
 from typing import Any, Final, cast
 
@@ -230,10 +230,21 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
     # the following methods are integration-specific service calls
 
-    @callback
-    def async_fake_dhw_temp(self, temperature: float) -> None:
+    async def async_fake_dhw_temp(self, temperature: float) -> None:
         """Cast the temperature of this water heater (if faked)."""
-        cast(Any, self._device).sensor.temperature = temperature  # would accept None
+        sensor = cast(Any, self._device).sensor
+        if sensor is None:
+            raise HomeAssistantError(
+                f"Water heater {self.entity_id} has no sensor to fake temp on."
+            )
+        await sensor.set_temperature(temperature)
+
+        # Also update the DHW zone's temp_state so that current_temperature
+        # reflects the faked value immediately
+        dhw = cast(Any, self._device)
+        if hasattr(dhw, "temp_state"):
+            dhw.temp_state = dc_replace(dhw.temp_state, temperature=temperature)
+        self.async_write_ha_state()
 
     async def async_reset_dhw_mode(self) -> None:
         """Reset the operating mode of the water heater.

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -33,6 +33,7 @@ from custom_components.ramses_cc.const import (
     SZ_KNOWN_LIST,
 )
 from ramses_rf.devices import HvacVentilator
+from ramses_rf.models import TemperatureState
 from ramses_rf.systems.tcs import Evohome
 from ramses_rf.systems.zones import Zone
 from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
@@ -656,11 +657,13 @@ async def test_zone_methods_and_services(
     # async_fake_zone_temp
     mock_device.sensor = None
     with pytest.raises(HomeAssistantError):
-        zone.async_fake_zone_temp(20.0)
+        await zone.async_fake_zone_temp(20.0)
 
-    mock_device.sensor = MagicMock()
-    zone.async_fake_zone_temp(22.5)
-    assert mock_device.sensor.temperature == 22.5
+    mock_device.sensor = AsyncMock()
+    mock_device.temp_state = TemperatureState()
+    await zone.async_fake_zone_temp(22.5)
+    mock_device.sensor.set_temperature.assert_awaited_with(22.5)
+    assert mock_device.temp_state.temperature == 22.5
 
     # Config / Schedule
     await zone.async_reset_zone_config()

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -358,10 +358,11 @@ def test_async_put_co2_level(mock_coordinator: MagicMock) -> None:
         sensor_bad.async_put_co2_level(800)
 
 
-def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:
+async def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:
     """Test async_put_dhw_temp."""
     device = MagicMock(spec=DhwSensor)
     device.id = "07:111111"
+    device.set_temperature = AsyncMock()
     desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "dhw"
     desc.ramses_rf_attr = "temperature"
@@ -369,10 +370,11 @@ def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:
     sensor = RamsesSensor(mock_coordinator, device, desc)
     sensor._attr_device_class = SensorDeviceClass.TEMPERATURE
     sensor._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    sensor.async_write_ha_state = MagicMock()
 
     # 1. Success
-    sensor.async_put_dhw_temp(55.0)
-    assert device.temperature == 55.0
+    await sensor.async_put_dhw_temp(55.0)
+    device.set_temperature.assert_awaited_with(55.0)
 
     # 2. TypeError: Wrong device type
     wrong_device = MagicMock(spec=RamsesRFEntity)
@@ -382,7 +384,7 @@ def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:
     sensor_bad._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     with pytest.raises(TypeError, match="Cannot set DHW temperature"):
-        sensor_bad.async_put_dhw_temp(50.0)
+        await sensor_bad.async_put_dhw_temp(50.0)
 
 
 def test_async_put_indoor_humidity(mock_coordinator: MagicMock) -> None:
@@ -412,10 +414,11 @@ def test_async_put_indoor_humidity(mock_coordinator: MagicMock) -> None:
         sensor_bad.async_put_indoor_humidity(50.0)
 
 
-def test_async_put_room_temp(mock_coordinator: MagicMock) -> None:
+async def test_async_put_room_temp(mock_coordinator: MagicMock) -> None:
     """Test async_put_room_temp."""
     device = MagicMock(spec=Thermostat)
     device.id = "03:111111"
+    device.set_temperature = AsyncMock()
     desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "temp"
     desc.ramses_rf_attr = "temperature"
@@ -423,10 +426,11 @@ def test_async_put_room_temp(mock_coordinator: MagicMock) -> None:
     sensor = RamsesSensor(mock_coordinator, device, desc)
     sensor._attr_device_class = SensorDeviceClass.TEMPERATURE
     sensor._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    sensor.async_write_ha_state = MagicMock()
 
     # 1. Success
-    sensor.async_put_room_temp(21.0)
-    assert device.temperature == 21.0
+    await sensor.async_put_room_temp(21.0)
+    device.set_temperature.assert_awaited_with(21.0)
 
     # 2. TypeError
     wrong_device = MagicMock(spec=RamsesRFEntity)
@@ -436,7 +440,7 @@ def test_async_put_room_temp(mock_coordinator: MagicMock) -> None:
     sensor_bad._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     with pytest.raises(TypeError, match="Cannot set room temperature"):
-        sensor_bad.async_put_room_temp(21.0)
+        await sensor_bad.async_put_room_temp(21.0)
 
 
 async def test_async_setup_entry_full_descriptions(

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -18,6 +18,7 @@ from custom_components.ramses_cc.water_heater import (
     RamsesWaterHeater,
     async_setup_entry,
 )
+from ramses_rf.models import TemperatureState
 from ramses_rf.systems.zones import DhwZone
 from ramses_tx.const import SZ_SYSTEM_MODE
 from ramses_tx.exceptions import ProtocolSendFailed
@@ -335,8 +336,10 @@ async def test_integration_services(
 ) -> None:
     """Test integration-specific service calls."""
     # fake_dhw_temp
-    water_heater.async_fake_dhw_temp(45.0)
-    assert mock_device.sensor.temperature == 45.0
+    mock_device.sensor = AsyncMock()
+    mock_device.temp_state = TemperatureState()
+    await water_heater.async_fake_dhw_temp(45.0)
+    mock_device.sensor.set_temperature.assert_awaited_with(45.0)
 
     # reset_dhw_mode
     await water_heater.async_reset_dhw_mode()


### PR DESCRIPTION
The ramses_rf 0.56.1 async refactor changed temperature from a sync property with a setter to an async method. The old code `sensor.temperature = value` silently overwrote the async method with a float, doing nothing — faking appeared to succeed but the temperature never changed.

Changes:
- climate.py: async_fake_zone_temp is now async, calls `await sensor.set_temperature(temperature)`, and also updates the zone's temp_state directly (the zone has its own separate temp_state in ramses_rf's CQRS model)
- sensor.py: async_put_dhw_temp and async_put_room_temp are now async and call `await ...set_temperature(temperature)`
- All three methods call async_write_ha_state() for immediate UI update

see https://github.com/ramses-rf/ramses_cc/issues/608

AI used: GLM-5.2 high