### PR TITLE
fix(825): don't place remotes[] under a CTL/TCS in discovery schema

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -688,10 +688,20 @@ class DiscoveryManager:
         #  in remotes[] for now — the sensors[] list is reserved for the
         #  future when load_fan is implemented and the Builder pattern
         #  can distinguish dual-role devices (CO2 sensor + REM).
+        #
+        #  remotes[] is only valid under a FAN/VCS entry (ramses_rf's
+        #  SCH_VCS).  It must NEVER be placed under a CTL/TCS entry
+        #  (SCH_TCS rejects 'remotes' with PREVENT_EXTRA), so we must not
+        #  fall back to ctl_id (the TCS) when bound_to (the FAN) is
+        #  unknown — that corrupts the schema and breaks setup (issue
+        #  825).  CTL device IDs use the 01:/23: prefixes (see
+        #  ramses_tx DEVICE_ID_REGEX.CTL), so a bound_to pointing at a CTL
+        #  is treated as unknown and the device is orphaned to
+        #  orphans_hvac rather than incorrectly nested under the TCS.
+        _CTL_PREFIXES = ("01:", "23:")
         if lt in ("REM", "CO2"):
-            parent = bound_to or ctl_id
-            if parent:
-                return _merge({parent: {SZ_REMOTES: [device_id]}})
+            if bound_to and not bound_to.startswith(_CTL_PREFIXES):
+                return _merge({bound_to: {SZ_REMOTES: [device_id]}})
             return _merge({SZ_ORPHANS_HVAC: [device_id]})
 
         # ── OTB: OpenTherm Bridge — appliance_control for a CTL ─────

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -537,24 +537,53 @@ class TestGenerateSchemaEntry:
             SZ_ORPHANS_HEAT, []
         )
 
-    def test_co2_with_ctl_no_fan_uses_ctl_as_fallback_parent(self) -> None:
-        """CO2 sensor with ctl_id but no bound_to uses ctl_id as fallback parent.
+    def test_co2_with_ctl_no_fan_goes_to_hvac_orphans(self) -> None:
+        """CO2 sensor with ctl_id but no bound_to goes to orphans_hvac.
 
-        This mirrors the REM behaviour — ctl_id is used as a fallback parent
-        when bound_to (the FAN) is unknown.  Note: this places the CO2 sensor
-        under the CTL's remotes[], which is technically incorrect (CTLs don't
-        have remotes — that's a FAN concept).  This is a pre-existing issue
-        with the REM branch and will be addressed when the HVAC topology is
-        properly implemented (LATER item 8-10 in schema_architecture.md).
+        remotes[] is only valid under a FAN/VCS entry — placing it under a
+        CTL/TCS corrupts the schema and breaks setup (issue 825).  When the
+        FAN parent (bound_to) is unknown, the device is orphaned to
+        orphans_hvac rather than incorrectly nested under the CTL.
         """
-        from ramses_rf.schemas import SZ_REMOTES
+        from ramses_rf.schemas import SZ_ORPHANS_HVAC, SZ_REMOTES
 
         result = DiscoveryManager.generate_schema_entry(
             "37:123456", "CO2", ctl_id="01:216136"
         )
-        # ctl_id is used as fallback parent (same as REM)
-        assert "01:216136" in result
-        assert "37:123456" in result["01:216136"][SZ_REMOTES]
+        # Must NOT be placed under the CTL's remotes[]
+        assert "01:216136" not in result or SZ_REMOTES not in result.get(
+            "01:216136", {}
+        )
+        assert "37:123456" in result[SZ_ORPHANS_HVAC]
+
+    def test_rem_with_ctl_no_fan_goes_to_hvac_orphans(self) -> None:
+        """REM with ctl_id (TCS) but no FAN bound_to is orphaned, not nested under CTL.
+
+        Regression test for issue 825: a REM discovered with only a ctl_id
+        (the TCS) must not be placed under the CTL's remotes[], because
+        SCH_TCS rejects 'remotes' and breaks setup.  It goes to orphans_hvac.
+        """
+        from ramses_rf.schemas import SZ_ORPHANS_HVAC, SZ_REMOTES
+
+        result = DiscoveryManager.generate_schema_entry(
+            "29:091138", "REM", ctl_id="01:088175"
+        )
+        assert "01:088175" not in result or SZ_REMOTES not in result.get(
+            "01:088175", {}
+        )
+        assert "29:091138" in result[SZ_ORPHANS_HVAC]
+
+    def test_rem_with_non_fan_bound_to_goes_to_hvac_orphans(self) -> None:
+        """REM whose bound_to is not a 32: FAN is orphaned (no remotes under CTL)."""
+        from ramses_rf.schemas import SZ_ORPHANS_HVAC, SZ_REMOTES
+
+        result = DiscoveryManager.generate_schema_entry(
+            "37:123456", "REM", bound_to="01:088175"
+        )
+        assert "01:088175" not in result or SZ_REMOTES not in result.get(
+            "01:088175", {}
+        )
+        assert "37:123456" in result[SZ_ORPHANS_HVAC]
 
     def test_unknown_type_goes_to_heat_orphans(self) -> None:
         result = DiscoveryManager.generate_schema_entry("04:999999", "unknown")


### PR DESCRIPTION
generate_schema_entry fell back to ctl_id (the TCS) when bound_to (the FAN) was unknown, placing remotes[] under a CTL entry. SCH_TCS rejects 'remotes' (PREVENT_EXTRA), so the next setup failed with:
  not a valid value @ data['01:088175']['remotes']

remotes[] is only valid under a FAN/VCS entry. Now place it under bound_to only when it is not a CTL prefix (01:/23:); otherwise orphan the REM/CO2 to orphans_hvac (schema-safe) instead of corrupting the TCS.

Tests updated: the CO2-with-ctl fallback test now expects orphans_hvac, and regression tests cover the issue scenario (REM with ctl_id only) and a non-FAN bound_to.

Issue: https://github.com/ramses-rf/ramses_cc/issues/825

AI used: GLM 5.2 high