### PR TITLE
fix: exclude foreign HGIs (18:) from block_list

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1507,20 +1507,27 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         config_schema_check = self.options.get(CONF_SCHEMA, {})
         if isinstance(config_schema_check, dict):
             coordinator.discovery_manager.check_class_mismatches(config_schema_check)
+            coordinator.discovery_manager.check_missing_class(config_schema_check)
 
         new_devices = coordinator.discovery_manager.get_devices(
             status=DiscoveryStatus.NEW
         )
         mismatched_devices = coordinator.discovery_manager.get_mismatched_devices()
-        # Deduplicate: a device could be both NEW and mismatched (unlikely
-        # but safe) — only show it once, in the NEW section.
+        missing_class_devices = (
+            coordinator.discovery_manager.get_missing_class_devices()
+        )
+        # Deduplicate: a device could appear in multiple categories — only
+        # show it once.  Priority: NEW > class_mismatch > missing_class.
+        new_ids = {d.device.device_id for d in new_devices}
         mismatched_only = [
-            e
-            for e in mismatched_devices
-            if e.device.device_id not in {d.device.device_id for d in new_devices}
+            e for e in mismatched_devices if e.device.device_id not in new_ids
+        ]
+        seen_ids = new_ids | {e.device.device_id for e in mismatched_only}
+        missing_class_only = [
+            e for e in missing_class_devices if e.device.device_id not in seen_ids
         ]
         devices = new_devices
-        if not devices and not mismatched_only:
+        if not devices and not mismatched_only and not missing_class_only:
             # If the user already submitted the form, close it.
             # Otherwise show the "no devices" message once.
             if user_input is not None:
@@ -1671,6 +1678,32 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             # doesn't re-flag this device on the next checkpoint
                             meta.class_mismatch_dismissed = True
 
+            # Process missing_class devices (accepted, no _class in schema,
+            # but discovery has a likely_type).  The user can add _class
+            # from the discovery suggestion or skip.
+            for entry in missing_class_only:
+                device_id = entry.device.device_id
+                action = user_input.get(f"missing_class_{device_id}", "skip")
+                if action == "add_class":
+                    dev_entry = config_schema.get(device_id)
+                    if isinstance(dev_entry, dict):
+                        dev_entry[SZ_TR_CLASS] = str(entry.device.likely_type)
+                        changed = True
+                        _LOGGER.info(
+                            "review_discovered: added _class=%s for %s "
+                            "(was missing, discovery suggestion accepted)",
+                            entry.device.likely_type,
+                            device_id,
+                        )
+                # Clear the missing_class flag for both "add_class" and "skip"
+                # so the notification doesn't re-fire immediately.  For "skip"
+                # the flag will be re-set on the next checkpoint if the schema
+                # still lacks _class — but that's the next review cycle.
+                if action in ("add_class", "skip"):
+                    meta = coordinator.discovery_manager._metadata.get(device_id)
+                    if meta:
+                        meta.missing_class = None
+
             if changed:
                 self.options[CONF_SCHEMA] = order_schema(config_schema)
 
@@ -1715,8 +1748,23 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     f"| `{d.device_id}` | {schema_cls} | {disc_cls} | {d.confidence} |"
                 )
 
+        if missing_class_only:
+            if lines:
+                lines.append("\n")
+            lines.append(
+                f"**{len(missing_class_only)} device(s) with missing _class:**\n"
+            )
+            lines.append("| Device | Discovery suggests | Confidence |")
+            lines.append("|--------|-------------------|------------|")
+            for entry in missing_class_only:
+                d = entry.device
+                # Parse the missing_class desc: "discovery=FAN"
+                mc = entry.metadata.missing_class or ""
+                disc_cls = mc.split("discovery=")[1] if "discovery=" in mc else "?"
+                lines.append(f"| `{d.device_id}` | {disc_cls} | {d.confidence} |")
+
         if not lines:
-            lines.append("No new devices or class mismatches to review.")
+            lines.append("No new devices or mismatches to review.")
         summary = "\n".join(lines)
 
         # Build form with device selectors — each field name includes
@@ -1820,6 +1868,31 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         {"value": "skip", "label": "Skip for now"},
                         {"value": "update_class", "label": f"Update to {disc_cls}"},
                         {"value": "keep", "label": f"Keep {schema_cls}"},
+                    ],
+                )
+            )
+
+        # Add form fields for missing_class devices
+        for entry in missing_class_only:
+            d = entry.device
+            device_id = d.device_id
+            mc = entry.metadata.missing_class or ""
+            disc_cls = mc.split("discovery=")[1] if "discovery=" in mc else "?"
+            field_label = (
+                f"{device_id} | no _class in schema → "
+                f"discovery suggests {disc_cls} (conf={d.confidence})"
+            )
+            form_fields[
+                vol.Required(
+                    f"missing_class_{device_id}",
+                    default="skip",
+                    description={"label": field_label},
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        {"value": "skip", "label": "Skip for now"},
+                        {"value": "add_class", "label": f"Add _class: {disc_cls}"},
                     ],
                 )
             )

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1601,8 +1601,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         if isinstance(dev_entry, dict):
                             dev_entry.pop(SZ_TR_SKIPPED, None)
                             dev_entry.pop("_comment", None)
-                            # Set owner to root owner (accepted = ours)
-                            dev_entry[SZ_TR_OWNER] = root_owner
+                            # Use per-device owner if provided, otherwise root
+                            # owner.  This lets the user accept a device (create
+                            # entities) while tagging it as foreign (e.g. a
+                            # neighbour's FAN you want to monitor but not own).
+                            per_device_owner = (
+                                user_input.get(f"owner_{device_id}", "") or ""
+                            ).strip()
+                            dev_entry[SZ_TR_OWNER] = (
+                                per_device_owner if per_device_owner else root_owner
+                            )
                         changed = True
                 elif action == "decline":
                     # Decline — mark as foreign owner so it goes to block_list

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1655,6 +1655,13 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     dev_entry = config_schema.get(device_id)
                     if isinstance(dev_entry, dict):
                         dev_entry[SZ_TR_CLASS] = str(entry.device.likely_type)
+                        # Apply per-device owner if provided, else root owner
+                        per_device_owner = (
+                            user_input.get(f"owner_{device_id}", "") or ""
+                        ).strip()
+                        dev_entry[SZ_TR_OWNER] = (
+                            per_device_owner if per_device_owner else root_owner
+                        )
                         changed = True
                         class_updates.append(device_id)
                         _LOGGER.info(
@@ -1667,7 +1674,21 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     meta = coordinator.discovery_manager._metadata.get(device_id)
                     if meta:
                         meta.class_mismatch_dismissed = False
-                # "keep" or "skip" — do nothing, schema stays as-is
+                elif action == "keep":
+                    # Keep existing _class — but still apply owner
+                    dev_entry = config_schema.get(device_id)
+                    if isinstance(dev_entry, dict):
+                        per_device_owner = (
+                            user_input.get(f"owner_{device_id}", "") or ""
+                        ).strip()
+                        if per_device_owner or dev_entry.get(SZ_TR_OWNER) != (
+                            per_device_owner if per_device_owner else root_owner
+                        ):
+                            dev_entry[SZ_TR_OWNER] = (
+                                per_device_owner if per_device_owner else root_owner
+                            )
+                            changed = True
+                # "keep" or "skip" — do nothing to _class, schema stays as-is
                 # Clear the mismatch flag for both "update_class" and "keep"
                 if action in ("update_class", "keep"):
                     meta = coordinator.discovery_manager._metadata.get(device_id)
@@ -1688,6 +1709,13 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     dev_entry = config_schema.get(device_id)
                     if isinstance(dev_entry, dict):
                         dev_entry[SZ_TR_CLASS] = str(entry.device.likely_type)
+                        # Apply per-device owner if provided, else root owner
+                        per_device_owner = (
+                            user_input.get(f"owner_{device_id}", "") or ""
+                        ).strip()
+                        dev_entry[SZ_TR_OWNER] = (
+                            per_device_owner if per_device_owner else root_owner
+                        )
                         changed = True
                         _LOGGER.info(
                             "review_discovered: added _class=%s for %s "
@@ -1771,15 +1799,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # the device info so the user can see what they're accepting.
         form_fields: dict[Any, Any] = {}
 
-        # Owner name field — sets the root _owner in the schema.
-        # Devices accepted get this owner; declined devices get "not-me".
+        # Owner name field — sets the ROOT _owner in the schema.
+        # This is the system-wide owner.  Per-device owner fields below
+        # override it for individual devices.  If no root _owner was set
+        # yet, this fills it in.
         existing_owner = self.options.get(CONF_SCHEMA, {}).get(SZ_OWNER, "")
         form_fields[
             vol.Required(
                 "owner_name",
                 default=existing_owner or "me",
                 description={
-                    "label": "System owner name (your devices will be tagged with this)",
+                    "label": "Root owner name (applies to all devices without a per-device owner below)",
                 },
             )
         ] = selector.TextSelector()
@@ -1839,11 +1869,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             form_fields[
                 vol.Optional(
                     f"owner_{device_id}",
-                    description={"label": f"Alias for {device_id} (optional)"},
+                    description={
+                        "label": f"Owner for {device_id} (overrides root owner)"
+                    },
                 )
             ] = selector.TextSelector()
 
         # Add form fields for class mismatch devices
+        config_schema_for_prefill = self.options.get(CONF_SCHEMA, {})
         for entry in mismatched_only:
             d = entry.device
             device_id = d.device_id
@@ -1871,6 +1904,20 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     ],
                 )
             )
