### PR TITLE
Feature/phase3b commands on fan

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -61,7 +61,7 @@ from .const import (
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import fields_to_aware, resolve_async_attr
-from .remote import _build_packet_from_template, _is_command_dict
+from .remote import _build_packet_from_template, _is_command_dict, _split_commands
 from .schemas import SCH_SET_SYSTEM_MODE_EXTRA, SCH_SET_ZONE_MODE_EXTRA
 
 _LOGGER = logging.getLogger(__name__)
@@ -1051,9 +1051,11 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
         remotes = getattr(self.coordinator, "_remotes", {}) or {}
 
         # Phase 3b: FAN's own _commands (dict templates)
+        # _split_commands strips metadata (_comment, future Builder keys)
         fan_commands = remotes.get(self._device.id, {})
         if isinstance(fan_commands, dict):
-            for cmd_name in fan_commands:
+            cmds, _ = _split_commands(fan_commands)
+            for cmd_name in cmds:
                 if cmd_name not in base_modes:
                     base_modes.append(cmd_name)
 
@@ -1062,7 +1064,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
         if bound_rem:
             rem_commands = remotes.get(str(bound_rem), {})
             if isinstance(rem_commands, dict):
-                for cmd_name in rem_commands:
+                cmds, _ = _split_commands(rem_commands)
+                for cmd_name in cmds:
                     if cmd_name not in base_modes:
                         base_modes.append(cmd_name)
         return base_modes
@@ -1130,12 +1133,16 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
             # a. FAN's own _commands (Phase 3b — dict templates)
             fan_commands = remotes.get(self._device.id, {})
+            if isinstance(fan_commands, dict):
+                fan_commands, _ = _split_commands(fan_commands)
 
             # b. Bound REM's _commands (Phase 3a — packet strings)
             bound_rem = self._bound_rem or self._device.get_bound_rem()
             rem_commands: dict[str, Any] = {}
             if bound_rem:
                 rem_commands = remotes.get(str(bound_rem), {})
+                if isinstance(rem_commands, dict):
+                    rem_commands, _ = _split_commands(rem_commands)
                 if not rem_commands:
                     # c. Legacy fallback: known_list[bound_rem][commands]
                     rem_config = self.coordinator.options.get(SZ_KNOWN_LIST, {}).get(

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -61,6 +61,7 @@ from .const import (
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import fields_to_aware, resolve_async_attr
+from .remote import _build_packet_from_template, _is_command_dict
 from .schemas import SCH_SET_SYSTEM_MODE_EXTRA, SCH_SET_ZONE_MODE_EXTRA
 
 _LOGGER = logging.getLogger(__name__)
@@ -1038,18 +1039,30 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
     def fan_modes(self) -> list[str] | None:
         """Return the list of available fan modes.
 
-        Extends the standard fan modes with custom command names from
-        the bound REM's schema ``_commands`` (Phase 3a SSOT) so that
-        ``climate.set_fan_mode`` accepts custom command names like
+        Extends the standard fan modes with custom command names from:
+
+        1. The FAN's own schema ``_commands`` (Phase 3b — dict templates)
+        2. The bound REM's ``_commands`` (Phase 3a — packet strings)
+
+        So that ``climate.set_fan_mode`` accepts custom command names like
         ``boost`` or ``speed_1``.
         """
         base_modes = list(self._attr_fan_modes or [])
+        remotes = getattr(self.coordinator, "_remotes", {}) or {}
+
+        # Phase 3b: FAN's own _commands (dict templates)
+        fan_commands = remotes.get(self._device.id, {})
+        if isinstance(fan_commands, dict):
+            for cmd_name in fan_commands:
+                if cmd_name not in base_modes:
+                    base_modes.append(cmd_name)
+
+        # Phase 3a: bound REM's _commands (packet strings, fallback)
         bound_rem = self._bound_rem or self._device.get_bound_rem()
         if bound_rem:
-            remotes = getattr(self.coordinator, "_remotes", {}) or {}
-            commands = remotes.get(str(bound_rem), {})
-            if isinstance(commands, dict):
-                for cmd_name in commands:
+            rem_commands = remotes.get(str(bound_rem), {})
+            if isinstance(rem_commands, dict):
+                for cmd_name in rem_commands:
                     if cmd_name not in base_modes:
                         base_modes.append(cmd_name)
         return base_modes
@@ -1107,25 +1120,50 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
         try:
             # 1. Check for user-defined custom commands.
-            # Priority: schema _commands (SSOT, via coordinator._remotes)
-            #          > known_list[bound_rem][commands] (legacy fallback)
+            # Priority (highest first):
+            #   a. FAN's schema _commands (Phase 3b — dict templates)
+            #   b. Bound REM's schema _commands (Phase 3a — packet strings)
+            #   c. known_list[bound_rem][commands] (legacy fallback)
+            remotes = getattr(self.coordinator, "_remotes", {}) or {}
+            if not isinstance(remotes, dict):
+                remotes = {}
+
+            # a. FAN's own _commands (Phase 3b — dict templates)
+            fan_commands = remotes.get(self._device.id, {})
+
+            # b. Bound REM's _commands (Phase 3a — packet strings)
             bound_rem = self._bound_rem or self._device.get_bound_rem()
-            commands: dict[str, str] = {}
+            rem_commands: dict[str, Any] = {}
             if bound_rem:
-                # Schema _commands (Phase 3a SSOT — populated from
-                # config_entry.options[schema][rem_id][_commands])
-                remotes = getattr(self.coordinator, "_remotes", {}) or {}
-                if isinstance(remotes, dict):
-                    commands = remotes.get(str(bound_rem), {})
-                if not commands:
-                    # Legacy fallback: known_list[bound_rem][commands]
+                rem_commands = remotes.get(str(bound_rem), {})
+                if not rem_commands:
+                    # c. Legacy fallback: known_list[bound_rem][commands]
                     rem_config = self.coordinator.options.get(SZ_KNOWN_LIST, {}).get(
                         str(bound_rem), {}
                     )
-                    commands = rem_config.get(CONF_COMMANDS, {})
+                    rem_commands = rem_config.get(CONF_COMMANDS, {})
 
-            if fan_mode in commands:
-                cmd_str = commands[fan_mode]
+            # Check FAN dict templates first (highest priority)
+            if fan_mode in fan_commands and _is_command_dict(fan_commands[fan_mode]):
+                cmd_def = fan_commands[fan_mode]
+                packet_str = _build_packet_from_template(
+                    cmd_def, self._device, self.coordinator
+                )
+                _LOGGER.info(
+                    "Intercepted fan_mode '%s'; building from FAN template: %s",
+                    fan_mode,
+                    packet_str,
+                )
+                cmd = Command(packet_str)
+                await self._device._gwy.async_send_cmd(
+                    cmd, num_repeats=2, priority=Priority.HIGH
+                )
+                self.async_write_ha_state()
+                return
+
+            # Check REM packet strings (Phase 3a fallback)
+            if fan_mode in rem_commands:
+                cmd_str = rem_commands[fan_mode]
                 _LOGGER.info(
                     "Intercepted fan_mode '%s'; sending custom command: %s",
                     fan_mode,
@@ -1134,10 +1172,10 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
                 # Users might enter a CLI shorthand OR a raw frame string
                 try:
-                    cmd = Command.from_cli(cmd_str)
+                    cmd = Command.from_cli(str(cmd_str))
                 except (ValueError, RamsesException):
                     # Fallback for raw packet frames copied from logs
-                    cmd = Command(cmd_str)
+                    cmd = Command(str(cmd_str))
 
                 await self._device._gwy.async_send_cmd(
                     cmd, num_repeats=2, priority=Priority.HIGH

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1607,7 +1607,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             else:
                 continue
 
-            # Collect commands from bound REMs
+            # Collect commands from bound REMs (skip _comment etc.)
             rem_commands: dict[str, str] = {}
             for rem_id in bound_rems:
                 rem_entry = new_schema.get(rem_id)
@@ -1615,6 +1615,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     rem_cmds = rem_entry.get(SZ_TR_COMMANDS, {})
                     if isinstance(rem_cmds, dict):
                         for cmd_name, cmd_val in rem_cmds.items():
+                            if cmd_name.startswith("_"):
+                                continue  # skip metadata (_comment, etc.)
                             if cmd_name not in rem_commands:
                                 rem_commands[cmd_name] = str(cmd_val)
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2546,8 +2546,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
         await async_add_entities(
             Platform.CLIMATE, [d for d in new_devices if isinstance(d, HvacVentilator)]
         )
+        # Phase 3b: remote entities on both REMs (HvacRemoteBase) and
+        # FANs (HvacVentilator).  FAN entity is the primary target for
+        # dict-template commands; REM entity stays for backward compat.
         await async_add_entities(
-            Platform.REMOTE, [d for d in new_devices if isinstance(d, HvacRemoteBase)]
+            Platform.REMOTE,
+            [d for d in new_devices if isinstance(d, (HvacRemoteBase, HvacVentilator))],
         )
         await async_add_entities(Platform.CLIMATE, new_systems)
         await async_add_entities(Platform.CLIMATE, new_zones)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2201,8 +2201,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
             schema = self.options.get(CONF_SCHEMA, {})
 
         # Explicitly declare intermediate dict to solve Pylance 'Never is not iterable'
+        # Use _commands_for_save (includes _comment metadata) instead of
+        # _commands (which has metadata stripped by _split_commands)
         remotes_from_entities: dict[str, Any] = {
-            k: getattr(v, "_commands", {})
+            k: getattr(v, "_commands_for_save", getattr(v, "_commands", {}))
             for k, v in self._entities.items()
             if hasattr(v, "_commands")
         }

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1675,7 +1675,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                         and "_comment" not in rem_cmds
                     ):
                         rem_cmds["_comment"] = (
-                            "Commands on REM (Phase 3a) — consider moving to FAN"
+                            "Commands on REM (Phase 3a) — will be deprecated, use FAN instead"
                         )
                         rem_entry[SZ_TR_COMMANDS] = rem_cmds
                         changed = True
@@ -1722,7 +1722,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     )
                 elif dev_class == "REM":
                     cmds["_comment"] = (
-                        "Commands on REM (Phase 3a) — consider moving to FAN"
+                        "Commands on REM (Phase 3a) — will be deprecated, use FAN instead"
                     )
             entry[SZ_TR_COMMANDS] = cmds
         elif SZ_TR_COMMANDS in entry:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1656,6 +1656,30 @@ class RamsesCoordinator(DataUpdateCoordinator):
             if changed:
                 entry[SZ_TR_COMMANDS] = fan_commands
 
+            # Auto-inject _comment hint on FAN if it has commands but no _comment
+            if fan_commands and "_comment" not in fan_commands:
+                fan_commands["_comment"] = (
+                    "Commands on FAN (Phase 3b) — target this entity for automations"
+                )
+                entry[SZ_TR_COMMANDS] = fan_commands
+                changed = True
+
+            # Auto-inject _comment hint on bound REMs that have commands
+            for rem_id in bound_rems:
+                rem_entry = new_schema.get(rem_id)
+                if isinstance(rem_entry, dict):
+                    rem_cmds = rem_entry.get(SZ_TR_COMMANDS, {})
+                    if (
+                        isinstance(rem_cmds, dict)
+                        and rem_cmds
+                        and "_comment" not in rem_cmds
+                    ):
+                        rem_cmds["_comment"] = (
+                            "Commands on REM (Phase 3a) — consider moving to FAN"
+                        )
+                        rem_entry[SZ_TR_COMMANDS] = rem_cmds
+                        changed = True
+
         if changed:
             _LOGGER.info("Phase 3b migration: REM _commands → FAN dict templates")
             from .schemas import order_schema
@@ -1688,7 +1712,19 @@ class RamsesCoordinator(DataUpdateCoordinator):
             entry = {}
             new_schema[device_id] = entry
         if commands:
-            entry[SZ_TR_COMMANDS] = dict(commands)
+            cmds = dict(commands)
+            # Auto-inject _comment hint if missing
+            if "_comment" not in cmds:
+                dev_class = entry.get(SZ_TR_CLASS, "")
+                if dev_class == "FAN":
+                    cmds["_comment"] = (
+                        "Commands on FAN (Phase 3b) — target this entity for automations"
+                    )
+                elif dev_class == "REM":
+                    cmds["_comment"] = (
+                        "Commands on REM (Phase 3a) — consider moving to FAN"
+                    )
+            entry[SZ_TR_COMMANDS] = cmds
         elif SZ_TR_COMMANDS in entry:
             del entry[SZ_TR_COMMANDS]
         new_options = dict(self.options)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1573,6 +1573,94 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return order_schema(new_schema)
         return schema
 
+    @staticmethod
+    def _migrate_rem_commands_to_fan(
+        schema: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Migrate ``_commands`` from REM entries to FAN entries (Phase 3b).
+
+        For each FAN entry with ``_bound``, copies ``_commands`` from the
+        bound REM entries to the FAN entry as ``{verb, code, payload}`` dict
+        templates.  REM ``_commands`` (packet strings) are NOT deleted —
+        they stay for backward compatibility (downgrade path: v2 code
+        ignores FAN ``_commands``, reads REM ``_commands``).
+
+        Only copies commands that are NOT already on the FAN entry —
+        FAN ``_commands`` is authoritative.
+
+        :param schema: The schema to migrate.
+        :return: The schema with FAN ``_commands`` populated.
+        """
+        changed = False
+        new_schema = dict(schema)
+
+        for fan_id, entry in new_schema.items():
+            if not isinstance(entry, dict) or entry.get(SZ_TR_CLASS) != "FAN":
+                continue
+
+            # Get bound REMs
+            bound = entry.get(SZ_TR_BOUND, [])
+            if isinstance(bound, str):
+                bound_rems = [bound]
+            elif isinstance(bound, list):
+                bound_rems = bound
+            else:
+                continue
+
+            # Collect commands from bound REMs
+            rem_commands: dict[str, str] = {}
+            for rem_id in bound_rems:
+                rem_entry = new_schema.get(rem_id)
+                if isinstance(rem_entry, dict):
+                    rem_cmds = rem_entry.get(SZ_TR_COMMANDS, {})
+                    if isinstance(rem_cmds, dict):
+                        for cmd_name, cmd_val in rem_cmds.items():
+                            if cmd_name not in rem_commands:
+                                rem_commands[cmd_name] = str(cmd_val)
+
+            if not rem_commands:
+                continue
+
+            # Parse packet strings to dict templates and merge into FAN
+            fan_commands = entry.get(SZ_TR_COMMANDS, {})
+            if not isinstance(fan_commands, dict):
+                fan_commands = {}
+
+            from .remote import _parse_packet_to_template
+
+            for cmd_name, packet_str in rem_commands.items():
+                if cmd_name in fan_commands:
+                    # FAN already has this command — skip (FAN is authoritative)
+                    continue
+                try:
+                    fan_commands[cmd_name] = _parse_packet_to_template(packet_str)
+                    changed = True
+                    _LOGGER.info(
+                        "Phase 3b migration: copied command '%s' from REM to "
+                        "FAN %s as dict template",
+                        cmd_name,
+                        fan_id,
+                    )
+                except (ValueError, IndexError) as err:
+                    _LOGGER.warning(
+                        "Phase 3b migration: failed to parse packet '%s' for "
+                        "command '%s' on FAN %s: %s",
+                        packet_str,
+                        cmd_name,
+                        fan_id,
+                        err,
+                    )
+
+            if changed:
+                entry[SZ_TR_COMMANDS] = fan_commands
+
+        if changed:
+            _LOGGER.info("Phase 3b migration: REM _commands → FAN dict templates")
+            from .schemas import order_schema
+
+            return order_schema(new_schema)
+        return schema
+
     async def _async_update_schema_commands(
         self, device_id: str, commands: dict[str, str]
     ) -> None:
@@ -2019,6 +2107,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             reason="ssot_phase3a",
                         )
                     enriched = self._sync_remotes_to_schema(enriched, self._remotes)
+                # Phase 3b: migrate REM _commands (packet strings) to FAN
+                # _commands (dict templates).  REM entries are kept for
+                # backward compatibility (downgrade path).
+                enriched = self._migrate_rem_commands_to_fan(enriched)
                 # Validate the stripped schema against ramses_rf's strict
                 # validator before saving.  This catches root-level _ traits
                 # or invalid device IDs early, instead of failing silently
@@ -2059,6 +2151,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 config_schema = self._sync_remotes_to_schema(
                     config_schema, self._remotes
                 )
+                # Phase 3b: also migrate REM → FAN dict templates
+                config_schema = self._migrate_rem_commands_to_fan(config_schema)
                 new_options = dict(self.options)
                 new_options[CONF_SCHEMA] = config_schema
                 self.options = new_options
@@ -2076,6 +2170,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     migrated_schema = self._sync_remotes_to_schema(
                         config_schema, self._remotes
                     )
+                    # Phase 3b: also migrate REM → FAN dict templates
+                    migrated_schema = self._migrate_rem_commands_to_fan(migrated_schema)
                     if migrated_schema is not config_schema:
                         _LOGGER.info(
                             "No topology changes, but remotes synced to "

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity_platform import (
 )
 from homeassistant.helpers.event import async_track_state_change_event
 
-from ramses_rf.devices import HvacRemote
+from ramses_rf.devices import HvacRemote, HvacVentilator
 from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_tx.command import Command
 from ramses_tx.const import DEFAULT_GAP_DURATION, Priority
@@ -36,11 +36,114 @@ from .schemas import DEFAULT_NUM_REPEATS, DEFAULT_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
+# Packet template keys (Phase 3b — {verb, code, payload} dict format)
+_CMD_VERB: str = "verb"
+_CMD_CODE: str = "code"
+_CMD_PAYLOAD: str = "payload"
+_CMD_SRC: str = "src"  # optional explicit src override
+
+# Codes that learn_command listens for (22F1/22F3/22F7/22B0)
+_LEARN_CODES: tuple[str, ...] = ("22F1", "22F3", "22F7", "22B0")
+
+
+def _build_packet_from_template(
+    cmd_def: dict[str, str],
+    fan_device: HvacVentilator,
+    coordinator: RamsesCoordinator,
+) -> str:
+    """Build a packet string from a ``{verb, code, payload}`` template.
+
+    Addresses are filled at send time:
+    - src: explicit ``src`` field, or first bound REM (via get_bound_rem),
+      or HGI gateway ID as fallback
+    - dst: the FAN's own device ID
+    - brd: broadcast address (always ``--:------``)
+    - length: calculated from payload (bytes = len(payload) // 2)
+
+    :param cmd_def: Command dict with ``verb``, ``code``, ``payload``,
+        optional ``src``.
+    :param fan_device: The FAN (HvacVentilator) device that owns the command.
+    :param coordinator: The coordinator (for HGI fallback lookup).
+    :return: A full packet string ready for ``Command()``.
+    :raises HomeAssistantError: If no src can be resolved.
+    """
+    verb = cmd_def[_CMD_VERB]
+    code = cmd_def[_CMD_CODE]
+    payload = cmd_def[_CMD_PAYLOAD]
+
+    # src resolution: explicit src > bound REM > HGI fallback
+    src = cmd_def.get(_CMD_SRC)
+    if not src:
+        src = str(fan_device.get_bound_rem() or "")
+    if not src:
+        # Fallback to HGI gateway ID
+        client = coordinator.client
+        if client:
+            hgi = getattr(client, "_gwy", None)
+            if hgi:
+                hgi_dev = getattr(hgi, "_hgi", None) or getattr(hgi, "hgi", None)
+                if hgi_dev:
+                    src = str(hgi_dev.id)
+    if not src:
+        raise HomeAssistantError(
+            "No bound REM or HGI available to send command — set _bound on the FAN"
+        )
+
+    dst = fan_device.id
+    brd = "--:------"
+    length = f"{len(payload) // 2:03d}"
+    return f"{verb} --- {src} {dst} {brd} {code} {length} {payload}"
+
+
+def _parse_packet_to_template(packet: str) -> dict[str, str]:
+    """Extract ``{verb, code, payload}`` from a captured packet string.
+
+    Inverse of :func:`_build_packet_from_template`.  Used by
+    ``learn_command`` to store captured packets as templates (no hardcoded
+    addresses).
+
+    Packet format: ``{verb} --- {src} {dst} {brd} {code} {len} {payload}``
+
+    :param packet: Full packet string (e.g.
+        ``"W --- 32:153001 30:160000 --:------ 22F7 003 0000EF"``).
+    :return: Dict with ``verb``, ``code``, ``payload`` keys.
+    :raises ValueError: If the packet doesn't have enough parts.
+    """
+    parts = packet.split()
+    if len(parts) < 8:
+        raise ValueError(f"Packet too short to parse: {packet}")
+    verb = parts[0]
+    code = parts[5]
+    payload = parts[7]
+    return {_CMD_VERB: verb, _CMD_CODE: code, _CMD_PAYLOAD: payload}
+
+
+def _is_command_dict(value: Any) -> bool:
+    """Check if a command value is a Phase 3b dict template.
+
+    Dict templates have ``verb``, ``code``, ``payload`` keys (at minimum).
+    String values are Phase 3a packet strings (backward compat).
+
+    :param value: The command value to check.
+    :return: True if the value is a dict command template.
+    """
+    return (
+        isinstance(value, dict)
+        and _CMD_VERB in value
+        and _CMD_CODE in value
+        and _CMD_PAYLOAD in value
+    )
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the remote platform.
+
+    Phase 3b: ``remote`` entities are created on both REMs (``HvacRemote``)
+    and FANs (``HvacVentilator``).  The FAN entity is the primary target for
+    Phase 3b commands (dict templates); the REM entity stays for backward
+    compatibility (packet strings).
 
     :param hass: The Home Assistant instance.
     :param entry: The config entry.
@@ -55,12 +158,13 @@ async def async_setup_entry(
         device_list = devices if isinstance(devices, Sequence) else [devices]
 
         # 2. Iterate over device_list (not 'devices')
+        # Phase 3b: create remote entities on both REMs and FANs
         entities = [
             RamsesRemoteEntityDescription.ramses_cc_class(
                 coordinator, device, RamsesRemoteEntityDescription(key="remote")
             )
             for device in device_list
-            if isinstance(device, HvacRemote)
+            if isinstance(device, (HvacRemote, HvacVentilator))
         ]
         async_add_entities(entities)
 
@@ -68,9 +172,19 @@ async def async_setup_entry(
 
 
 class RamsesRemote(RamsesEntity, RemoteEntity):
-    """Representation of a RAMSES RF remote."""
+    """Representation of a RAMSES RF remote.
 
-    _device: HvacRemote
+    Phase 3b: This entity is created on both REMs (``HvacRemote``) and
+    FANs (``HvacVentilator``).  The FAN entity stores commands as
+    ``{verb, code, payload}`` dict templates; the REM entity stores
+    commands as full packet strings (backward compat).
+
+    For a FAN entity, ``_commands`` is loaded from:
+    1. The FAN's own schema ``_commands`` (dict templates — Phase 3b)
+    2. The bound REM's ``_commands`` (packet strings — Phase 3a fallback)
+    """
+
+    _device: HvacRemote | HvacVentilator
 
     _attr_assumed_state: bool = True
     _attr_supported_features: int = (
@@ -80,34 +194,86 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
     def __init__(
         self,
         coordinator: RamsesCoordinator,
-        device: HvacRemote,
+        device: HvacRemote | HvacVentilator,
         entity_description: RamsesRemoteEntityDescription,
     ) -> None:
         """Initialize a HVAC remote.
 
         :param coordinator: The RamsesCoordinator instance.
-        :param device: The backend device instance.
+        :param device: The backend device instance (REM or FAN).
         :param entity_description: The entity description.
         """
-        _LOGGER.info("Found %s", device.id)
+        _LOGGER.info("Found %s (remote entity)", device.id)
         super().__init__(coordinator, device, entity_description)
 
         self._attr_is_on = True
-        self._commands: dict[str, str] = coordinator._remotes.get(device.id, {})
+        # Load commands: FAN gets its own + bound REM's; REM gets its own
+        self._commands: dict[str, Any] = coordinator._remotes.get(device.id, {})
+        if isinstance(device, HvacVentilator):
+            # FAN: also load commands from bound REMs (backward compat)
+            bound_rem = device.get_bound_rem()
+            if bound_rem:
+                rem_commands = coordinator._remotes.get(str(bound_rem), {})
+                if rem_commands:
+                    # REM commands (strings) are lower priority than
+                    # FAN commands (dicts) — only add if not already present
+                    for cmd_name, cmd_val in rem_commands.items():
+                        if cmd_name not in self._commands:
+                            self._commands[cmd_name] = cmd_val
+
+    @property
+    def is_fan_entity(self) -> bool:
+        """Return True if this entity is on a FAN (not a REM).
+
+        :return: True if the underlying device is an HvacVentilator.
+        """
+        return isinstance(self._device, HvacVentilator)
+
+    @property
+    def _bound_rem_ids(self) -> list[str]:
+        """Return the list of bound REM device IDs (FAN entity only).
+
+        For a FAN entity, reads ``_bound`` from the schema to get all
+        bound REM IDs.  For a REM entity, returns an empty list.
+
+        :return: List of bound REM device IDs, or empty list.
+        """
+        if not self.is_fan_entity:
+            return []
+        schema = self.coordinator.options.get("schema", {})
+        entry = schema.get(self._device.id, {})
+        if not isinstance(entry, dict):
+            return []
+        bound = entry.get("_bound", [])
+        if isinstance(bound, str):
+            return [bound]
+        if isinstance(bound, list):
+            return bound
+        return []
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the integration-specific state attributes.
 
+        For REM entities: ``commands`` (packet strings) + ``bound_to_fan``.
+        For FAN entities: ``commands`` (dict templates) + ``bound_rems``.
+
         :return: A dictionary of state attributes.
         """
         attrs = super().extra_state_attributes | {"commands": self._commands}
-        # Expose which FAN this REM is bound to (if any), derived from
-        # fan_handler's _fan_bound_to_remote dict.  Gives automations
-        # access to binding info without reading the schema directly.
-        fan_handler = self.coordinator.fan_handler
-        if fan_handler and self._device.id in fan_handler._fan_bound_to_remote:
-            attrs["bound_to_fan"] = fan_handler._fan_bound_to_remote[self._device.id]
+
+        if self.is_fan_entity:
+            # FAN entity: expose bound REMs list
+            bound_rems = self._bound_rem_ids
+            if bound_rems:
+                attrs["bound_rems"] = bound_rems
+        else:
+            # REM entity: expose which FAN this REM is bound to
+            fan_handler = self.coordinator.fan_handler
+            if fan_handler and self._device.id in fan_handler._fan_bound_to_remote:
+                attrs["bound_to_fan"] = fan_handler._fan_bound_to_remote[
+                    self._device.id
+                ]
         return attrs
 
     async def async_delete_command(
@@ -184,22 +350,35 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         async def _async_on_change(event: Any) -> None:
             """Save the new command to storage.
 
+            For REM entities: listens to ``src == self._device.id``,
+            stores as packet string.
+
+            For FAN entities: listens to ``src in self._bound_rem_ids``,
+            stores as ``{verb, code, payload}`` dict template.
+
             :param event: Event to evaluate
             """
 
-            codes = ("22F1", "22F3", "22F7")
-
-            # if event.data["packet"] in self._commands.values():  # TODO
-            #     raise DuplicateError
-
             new_state: State = event.data["new_state"]
-            # _LOGGER.debug("REM event new_state: %s", new_state)
             new_data = new_state.attributes["extra_data"]
             # to extract e.g. 'code' in a jinja template, use:
             # {{ state_attr('event.ramses_cc_learn_event', 'extra_data')['code'] }}
 
-            if new_data["src"] == self._device.id and new_data["code"] in codes:
-                self._commands[command[0]] = new_data["packet"]
+            # Determine valid src IDs for this entity
+            if self.is_fan_entity:
+                valid_srcs = set(self._bound_rem_ids)
+            else:
+                valid_srcs = {self._device.id}
+
+            if new_data["src"] in valid_srcs and new_data["code"] in _LEARN_CODES:
+                if self.is_fan_entity:
+                    # FAN entity: store as dict template (Phase 3b)
+                    self._commands[command[0]] = _parse_packet_to_template(
+                        new_data["packet"]
+                    )
+                else:
+                    # REM entity: store as packet string (Phase 3a)
+                    self._commands[command[0]] = new_data["packet"]
                 learning_session.set()  # stops learn session
                 # Persist to schema (SSOT) — .storage[remotes] is updated
                 # on the next 5-min save cycle.
@@ -207,7 +386,12 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
                     self._device.id, self._commands
                 )
             else:
-                _LOGGER.debug("REM FILTER FAILED: %s", new_data["code"])
+                _LOGGER.debug(
+                    "REM FILTER FAILED: src=%s code=%s (valid_srcs=%s)",
+                    new_data["src"],
+                    new_data["code"],
+                    valid_srcs,
+                )
 
         with self.coordinator._sem:
             _LOGGER.debug("LEARN _sem set, setting up listener")
@@ -289,10 +473,30 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         if command[0] not in self._commands:
             raise HomeAssistantError(f"command '{command[0]}' is not known")
 
-        if not self._device.is_faked:  # have to check here, as not using device method
-            raise HomeAssistantError(f"{self._device.id} is not configured for faking")
+        cmd_value = self._commands[command[0]]
 
-        cmd = Command(self._commands[command[0]])
+        # Phase 3b: dict templates are built at send time; packet strings
+        # (Phase 3a) are used directly
+        if _is_command_dict(cmd_value):
+            # FAN entity with dict template — build packet
+            if not isinstance(self._device, HvacVentilator):
+                raise HomeAssistantError(
+                    "Dict-format commands require a FAN entity target"
+                )
+            packet_str = _build_packet_from_template(
+                cmd_value, self._device, self.coordinator
+            )
+        else:
+            # REM entity with packet string (Phase 3a backward compat)
+            packet_str = str(cmd_value)
+            if (
+                not self._device.is_faked
+            ):  # have to check here, as not using device method
+                raise HomeAssistantError(
+                    f"{self._device.id} is not configured for faking"
+                )
+
+        cmd = Command(packet_str)
 
         if not self.coordinator.client:
             raise HomeAssistantError(
@@ -342,6 +546,10 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
             target:
               entity_id: remote.device_id
 
+        For FAN entities (Phase 3b), the packet string is parsed into a
+        ``{verb, code, payload}`` dict template before storing.  For REM
+        entities, the full packet string is stored as-is (backward compat).
+
         :param command: The command name to add.
         :param packet_string: The raw packet string for the command.
         :param kwargs: Arbitrary keyword arguments.
@@ -363,7 +571,12 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         if command[0] in self._commands:
             await self.async_delete_command(command)
 
-        self._commands[command[0]] = packet_string
+        if self.is_fan_entity:
+            # FAN entity: parse to dict template (Phase 3b)
+            self._commands[command[0]] = _parse_packet_to_template(packet_string)
+        else:
+            # REM entity: store packet string as-is (Phase 3a)
+            self._commands[command[0]] = packet_string
         await self.coordinator._async_update_schema_commands(
             self._device.id, self._commands
         )

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -350,6 +350,18 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
                 ]
         return attrs
 
+    @property
+    def _commands_for_save(self) -> dict[str, Any]:
+        """Return commands + metadata for schema persistence.
+
+        The coordinator reads this during ``async_save_client_state`` to
+        build the ``remotes`` dict.  It re-attaches ``_comment`` (and any
+        other reserved metadata) that was stripped from ``self._commands``
+        by ``_split_commands`` during ``__init__``.
+        """
+        meta = {"_comment": self._command_comment} if self._command_comment else {}
+        return _with_metadata(self._commands, meta)
+
     async def async_delete_command(
         self,
         command: Iterable[str] | str,

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -42,8 +42,78 @@ _CMD_CODE: str = "code"
 _CMD_PAYLOAD: str = "payload"
 _CMD_SRC: str = "src"  # optional explicit src override
 
+# Reserved metadata keys inside _commands dicts (not commands themselves).
+# These are stripped when iterating commands, but preserved when writing
+# back to the schema.  Add future Builder metadata keys here (e.g.
+# "_description", "_category", "_deprecated") — one place, no scatter.
+_RESERVED_CMD_KEYS: frozenset[str] = frozenset({"_comment"})
+
 # Codes that learn_command listens for (22F1/22F3/22F7/22B0)
 _LEARN_CODES: tuple[str, ...] = ("22F1", "22F3", "22F7", "22B0")
+
+
+def _split_commands(raw: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split a raw ``_commands`` dict into (commands, metadata).
+
+    Reserved keys (``_comment``, future Builder metadata) are separated
+    from actual command entries.  This is the single place that knows
+    which keys are metadata — all callers use this helper instead of
+    inline checks.
+
+    :param raw: The raw ``_commands`` dict from schema/coordinator.
+    :return: A tuple of (commands, metadata) dicts.
+    """
+    commands: dict[str, Any] = {}
+    metadata: dict[str, Any] = {}
+    for k, v in raw.items():
+        if k in _RESERVED_CMD_KEYS:
+            metadata[k] = v
+        else:
+            commands[k] = v
+    return commands, metadata
+
+
+def _with_metadata(
+    commands: dict[str, Any], metadata: dict[str, Any]
+) -> dict[str, Any]:
+    """Re-attach metadata to a commands dict for schema persistence.
+
+    Inverse of ``_split_commands``: used when writing back to the schema
+    after modifying commands (delete, learn, add).  Metadata keys like
+    ``_comment`` are preserved across mutations.
+
+    :param commands: The command entries (no metadata).
+    :param metadata: The metadata entries (e.g. ``_comment``).
+    :return: A combined dict suitable for schema persistence.
+    """
+    result = dict(commands)
+    result.update(metadata)
+    return result
+
+
+def _merge_commands(*sources: dict[str, Any]) -> dict[str, Any]:
+    """Merge multiple ``_commands`` dicts, keeping metadata from the first.
+
+    Later sources only contribute commands (not metadata) — metadata
+    from the first source wins.  This matches the FAN-over-REM priority:
+    the FAN's own ``_comment`` is kept, REM metadata is ignored.
+
+    :param sources: Ordered ``_commands`` dicts (highest priority first).
+    :return: A merged dict with commands + metadata from the first source.
+    """
+    if not sources:
+        return {}
+    result: dict[str, Any] = {}
+    metadata: dict[str, Any] = {}
+    for i, src in enumerate(sources):
+        cmds, meta = _split_commands(src)
+        if i == 0:
+            metadata = meta
+        for cmd_name, cmd_val in cmds.items():
+            if cmd_name not in result:
+                result[cmd_name] = cmd_val
+    result.update(metadata)
+    return result
 
 
 def _build_packet_from_template(
@@ -207,19 +277,21 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         super().__init__(coordinator, device, entity_description)
 
         self._attr_is_on = True
-        # Load commands: FAN gets its own + bound REM's; REM gets its own
-        self._commands: dict[str, Any] = coordinator._remotes.get(device.id, {})
+        # Load commands: FAN gets its own + bound REM's; REM gets its own.
+        # _split_commands separates metadata (_comment) from actual commands.
+        raw_commands = coordinator._remotes.get(device.id, {})
+        self._commands, meta = _split_commands(raw_commands)
+        self._command_comment: str | None = meta.get("_comment")
         if isinstance(device, HvacVentilator):
-            # FAN: also load commands from bound REMs (backward compat)
+            # FAN: also load commands from bound REMs (backward compat).
+            # _merge_commands keeps FAN metadata, ignores REM metadata.
             bound_rem = device.get_bound_rem()
             if bound_rem:
                 rem_commands = coordinator._remotes.get(str(bound_rem), {})
                 if rem_commands:
-                    # REM commands (strings) are lower priority than
-                    # FAN commands (dicts) — only add if not already present
-                    for cmd_name, cmd_val in rem_commands.items():
-                        if cmd_name not in self._commands:
-                            self._commands[cmd_name] = cmd_val
+                    merged = _merge_commands(raw_commands, rem_commands)
+                    self._commands, meta = _split_commands(merged)
+                    self._command_comment = meta.get("_comment")
 
     @property
     def is_fan_entity(self) -> bool:
@@ -261,6 +333,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         :return: A dictionary of state attributes.
         """
         attrs = super().extra_state_attributes | {"commands": self._commands}
+        if self._command_comment:
+            attrs["command_comment"] = self._command_comment
 
         if self.is_fan_entity:
             # FAN entity: expose bound REMs list
@@ -304,8 +378,9 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         assert not kwargs, kwargs  # TODO: remove me
 
         self._commands = {k: v for k, v in self._commands.items() if k not in command}
+        meta = {"_comment": self._command_comment} if self._command_comment else {}
         await self.coordinator._async_update_schema_commands(
-            self._device.id, self._commands
+            self._device.id, _with_metadata(self._commands, meta)
         )
 
     async def async_learn_command(
@@ -381,9 +456,12 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
                     self._commands[command[0]] = new_data["packet"]
                 learning_session.set()  # stops learn session
                 # Persist to schema (SSOT) — .storage[remotes] is updated
-                # on the next 5-min save cycle.
+                # on the next 5-min save cycle.  Re-attach metadata.
+                meta = (
+                    {"_comment": self._command_comment} if self._command_comment else {}
+                )
                 await self.coordinator._async_update_schema_commands(
-                    self._device.id, self._commands
+                    self._device.id, _with_metadata(self._commands, meta)
                 )
             else:
                 _LOGGER.debug(
@@ -577,8 +655,9 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         else:
             # REM entity: store packet string as-is (Phase 3a)
             self._commands[command[0]] = packet_string
+        meta = {"_comment": self._command_comment} if self._command_comment else {}
         await self.coordinator._async_update_schema_commands(
-            self._device.id, self._commands
+            self._device.id, _with_metadata(self._commands, meta)
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -344,7 +344,7 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
-        'commands': NodeDictClass({
+        'commands': dict({
           'auto': ' I --- 29:179540 32:157747 --:------ 22F1 003 000404',
           'away': ' I --- 29:179540 32:157747 --:------ 22F1 003 000004',
           'high': ' I --- 29:179540 32:157747 --:------ 22F1 003 000304',

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -4936,3 +4936,157 @@ async def test_async_save_client_state_no_backup_when_already_migrated(
 
     # No backup should be created (already migrated)
     mock_backup.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3b: _migrate_rem_commands_to_fan tests
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateRemCommandsToFan:
+    """Tests for RamsesCoordinator._migrate_rem_commands_to_fan (Phase 3b)."""
+
+    def test_no_fan_no_change(self) -> None:
+        """No FAN entries → no migration."""
+        schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        assert result is schema
+
+    def test_fan_no_bound_no_change(self) -> None:
+        """FAN without _bound → no migration."""
+        schema: dict[str, Any] = {"30:160000": {"_class": "FAN"}}
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        assert result is schema
+
+    def test_fan_bound_rem_no_commands_no_change(self) -> None:
+        """FAN with bound REM that has no _commands → no migration."""
+        schema: dict[str, Any] = {
+            "30:160000": {"_class": "FAN", "_bound": ["32:153001"]},
+            "32:153001": {"_class": "REM"},
+        }
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        assert result is schema
+
+    def test_rem_commands_copied_to_fan_as_dicts(self) -> None:
+        """REM _commands (packet strings) copied to FAN as dict templates."""
+        schema: dict[str, Any] = {
+            "30:160000": {
+                "_class": "FAN",
+                "_bound": ["32:153001"],
+            },
+            "32:153001": {
+                "_class": "REM",
+                "_commands": {
+                    "boost": "I --- 32:153001 30:160000 --:------ 22F1 003 000030",
+                },
+            },
+        }
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        fan_entry = result["30:160000"]
+        assert SZ_TR_COMMANDS in fan_entry
+        cmd = fan_entry[SZ_TR_COMMANDS]["boost"]
+        assert cmd == {"verb": "I", "code": "22F1", "payload": "000030"}
+
+    def test_rem_commands_not_deleted(self) -> None:
+        """REM _commands are NOT deleted (downgrade safety)."""
+        schema: dict[str, Any] = {
+            "30:160000": {
+                "_class": "FAN",
+                "_bound": ["32:153001"],
+            },
+            "32:153001": {
+                "_class": "REM",
+                "_commands": {
+                    "boost": "I --- 32:153001 30:160000 --:------ 22F1 003 000030",
+                },
+            },
+        }
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        # REM entry still has _commands
+        assert SZ_TR_COMMANDS in result["32:153001"]
+
+    def test_fan_commands_authoritative(self) -> None:
+        """FAN _commands not overwritten by REM _commands."""
+        schema: dict[str, Any] = {
+            "30:160000": {
+                "_class": "FAN",
+                "_bound": ["32:153001"],
+                "_commands": {
+                    "boost": {"verb": "W", "code": "22F7", "payload": "0000EF"},
+                },
+            },
+            "32:153001": {
+                "_class": "REM",
+                "_commands": {
+                    "boost": "I --- 32:153001 30:160000 --:------ 22F1 003 000030",
+                },
+            },
+        }
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        # FAN's dict template wins
+        cmd = result["30:160000"][SZ_TR_COMMANDS]["boost"]
+        assert cmd == {"verb": "W", "code": "22F7", "payload": "0000EF"}
+
+    def test_multi_rem_all_copied(self) -> None:
+        """Commands from multiple bound REMs are all copied to FAN."""
+        schema: dict[str, Any] = {
+            "30:160000": {
+                "_class": "FAN",
+                "_bound": ["32:153001", "32:153002"],
+            },
+            "32:153001": {
+                "_class": "REM",
+                "_commands": {
+                    "boost": "I --- 32:153001 30:160000 --:------ 22F1 003 000030",
+                },
+            },
+            "32:153002": {
+                "_class": "REM",
+                "_commands": {
+                    "bypass": "W --- 32:153002 30:160000 --:------ 22F7 003 0000EF",
+                },
+            },
+        }
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        fan_cmds = result["30:160000"][SZ_TR_COMMANDS]
+        assert "boost" in fan_cmds
+        assert "bypass" in fan_cmds
+        assert fan_cmds["boost"] == {"verb": "I", "code": "22F1", "payload": "000030"}
+        assert fan_cmds["bypass"] == {"verb": "W", "code": "22F7", "payload": "0000EF"}
+
+    def test_bound_as_str_normalized(self) -> None:
+        """_bound as string (single REM) is normalized to list."""
+        schema: dict[str, Any] = {
+            "30:160000": {
+                "_class": "FAN",
+                "_bound": "32:153001",
+            },
+            "32:153001": {
+                "_class": "REM",
+                "_commands": {
+                    "boost": "I --- 32:153001 30:160000 --:------ 22F1 003 000030",
+                },
+            },
+        }
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        assert SZ_TR_COMMANDS in result["30:160000"]
+
+    def test_invalid_packet_logged_not_crash(self) -> None:
+        """Invalid packet string is skipped, not crashing."""
+        schema: dict[str, Any] = {
+            "30:160000": {
+                "_class": "FAN",
+                "_bound": ["32:153001"],
+            },
+            "32:153001": {
+                "_class": "REM",
+                "_commands": {
+                    "bad": "invalid_packet",
+                },
+            },
+        }
+        # Should not raise
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        # Bad command not copied to FAN
+        fan_cmds = result["30:160000"].get(SZ_TR_COMMANDS, {})
+        assert "bad" not in fan_cmds

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -19,6 +19,9 @@ from custom_components.ramses_cc.event import RamsesEventType, RamsesLearnEvent
 from custom_components.ramses_cc.remote import (
     RamsesRemote,
     RamsesRemoteEntityDescription,
+    _merge_commands,
+    _split_commands,
+    _with_metadata,
     async_setup_entry,
 )
 from ramses_tx.command import Command
@@ -1491,3 +1494,76 @@ async def test_rem_add_command_keeps_string(
     saved_commands = mock_coordinator._async_update_schema_commands.call_args.args[1]
     assert saved_commands["test_cmd"] == VALID_PKT
     assert not _is_command_dict(saved_commands["test_cmd"])
+
+
+# ── _split_commands / _merge_commands / _with_metadata ──────────────
+
+
+def test_split_commands_separates_comment() -> None:
+    """_split_commands separates _comment from actual commands."""
+    raw = {
+        "_comment": "Target the FAN for automations",
+        "bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF"},
+        "speed_1": "RQ --- 37:170000 18:001234 --:------ 22F1 003 000031",
+    }
+    cmds, meta = _split_commands(raw)
+    assert "_comment" not in cmds
+    assert "bypass_on" in cmds
+    assert "speed_1" in cmds
+    assert meta == {"_comment": "Target the FAN for automations"}
+
+
+def test_split_commands_no_metadata() -> None:
+    """_split_commands returns empty metadata when no reserved keys."""
+    raw = {"bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF"}}
+    cmds, meta = _split_commands(raw)
+    assert cmds == raw
+    assert meta == {}
+
+
+def test_split_commands_empty() -> None:
+    """_split_commands handles empty dict."""
+    cmds, meta = _split_commands({})
+    assert cmds == {}
+    assert meta == {}
+
+
+def test_merge_commands_fan_priority() -> None:
+    """_merge_commands keeps FAN metadata, ignores REM metadata."""
+    fan = {
+        "_comment": "FAN comment",
+        "bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF"},
+    }
+    rem = {
+        "_comment": "REM comment (should be ignored)",
+        "speed_1": "RQ --- 37:170000 18:001234 --:------ 22F1 003 000031",
+    }
+    merged = _merge_commands(fan, rem)
+    assert merged["_comment"] == "FAN comment"
+    assert "bypass_on" in merged
+    assert "speed_1" in merged
+
+
+def test_merge_commands_first_wins() -> None:
+    """_merge_commands: first source's command wins for duplicates."""
+    fan = {"bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF"}}
+    rem = {"bypass_on": "RQ --- 37:170000 18:001234 --:------ 22F7 003 0000EF"}
+    merged = _merge_commands(fan, rem)
+    assert _is_command_dict(merged["bypass_on"])  # FAN dict wins
+
+
+def test_with_metadata_reattaches_comment() -> None:
+    """_with_metadata re-attaches _comment for schema persistence."""
+    cmds = {"bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF"}}
+    meta = {"_comment": "Target the FAN"}
+    result = _with_metadata(cmds, meta)
+    assert result["_comment"] == "Target the FAN"
+    assert "bypass_on" in result
+
+
+def test_with_metadata_empty_meta() -> None:
+    """_with_metadata with empty metadata returns plain commands."""
+    cmds = {"bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF"}}
+    result = _with_metadata(cmds, {})
+    assert "_comment" not in result
+    assert "bypass_on" in result

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -1183,3 +1183,311 @@ async def test_send_command_not_faked_raises_error(
 
     with pytest.raises(HomeAssistantError, match="is not configured for faking"):
         await remote_entity.async_send_command("boost")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3b: Packet template builder + FAN entity tests
+# ---------------------------------------------------------------------------
+
+from custom_components.ramses_cc.remote import (  # noqa: E402
+    _build_packet_from_template,
+    _is_command_dict,
+    _parse_packet_to_template,
+)
+from ramses_rf.devices import HvacVentilator  # noqa: E402
+
+FAN_ID = "30:160000"
+BOUND_REM_ID = "32:153001"
+FAN_PKT = "I --- 32:153001 30:160000 --:------ 22F1 003 000030"
+BYPASS_PKT = "W --- 32:153001 30:160000 --:------ 22F7 003 0000EF"
+
+
+def test_parse_packet_to_template() -> None:
+    """_parse_packet_to_template extracts verb, code, payload from packet."""
+    result = _parse_packet_to_template(FAN_PKT)
+    assert result == {"verb": "I", "code": "22F1", "payload": "000030"}
+
+
+def test_parse_packet_to_template_bypass() -> None:
+    """_parse_packet_to_template handles 22F7 (bypass) packets."""
+    result = _parse_packet_to_template(BYPASS_PKT)
+    assert result == {"verb": "W", "code": "22F7", "payload": "0000EF"}
+
+
+def test_parse_packet_to_template_short_packet_raises() -> None:
+    """_parse_packet_to_template raises ValueError for short packets."""
+    with pytest.raises(ValueError, match="Packet too short"):
+        _parse_packet_to_template("I --- 22F1")
+
+
+def test_is_command_dict_true() -> None:
+    """_is_command_dict returns True for valid dict templates."""
+    assert _is_command_dict({"verb": "W", "code": "22F7", "payload": "0000EF"})
+
+
+def test_is_command_dict_false_for_string() -> None:
+    """_is_command_dict returns False for packet strings."""
+    assert not _is_command_dict(FAN_PKT)
+
+
+def test_is_command_dict_false_for_incomplete_dict() -> None:
+    """_is_command_dict returns False for dicts missing required keys."""
+    assert not _is_command_dict({"verb": "W", "code": "22F7"})
+    assert not _is_command_dict({"verb": "W"})
+    assert not _is_command_dict({})
+
+
+def test_build_packet_from_template() -> None:
+    """_build_packet_from_template builds a full packet from dict."""
+    fan = MagicMock(spec=HvacVentilator)
+    fan.id = FAN_ID
+    fan.get_bound_rem = MagicMock(return_value=BOUND_REM_ID)
+
+    coordinator = MagicMock()
+    coordinator.client = MagicMock()
+
+    cmd_def = {"verb": "W", "code": "22F7", "payload": "0000EF"}
+    result = _build_packet_from_template(cmd_def, fan, coordinator)
+    assert result == "W --- 32:153001 30:160000 --:------ 22F7 003 0000EF"
+
+
+def test_build_packet_from_template_explicit_src() -> None:
+    """_build_packet_from_template uses explicit src if provided."""
+    fan = MagicMock(spec=HvacVentilator)
+    fan.id = FAN_ID
+    fan.get_bound_rem = MagicMock(return_value=BOUND_REM_ID)
+
+    coordinator = MagicMock()
+    coordinator.client = MagicMock()
+
+    cmd_def = {
+        "verb": "W",
+        "code": "22F7",
+        "payload": "0000EF",
+        "src": "32:153002",
+    }
+    result = _build_packet_from_template(cmd_def, fan, coordinator)
+    assert "32:153002" in result
+    assert "32:153001" not in result
+
+
+def test_build_packet_from_template_hgi_fallback() -> None:
+    """_build_packet_from_template falls back to HGI when no bound REM."""
+    fan = MagicMock(spec=HvacVentilator)
+    fan.id = FAN_ID
+    fan.get_bound_rem = MagicMock(return_value=None)
+
+    hgi = MagicMock()
+    hgi.id = "18:001234"
+    gwy = MagicMock()
+    gwy._hgi = hgi
+    coordinator = MagicMock()
+    coordinator.client = MagicMock()
+    coordinator.client._gwy = gwy
+
+    cmd_def = {"verb": "W", "code": "22F7", "payload": "0000EF"}
+    result = _build_packet_from_template(cmd_def, fan, coordinator)
+    assert "18:001234" in result
+
+
+def test_build_packet_from_template_no_src_raises() -> None:
+    """_build_packet_from_template raises when no src can be resolved."""
+    fan = MagicMock(spec=HvacVentilator)
+    fan.id = FAN_ID
+    fan.get_bound_rem = MagicMock(return_value=None)
+
+    coordinator = MagicMock()
+    coordinator.client = None
+
+    cmd_def = {"verb": "W", "code": "22F7", "payload": "0000EF"}
+    with pytest.raises(HomeAssistantError, match="No bound REM or HGI"):
+        _build_packet_from_template(cmd_def, fan, coordinator)
+
+
+def test_build_packet_length_calculated() -> None:
+    """_build_packet_from_template calculates length from payload."""
+    fan = MagicMock(spec=HvacVentilator)
+    fan.id = FAN_ID
+    fan.get_bound_rem = MagicMock(return_value=BOUND_REM_ID)
+
+    coordinator = MagicMock()
+    coordinator.client = MagicMock()
+
+    # 6 hex chars = 3 bytes → "003"
+    cmd_def = {"verb": "W", "code": "22F7", "payload": "0000EF"}
+    result = _build_packet_from_template(cmd_def, fan, coordinator)
+    assert " 003 " in result
+
+    # 4 hex chars = 2 bytes → "002"
+    cmd_def2 = {"verb": "W", "code": "22B0", "payload": "0005"}
+    result2 = _build_packet_from_template(cmd_def2, fan, coordinator)
+    assert " 002 " in result2
+
+
+@pytest.fixture
+def mock_fan_device() -> MagicMock:
+    """Return a mock HvacVentilator device."""
+    device = MagicMock(spec=HvacVentilator)
+    device.id = FAN_ID
+    device.get_bound_rem = MagicMock(return_value=BOUND_REM_ID)
+    return device
+
+
+@pytest.fixture
+def fan_coordinator(hass: HomeAssistant) -> MagicMock:
+    """Return a mock coordinator for FAN entity tests."""
+    coordinator = MagicMock()
+    coordinator._remotes = {
+        FAN_ID: {"bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF"}},
+        BOUND_REM_ID: {"boost": FAN_PKT},
+    }
+    coordinator.learn_device_id = None
+    coordinator.fan_handler = MagicMock()
+    coordinator.fan_handler._fan_bound_to_remote = {BOUND_REM_ID: FAN_ID}
+    coordinator._sem = MagicMock()
+    coordinator._sem.__enter__ = MagicMock(return_value=None)
+    coordinator._sem.__exit__ = MagicMock(return_value=None)
+    coordinator.client = MagicMock()
+    coordinator.client.async_send_cmd = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+    coordinator._async_update_schema_commands = AsyncMock()
+    coordinator.options = {
+        "schema": {
+            FAN_ID: {"_class": "FAN", "_bound": [BOUND_REM_ID]},
+        },
+    }
+    return coordinator
+
+
+@pytest.fixture
+def fan_remote_entity(
+    hass: HomeAssistant,
+    fan_coordinator: MagicMock,
+    mock_fan_device: MagicMock,
+) -> RamsesRemote:
+    """Return a RamsesRemote entity on a FAN device."""
+    desc = RamsesRemoteEntityDescription(key="remote")
+    entity = RamsesRemote(fan_coordinator, mock_fan_device, desc)
+    entity.hass = hass
+    return entity
+
+
+def test_fan_entity_is_fan_entity(
+    fan_remote_entity: RamsesRemote,
+) -> None:
+    """FAN entity reports is_fan_entity=True."""
+    assert fan_remote_entity.is_fan_entity is True
+
+
+def test_rem_entity_is_not_fan_entity(
+    remote_entity: RamsesRemote,
+) -> None:
+    """REM entity reports is_fan_entity=False."""
+    assert remote_entity.is_fan_entity is False
+
+
+def test_fan_entity_bound_rem_ids(
+    fan_remote_entity: RamsesRemote,
+) -> None:
+    """FAN entity reads _bound from schema to get bound REM IDs."""
+    assert fan_remote_entity._bound_rem_ids == [BOUND_REM_ID]
+
+
+def test_fan_entity_loads_own_commands(
+    fan_coordinator: MagicMock,
+    mock_fan_device: MagicMock,
+    hass: HomeAssistant,
+) -> None:
+    """FAN entity loads its own _commands (dicts) from coordinator._remotes."""
+    desc = RamsesRemoteEntityDescription(key="remote")
+    entity = RamsesRemote(fan_coordinator, mock_fan_device, desc)
+    entity.hass = hass
+    # FAN's own commands (dicts) should be loaded
+    assert "bypass_on" in entity._commands
+    assert _is_command_dict(entity._commands["bypass_on"])
+
+
+def test_fan_entity_loads_bound_rem_commands_as_fallback(
+    fan_coordinator: MagicMock,
+    mock_fan_device: MagicMock,
+    hass: HomeAssistant,
+) -> None:
+    """FAN entity loads bound REM's commands (strings) as fallback."""
+    desc = RamsesRemoteEntityDescription(key="remote")
+    entity = RamsesRemote(fan_coordinator, mock_fan_device, desc)
+    entity.hass = hass
+    # REM's commands (strings) should be loaded as fallback
+    assert "boost" in entity._commands
+    assert entity._commands["boost"] == FAN_PKT
+
+
+def test_fan_entity_extra_state_attributes_bound_rems(
+    fan_remote_entity: RamsesRemote,
+) -> None:
+    """FAN entity extra_state_attributes includes bound_rems."""
+    attrs = fan_remote_entity.extra_state_attributes
+    assert "bound_rems" in attrs
+    assert attrs["bound_rems"] == [BOUND_REM_ID]
+
+
+def test_rem_entity_extra_state_attributes_bound_to_fan(
+    remote_entity: RamsesRemote,
+) -> None:
+    """REM entity extra_state_attributes includes bound_to_fan."""
+    attrs = remote_entity.extra_state_attributes
+    assert "bound_to_fan" in attrs
+
+
+async def test_fan_send_command_dict_template(
+    fan_remote_entity: RamsesRemote,
+    fan_coordinator: MagicMock,
+) -> None:
+    """FAN entity send_command builds packet from dict template."""
+    with patch("custom_components.ramses_cc.remote.Command", side_effect=lambda x: x):
+        await fan_remote_entity.async_send_command("bypass_on")
+    # Verify async_send_cmd was called with the built packet string
+    fan_coordinator.client.async_send_cmd.assert_called_once()
+    cmd = fan_coordinator.client.async_send_cmd.call_args.args[0]
+    assert "22F7" in str(cmd)
+    assert "0000EF" in str(cmd)
+    assert FAN_ID in str(cmd)
+
+
+async def test_fan_send_command_rem_string_fallback(
+    fan_remote_entity: RamsesRemote,
+    fan_coordinator: MagicMock,
+) -> None:
+    """FAN entity send_command uses REM packet string for fallback commands."""
+    # "boost" is a REM command (packet string), not a FAN dict template
+    with patch("custom_components.ramses_cc.remote.Command", side_effect=lambda x: x):
+        await fan_remote_entity.async_send_command("boost")
+    fan_coordinator.client.async_send_cmd.assert_called_once()
+    cmd = fan_coordinator.client.async_send_cmd.call_args.args[0]
+    assert "22F1" in str(cmd)
+
+
+async def test_fan_add_command_parses_to_dict(
+    fan_remote_entity: RamsesRemote,
+    fan_coordinator: MagicMock,
+) -> None:
+    """FAN entity add_command parses packet string to dict template."""
+    # Use a valid packet for Command validation
+    valid_pkt = "RQ --- 32:153001 30:160000 --:------ 22F1 003 000030"
+    await fan_remote_entity.async_add_command("calendar_on", valid_pkt)
+    # Verify _async_update_schema_commands was called with dict format
+    fan_coordinator._async_update_schema_commands.assert_called_once()
+    saved_commands = fan_coordinator._async_update_schema_commands.call_args.args[1]
+    assert "calendar_on" in saved_commands
+    assert _is_command_dict(saved_commands["calendar_on"])
+
+
+async def test_rem_add_command_keeps_string(
+    remote_entity: RamsesRemote,
+    mock_coordinator: MagicMock,
+) -> None:
+    """REM entity add_command stores packet string as-is (backward compat)."""
+    await remote_entity.async_add_command("test_cmd", VALID_PKT)
+    mock_coordinator._async_update_schema_commands.assert_called_once()
+    saved_commands = mock_coordinator._async_update_schema_commands.call_args.args[1]
+    assert saved_commands["test_cmd"] == VALID_PKT
+    assert not _is_command_dict(saved_commands["test_cmd"])


### PR DESCRIPTION
# Phase 3b Design: Commands on FAN

**Created:** Jul 2026
**Status:** Implemented — Phase 3a complete (PR 811), Phase 3b complete (branch `feature/phase3b-commands-on-fan`)
**Depends on:** Phase 3a (complete), ramses_rf issue 547, ramses_rf PR 546
**Does NOT depend on:** ramses_rf issue 530 (Builder Pattern — that's
future work that would eventually shrink `_commands`, not a blocker)

> **Naming note:** There are two "Phase 3"s that are easy to confuse:
> - **ramses_cc Phase 3** (this doc) — commands in schema, our work.
>   Split into **3a** (commands on REM, PR 811) and **3b** (commands on
>   FAN + strip+map pipeline, this design).
> - **ramses_rf issue 530 Phase 3** (PWhite-Eng) — Builder Pattern,
>   `supported_commands()`, dynamic strategies. NOT started. NOT a
>   dependency for our 3b.
>
> When issue 530 Phase 3 lands, it will make some `_commands` entries
> obsolete (22F7 bypass, 22B0 calendar get native builders). But our
> `_commands` stays as the user override layer.

## Contents

- [Overview](#overview)
- [Two command layers](#two-command-layers)
- [Current state (after Phase 3a — complete)](#current-state-after-phase-3a--complete)
- [Phase 3b design](#phase-3b-design)
  - [Schema format](#schema-format)
  - [Packet template](#packet-template)
  - [`_bound` as list](#_bound-as-list)
  - [Entity: `remote.30_160000` on the FAN](#entity-remote30_160000-on-the-fan)
  - [Send flow](#send-flow)
  - [Learn flow](#learn-flow)
  - [State attributes](#state-attributes)
  - [What happens to REM entities](#what-happens-to-rem-entities)
- [Changes](#changes)
  - [ramses_cc](#ramses_cc)
  - [ramses_rf](#ramses_rf)
  - [CLI testing (outside HA)](#cli-testing-outside-ha)
- [Migration (runtime — no store version bump)](#migration-runtime--no-store-version-bump)
- [Backward compatibility](#backward-compatibility)
- [Alignment with ramses_rf](#alignment-with-ramses_rf)
  - [Issue 530: master plan](#issue-530-master-plan)
  - [Discussion 191: consensus](#discussion-191-consensus)
  - [Boundaries](#boundaries)
  - [What we can do now (Phase 3a + 3b)](#what-we-can-do-now-phase-3a-changes--all-done-phase-3b--all-done)
- [Open questions](#open-questions)
- [Implementation Plan (Phase 3b)](#implementation-plan-phase-3b)
- [References](#references)

---

## Overview

Phase 3a moved `_commands` from `.storage[remotes]` to the schema, but kept
them on **REM device entries**. Phase 3b moves `_commands` to **FAN device
entries**, where the FAN owns the commands and REMs are just transport.

This solves the multi-REM problem: a FAN with 2+ REMs currently requires
duplicating commands on each REM entry. With this design, commands are
defined once on the FAN.

silverailscolo's direction (Discussion 191): commands should be on the
device that **handles** them, not the faked REM that sends them.

---

## Two command layers

ramses_rf already has `HvacVentilator.set_fan_mode()` (PR 546) and
scheme-aware `Command.set_fan_mode()` (issue 547). Standard fan modes
no longer need raw packet strings. The `_commands` workaround from
issue 210 is only needed for non-standard commands.

| Layer | What | How to send | Where stored |
|-------|------|-------------|--------------|
| **Standard modes** | low, medium, high, boost, away, off | `device.set_fan_mode("low")` — ramses_rf builds from `_scheme` | Not stored — ramses_rf knows the scheme |
| **Non-standard** | bypass_on, bypass_off, calendar_on, calendar_off, custom | `Command(packet)` from `_commands` template | `_commands` on FAN in schema |

**Standard modes** — ramses_cc calls `await device.set_fan_mode("low")`.
ramses_rf picks the bound REM (`get_bound_rem()`), builds the scheme-aware
packet, and sends it. No raw payloads, no packet building, no REM picking.

**Non-standard commands** — issue 210's known_list had commands with no
builder: `22F7` (bypass), `22B0` (calendar). `_commands` is the only way
to send these until ramses_rf gets builders for them (future Phase 3).

---

## Current state (after Phase 3a — complete)

```
SCHEMA:
  "32:153001": {                          ← REM device
    _class: "REM",
    _faked: true,
    _commands: {
      "turn_on": "I --- 32:153001 30:160000 --:------ 22F1 003 000030"
    }
  }
  "30:160000": {                          ← FAN device
    _class: "FAN",
    _bound: "32:153001"                   ← str | list[str] (Phase 3a)
  }
```

**What Phase 3a delivered:**
- `_commands` stores the **full packet string** with hardcoded REM address
- `_bound` accepts `str | list[str]` (multi-REM binding works)
- `remote.py` entity lives on the REM (no change for 3a)
- `learn_command` listens to one REM src (no change for 3a)
- `send_command` uses the hardcoded packet string
- `climate.set_fan_mode` calls `device.set_fan_mode()` + intercepts custom commands
- `bound_to_fan` attribute on REM entity
- Schema `_commands` is SSOT (persists across reloads, migrates from `.storage[remotes]`)
- `_strip_schema_extensions` delegates stage 1 to ramses_rf's `strip_traits`
- Store `max_readable_version=2` for downgrade safety

**What Phase 3a did NOT change (still Phase 3b scope):**
- `_commands` still on REM entries (not FAN)
- `_commands` still full packet strings (not `{verb, code, payload}` dicts)
- `remote.py` entity still on REM (not FAN)
- `learn_command` still listens to one REM src (not all bound REMs)
- `send_command` still uses hardcoded packet (not template builder)
- With 2 REMs, user still duplicates commands on each REM entry

---

## Phase 3b design

### Schema format

```json
"30:160000": {
  "_class": "FAN",
  "_scheme": "vasco",
  "_bound": ["32:153001", "32:153002"],
  "_commands": {
    "bypass_on":   {"verb": "W", "code": "22F7", "payload": "0000EF"},
    "bypass_off":  {"verb": "W", "code": "22F7", "payload": "00C8EF"},
    "bypass_auto": {"verb": "W", "code": "22F7", "payload": "00FFEF"},
    "calendar_on": {"verb": "W", "code": "22B0", "payload": "0005"},
    "calendar_off":{"verb": "W", "code": "22B0", "payload": "0006"}
  }
}
```

Standard modes (low/medium/high/boost/away) are **not in `_commands`** —
they go through `device.set_fan_mode()` which uses `_scheme` to build
the correct payload. Only non-standard commands that have no builder
are stored in `_commands`.

### Packet template

`_commands` stores verb, code, and payload. Addresses are filled at
send time. This makes automations simple — the user calls
`send_command` with just the command name.

```
Packet format:  {verb} --- {src} {dst} {brd} {code} {len} {payload}

Placeholders (filled at send time):
  %src%  → resolved automatically (see below)
  %dst%  → the FAN's own device ID (e.g. "30:160000")
  %brd%  → broadcast address, always "--:------"
```

**src resolution** (same pattern as ramses_rf's `set_fan_mode`):
1. If command has explicit `src` field → use it
2. Otherwise: pick first bound REM from `_bound` list
3. If no bound REM → fallback to HGI gateway ID
4. If no HGI → error

This mirrors `HvacVentilator.set_fan_mode()` (PR 546):
```python
src_id = self.get_bound_rem()    # try bound REM first
if not src_id:
    src_id = self.hgi.id         # fallback to HGI
```

**Three levels of flexibility:**
1. **No `src` field (default)** — system picks bound REM or HGI. Best for automations.
2. **Explicit `src`** — user hardcodes a specific REM (e.g. only that REM is in range):
   ```json
   "bypass_on": {"verb": "W", "code": "22F7", "payload": "0000EF", "src": "32:153002"}
   ```

**At send time:**
```python
src = cmd_def.get("src") or pick_bound_rem(fan) or fan.hgi.id
dst = fan.id
brd = "--:------"
length = f"{len(payload) // 2:03d}"          # calculated from payload

packet = f"{verb} --- {src} {dst} {brd} {code} {length} {payload}"
# → "W --- 32:153001 30:160000 --:------ 22F7 003 0000EF"
```

Length is **calculated** from the payload, not stored. This avoids
mismatches (e.g. payload "0000EF" → 3 bytes → "003").

**Why verb + code + payload (not just payload)?**

`learn_command` captures packets with different codes (`22F1`, `22F3`,
`22F7`, `22B0`). The verb matters because `22F7` can be both `I` and `W`.

| Code | Name | Verb | Example payload | Meaning |
|------|------|------|-----------------|---------|
| 22F1 | fan_mode | I | `000030` | set fan speed (standard — use set_fan_mode) |
| 22F3 | fan_boost | I | `021E000031` | boost (standard — use set_fan_mode) |
| 22F7 | bypass | I/W | `0000EF` | bypass control (no builder — needs _commands) |
| 22B0 | calendar | W | `0005` | calendar on/off (no builder — needs _commands) |

### `_bound` as list

```json
"_bound": ["32:153001", "32:153002", "29:091138"]
```

`_bound` becomes `str | list[str]`. `fan_handler.setup_fan_bound_devices`
loops over all entries instead of returning after the first.

CO2 devices can also appear in `_bound` — they can send `I 22F1` if
declared as `_class: "REM"` (faked). The FAN doesn't care what type of
device sends the `I 22F1` — it just acts on the payload.

### Entity: `remote.30_160000` on the FAN

The `remote.py` entity moves from the REM to the FAN. The FAN gets one
`remote` entity that exposes all non-standard commands. Standard modes
go through the `climate.py` entity on the FAN (calling
`device.set_fan_mode()`), not through `remote.py`.

### Send flow

**Standard modes:**
```
Automation:
  service: climate.set_fan_mode
  target: climate.30_160000
  data: {fan_mode: "low"}

climate.py:
  1. await self._device.set_fan_mode("low")
  2. ramses_rf picks bound REM, builds scheme-aware packet, sends it
```

**Non-standard commands:**
```
Automation:
  service: remote.send_command
  target: remote.30_160000              ← targets the FAN, not a REM
  data: {command: "bypass_on"}

remote.py:
  1. cmd_def = self._commands["bypass_on"]
     → {"verb": "W", "code": "22F7", "payload": "0000EF"}
  2. src = cmd_def.get("src") or pick_bound_rem(fan) or fan.hgi.id
     → "32:153001" (first bound REM, or HGI fallback)
  3. dst = self._device.id              → "30:160000"
  4. length = f"{len(payload) // 2:03d}" → "003"
  5. packet = f"{verb} --- {src} {dst} --:------ {code} {length} {payload}"
     → "W --- 32:153001 30:160000 --:------ 22F7 003 0000EF"
  6. cmd = Command(packet)
  7. ramses_rf sends it → FAN receives W 22F7, acts on it
```

No hardcoded REM address. Any bound REM can send. If no bound REM,
falls back to HGI. If one REM is offline, pick another.

### Learn flow

```
Automation:
  service: remote.learn_command
  target: remote.30_160000
  data: {command: "bypass_on"}

remote.py:
  1. Listen for 22F1/22F3/22F7/22B0 from ANY bound REM
     - filter: src in self._bound_rem_ids AND code in _LEARN_CODES
     - _LEARN_CODES = ("22F1", "22F3", "22F7", "22B0")
  2. Capture packet:
     "W --- 32:153001 30:160000 --:------ 22F7 003 0000EF"
  3. Extract: verb="W", code="22F7", payload="0000EF"
     (src, dst, brd, length are discarded — they're placeholders)
  4. Store: self._commands["bypass_on"] = {"verb": "W", "code": "22F7", "payload": "0000EF"}
  5. Persist to schema[fan_id][_commands]
```

Currently `learn_command` only listens to one REM (`src == self._device.id`).
With this design, it listens to all bound REMs — so the user can press any
physical remote to learn.

### State attributes

```yaml
# remote.30_160000
commands:
  bypass_on:   {"verb": "W", "code": "22F7", "payload": "0000EF"}
  bypass_off:  {"verb": "W", "code": "22F7", "payload": "00C8EF"}
  calendar_on: {"verb": "W", "code": "22B0", "payload": "0005"}
bound_rems:
  - "32:153001"
  - "32:153002"
```

Automation access:
```yaml
{{ state_attr('remote.30_160000', 'commands') }}
{{ state_attr('remote.30_160000', 'bound_rems') }}
```

### What happens to REM entities

REM entities keep existing. The only change: `commands` moves off the
REM to the FAN. The binding is already defined by `_bound` on the FAN
and `_fan_bound_to_remote` in `fan_handler` — no extra attributes needed.

What changes on the REM entity:
- `commands` attribute: **kept** (packet strings, backward compat — existing
  automations targeting `remote.32_153001` keep working)
- `bound_to_fan` attribute: stays (Phase 3a)
- Everything else stays the same

The FAN entity (`climate.30_160000` + `remote.30_160000`) is the
primary interface for sending commands. The REM is transport.

CO2 threshold automation works naturally — the CO2 has its sensor
entity, the automation targets the FAN:
```yaml
alias: "CO2 > 1000ppm → fan high"
trigger:
  platform: numeric_state
  entity_id: sensor.co2_29_091138
  above: 1000
action:
  service: climate.set_fan_mode
  target:
    entity_id: climate.30_160000
  data:
    fan_mode: "high"
```

---

## Changes

### ramses_cc

| Component | Phase 3a (before) | Phase 3a (DONE) | Phase 3b (DONE) |
|-----------|-------------------|-----------------|-----------------|
| `remote.py` entity | On REM (`HvacRemote`) | No change | On REM **and** FAN (`HvacRemote` + `HvacVentilator`) |
| `_commands` content | Full packet string | No change | `{verb, code, payload}` dict (both accepted at runtime) |
| `_commands` location | REM entry in schema | No change | FAN entry in schema (REM entries kept for downgrade) |
| `_commands` scope | All commands (standard + non-standard) | No change | Non-standard only (standard via `set_fan_mode`) |
| `_bound` type | `str` (single REM) | `str \| list[str]` DONE | `str \| list[str]` (no change) |
| `learn_command` | Listens to one REM src | No change | FAN: listens to all bound REM srcs; REM: one src (backward compat) |
| `send_command` | Uses hardcoded packet | No change | FAN: builds from template; REM: uses packet string (backward compat) |
| `climate.set_fan_mode` | Not implemented (NotImplementedError) | Calls `device.set_fan_mode()` DONE | Also checks FAN dict templates first, then REM strings |
| `_remotes` dict | Keyed by REM ID | No change | Mixed keys: FAN IDs → dicts, REM IDs → strings (both coexist) |
| `fan_handler.setup_fan_bound_devices` | Binds one REM, returns | Loops over all bound REMs DONE | Same (no change) |
| `fan_handler` bound device check | REM or DIS only | REM, DIS, CO2 (`_class: REM`) DONE | Same (no change) |
| `extra_state_attributes` | `commands` only | Add `bound_to_fan` DONE | FAN: add `bound_rems` (list); REM: `bound_to_fan` stays |
| `_strip_schema_extensions` | Does all 3 stages inline | Delegates stage 1 to ramses_rf `strip_traits` DONE | Same (no change) |
| `_derive_known_list_from_schema` | Inline `_bound`→`bound` mapping | Uses ramses_rf `strip_and_map_traits` DONE | Same (no change) |
| Store migration | v1 only | `max_readable_version=2`, v2→v1 identity DONE | Runtime migration (no version bump) — `_migrate_rem_commands_to_fan` |
| Startup load | `.storage[remotes]` only | Schema `_commands` → `_remotes` (SSOT) DONE | Same — loads all schema `_commands` (FAN dicts + REM strings) |
| `_discover_new_entities` | REMs to remote platform | No change | REMs **and** FANs to remote platform |

### ramses_rf

| Component | Phase 3a (before) | Phase 3a (DONE) | Phase 3b |
|-----------|-------------------|-----------------|----------|
| `SCH_TRAITS_HVAC` `bound` | `vol.Any(None, str)` | `vol.Any(None, str, list[str])` DONE | Same (no change) |
| Schema strip+map pipeline | Does not exist | `strip_and_map_traits()` + `strip_traits()` DONE | Stage 2 adds `_commands`→`commands` (future, when ramses_rf needs it) |
| `strip_and_map_traits` recursion | N/A | Recursive into nested dicts DONE | Same (no change) |
| `HvacVentilator.set_fan_mode()` | Already works (PR 546) | No change | No change |
| `Command.set_fan_mode()` | Already scheme-aware (issue 547) | No change | No change |
| `get_bound_rem()` | Returns first bound REM/DIS | No change | No change |
| `supported_commands()` | Does not exist | Not needed | Future (issue 530 Phase 3) |

**Phase 3a completed items (no further work needed for 3b):**

1. `_bound` accepts `str | list[str]` — ramses_rf `SCH_TRAITS_HVAC` + ramses_cc `fan_handler`
2. `fan_handler.setup_fan_bound_devices` loops over all bound REMs
3. CO2-as-REM binding works via `_class: REM` override in ramses_rf
4. `bound_to_fan` state attribute on REM entity
5. `climate.set_fan_mode` calls `device.set_fan_mode()` + intercepts custom commands
6. `_strip_schema_extensions` delegates stage 1 to ramses_rf's `strip_traits`
7. `_derive_known_list_from_schema` uses ramses_rf's `strip_and_map_traits`
8. `strip_and_map_traits` is recursive (handles nested dicts like zones)
9. Store `max_readable_version=2` for downgrade safety
10. Startup load: schema `_commands` → `_remotes` (SSOT precedence)
11. `async_save_client_state` else branch syncs remotes to schema
12. Backup with `reason="ssot_phase3a"` before migration

**Phase 3a test coverage (all 15 code paths + extras):**

- 993 ramses_cc unit tests (31 new for Phase 3a)
- 17 ha_sim integration tests (R24-R25)
- 17 ramses_rf strip_and_map tests
- All passing, ruff/mypy clean

**Phase 3b test coverage:**

- 1026 ramses_cc unit tests (33 new: 23 remote, 9 coordinator migration, 1 climate)
- 28 ha_sim integration checks (R24: 10, R25: 6, R26: 12)
- All passing, ruff/mypy clean

### CLI testing (outside HA)

The schema format must also work with `ramses_cli` (the ramses_rf CLI).
Users can paste a working schema into `config.json` and run the CLI
with `-monitor` to load the schema from file, use it as a filter for
RF traffic, and run:

```json
{
    "config": {
        "use_schema": true
    },
    "schema": {
        "controller": "01:145038",
        "system": {
            "heating_control": "13:237335"
        }
    }
}
```

The `known_list` and `block_list` can be provided as part of
`config.json`.

This means any schema changes must be validated against the CLI, not
just HA. There are two issues that affect both Phase 3a and 3b:

**1. `_bound` as list — blocked by ramses_rf schema validation**

ramses_rf's `SCH_TRAITS_HVAC` (config.py:89) only accepts a single string:
```python
vol.Optional(SZ_BOUND_TO): vol.Any(None, vol.Match(DEVICE_ID_REGEX.ANY))
```
A list `["32:153001", "32:153002"]` would be rejected. This needs to
change to `vol.Any(None, str, [str])` in ramses_rf — and it's needed
for **Phase 3a** (the "3a changes needed" column), not just 3b.

**2. `_commands` — stripped by ramses_cc, but CLI has no stripper**

ramses_cc strips `_` prefixed keys via `_strip_schema_extensions`
before passing to ramses_rf. So ramses_rf never sees `_commands`. But
the CLI loads `config.json` directly into ramses_rf — no stripping.
`SCH_TRAITS` has `extra=vol.PREVENT_EXTRA`, so `_commands` would
**reject the entire schema**.

**Does ramses_rf need `_commands` today?** No. ramses_cc reads
`_commands`, builds the packet, sends via ramses_rf. ramses_rf just
sends it. This follows the same pattern as `_bound`:

```
ramses_cc schema    →    ramses_rf known_list
─────────────────         ───────────────────
_bound (underscore)  →    bound (no underscore)    coordinator.py:1277
_scheme (underscore) →    scheme (no underscore)   coordinator.py:1279
_commands (underscore) →   stripped, not passed    ramses_rf doesn't need it
```

ramses_cc maps `_bound` → `bound` when building the known_list for
ramses_rf (coordinator.py:1277). `_commands` is not mapped because
ramses_rf doesn't need it — `HvacVentilator.set_fan_mode()` builds
packets from `_scheme` + `get_bound_rem()`, not from `_commands`.

**Future (Phase 3 / Builder Pattern):** When ramses_rf gets
`supported_commands()`, it will need to know what the user configured.
At that point, `_commands` would map to `commands` (no underscore),
same pattern as `_bound` → `bound`. ramses_rf's schema would define
`commands` as a proper trait.

Options for the CLI issue today:
- **a)** ramses_rf's `SCH_TRAITS` changes `PREVENT_EXTRA` to allow `_`
  prefixed keys (ignore them). Simplest, but a blanket ignore — no
  control over which keys are stripped, no logging, no mapping.
- **b)** Move the strip+map logic to ramses_rf as a transformation
  pipeline. Both the CLI and ramses_cc call the same function.
  ramses_cc keeps its own orchestration logic (`_disabled`/`_skipped`/
  orphan routing) on top. Avoids a duplicate stripper.
- **c)** Users don't put `_commands` in `config.json` for the CLI —
  only in HA's schema. The CLI is for monitoring, not sending commands.

**Recommendation: (b)** — gives control over the different stages.

Currently ramses_cc jumbles three stages together. Splitting them gives
clear ownership:

```
Stage 1 (ramses_rf):  strip _ keys ramses_rf doesn't need
                      (_commands, _disabled, _name, _note, etc.)
Stage 2 (ramses_rf):  map _ keys ramses_rf does need
                      (_bound→bound, _scheme→scheme)
                      — ramses_rf knows its own traits
Stage 3 (ramses_cc):  orchestration
                      (orphan routing, HGI dropping, disabled/skipped
                      filtering, foreign-owner handling)
```

ramses_rf owns stages 1+2 (it knows which `_` keys map to which native
traits). ramses_cc owns stage 3 (it knows about disabled/skipped/orphans).

Both the CLI and ramses_cc call ramses_rf's stage 1+2 function. No
duplicate stripper. The CLI doesn't need stage 3 (no orphan routing).

**Impact on Phase 2.95 code (CQRS Read-Models):** None. The strip+map
function runs BEFORE `SCH_TRAITS()` validation (config.py), not in the
device creation or state ingestion path. It doesn't touch:
- `dev_registry.py` (`_handle_promote_class`, `device_factory_cb`)
- `TopologyBuilder` (heuristic eavesdropping rules)
- `state/store.py` (CQRS read-models, SQLite cache)
- `routing.py` (routing keys)

ramses_rf already strips `commands` from known_list before validation
(`dev_registry.py:492`: `_traits_raw.pop("commands", None)`). The
strip+map pipeline generalizes this existing pattern — it doesn't
restructure the CQRS architecture.

**Note:** Phase 3a requires a ramses_rf PR (not just ramses_cc):
1. Add `strip_and_map_traits()` function (stages 1+2)
2. Change `SCH_TRAITS_HVAC` `bound` to accept `str | list[str]`
3. ramses_cc calls ramses_rf's function instead of inline `_strip_traits`

**Future (Phase 3):** Stage 2 just adds `_commands`→`commands` mapping
when ramses_rf needs it. No new stripper, no new function — just add a
line to the existing map.

---

## Migration (runtime — no store version bump)

Phase 3b uses **runtime migration** (same pattern as Phase 3a), not a store
version bump. The migration runs in `_migrate_rem_commands_to_fan` during
`async_save_client_state`, on every save cycle.

`STORAGE_VERSION` stays at 1. The migration is idempotent — it only copies
commands that are NOT already on the FAN entry (FAN is authoritative).

```python
@staticmethod
def _migrate_rem_commands_to_fan(schema: dict[str, Any]) -> dict[str, Any]:
    """Migrate _commands from REM entries to FAN entries (Phase 3b).

    For each FAN entry with _bound, copies _commands from the bound REM
    entries to the FAN entry as {verb, code, payload} dict templates.
    REM _commands (packet strings) are NOT deleted — kept for backward
    compatibility (downgrade path: v2 code ignores FAN _commands, reads
    REM _commands).
    """
    for fan_id, entry in schema.items():
        if not isinstance(entry, dict) or entry.get("_class") != "FAN":
            continue
        bound = entry.get("_bound", [])
        if isinstance(bound, str):
            bound_rems = [bound]
        elif isinstance(bound, list):
            bound_rems = bound
        else:
            continue

        # Collect commands from bound REMs
        rem_commands = {}
        for rem_id in bound_rems:
            rem_entry = schema.get(rem_id, {})
            if isinstance(rem_entry, dict):
                rem_cmds = rem_entry.get("_commands", {})
                for cmd_name, cmd_val in rem_cmds.items():
                    if cmd_name not in rem_commands:
                        rem_commands[cmd_name] = str(cmd_val)

        # Parse packet strings to dict templates, merge into FAN
        fan_commands = entry.get("_commands", {})
        for cmd_name, packet_str in rem_commands.items():
            if cmd_name in fan_commands:
                continue  # FAN is authoritative
            parts = packet_str.split()
            fan_commands[cmd_name] = {
                "verb": parts[0],    # "I"
                "code": parts[5],    # "22F1"
                "payload": parts[7], # "000030"
            }
        entry["_commands"] = fan_commands

    # REM _commands are NOT deleted — downgrade safety
```

Called in all 3 branches of `async_save_client_state`:
1. When topology is richer (enriched path)
2. When only comments refreshed (else-if path)
3. When no topology changes (else path)

## Backward compatibility

- v2 code ignores `_commands` on FAN (stripped by `_strip_schema_extensions`)
- v2 code still reads `_commands` on REM entries (if not yet migrated)
- v3 code reads `_commands` from FAN first, falls back to REM entries
- If user downgrades v3 → v2: `_commands` on FAN ignored, REM entries
  still have `_commands` (NOT deleted during migration — downgrade safety)
- No store version bump — migration is runtime, same as Phase 3a
- REM `remote` entities stay (existing automations targeting
  `remote.32_153001` keep working)

---

## Alignment with ramses_rf

This design must align with PWhite-Eng's architectural refactor
(issue 530) and the Discussion 191 consensus. **Issue 530 Phase 3**
(Builder Pattern, `supported_commands()`) is PWhite-Eng's work — we
must not conflict with it. Our Phase 3b is ramses_cc-only and does
**not** depend on issue 530.

### Issue 530: master plan

| Phase | Description | Status |
|-------|-------------|--------|
| 1 | Flight Recorder (rotating packet logs) | MERGED |
| 2 | Database & State Architecture (SQLite, RAM cache) | MERGED |
| 2.2 | Strategy Lookup Table (composite keys) | MERGED (PR 559) |
| 2.9 | TopologyBuilder (heuristic eavesdropping) | MERGED (PR 639) |
| 2.95 | CQRS Read-Models, legacy purge | MERGED |
| **3** | **Dynamic Strategy Pattern + `supported_commands()`** | **NOT STARTED** |
| 4 | Isolated Routing Logic | NOT STARTED |

**Already done (discovery/classification):**
- `TopologyBuilder` engine — centralizes heuristic eavesdropping (PR 639)
- `TopologyChangedEvent` with `TopologyAction` enum (`PROMOTE_CLASS`, `BIND_DEVICE`)
- `_handle_promote_class` in `dev_registry.py` — safely promotes device class
- `HVAC_KLASS_BY_VC_PAIR` — class detection from verb+code pairs
  (REM from `I 22F1`, CO2 from `I 1298`, FAN from `I 31D9/31DA`)
- Class promotion purged from entities — they're now pure CQRS Read-Models
- REM/CO2 parent FAN inference from RP replies (commit 10939476)

**NOT yet started (the actual Phase 3):**
- Dynamic Strategy Pattern (`GenericStrategy` → `OrconStrategy` etc.)
  — no `Strategy` classes exist in the codebase yet
- `supported_commands()` — not found in any source file
- Event Sourcing for replay (retroactive re-parse from history)
- Known-List Seeding (hydrate Builder from config at t=0)

### Discussion 191: consensus

**1. Commands belong on the device that handles them** (wimpie70):
> "Currently commands are configured on the (faked) REM devices. I think
> it would be better to provide them on the device that will handle that
> command: the FAN, CO2, or the heater. So, yes... define them on
> `supported_commands()` and/or on `strategies()`"

This is exactly what Phase 3b does — `_commands` moves to the FAN.

**2. `supported_commands()` is the ramses_rf side** (silverailscolo):
> "each model/class can then provide `friendly_name()`,
> `supported_commands()` and `strategies()`. The Builder pattern can use
> these replies to dress up a device."

ramses_rf's `supported_commands()` (future, issue 530 Phase 3) defines
what a FAN **can** do. ramses_cc's `_commands` in schema is the user
override layer — what the user **configured** it to do.

**3. known_list as "Seeding Mechanism"** (PWhite-Eng):
> "Instead of the `known_list` just being a passive filter (Allow/Block),
> it becomes the Long-Term Memory for the Detective."

The schema's `_commands` on FAN entries is part of this seeding — it
tells the Builder what commands the user has configured.

**4. `class` will be replaced** (silverailscolo):
> "Existing class entries in config will be ignored in the future."

`_class` in schema is a transitional trait. In the future,
manufacturer+model+revision (from 10E0) will drive strategy selection.
Our `_commands` design doesn't depend on `_class` — it depends on
`_bound` and the FAN entry, which will survive the class removal.

**5. Multi-role devices** (PWhite-Eng + silverailscolo):
> silverailscolo: "the future approach will no longer require to pick
> either one (class) if a device(_id) does both jobs."

A CO2 with buttons can be both a sensor and a REM. In `_bound`, it
appears as a transport device. Its sensor role is separate. `_bound`
doesn't care about the device type, only that it can send packets.

**6. Template-based commands** (wimpie70):
> "In Ramses Extras I create the commands with templates, just needs a
> target and a bound REM to fully control a FAN. No need for the commands
> defined in known devices."

This validates the placeholder approach (`%src%`, `%dst%`, calculated
length). The user defines the command once, the system fills in the
addresses at send time.

**Issue 714: Strict DTOs (CQRS Read-Models)** — PWhite-Eng also plans to
replace dict-based API boundaries with strict DTOs. Our `_commands`
design stores dicts in the schema, but the send path builds a `Command`
object (already typed), so this is compatible.

### Boundaries

**What we must NOT do:**
- **Don't add `supported_commands()` to ramses_rf** — that's PWhite-Eng's
  Phase 3 work. Our Phase 3b is ramses_cc-only (schema + entity changes).
- **Don't change `HvacVentilator.set_fan_mode()`** — it already works
  (PR 546). We just need to call it from `climate.py`.
- **Don't change `Command.set_fan_mode()`** — it already handles schemes
  (issue 547). We just need to pass `_scheme` through.
- **Don't remove `known_list`** — it's the "Seeding Mechanism" for the
  future Builder. Our schema `_commands` is an overlay, not a replacement.

### What we can do now (Phase 3a changes — ALL DONE, Phase 3b — ALL DONE)

These were small changes to PR 811 that aligned with Phase 3b.
All completed and tested:

1. **`_bound` accepts `str | list[str]`** — `fan_handler` loops over
   all bound REMs. ramses_rf `SCH_TRAITS_HVAC` accepts list. DONE.
2. **`bound_to_fan` state attribute on REM entity** — in `remote.py`. DONE.
3. **`climate.set_fan_mode` calls `device.set_fan_mode()`** — wired to
   ramses_rf PR 546. Also intercepts custom commands from `_commands`. DONE.
4. **`_strip_schema_extensions` delegates to ramses_rf** — stage 1 via
   `strip_traits`, stage 2 via `strip_and_map_traits`. DONE.
5. **CO2-as-REM binding** — works via `_class: REM` override in ramses_rf. DONE.
6. **Store `max_readable_version=2`** — downgrade safety. DONE.

---

## Open questions

1. **Which REM to pick at send time?** First available? Round-robin?
   **Resolved:** First available. ramses_rf's `get_bound_rem()` already
   returns the first bound REM/DIS from `_bound_devices` dict. Since
   `fan_handler.setup_fan_bound_devices` loops over all bound REMs
   (Phase 3a), `_bound_devices` has all of them. No change needed.

2. **22F7 (bypass) and 22B0 (calendar) builders?** When ramses_rf gets
   builders for these, the commands move from `_commands` to native
   method calls. Same pattern as 22F1 → issue 547.
   **Status:** Not sure yet — depends on ramses_rf Builder Pattern
   (issue 530 Phase 3). For now, `_commands` is the only way to send
   these. When builders arrive, commands move from `_commands` to
   native method calls.

3. **2411 parameter commands?** Separate from `_commands` (they go
   through `fan_handler` + `add_bound_device`). This design doesn't
   change 2411 routing — `_bound` still tells `fan_handler` which REM
   to use for 2411 RQ/W.
   **Status:** Keep separate for now. Some fans can handle 2411, not
   all. This will be a builder thing in the future (issue 530 Phase 3).
   `_commands` does not touch 2411 routing.

4. **What if a FAN has no `_bound`?** No REMs to send through.
   `send_command` raises an error. `learn_command` can't capture
   anything. User must set `_bound` first.
   **Resolved:** Give a warning (rate-limited, not spamming). The user
   must set `_bound` and bind a faked REM. The warning guides them to
   the fix without flooding the log.

5. **Multiple FANs sharing a REM?** A REM could be bound to 2 FANs
   (unusual but possible). The `_bound` list is per-FAN, so the same
   REM ID could appear in multiple FAN entries. No conflict — each
   FAN sends its own commands with its own dst address.
   **Resolved:** A REM should never control more than 1 FAN. This is
   a constraint we enforce — if a user tries to bind a REM to 2 FANs,
   warn or reject. In practice, each REM is bound to exactly one FAN.

6. **Should standard modes also be in `_commands`?** No — that would
   duplicate what ramses_rf already knows via `_scheme`. But a user
   could override a standard mode with a custom payload in `_commands`
   if their device needs a non-standard format (edge case).
   **Status:** Agreed — standard modes go through `set_fan_mode()` +
   `_scheme`. The Builder Pattern (issue 530 Phase 3) will make this
   more diverse: each strategy/manufacturer will define its own
   standard modes. `_commands` stays as the user override layer for
   non-standard commands that have no builder.

---

## Implementation Plan (Phase 3b)

**Format decision:** Both packet string (v2) and dict (v3) formats
accepted at runtime. Migration copies REM `_commands` to FAN as dicts
but does NOT delete REM entries — this gives a clean downgrade path
(v2 code ignores FAN `_commands`, reads REM `_commands`).

### PR structure

Phase 3b requires changes in 2 repos:

1. **ramses_cc PR** — the main work (schema, entity, send/learn, migration)
2. **ramses_rf PR** — minor: `strip_and_map_traits` stage 2 adds
   `_commands`→`commands` mapping (only needed when ramses_rf gets
   `supported_commands()` — can be deferred)

The ramses_rf PR is NOT a blocker for 3b. ramses_cc strips `_commands`
before ramses_rf sees the schema (via `strip_traits`). The mapping is
only needed in the future when ramses_rf's Builder Pattern reads
`commands` directly.

### Work items (ramses_cc PR)

#### Item 1: Schema format — `_commands` as `{verb, code, payload}` dicts on FAN

**Files:** `coordinator.py`, `const.py`

- `const.py`: Add `SZ_TR_COMMANDS_DICT` type alias (if needed for typing)
- `coordinator.py` `_async_update_schema_commands`: Accept both formats:
  - `str` (v2 packet string) — store as-is on REM entry (backward compat)
  - `dict` with `verb`, `code`, `payload` — store on FAN entry
- `coordinator.py` startup load: Read `_commands` from FAN entries
  (dicts) AND REM entries (packet strings), merge into `_remotes`
  - FAN `_commands` (dicts) keyed by FAN ID
  - REM `_commands` (packet strings) keyed by REM ID (fallback)
  - Both coexist in `_remotes` dict

**No ramses_rf changes needed** — `_commands` is stripped by
`strip_traits` before ramses_rf sees the schema.

#### Item 2: Packet template builder

**Files:** `remote.py` (new helper function)

```python
def _build_packet_from_template(
    cmd_def: dict[str, str],
    fan_device: HvacVentilator,
    coordinator: RamsesCoordinator,
) -> str:
    """Build a packet string from a {verb, code, payload} template."""
    verb = cmd_def["verb"]
    code = cmd_def["code"]
    payload = cmd_def["payload"]
    # src resolution: explicit src > bound REM > HGI fallback
    src = cmd_def.get("src")
    if not src:
        src = str(fan_device.get_bound_rem() or "")
    if not src:
        # Fallback to HGI gateway ID
        client = coordinator.client
        if client:
            hgi = getattr(client, "_gwy", None)
            if hgi:
                hgi_dev = getattr(hgi, "_hgi", None) or getattr(hgi, "hgi", None)
                if hgi_dev:
                    src = str(hgi_dev.id)
    if not src:
        raise HomeAssistantError(
            "No bound REM or HGI available to send command — set _bound on the FAN"
        )
    dst = fan_device.id
    brd = "--:------"
    length = f"{len(payload) // 2:03d}"
    return f"{verb} --- {src} {dst} {brd} {code} {length} {payload}"
```

- Also add `_parse_packet_to_template(packet: str) -> dict[str, str]`
  for `learn_command` (extract verb, code, payload from captured packet)

#### Item 3: `remote.py` entity on FAN

**Files:** `remote.py`, `climate.py` (or `fan_handler.py`)

- `remote.py` `async_setup_entry`: Currently filters `isinstance(device, HvacRemote)`.
  Add `isinstance(device, HvacVentilator)` — FAN devices also get a
  `remote` entity.
- `RamsesRemote.__init__`: Accept `HvacVentilator` as well as `HvacRemote`.
  The `_commands` initialization changes:
  - For REM: `coordinator._remotes.get(device.id, {})` (packet strings)
  - For FAN: `coordinator._remotes.get(device.id, {})` (dicts) +
    `coordinator._remotes.get(bound_rem_id, {})` (fallback to REM's
    packet strings)
- `extra_state_attributes`:
  - For REM: `commands` (packet strings) + `bound_to_fan` (existing)
  - For FAN: `commands` (dicts) + `bound_rems` (list of bound REM IDs)

**Key decision:** Both REM and FAN get `remote` entities. The REM entity
is kept for backward compatibility (existing automations target
`remote.32_153001`). The FAN entity is the new primary
(`remote.30_160000`).

#### Item 4: `send_command` builds from template

**Files:** `remote.py`

- `async_send_command`: If `_commands[command]` is a dict, build packet
  via `_build_packet_from_template()`. If it's a string (v2 format),
  use directly (existing behavior).
- The FAN entity's `send_command` uses `self._device.get_bound_rem()` to
  pick the src REM.
- The REM entity's `send_command` still works (uses hardcoded packet
  string from its own `_commands`).

#### Item 5: `learn_command` listens to all bound REMs

**Files:** `remote.py`

- For FAN entity: `learn_command` callback filter changes from
  `src == self._device.id` to `src in self._bound_rems`
  where `_bound_rems` is read from the schema `_bound` trait.
- Captured packet is parsed via `_parse_packet_to_template()` and stored
  as a dict on the FAN entry.
- For REM entity: `learn_command` still listens to one REM src (backward
  compat). Stores as packet string on REM entry.

#### Item 6: `climate.py` `fan_modes` reads FAN `_commands`

**Files:** `climate.py`

- `fan_modes` property: Currently reads `coordinator._remotes[bound_rem]`.
  Update to also read `coordinator._remotes[fan_id]` (FAN's own dicts).
  Merge both: FAN commands (dicts) + REM commands (packet strings).
- `async_set_fan_mode` intercept: Currently checks `commands[fan_mode]`
  and sends as packet string. Update to handle dict format:
  if `commands[fan_mode]` is a dict, build via
  `_build_packet_from_template()`. If string, use directly.

#### Item 7: Runtime migration REM → FAN dict templates

**Files:** `coordinator.py` (no `store.py` changes needed)

- `coordinator.py`: Add `_migrate_rem_commands_to_fan` static method.
  - For each FAN entry in schema with `_bound`:
    - Normalize `_bound` to list (if string)
    - For each bound REM, copy its `_commands` (packet strings) to the
      FAN entry as dicts (parse via `_parse_packet_to_template`)
    - Do NOT delete REM `_commands` (downgrade safety)
    - Only copy commands NOT already on the FAN (FAN is authoritative)
  - Called in all 3 branches of `async_save_client_state`
- **No store version bump** — `STORAGE_VERSION` stays at 1.
  Migration is runtime (same pattern as Phase 3a's `_sync_remotes_to_schema`).
- Downgrade safety:
  - v3→v2: v2 code ignores FAN `_commands` (stripped), reads REM
    `_commands` (still present as packet strings — NOT deleted)
  - v2→v1: identity (already handled)

#### Item 8: Config flow `_commands` on FAN

**Files:** `config_flow.py`, `schemas.py`

- Config flow schema step already preserves `_commands` through round-trip
  (tested in Phase 3a). No change needed for dict format —
  `strip_traits` strips `_commands` regardless of value type.
- Config flow UI: Consider adding a FAN-specific command editor in a
  future iteration. For now, users edit `_commands` in the schema
  YAML/JSON directly (same as Phase 3a).

### Test plan

#### Unit tests (ramses_cc) — 33 new, 1026 total

1. `_build_packet_from_template` — builds correct packet from dict
2. `_build_packet_from_template` — explicit src override
3. `_build_packet_from_template` — HGI fallback when no bound REM
4. `_build_packet_from_template` — raises when no src resolvable
5. `_build_packet_from_template` — length calculated from payload
6. `_parse_packet_to_template` — extracts verb/code/payload from packet
7. `_parse_packet_to_template` — handles 22F7 (bypass) packets
8. `_parse_packet_to_template` — raises ValueError for short packets
9. `_is_command_dict` — True for valid dict templates
10. `_is_command_dict` — False for packet strings
11. `_is_command_dict` — False for incomplete dicts
12. FAN entity `is_fan_entity` — True for HvacVentilator
13. REM entity `is_fan_entity` — False for HvacRemote
14. FAN entity `_bound_rem_ids` — reads _bound from schema
15. FAN entity loads own `_commands` (dicts) from coordinator._remotes
16. FAN entity loads bound REM's `_commands` (strings) as fallback
17. FAN entity `extra_state_attributes` — includes `bound_rems`
18. REM entity `extra_state_attributes` — includes `bound_to_fan`
19. FAN `send_command` with dict template — builds + sends
20. FAN `send_command` with REM string fallback — uses packet string
21. FAN `add_command` — parses to dict template
22. REM `add_command` — stores packet string (backward compat)
23. `_migrate_rem_commands_to_fan` — no FAN → no change
24. `_migrate_rem_commands_to_fan` — FAN no _bound → no change
25. `_migrate_rem_commands_to_fan` — bound REM no _commands → no change
26. `_migrate_rem_commands_to_fan` — REM commands copied as dicts
27. `_migrate_rem_commands_to_fan` — REM commands NOT deleted (downgrade)
28. `_migrate_rem_commands_to_fan` — FAN commands authoritative
29. `_migrate_rem_commands_to_fan` — multi-REM all copied
30. `_migrate_rem_commands_to_fan` — _bound as str normalized
31. `_migrate_rem_commands_to_fan` — invalid packet skipped, no crash

#### Integration tests (ha_sim) — Recipe 26, 12 checks

32. FAN remote entity exists (`remote.fan_32_150000`)
33. FAN `bound_rems` attribute includes bound REM
34. `add_command` on FAN — stores dict template in schema
35. Dict template has correct verb/code/payload
36. `send_command` on FAN entity — succeeds
37. `fan_modes` includes FAN `_commands`
38. REM `_commands` migrated to FAN as dict templates
39. REM `_commands` not deleted after migration (downgrade safety)

**Backward compat:** R24 (10 checks) + R25 (6 checks) still pass.

### Implementation decisions (resolved)

1. **`_remotes` dict keying** — Mixed keys in a single `_remotes` dict.
   FAN IDs map to dict values (`{verb, code, payload}`), REM IDs map to
   string values (packet strings). The value type indicates the format.
   Simpler than a separate `_fan_commands` dict — no new state to manage.

2. **`remote` entity coexistence** — Both REM and FAN get `remote` entities.
   REM entity (`remote.32_153001`) stays for backward compat — existing
   automations keep working. FAN entity (`remote.30_160000`) is new and
   becomes the primary target for 3b features.

3. **`add_command` service target** — Accepts both REM and FAN entities.
   `add_command` on a FAN stores a `{verb, code, payload}` dict on the
   FAN's schema entry. `add_command` on a REM stores a packet string on
   the REM's schema entry (backward compat).

4. **`get_bound_rem()` with list `_bound`** — **Resolved:** ramses_rf's
   `get_bound_rem()` iterates over `_bound_devices` dict (populated by
   `fan_handler.setup_fan_bound_devices` which loops over all bound REMs)
   and returns the first REM/DIS. Works with multi-REM. No change needed.

5. **No `_bound` warning** — If a FAN has no `_bound`, `send_command` and
   `learn_command` emit a rate-limited warning (not spamming). The user
   must set `_bound` and bind a faked REM.

6. **REM-to-FAN constraint** — A REM should never control more than 1 FAN.
   If a user binds a REM to 2 FANs, warn. Each REM is bound to exactly
   one FAN.

---

## References

- **Discussion 191** (ramses_rf): "Untangling the Organic Code Knot" —
  the big architectural discussion. 34 comments. Key consensus: commands
  on FAN, `supported_commands()` in Builder, known_list as seeding.
- **Issue 530** (ramses_rf): Architectural Refactor — the master plan.
  Phase 1+2 merged, Phase 3 (Builder Pattern) not started.
- **Issue 714** (ramses_rf): Strict DTOs (CQRS Read-Models) — replace
  dict-based API boundaries. Not started, cross-repo breaking change.
- **Issue 547** (ramses_rf): Native 3-byte 22F1 payloads — scheme-aware
  builder, removed the need for raw command strings for standard modes.
- **PR 546** (ramses_rf): `HvacVentilator.set_fan_mode()` — FAN method
  that picks bound REM and sends.
- **Issue 210** (ramses_cc): `climate/set_fan_mode` NotImplementedError —
  the original problem, Siber DF Evo 4. Workaround was raw command
  strings in known_list.
- **Commit 10939476** (ramses_rf): infer REM/CO2 parent FAN from RP
  replies — binding detection from traffic.
