### PR TITLE
fix: refresh zone names in device registry after 0004 arrives

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2201,6 +2201,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # Register device in registry once upon discovery
             await self._async_update_device(device)
 
+        # Refresh device names for already-known zones.  Zone names arrive
+        # via 0004 packets which may reach ramses_rf *after* the zone was
+        # first created from the cached schema (issue 822).  Without this
+        # refresh, the device registry keeps the fallback name (e.g.
+        # "01:216136_01") forever.  _async_update_device's guard makes this
+        # a cheap no-op once the real name is in place, and HA's
+        # name/name_by_user split ensures user edits are never clobbered.
+        for zone in self._zones:
+            await self._async_update_device(zone)
+
         new_entities = new_systems + new_dhws + new_zones + new_devices
 
         if not new_entities:


### PR DESCRIPTION
Zone names arrive via 0004 packets which may reach ramses_rf *after* the zone was first created from the cached schema.  Previously _async_update_device was called only once (at zone creation), so the device registry kept the fallback name (e.g. "01:216136_01") forever even after the real Evohome name became available.

Now _discover_new_entities refreshes the device name for all known zones on every discovery cycle.  The existing guard in _async_update_device makes this a cheap no-op once the real name is in place, and HA's name/name_by_user split ensures user edits are never clobbered.

Requires the companion ramses_rf fix (0004 removed from HIGH_VOLUME_STATUS_CODES) to also restore cached zone names on restart.

https://github.com/ramses-rf/ramses_cc/issues/822


see https://github.com/ramses-rf/ramses_cc/issues/822

AI used: GLM 5.2 high