+            existing_dev_owner = (
+                config_schema_for_prefill.get(device_id, {}).get(SZ_TR_OWNER, "")
+                if isinstance(config_schema_for_prefill.get(device_id), dict)
+                else ""
+            )
+            form_fields[
+                vol.Optional(
+                    f"owner_{device_id}",
+                    description={
+                        "label": f"Owner for {device_id} (overrides root owner)",
+                        "suggested_value": existing_dev_owner,
+                    },
+                )
+            ] = selector.TextSelector()
 
         # Add form fields for missing_class devices
         for entry in missing_class_only:
@@ -1896,6 +1943,20 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     ],
                 )
             )
+            existing_dev_owner = (
+                config_schema_for_prefill.get(device_id, {}).get(SZ_TR_OWNER, "")
+                if isinstance(config_schema_for_prefill.get(device_id), dict)
+                else ""
+            )
+            form_fields[
+                vol.Optional(
+                    f"owner_{device_id}",
+                    description={
+                        "label": f"Owner for {device_id} (overrides root owner)",
+                        "suggested_value": existing_dev_owner,
+                    },
+                )
+            ] = selector.TextSelector()
 
         return self.async_show_form(
             step_id="review_discovered",

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2623,10 +2623,19 @@ class RamsesCoordinator(DataUpdateCoordinator):
         runs every 5 minutes (SAVE_STATE_INTERVAL), so users don't have to
         wait after ramses_rf has learned new topology (e.g. from 000C).
 
+        Also runs the discovery mismatch checks (Phase 3c) so mismatches
+        are detected immediately rather than waiting for the 30-minute
+        checkpoint.
+
         :param _: Unused service call argument.
         """
         _LOGGER.info("Manual topology sync requested (sync_topology service)")
         await self.async_save_client_state()
+        # Run mismatch checks immediately (Phase 3c)
+        if self.discovery_manager:
+            schema = self.options.get(CONF_SCHEMA, {})
+            if isinstance(schema, dict):
+                self.discovery_manager.check_all_mismatches(schema)
 
     async def async_send_packet(self, call: ServiceCall) -> None:
         """Delegate to Service Handler.

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -798,10 +798,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         stripped_schema = self._strip_schema_extensions(schema)
         schema_device_ids = self._extract_device_ids_from_stripped(stripped_schema)
         self.discovery_manager.sync_with_schema(schema_device_ids)
-        # Check for class mismatches between discovery and schema
-        # (schema is authoritative — this only logs warnings)
+        # Check for mismatches between discovery and schema
+        # (schema is authoritative — this only logs warnings + notification)
         if isinstance(schema, dict):
-            self.discovery_manager.check_class_mismatches(schema)
+            self.discovery_manager.check_all_mismatches(schema)
         self.discovery_manager.check_for_new_devices()
         self.discovery_manager.check_for_lost_devices()
         await self.async_save_client_state()

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1795,6 +1795,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # instead of known_list.  This prevents DeviceNotFoundError log spam
         # for neighbour's / other-RF-library devices — ramses_rf silently
         # drops their packets at the filter level.
+        #
+        # HGI devices (18:) are exempt: foreign HGIs communicate with our
+        # controller and the controller's responses (e.g. 0004 zone names,
+        # 2349 zone modes) are addressed to the foreign HGI.  Blocking them
+        # would prevent the active gateway from eavesdropping on those
+        # responses (issue 822).  ramses_rf's protocol filter already warns
+        # about foreign HGIs but lets their packets through for receiving.
         root_owner = schema.get(SZ_OWNER)
         block_list: dict[str, Any] = {}
         if root_owner:
@@ -1804,6 +1811,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     and _DEVICE_ID_RE.match(str(k))
                     and isinstance(v.get(SZ_TR_OWNER), str)
                     and v[SZ_TR_OWNER] != root_owner
+                    and str(k)[:2] != "18"  # don't block foreign HGIs
                 ):
                     block_list[str(k)] = {}
         # Also add _skipped devices to block_list (deferred decision — still

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -964,8 +964,16 @@ class DiscoveryManager:
         # by the user via the schema editor.  Without this, list-based
         # devices (REM/CO2 in remotes[], TRV in zones[], etc.) would have
         # no root entry and _owner could never be set — breaking SSOT.
+        #
+        # Also injects _class on the root entry so the scan engine's
+        # likely_type is persisted as the schema identity trait.  This
+        # matches the architecture intent (accept_discovered_device writes
+        # _class to schema) and prevents check_missing_class from flagging
+        # every accepted device on the next checkpoint.  Uses setdefault so
+        # a caller that already set _class (e.g. add_faked_rem) wins.
         def _merge(fragment: dict[str, Any]) -> dict[str, Any]:
-            fragment.setdefault(device_id, {})
+            root = fragment.setdefault(device_id, {})
+            root.setdefault(SZ_TR_CLASS, lt)
             fragment.update(_list_comment())
             return fragment
 
@@ -973,13 +981,13 @@ class DiscoveryManager:
         if lt == "CTL":
             return {
                 SZ_MAIN_TCS: device_id,
-                device_id: _with_comment({}),
+                device_id: _with_comment({SZ_TR_CLASS: lt}),
             }
 
         # ── FAN: HVAC controller ────────────────────────────────
         if lt == "FAN":
             return {
-                device_id: _with_comment({SZ_REMOTES: []}),
+                device_id: _with_comment({SZ_TR_CLASS: lt, SZ_REMOTES: []}),
             }
 
         # ── REM / CO2: HVAC remote or sensor — add to parent FAN ─────

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -464,6 +464,22 @@ class DiscoveryManager:
                 result.append(entry)
         return result
 
+    def get_missing_class_devices(self) -> list[DiscoveredDeviceEntry]:
+        """Get devices that have a missing_class flag set.
+
+        These are ACCEPTED devices whose schema entry has no ``_class``
+        but the scan engine has a ``likely_type``.  The review_discovered
+        step shows them so the user can add ``_class`` from the discovery
+        suggestion.
+
+        :return: List of device entries with missing_class set.
+        """
+        result: list[DiscoveredDeviceEntry] = []
+        for entry in self.get_devices():
+            if entry.metadata.missing_class:
+                result.append(entry)
+        return result
+
     def check_bound_mismatches(self, schema: dict[str, Any]) -> int:
         """Check for _bound mismatches between scan engine and schema.
 

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass, field
-from datetime import datetime as dt
+from datetime import datetime as dt, timedelta as td
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final
 
@@ -82,6 +82,16 @@ class DeviceMetadata:
     # step, dismissing the mismatch.  Prevents check_class_mismatches
     # from re-flagging the same device every checkpoint cycle.
     class_mismatch_dismissed: bool = False
+    # Set when the scan engine's bound_to differs from the schema's
+    # _bound.  Cleared when the mismatch is resolved.
+    bound_mismatch: str | None = None
+    # Set when the scan engine has a likely_type but the schema entry
+    # has no _class at all.  Cleared when the user adds a _class.
+    missing_class: str | None = None
+    # Set when a device is in the schema but has not been seen by the
+    # scan engine for longer than the orphan threshold.  Cleared when
+    # traffic is seen again.
+    orphaned: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict for JSON storage."""
@@ -94,6 +104,9 @@ class DeviceMetadata:
             "schema_entry": self.schema_entry,
             "class_mismatch": self.class_mismatch,
             "class_mismatch_dismissed": self.class_mismatch_dismissed,
+            "bound_mismatch": self.bound_mismatch,
+            "missing_class": self.missing_class,
+            "orphaned": self.orphaned,
         }
 
     @classmethod
@@ -112,6 +125,9 @@ class DeviceMetadata:
             schema_entry=data.get("schema_entry"),
             class_mismatch=data.get("class_mismatch"),
             class_mismatch_dismissed=data.get("class_mismatch_dismissed", False),
+            bound_mismatch=data.get("bound_mismatch"),
+            missing_class=data.get("missing_class"),
+            orphaned=data.get("orphaned"),
         )
 
 
@@ -173,6 +189,8 @@ class DiscoveryManager:
 
         # Notification ID for the "new devices" notification
         self._notification_id = f"{DOMAIN}_discovery"
+        # Notification ID for the "schema mismatches" notification
+        self._mismatch_notification_id = f"{DOMAIN}_discovery_mismatches"
 
         self._scan.start()
         _LOGGER.info("DiscoveryManager: started (passive scan running)")
@@ -445,6 +463,284 @@ class DiscoveryManager:
             if entry.metadata.class_mismatch:
                 result.append(entry)
         return result
+
+    def check_bound_mismatches(self, schema: dict[str, Any]) -> int:
+        """Check for _bound mismatches between scan engine and schema.
+
+        For each device that is in both the scan engine and the schema,
+        compares the scan's ``bound_to`` with the schema's ``_bound``.
+        If they differ, sets ``bound_mismatch`` on the device's metadata.
+
+        The schema is authoritative — this method does NOT modify the
+        schema.  It only warns the user that discovery suggests a
+        different binding.
+
+        :param schema: The current config entry schema (with _ traits).
+        :return: Number of mismatches found.
+        """
+        scan_devices = {d.device_id: d for d in self._scan.get_devices()}
+        mismatches: list[tuple[str, str, str]] = []
+
+        for device_id, dev in scan_devices.items():
+            if device_id.startswith("18:"):
+                continue
+
+            schema_entry = schema.get(device_id)
+            if not isinstance(schema_entry, dict):
+                continue
+
+            schema_bound = schema_entry.get(SZ_TR_BOUND)
+            if not isinstance(schema_bound, str) or not schema_bound:
+                continue  # no _bound in schema — nothing to compare
+
+            scan_bound = dev.bound_to or ""
+            if not scan_bound:
+                continue  # scan doesn't know — not a meaningful mismatch
+
+            # Normalize for comparison (case-insensitive)
+            if scan_bound.upper() != schema_bound.upper():
+                meta = self._metadata.get(device_id, DeviceMetadata())
+                meta.bound_mismatch = f"schema={schema_bound}, discovery={scan_bound}"
+                self._metadata[device_id] = meta
+                mismatches.append((device_id, schema_bound, scan_bound))
+                _LOGGER.debug(
+                    "DiscoveryManager: bound mismatch for %s — "
+                    "schema has _bound=%s but discovery suggests %s",
+                    device_id,
+                    schema_bound,
+                    scan_bound,
+                )
+            else:
+                # Mismatch resolved — clear the flag
+                existing_meta = self._metadata.get(device_id)
+                if existing_meta and existing_meta.bound_mismatch:
+                    existing_meta.bound_mismatch = None
+                    self._metadata[device_id] = existing_meta
+
+        if mismatches:
+            _LOGGER.warning(
+                "DiscoveryManager: %d device(s) have bound mismatches "
+                "between discovery and schema: %s",
+                len(mismatches),
+                ", ".join(f"{d} ({s}→{t})" for d, s, t in mismatches),
+            )
+
+        return len(mismatches)
+
+    def check_missing_class(self, schema: dict[str, Any]) -> int:
+        """Check for schema devices that have no _class but discovery has one.
+
+        For each device that is in both the scan engine and the schema,
+        if the scan engine has a ``likely_type`` but the schema entry has
+        no ``_class``, sets ``missing_class`` on the device's metadata.
+
+        :param schema: The current config entry schema (with _ traits).
+        :return: Number of missing-class flags set.
+        """
+        scan_devices = {d.device_id: d for d in self._scan.get_devices()}
+        missing: list[str] = []
+
+        for device_id, dev in scan_devices.items():
+            if device_id.startswith("18:"):
+                continue
+
+            schema_entry = schema.get(device_id)
+            if not isinstance(schema_entry, dict):
+                continue
+
+            schema_class = schema_entry.get(SZ_TR_CLASS)
+            if isinstance(schema_class, str) and schema_class:
+                # Has _class — clear any previous missing_class flag
+                existing_meta = self._metadata.get(device_id)
+                if existing_meta and existing_meta.missing_class:
+                    existing_meta.missing_class = None
+                    self._metadata[device_id] = existing_meta
+                continue
+
+            scan_type = str(dev.likely_type) if dev.likely_type else ""
+            if not scan_type or scan_type == "DEV":
+                continue  # scan doesn't know either — not actionable
+
+            meta = self._metadata.get(device_id, DeviceMetadata())
+            meta.missing_class = f"discovery={scan_type}"
+            self._metadata[device_id] = meta
+            missing.append(device_id)
+            _LOGGER.debug(
+                "DiscoveryManager: missing _class for %s — "
+                "discovery suggests %s but schema has no _class",
+                device_id,
+                scan_type,
+            )
+
+        if missing:
+            _LOGGER.info(
+                "DiscoveryManager: %d device(s) in schema have no _class "
+                "but discovery has a suggestion: %s",
+                len(missing),
+                ", ".join(missing),
+            )
+
+        return len(missing)
+
+    def check_orphaned_devices(
+        self, schema: dict[str, Any], *, threshold_days: int | None = None
+    ) -> int:
+        """Check for schema devices not seen by discovery for a long time.
+
+        For each device that is in the schema but NOT in the scan engine's
+        device list (or has a very old ``last_seen``), sets ``orphaned``
+        on the device's metadata.
+
+        :param schema: The current config entry schema (with _ traits).
+        :param threshold_days: Days without traffic before flagging.
+            Defaults to ``self._lost_threshold_days``.
+        :return: Number of orphaned flags set.
+        """
+        if threshold_days is None:
+            threshold_days = self._lost_threshold_days
+
+        scan_devices = {d.device_id: d for d in self._scan.get_devices()}
+        now = dt.now()
+        threshold = now - td(days=threshold_days)
+        orphaned: list[str] = []
+
+        for device_id, schema_entry in schema.items():
+            if not isinstance(schema_entry, dict):
+                continue
+            if device_id.startswith("18:"):
+                continue  # HGI — not a real device
+            # Skip structural keys (main_tcs, _owner, etc.)
+            if device_id.startswith("_") or device_id in ("main_tcs",):
+                continue
+
+            dev = scan_devices.get(device_id)
+            if dev is None:
+                # Not in scan at all — check if it was ever seen
+                meta = self._metadata.get(device_id, DeviceMetadata())
+                if meta.status == DiscoveryStatus.NEW:
+                    continue  # never accepted — not orphaned
+                meta.orphaned = f"not seen by scan (threshold={threshold_days}d)"
+                self._metadata[device_id] = meta
+                orphaned.append(device_id)
+                continue
+
+            # In scan — check last_seen
+            last_seen_str = getattr(dev, "last_seen", None)
+            if not last_seen_str:
+                continue
+            try:
+                last_seen = dt.fromisoformat(last_seen_str)
+            except (ValueError, TypeError):
+                continue
+
+            if last_seen < threshold:
+                meta = self._metadata.get(device_id, DeviceMetadata())
+                meta.orphaned = f"last seen {last_seen_str} (>{threshold_days}d)"
+                self._metadata[device_id] = meta
+                orphaned.append(device_id)
+                _LOGGER.debug(
+                    "DiscoveryManager: orphaned device %s — last seen %s",
+                    device_id,
+                    last_seen_str,
+                )
+            else:
+                # Seen recently — clear orphaned flag
+                existing_meta = self._metadata.get(device_id)
+                if existing_meta and existing_meta.orphaned:
+                    existing_meta.orphaned = None
+                    self._metadata[device_id] = existing_meta
+
+        if orphaned:
+            _LOGGER.info(
+                "DiscoveryManager: %d device(s) in schema appear orphaned "
+                "(not seen > %d days): %s",
+                len(orphaned),
+                threshold_days,
+                ", ".join(orphaned),
+            )
+
+        return len(orphaned)
+
+    def check_all_mismatches(self, schema: dict[str, Any]) -> dict[str, int]:
+        """Run all mismatch checks and send a persistent notification if needed.
+
+        Convenience method that calls all four checks:
+        - check_class_mismatches
+        - check_bound_mismatches
+        - check_missing_class
+        - check_orphaned_devices
+
+        :param schema: The current config entry schema (with _ traits).
+        :return: Dict with counts per check type.
+        """
+        counts = {
+            "class_mismatch": self.check_class_mismatches(schema),
+            "bound_mismatch": self.check_bound_mismatches(schema),
+            "missing_class": self.check_missing_class(schema),
+            "orphaned": self.check_orphaned_devices(schema),
+        }
+        total = sum(counts.values())
+        if total > 0:
+            self._send_mismatch_notification(counts)
+        else:
+            # All clear — dismiss any existing mismatch notification
+            async_dismiss_notification(self._hass, self._mismatch_notification_id)
+
+        return counts
+
+    def _send_mismatch_notification(self, counts: dict[str, int]) -> None:
+        """Send a persistent notification about schema/discovery mismatches."""
+        lines: list[str] = []
+
+        class_mm = self.get_mismatched_devices()
+        if counts["class_mismatch"] and class_mm:
+            lines.append(f"**{counts['class_mismatch']} class mismatch(es):**\n")
+            for entry in class_mm:
+                mm = entry.metadata.class_mismatch or ""
+                lines.append(f"- `{entry.device.device_id}` — {mm}")
+            lines.append("")
+
+        bound_mm = [e for e in self.get_devices() if e.metadata.bound_mismatch]
+        if counts["bound_mismatch"] and bound_mm:
+            lines.append(f"**{counts['bound_mismatch']} bound mismatch(es):**\n")
+            for entry in bound_mm:
+                lines.append(
+                    f"- `{entry.device.device_id}` — {entry.metadata.bound_mismatch}"
+                )
+            lines.append("")
+
+        missing_cls = [e for e in self.get_devices() if e.metadata.missing_class]
+        if counts["missing_class"] and missing_cls:
+            lines.append(f"**{counts['missing_class']} missing _class:**\n")
+            for entry in missing_cls:
+                lines.append(
+                    f"- `{entry.device.device_id}` — {entry.metadata.missing_class}"
+                )
+            lines.append("")
+
+        orphaned = [e for e in self.get_devices() if e.metadata.orphaned]
+        if counts["orphaned"] and orphaned:
+            lines.append(f"**{counts['orphaned']} orphaned device(s):**\n")
+            for entry in orphaned:
+                lines.append(
+                    f"- `{entry.device.device_id}` — {entry.metadata.orphaned}"
+                )
+            lines.append("")
+
+        if not lines:
+            return
+
+        lines.append(
+            "[Review discovered devices](/config/integrations/integration/ramses_cc)"
+            " — open **Configure → Review discovered devices** to resolve."
+        )
+
+        async_create_notification(
+            self._hass,
+            message="\n".join(lines),
+            title="RAMSES CC: Schema mismatches detected",
+            notification_id=self._mismatch_notification_id,
+        )
 
     def export_state(self) -> dict[str, Any]:
         """Export full state for persistence.
@@ -1080,6 +1376,7 @@ class DiscoveryManager:
         """Stop the scan engine and dismiss notifications."""
         self._scan.stop()
         async_dismiss_notification(self._hass, self._notification_id)
+        async_dismiss_notification(self._hass, self._mismatch_notification_id)
         _LOGGER.info("DiscoveryManager: stopped")
 
     def _send_notification(self, new_ids: list[str]) -> None:

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -336,6 +336,21 @@ class DiscoveryManager:
                     "DiscoveryManager: device %s not in schema, marked as REMOVED",
                     device_id,
                 )
+            elif device_id in schema_device_ids and meta.status == DiscoveryStatus.NEW:
+                # Device is in the schema (e.g. added manually via the schema
+                # editor) but discovery status is still NEW.  Mark it as
+                # ACCEPTED so it doesn't appear in the "new devices" section
+                # of the review form — it's already in the schema.  If there's
+                # a class mismatch, the review form will show it in the
+                # mismatch section where the user can resolve it.
+                meta.status = DiscoveryStatus.ACCEPTED
+                meta.enabled = True
+                self._metadata[device_id] = meta
+                _LOGGER.info(
+                    "DiscoveryManager: device %s is in schema but had NEW "
+                    "status, marked as ACCEPTED",
+                    device_id,
+                )
 
         # Second, add devices from the scan that aren't in discovery metadata
         # (e.g., devices seen by the system but not yet in discovery)

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -691,6 +691,10 @@ class DiscoveryManager:
 
     def _send_mismatch_notification(self, counts: dict[str, int]) -> None:
         """Send a persistent notification about schema/discovery mismatches."""
+        _LOGGER.debug(
+            "DiscoveryManager: _send_mismatch_notification called with counts=%s",
+            counts,
+        )
         lines: list[str] = []
 
         class_mm = self.get_mismatched_devices()

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -587,9 +587,15 @@ class DiscoveryManager:
     ) -> int:
         """Check for schema devices not seen by discovery for a long time.
 
-        For each device that is in the schema but NOT in the scan engine's
-        device list (or has a very old ``last_seen``), sets ``orphaned``
-        on the device's metadata.
+        For each device that is in the schema AND in the scan engine's
+        device list, checks ``last_seen``.  If the device hasn't been
+        seen for longer than the threshold, sets ``orphaned`` on the
+        device's metadata.
+
+        Devices that are in the schema but NOT in the scan engine are
+        skipped — the scan may simply not have seen them yet, so
+        flagging them would be a false positive.  This mirrors the
+        behaviour of ``check_for_lost_devices``.
 
         :param schema: The current config entry schema (with _ traits).
         :param threshold_days: Days without traffic before flagging.
@@ -615,13 +621,8 @@ class DiscoveryManager:
 
             dev = scan_devices.get(device_id)
             if dev is None:
-                # Not in scan at all — check if it was ever seen
-                meta = self._metadata.get(device_id, DeviceMetadata())
-                if meta.status == DiscoveryStatus.NEW:
-                    continue  # never accepted — not orphaned
-                meta.orphaned = f"not seen by scan (threshold={threshold_days}d)"
-                self._metadata[device_id] = meta
-                orphaned.append(device_id)
+                # Not in scan — skip (scan may not have seen it yet).
+                # Same logic as check_for_lost_devices.
                 continue
 
             # In scan — check last_seen
@@ -635,7 +636,7 @@ class DiscoveryManager:
 
             if last_seen < threshold:
                 meta = self._metadata.get(device_id, DeviceMetadata())
-                meta.orphaned = f"last seen {last_seen_str} (>{threshold_days}d)"
+                meta.orphaned = f"last seen {last_seen_str} (>{threshold_days} days)"
                 self._metadata[device_id] = meta
                 orphaned.append(device_id)
                 _LOGGER.debug(

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -119,6 +119,21 @@ class RamsesEntity(CoordinatorEntity):
                     # Safely resolve callable/async attributes
                     attrs[k] = resolve_async_attr(self, self._device, v)
 
+        # Surface discovery mismatch flags (Phase 3c) so they're visible
+        # in Developer Tools without opening the config flow review step.
+        discovery_mgr = getattr(self.coordinator, "discovery_manager", None)
+        if discovery_mgr is not None:
+            meta = discovery_mgr._metadata.get(self._device.id)
+            if meta is not None:
+                for flag_key, flag_val in (
+                    ("class_mismatch", meta.class_mismatch),
+                    ("bound_mismatch", meta.bound_mismatch),
+                    ("missing_class", meta.missing_class),
+                    ("orphaned", meta.orphaned),
+                ):
+                    if isinstance(flag_val, str) and flag_val:
+                        attrs[flag_key] = flag_val
+
         return attrs
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -91,6 +91,7 @@ from .const import (
     CONF_UNKNOWN_CODES,
     SZ_DEVICE_COMMENTS,
     SZ_OWNER,
+    SZ_TR_NAME,
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
     SystemMode,
@@ -1268,6 +1269,12 @@ def sync_learned_topology(
                     learned_class = learned_zone.get(SZ_CLASS)
                     if learned_class and SZ_CLASS not in config_zone:
                         config_zone[SZ_CLASS] = learned_class
+                        changed = True
+                    # Sync _name from learned schema (e.g. from 0004 zone_name
+                    # packets) if config doesn't already have one
+                    learned_name = learned_zone.get(SZ_TR_NAME)
+                    if learned_name and not config_zone.get(SZ_TR_NAME):
+                        config_zone[SZ_TR_NAME] = learned_name
                         changed = True
 
             # 1b-post. Sanitize zone assignments — ramses_rf's active discovery

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -1184,7 +1184,28 @@ class RamsesServiceHandler:
         #    _class, etc.) stay because the fragment doesn't contain them.
         current_options = dict(self._coordinator.options)
         current_schema: dict[str, Any] = dict(current_options.get(CONF_SCHEMA, {}))
+
+        # Safeguard: if the device already has a root entry in the schema
+        # (e.g. added manually via the schema editor), do NOT let the
+        # auto-generated fragment overwrite user-configured keys like
+        # _class, remotes, _commands, etc.  The fragment is only needed
+        # to place the device in the right location (orphans, remotes[],
+        # zones, etc.) — the root entry is already correct.
+        existing_root = current_schema.get(device_id)
+        has_existing_root = isinstance(existing_root, dict) and bool(existing_root)
+
         cleaned = remove_device_from_schema(current_schema, device_id)
+
+        if has_existing_root:
+            # Strip the device's root entry from the fragment so deep_merge
+            # doesn't overwrite it.  The fragment still has placement keys
+            # (orphans_hvac, remotes[], etc.) which are merged normally.
+            fragment = {k: v for k, v in fragment.items() if k != device_id}
+            # Ensure the existing root entry is preserved in cleaned
+            # (remove_device_from_schema keeps it, but be explicit)
+            if device_id not in cleaned:
+                cleaned[device_id] = existing_root
+
         merged = deep_merge(fragment, cleaned)
 
         # 1b. Clear _skipped flag — the device is being accepted, so it

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -41,6 +41,7 @@ from custom_components.ramses_cc.const import (
     DEFAULT_HGI_ID,
     DOMAIN,
     SZ_TR_COMMANDS,
+    SZ_TR_OWNER,
 )
 from ramses_tx.schemas import (
     SZ_ENFORCE_KNOWN_LIST,
@@ -1956,10 +1957,14 @@ async def test_review_discovered_accept_device(hass: HomeAssistant) -> None:
     mock_entry.device.src_count = 3
     mock_entry.device.dst_count = 0
 
-    # Mock accept_device to return an entry with a schema_entry
+    # Mock accept_device to return an entry with a schema_entry.
+    # Include a root-level entry for the device so the config flow can
+    # set traits (_owner, etc.) on it — generate_schema_entry always
+    # ensures one via _merge().
     accepted_entry = MagicMock()
     accepted_entry.metadata.schema_entry = {
-        "01:145038": {"zones": {"02": {"sensor": "04:056053"}}}
+        "04:056053": {},
+        "01:145038": {"zones": {"02": {"sensor": "04:056053"}}},
     }
     mock_coord = MagicMock()
     mock_coord.discovery_manager = MagicMock()
@@ -1979,7 +1984,7 @@ async def test_review_discovered_accept_device(hass: HomeAssistant) -> None:
     )
     assert result.get("type") == FlowResultType.FORM
 
-    # Submit form with accept action
+    # Submit form with accept action and a per-device owner
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
@@ -1992,6 +1997,11 @@ async def test_review_discovered_accept_device(hass: HomeAssistant) -> None:
     mock_coord.discovery_manager.accept_device.assert_called_once_with(
         "04:056053", owner="henk", ctl_id=None
     )
+    # Per-device owner must be written to the schema entry, not overridden
+    # by the root owner (regression: owner was silently replaced with
+    # root_owner "me" — see issue with 37:154519 accept + owner: not-me).
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert saved_schema.get("04:056053", {}).get(SZ_TR_OWNER) == "henk"
 
 
 async def test_review_discovered_decline_device(hass: HomeAssistant) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -40,6 +40,7 @@ from custom_components.ramses_cc.const import (
     CONF_SCHEMA,
     DEFAULT_HGI_ID,
     DOMAIN,
+    SZ_OWNER,
     SZ_TR_CLASS,
     SZ_TR_COMMANDS,
     SZ_TR_OWNER,
@@ -2166,6 +2167,80 @@ async def test_review_discovered_missing_class_add_class(hass: HomeAssistant) ->
     # Verify _class was set in the saved schema
     saved_schema = config_entry.options.get(CONF_SCHEMA, {})
     assert saved_schema.get("37:154519", {}).get(SZ_TR_CLASS) == "FAN"
+
+
+async def test_review_discovered_missing_class_per_device_owner(
+    hass: HomeAssistant,
+) -> None:
+    """Test per-device owner overrides root owner for missing_class devices.
+
+    The user sets a per-device owner of "not-me" on a missing_class device
+    while keeping the root owner as "me".  The device should get
+    _owner=not-me, not _owner=me.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "37:154519": {"remotes": []},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "37:154519"
+    mock_entry.device.likely_type = "FAN"
+    mock_entry.device.confidence = "medium"
+    mock_entry.metadata.missing_class = "discovery=FAN"
+    mock_entry.metadata.class_mismatch = None
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_devices.return_value = []
+    mock_coord.discovery_manager.get_mismatched_devices.return_value = []
+    mock_coord.discovery_manager.get_missing_class_devices.return_value = [mock_entry]
+    mock_coord.discovery_manager._metadata = {
+        "37:154519": mock_entry.metadata,
+    }
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    # Verify the form has a per-device owner field for the missing_class device
+    data_schema = result.get("data_schema")
+    schema_dict = data_schema.schema
+    field_names = {
+        str(k) if hasattr(k, "schema") else k for k, _ in schema_dict.items()
+    }
+    assert "owner_37:154519" in field_names
+
+    # Submit with add_class + per-device owner "not-me"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "missing_class_37:154519": "add_class",
+            "owner_37:154519": "not-me",
+        },
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    # _class should be set
+    assert saved_schema.get("37:154519", {}).get(SZ_TR_CLASS) == "FAN"
+    # Per-device owner should be "not-me", NOT root owner "me"
+    assert saved_schema.get("37:154519", {}).get(SZ_TR_OWNER) == "not-me"
+    # Root owner should still be "me"
+    assert saved_schema.get(SZ_OWNER) == "me"
 
 
 async def test_review_discovered_missing_class_skip(hass: HomeAssistant) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -40,6 +40,7 @@ from custom_components.ramses_cc.const import (
     CONF_SCHEMA,
     DEFAULT_HGI_ID,
     DOMAIN,
+    SZ_TR_CLASS,
     SZ_TR_COMMANDS,
     SZ_TR_OWNER,
 )
@@ -2098,6 +2099,132 @@ async def test_review_discovered_skip_device(hass: HomeAssistant) -> None:
     # Neither accept nor discard should have been called
     mock_coord.discovery_manager.accept_device.assert_not_called()
     mock_coord.discovery_manager.discard_device.assert_not_called()
+
+
+async def test_review_discovered_missing_class_add_class(hass: HomeAssistant) -> None:
+    """Test review_discovered step adding _class to a device that lacks it.
+
+    A device already in the schema (accepted) but without a _class trait
+    should appear in the review form when check_missing_class flags it.
+    Choosing "add_class" sets _class to the discovery suggestion.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                "37:154519": {"remotes": []},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    # Mock a missing_class device entry (no new devices, no mismatches)
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "37:154519"
+    mock_entry.device.likely_type = "FAN"
+    mock_entry.device.confidence = "medium"
+    mock_entry.metadata.missing_class = "discovery=FAN"
+    mock_entry.metadata.class_mismatch = None
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_devices.return_value = []  # no NEW devices
+    mock_coord.discovery_manager.get_mismatched_devices.return_value = []
+    mock_coord.discovery_manager.get_missing_class_devices.return_value = [mock_entry]
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    # Navigate to review_discovered
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    # Verify the form has the missing_class field
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    schema_dict = data_schema.schema
+    field_names = {
+        str(k) if hasattr(k, "schema") else k for k, _ in schema_dict.items()
+    }
+    assert "missing_class_37:154519" in field_names
+    # Verify summary mentions missing _class
+    placeholders = result.get("description_placeholders", {})
+    assert "missing _class" in placeholders.get("message", "")
+
+    # Submit form with add_class action
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"missing_class_37:154519": "add_class"},
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Verify _class was set in the saved schema
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert saved_schema.get("37:154519", {}).get(SZ_TR_CLASS) == "FAN"
+
+
+async def test_review_discovered_missing_class_skip(hass: HomeAssistant) -> None:
+    """Test review_discovered step skipping a missing_class device.
+
+    Skipping should not modify the schema (no _class added) but should
+    clear the missing_class flag so the notification doesn't re-fire
+    immediately.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                "37:154519": {"remotes": []},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "37:154519"
+    mock_entry.device.likely_type = "FAN"
+    mock_entry.device.confidence = "medium"
+    mock_entry.metadata.missing_class = "discovery=FAN"
+    mock_entry.metadata.class_mismatch = None
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_devices.return_value = []
+    mock_coord.discovery_manager.get_mismatched_devices.return_value = []
+    mock_coord.discovery_manager.get_missing_class_devices.return_value = [mock_entry]
+    # _metadata is accessed directly to clear the missing_class flag
+    mock_coord.discovery_manager._metadata = {
+        "37:154519": mock_entry.metadata,
+    }
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+
+    # Submit form with skip action
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"missing_class_37:154519": "skip"},
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # _class should NOT be set in the schema
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert SZ_TR_CLASS not in saved_schema.get("37:154519", {})
+    # The missing_class flag should be cleared
+    assert mock_entry.metadata.missing_class is None
 
 
 async def test_review_discovered_bulk_accept_all(hass: HomeAssistant) -> None:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -397,6 +397,38 @@ async def test_create_client_strips_commands_from_known_list(
 
 
 @pytest.mark.asyncio
+async def test_create_client_foreign_hgi_not_in_block_list(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Foreign HGIs (18:) must not be put in the block_list.
+
+    A foreign HGI communicates with our controller and the controller's
+    responses (e.g. 0004 zone names) are addressed to the foreign HGI.
+    Blocking the foreign HGI would prevent the active gateway from
+    eavesdropping on those responses (issue 822).
+    """
+    mock_coordinator.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "/dev/ttyUSB0"}
+
+    schema = {
+        "_owner": "me",
+        "main_tcs": "01:216136",
+        "01:216136": {"_owner": "me"},
+        "04:111111": {"_owner": "neighbour"},  # foreign non-HGI → block
+        "18:072981": {"_owner": "not-me"},  # foreign HGI → do NOT block
+    }
+
+    with patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy:
+        mock_coordinator._create_client(schema)
+
+        _, kwargs = cast(Any, mock_gwy).call_args
+        gwy_config = kwargs["config"]
+
+        block_list = dict(gwy_config.block_list or {})
+        assert "04:111111" in block_list  # foreign non-HGI is blocked
+        assert "18:072981" not in block_list  # foreign HGI is NOT blocked
+
+
+@pytest.mark.asyncio
 async def test_async_start_with_packet_handler(
     mock_coordinator: RamsesCoordinator, mock_client
 ):

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -941,6 +941,111 @@ class TestGenerateSchemaEntryRootEntry:
         assert isinstance(result["32:123456"], dict)
 
 
+class TestGenerateSchemaEntrySetsClass:
+    """Tests that generate_schema_entry sets _class on the root entry.
+
+    The architecture intent (schema_architecture.md: "accept_discovered_device
+    → writes _alias, _class to schema") requires that the scan engine's
+    likely_type is persisted as the _class trait on the device's root entry.
+    Without this, check_missing_class flags every accepted device on the next
+    checkpoint, and the user has to manually add _class in the schema editor.
+    """
+
+    def test_ctl_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry("01:145038", "CTL")
+        assert result["01:145038"][SZ_TR_CLASS] == "CTL"
+
+    def test_fan_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry("32:123456", "FAN")
+        assert result["32:123456"][SZ_TR_CLASS] == "FAN"
+
+    def test_rem_with_parent_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry(
+            "37:123456", "REM", bound_to="32:123456"
+        )
+        assert result["37:123456"][SZ_TR_CLASS] == "REM"
+
+    def test_rem_orphan_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry("37:123456", "REM")
+        assert result["37:123456"][SZ_TR_CLASS] == "REM"
+
+    def test_co2_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry(
+            "37:123456", "CO2", bound_to="32:123456"
+        )
+        assert result["37:123456"][SZ_TR_CLASS] == "CO2"
+
+    def test_trv_with_zone_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry(
+            "04:056053", "TRV", ctl_id="01:145038", zone_idx="02"
+        )
+        assert result["04:056053"][SZ_TR_CLASS] == "TRV"
+
+    def test_trv_orphan_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry("04:056053", "TRV")
+        assert result["04:056053"][SZ_TR_CLASS] == "TRV"
+
+    def test_otb_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry(
+            "10:064873", "OTB", ctl_id="01:145038"
+        )
+        assert result["10:064873"][SZ_TR_CLASS] == "OTB"
+
+    def test_bdr_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry(
+            "13:123456", "BDR", ctl_id="01:145038", zone_idx="01"
+        )
+        assert result["13:123456"][SZ_TR_CLASS] == "BDR"
+
+    def test_dhw_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry(
+            "07:123456", "DHW", ctl_id="01:145038"
+        )
+        assert result["07:123456"][SZ_TR_CLASS] == "DHW"
+
+    def test_dis_has_class(self) -> None:
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry("37:123456", "DIS")
+        assert result["37:123456"][SZ_TR_CLASS] == "DIS"
+
+    def test_unknown_type_has_class(self) -> None:
+        """Unknown likely_type is still written as _class (uppercased)."""
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry("04:999999", "unknown")
+        assert result["04:999999"][SZ_TR_CLASS] == "UNKNOWN"
+
+    def test_class_is_uppercased(self) -> None:
+        """likely_type is case-insensitive — _class is stored uppercased."""
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        result = DiscoveryManager.generate_schema_entry(
+            "37:333333", "co2", bound_to="32:123456"
+        )
+        assert result["37:333333"][SZ_TR_CLASS] == "CO2"
+
+
 class TestDiscoveredDeviceEntrySerialization:
     """Tests for DiscoveredDeviceEntry.to_dict and scan property."""
 

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1508,24 +1508,23 @@ class TestCheckMissingClass:
 class TestCheckOrphanedDevices:
     """Tests for DiscoveryManager.check_orphaned_devices."""
 
-    def test_orphaned_when_not_in_scan(self) -> None:
+    def test_not_orphaned_when_not_in_scan(self) -> None:
+        """Device in schema but not in scan is NOT orphaned — scan may
+        not have seen it yet (same logic as check_for_lost_devices)."""
         scan = make_mock_scan([])  # no devices in scan
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
-        # Device in schema, accepted, but not in scan
+        # Device in schema, accepted, but not in scan — should NOT flag
         manager._metadata["04:056053"] = DeviceMetadata(status=DiscoveryStatus.ACCEPTED)
         schema = {"04:056053": {"_class": "TRV"}}
         count = manager.check_orphaned_devices(schema)
-        assert count == 1
-        meta = manager._metadata.get("04:056053")
-        assert meta is not None
-        assert meta.orphaned is not None
+        assert count == 0
 
     def test_not_orphaned_when_new_and_not_in_scan(self) -> None:
         scan = make_mock_scan([])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
-        # NEW device not in scan — not orphaned (never accepted)
+        # NEW device not in scan — not orphaned
         manager._metadata["04:056053"] = DeviceMetadata(status=DiscoveryStatus.NEW)
         schema = {"04:056053": {"_class": "TRV"}}
         count = manager.check_orphaned_devices(schema)

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1749,3 +1749,78 @@ class TestCheckAllMismatches:
         ) as mock_dismiss:
             manager.check_all_mismatches(schema)
             mock_dismiss.assert_called_once()
+
+
+class TestSyncWithSchema:
+    """Tests for DiscoveryManager.sync_with_schema.
+
+    sync_with_schema reconciles discovery metadata with the current schema.
+    Devices in the schema but with NEW status should be marked ACCEPTED —
+    they're already in the schema (e.g. added manually via the schema
+    editor), so showing them as "new devices to review" is confusing and
+    prevents the user from resolving class mismatches (the review form's
+    NEW section only has Accept/Decline/Skip, not Update _class).
+    """
+
+    def test_new_device_in_schema_marked_accepted(self) -> None:
+        """A device with NEW status that's in the schema is marked ACCEPTED."""
+        dev = make_discovered_device("37:154519", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # First sync to populate metadata from scan (status=NEW by default)
+        manager.sync_with_schema(set())
+        assert manager._metadata["37:154519"].status == DiscoveryStatus.NEW
+
+        # Now sync with schema that includes 37:154519 — should mark ACCEPTED
+        manager.sync_with_schema({"37:154519", "32:153289"})
+
+        entry = manager.get_device("37:154519")
+        assert entry is not None
+        assert entry.metadata.status == DiscoveryStatus.ACCEPTED
+        assert entry.metadata.enabled is True
+
+    def test_new_device_not_in_schema_stays_new(self) -> None:
+        """A device with NEW status that's NOT in the schema stays NEW."""
+        dev = make_discovered_device("37:154519", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # sync_with_schema — 37:154519 is NOT in the schema
+        manager.sync_with_schema({"32:153289"})
+
+        entry = manager.get_device("37:154519")
+        assert entry is not None
+        assert entry.metadata.status == DiscoveryStatus.NEW
+
+    def test_accepted_device_not_in_schema_marked_removed(self) -> None:
+        """An ACCEPTED device that's removed from the schema is marked REMOVED."""
+        dev = make_discovered_device("37:154519", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager.accept_device("37:154519")
+        assert (
+            manager.get_device("37:154519").metadata.status == DiscoveryStatus.ACCEPTED
+        )
+
+        # sync_with_schema — 37:154519 is no longer in the schema
+        manager.sync_with_schema({"32:153289"})
+
+        entry = manager.get_device("37:154519")
+        assert entry is not None
+        assert entry.metadata.status == DiscoveryStatus.REMOVED
+
+    def test_hgi_gateway_skipped(self) -> None:
+        """HGI gateways (18:) are skipped by sync_with_schema."""
+        dev = make_discovered_device("18:130236", "HGI")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # 18: devices are skipped — status stays whatever it was
+        manager.sync_with_schema(set())  # empty schema
+
+        # 18:130236 should not be in metadata (skipped by sync_with_schema)
+        # or if it is, its status should not be REMOVED
+        if "18:130236" in manager._metadata:
+            assert manager._metadata["18:130236"].status != DiscoveryStatus.REMOVED

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1368,3 +1368,280 @@ class TestGetMismatchedDevices:
 
         result = manager.get_mismatched_devices()
         assert result == []
+
+
+class TestCheckBoundMismatches:
+    """Tests for DiscoveryManager.check_bound_mismatches."""
+
+    def test_no_mismatch_when_bound_matches(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN", "_bound": "01:145038"}}
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is None or meta.bound_mismatch is None
+
+    def test_bound_mismatch_detected(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        # make_discovered_device sets bound_to="01:145038"
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN", "_bound": "22:999999"}}
+        count = manager.check_bound_mismatches(schema)
+        assert count == 1
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.bound_mismatch is not None
+        assert "22:999999" in meta.bound_mismatch
+        assert "01:145038" in meta.bound_mismatch
+
+    def test_bound_mismatch_cleared_when_resolved(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager._metadata["32:153289"] = DeviceMetadata(
+            bound_mismatch="schema=22:999999, discovery=01:145038"
+        )
+        # Now schema matches scan
+        schema = {"32:153289": {"_class": "FAN", "_bound": "01:145038"}}
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.bound_mismatch is None
+
+    def test_no_bound_mismatch_for_device_without_bound(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN"}}  # no _bound
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+
+    def test_no_bound_mismatch_for_device_not_in_scan(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:999999": {"_class": "TRV", "_bound": "01:145038"}}
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+
+    def test_bound_mismatch_case_insensitive(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Same ID, different case — should NOT be a mismatch
+        schema = {"32:153289": {"_class": "FAN", "_bound": "01:145038"}}
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+
+
+class TestCheckMissingClass:
+    """Tests for DiscoveryManager.check_missing_class."""
+
+    def test_missing_class_detected(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {}}  # no _class
+        count = manager.check_missing_class(schema)
+        assert count == 1
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.missing_class is not None
+        assert "FAN" in meta.missing_class
+
+    def test_no_missing_class_when_class_present(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN"}}
+        count = manager.check_missing_class(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is None or meta.missing_class is None
+
+    def test_missing_class_cleared_when_added(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # First: flag as missing
+        manager._metadata["32:153289"] = DeviceMetadata(missing_class="discovery=FAN")
+        # Now schema has _class
+        schema = {"32:153289": {"_class": "FAN"}}
+        count = manager.check_missing_class(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.missing_class is None
+
+    def test_no_missing_class_for_unknown_scan_type(self) -> None:
+        dev = make_discovered_device("32:153289", "DEV")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {}}
+        count = manager.check_missing_class(schema)
+        assert count == 0
+
+    def test_no_missing_class_for_device_not_in_scan(self) -> None:
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:999999": {}}  # not in scan
+        count = manager.check_missing_class(schema)
+        assert count == 0
+
+
+class TestCheckOrphanedDevices:
+    """Tests for DiscoveryManager.check_orphaned_devices."""
+
+    def test_orphaned_when_not_in_scan(self) -> None:
+        scan = make_mock_scan([])  # no devices in scan
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Device in schema, accepted, but not in scan
+        manager._metadata["04:056053"] = DeviceMetadata(status=DiscoveryStatus.ACCEPTED)
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema)
+        assert count == 1
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is not None
+
+    def test_not_orphaned_when_new_and_not_in_scan(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # NEW device not in scan — not orphaned (never accepted)
+        manager._metadata["04:056053"] = DeviceMetadata(status=DiscoveryStatus.NEW)
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema)
+        assert count == 0
+
+    def test_orphaned_when_last_seen_too_old(self) -> None:
+        old_date = (dt.now() - td(days=30)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 1
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is not None
+
+    def test_not_orphaned_when_recently_seen(self) -> None:
+        recent_date = (dt.now() - td(days=1)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=recent_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0
+
+    def test_orphaned_cleared_when_seen_again(self) -> None:
+        recent_date = (dt.now() - td(days=1)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=recent_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Was orphaned, now seen recently
+        manager._metadata["04:056053"] = DeviceMetadata(orphaned="old")
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is None
+
+    def test_hgi_not_orphaned(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"18:123456": {"_class": "HGI"}}
+        count = manager.check_orphaned_devices(schema)
+        assert count == 0
+
+    def test_structural_keys_skipped(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"main_tcs": "01:145038", "_owner": "me"}
+        count = manager.check_orphaned_devices(schema)
+        assert count == 0
+
+
+class TestCheckAllMismatches:
+    """Tests for DiscoveryManager.check_all_mismatches (unified check)."""
+
+    def test_all_clear_when_no_mismatches(self) -> None:
+        recent = (dt.now() - td(days=1)).isoformat()
+        dev = make_discovered_device("32:153289", "FAN", last_seen=recent)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN", "_bound": "01:145038"}}
+        counts = manager.check_all_mismatches(schema)
+        assert counts == {
+            "class_mismatch": 0,
+            "bound_mismatch": 0,
+            "missing_class": 0,
+            "orphaned": 0,
+        }
+
+    def test_multiple_mismatch_types(self) -> None:
+        recent = (dt.now() - td(days=1)).isoformat()
+        dev = make_discovered_device("32:153289", "DIS", last_seen=recent)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Bound mismatch + missing class on same device (no _class to
+        # compare, so class_mismatch is 0 — that's a missing_class instead)
+        schema = {"32:153289": {"_bound": "22:999999"}}  # no _class, wrong bound
+        counts = manager.check_all_mismatches(schema)
+        assert counts["class_mismatch"] == 0
+        assert counts["bound_mismatch"] == 1
+        assert counts["missing_class"] == 1
+
+    def test_notification_sent_when_mismatches_found(self) -> None:
+        recent = (dt.now() - td(days=1)).isoformat()
+        dev = make_discovered_device("32:153289", "DIS", last_seen=recent)
+        scan = make_mock_scan([dev])
+        hass = make_mock_hass()
+        manager = DiscoveryManager(hass, scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN"}}
+        with patch(
+            "custom_components.ramses_cc.discovery.async_create_notification"
+        ) as mock_create:
+            manager.check_all_mismatches(schema)
+            mock_create.assert_called_once()
+
+    def test_notification_dismissed_when_all_clear(self) -> None:
+        recent = (dt.now() - td(days=1)).isoformat()
+        dev = make_discovered_device("32:153289", "FAN", last_seen=recent)
+        scan = make_mock_scan([dev])
+        hass = make_mock_hass()
+        manager = DiscoveryManager(hass, scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN", "_bound": "01:145038"}}
+        with patch(
+            "custom_components.ramses_cc.discovery.async_dismiss_notification"
+        ) as mock_dismiss:
+            manager.check_all_mismatches(schema)
+            mock_dismiss.assert_called_once()

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -14,6 +14,7 @@ from custom_components.ramses_cc.const import (
     CONF_RAMSES_RF,
     SZ_DEVICE_COMMENTS,
     SZ_OWNER,
+    SZ_TR_NAME,
 )
 from custom_components.ramses_cc.schemas import (
     extract_hvac_schema,
@@ -644,6 +645,53 @@ def test_sync_learned_topology_preserves_existing_zone_class() -> None:
     }
     result = sync_learned_topology(config, learned)
     assert result is None  # No changes — user's class stays
+
+
+def test_sync_learned_topology_adds_zone_name() -> None:
+    """Adds _name from learned schema (e.g. from 0004 zone_name packets)."""
+    config: dict[str, Any] = {
+        "main_tcs": "01:123456",
+        "01:123456": {
+            SZ_ZONES: {"03": {SZ_SENSOR: "22:111111"}},
+        },
+        "22:111111": {},  # root entry exists — no backfill needed
+    }
+    learned: dict[str, Any] = {
+        "main_tcs": "01:123456",
+        "01:123456": {
+            SZ_ZONES: {
+                "03": {SZ_SENSOR: "22:111111", SZ_TR_NAME: "Bedroom"},
+            },
+        },
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    assert result["01:123456"][SZ_ZONES]["03"][SZ_TR_NAME] == "Bedroom"
+
+
+def test_sync_learned_topology_preserves_existing_zone_name() -> None:
+    """Does not overwrite _name the user already set."""
+    config: dict[str, Any] = {
+        "main_tcs": "01:123456",
+        "01:123456": {
+            SZ_ZONES: {"03": {SZ_SENSOR: "22:111111", SZ_TR_NAME: "My Name"}},
+        },
+        "22:111111": {},  # root entry exists — no backfill needed
+    }
+    learned: dict[str, Any] = {
+        "main_tcs": "01:123456",
+        "01:123456": {
+            SZ_ZONES: {
+                "03": {SZ_SENSOR: "22:111111", SZ_TR_NAME: "Learned Name"},
+            },
+        },
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is None  # No changes — user's name stays
 
 
 def test_sync_learned_topology_dhw_sensor() -> None:

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -3023,6 +3023,110 @@ async def test_apply_schema_entry_does_not_overwrite_zone_sensor(
     # This is expected — the old device's orphan status is handled by ramses_rf's topology
 
 
+async def test_apply_schema_entry_preserves_existing_root_entry(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _apply_schema_entry does NOT overwrite an existing root entry.
+
+    If a device already has a root entry in the schema (e.g. added manually
+    via the schema editor with _class, remotes, _commands), accepting it
+    via discovery should NOT overwrite those user-configured keys.
+
+    Regression test for the bug where accept_discovered_device overwrote
+    a manually-configured FAN entry (remotes: ["37:170000"], _commands: {...})
+    with the auto-generated fragment (remotes: [], _class: "FAN").
+    """
+    handler = RamsesServiceHandler(mock_coordinator)
+    mock_client = MagicMock()
+    mock_engine = MagicMock()
+    mock_engine._include = []
+    mock_client._engine = mock_engine
+    mock_dev_filter = MagicMock()
+    mock_dev_filter._include = []
+    mock_client._device_filter = mock_dev_filter
+    mock_coordinator.client = mock_client
+
+    # FAN already in schema with user-configured remotes and _commands
+    mock_coordinator.options = {
+        CONF_SCHEMA: {
+            "32:150000": {
+                "_class": "FAN",
+                "remotes": ["37:170000"],
+                "_commands": {
+                    "boost": {"code": "22F1", "payload": "000607", "verb": "I"}
+                },
+            },
+        }
+    }
+
+    # Auto-generated fragment for FAN — has remotes: [] and _class: "FAN"
+    # which would overwrite the user's remotes and _commands if merged
+    # with fragment as src
+    fragment = {
+        "32:150000": {
+            "_class": "FAN",
+            "remotes": [],
+        }
+    }
+    handler._apply_schema_entry(fragment, "32:150000")
+
+    schema = mock_coordinator.options[CONF_SCHEMA]
+    fan_entry = schema["32:150000"]
+    # _class should be preserved (fragment has same value, but the point is
+    # the user's value wins)
+    assert fan_entry["_class"] == "FAN"
+    # remotes should NOT be overwritten with []
+    assert fan_entry["remotes"] == ["37:170000"]
+    # _commands should be preserved (fragment doesn't have it, but we're
+    # verifying the existing entry isn't touched)
+    assert "_commands" in fan_entry
+    assert fan_entry["_commands"]["boost"]["payload"] == "000607"
+
+
+async def test_apply_schema_entry_preserves_existing_rem_root(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _apply_schema_entry preserves an existing REM root entry.
+
+    A REM with a user-configured root entry (_class, _owner) should keep
+    those traits when the REM is re-accepted via discovery.  The fragment
+    only adds the placement (remotes[] under the FAN), not the root entry.
+    """
+    handler = RamsesServiceHandler(mock_coordinator)
+    mock_client = MagicMock()
+    mock_engine = MagicMock()
+    mock_engine._include = []
+    mock_client._engine = mock_engine
+    mock_dev_filter = MagicMock()
+    mock_dev_filter._include = []
+    mock_client._device_filter = mock_dev_filter
+    mock_coordinator.client = mock_client
+
+    mock_coordinator.options = {
+        CONF_SCHEMA: {
+            "32:150000": {"_class": "FAN", "remotes": []},
+            "37:170000": {"_class": "REM", "_owner": "not-me"},
+        }
+    }
+
+    # Fragment for REM bound to FAN — has remotes: ["37:170000"] under FAN
+    # and a root entry with _class: "REM" which would overwrite _owner
+    fragment = {
+        "32:150000": {"remotes": ["37:170000"]},
+        "37:170000": {"_class": "REM"},
+    }
+    handler._apply_schema_entry(fragment, "37:170000")
+
+    schema = mock_coordinator.options[CONF_SCHEMA]
+    rem_entry = schema["37:170000"]
+    # _class should be REM (same in both)
+    assert rem_entry["_class"] == "REM"
+    # _owner should be preserved — NOT overwritten by the fragment
+    assert rem_entry["_owner"] == "not-me"
+    # REM should be placed under the FAN's remotes
+    assert "37:170000" in schema["32:150000"].get("remotes", [])
+
+
 async def test_discard_discovered_device_no_manager(
     mock_coordinator: RamsesCoordinator,
 ) -> None:


### PR DESCRIPTION
Foreign HGIs (18: devices with _owner != root_owner) were being put in the block_list alongside other foreign devices.  This caused ramses_rf's protocol filter to silently drop all packets to/from the foreign HGI, including the controller's 0004 zone name responses that are addressed to the foreign HGI.

The active gateway eavesdrops on these responses to populate zone names and other state.  Blocking the foreign HGI prevented this eavesdropping, so zone._name stayed None and the device registry showed fallback names like "01:216136_xx" (issue 822).

Now 18: devices are exempt from the block_list.  ramses_rf's protocol filter already has foreign-HGI handling (warn but pass through for receiving) — this fix ensures those packets actually reach that logic instead of being dropped by the block_list check.

Requires the companion ramses_rf fix (foreign-HGI exception moved before block_list check in _is_wanted_addrs) for full defense-in-depth.


see https://github.com/ramses-rf/ramses_cc/issues/822

AI used: GLM 5.2 High