### PR TITLE
Fix/834 bdr appliance control

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1060,8 +1060,13 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                     base_modes.append(cmd_name)
 
         # Phase 3a: bound REM's _commands (packet strings, fallback)
+        # Only offer REM commands if the REM is faked — sending as a
+        # non-faked REM would collide with the physical remote's transmissions.
         bound_rem = self._bound_rem or self._device.get_bound_rem()
         if bound_rem:
+            rem_dev = self.coordinator._get_device(str(bound_rem))
+            if rem_dev is not None and not rem_dev.is_faked:
+                return base_modes  # REM not faked — don't offer its commands
             rem_commands = remotes.get(str(bound_rem), {})
             if isinstance(rem_commands, dict):
                 cmds, _ = _split_commands(rem_commands)
@@ -1170,6 +1175,18 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
             # Check REM packet strings (Phase 3a fallback)
             if fan_mode in rem_commands:
+                # Verify the bound REM is faked — we're sending a packet
+                # as if it came from that REM, which only makes sense if
+                # the REM is configured for faking.  This mirrors the
+                # check in remote.py's async_send_command.
+                if bound_rem:
+                    rem_dev = self.coordinator._get_device(str(bound_rem))
+                    if rem_dev is not None and not rem_dev.is_faked:
+                        raise HomeAssistantError(
+                            f"Bound REM {bound_rem} is not configured for "
+                            f"faking — cannot send custom command"
+                        )
+
                 cmd_str = rem_commands[fan_mode]
                 _LOGGER.info(
                     "Intercepted fan_mode '%s'; sending custom command: %s",

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1725,12 +1725,19 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         )
                 # Clear the missing_class flag for both "add_class" and "skip"
                 # so the notification doesn't re-fire immediately.  For "skip"
-                # the flag will be re-set on the next checkpoint if the schema
-                # still lacks _class — but that's the next review cycle.
+                # also set missing_class_dismissed to prevent check_missing_class
+                # from re-flagging the same device on the next checkpoint.
                 if action in ("add_class", "skip"):
                     meta = coordinator.discovery_manager._metadata.get(device_id)
                     if meta:
                         meta.missing_class = None
+                        if action == "skip":
+                            # Persist the dismissal so check_missing_class
+                            # doesn't re-flag this device on the next checkpoint
+                            meta.missing_class_dismissed = True
+                        elif action == "add_class":
+                            # User added a class — clear any prior dismissal
+                            meta.missing_class_dismissed = False
 
             if changed:
                 self.options[CONF_SCHEMA] = order_schema(config_schema)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2161,25 +2161,44 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # validator before saving.  This catches root-level _ traits
                 # or invalid device IDs early, instead of failing silently
                 # when ramses_rf rejects the schema on the next reload.
-                self._validate_schema_for_ramserf(enriched)
-                _LOGGER.info("Learned topology is richer than config, syncing back")
-                new_options = dict(self.options)
-                new_options[CONF_SCHEMA] = enriched
-                self.options = new_options
-                # Suppress the reload that async_update_entry would trigger,
-                # since the running coordinator already has the updated options
-                # and a reload would tear down the transport while pending
-                # _send_cmd tasks are still in flight (causing lingering tasks).
                 #
-                # NOTE: async_update_entry schedules the update listener as an
-                # async task.  Setting _suppress_reload to a timestamp and
-                # checking it with a 5-second window in the update listener
-                # avoids the race condition where the flag is reset before the
-                # listener runs.
-                self._suppress_reload = time.time()
-                self.hass.config_entries.async_update_entry(
-                    self.entry, options=new_options
-                )
+                # If validation fails, log the error and skip the config
+                # entry update — saving an invalid schema would cause a
+                # reload failure on the next restart.  The current config
+                # entry schema stays as-is (stale but valid) rather than
+                # being overwritten with an invalid one.  The rest of the
+                # save cycle (packets, remotes, discovery state) continues.
+                validation_ok = True
+                try:
+                    self._validate_schema_for_ramserf(enriched)
+                except ValueError as err:
+                    _LOGGER.error(
+                        "Schema validation failed during save cycle — "
+                        "skipping topology sync to avoid corrupting the "
+                        "config entry: %s",
+                        err,
+                    )
+                    validation_ok = False
+                if validation_ok:
+                    _LOGGER.info("Learned topology is richer than config, syncing back")
+                    new_options = dict(self.options)
+                    new_options[CONF_SCHEMA] = enriched
+                    self.options = new_options
+                    # Suppress the reload that async_update_entry would
+                    # trigger, since the running coordinator already has the
+                    # updated options and a reload would tear down the
+                    # transport while pending _send_cmd tasks are still in
+                    # flight (causing lingering tasks).
+                    #
+                    # NOTE: async_update_entry schedules the update listener
+                    # as an async task.  Setting _suppress_reload to a
+                    # timestamp and checking it with a 5-second window in
+                    # the update listener avoids the race condition where
+                    # the flag is reset before the listener runs.
+                    self._suppress_reload = time.time()
+                    self.hass.config_entries.async_update_entry(
+                        self.entry, options=new_options
+                    )
             elif comments_refreshed:
                 # No topology changes (enriched is None), but the scan engine
                 # captured new zone bindings in device_comments.  Persist the

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -259,7 +259,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Config = %s", print_options)
 
         self.client: Gateway | None = None
-        self._remotes: dict[str, dict[str, str]] = {}
+        self._remotes: dict[str, dict[str, Any]] = {}
+        # Track device IDs that have _commands in the schema at load time.
+        # Used by _sync_remotes_to_schema to prevent resurrecting
+        # user-deleted _commands from .storage[remotes].
+        self._devices_with_commands: set[str] = set()
 
         self._platform_setup_tasks: dict[str, asyncio.Task[Any]] = {}
         self._entities: dict[str, RamsesEntity] = {}  # domain entities
@@ -417,6 +421,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     "Loaded %d device(s) with _commands from schema",
                     len(remotes_from_schema),
                 )
+            # Track which devices have _commands in the schema at load
+            # time, so _sync_remotes_to_schema can skip them if _commands
+            # is later absent (user deletion → don't resurrect from remotes).
+            self._devices_with_commands = set(remotes_from_schema.keys())
 
         client_state: dict[str, Any] = storage.get(SZ_CLIENT_STATE, {})
 
@@ -1521,7 +1529,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
     @staticmethod
     def _sync_remotes_to_schema(
-        schema: dict[str, Any], remotes: dict[str, dict[str, str]]
+        schema: dict[str, Any],
+        remotes: dict[str, dict[str, Any]],
+        known_command_devices: set[str] | None = None,
     ) -> dict[str, Any]:
         """Copy learned commands from ``remotes`` into schema ``_commands``.
 
@@ -1533,8 +1543,17 @@ class RamsesCoordinator(DataUpdateCoordinator):
         Only copies commands that are NOT already in the schema — schema
         is authoritative, ``remotes`` fills gaps.
 
+        If ``known_command_devices`` is provided, devices in this set that
+        don't have ``_commands`` in their schema entry are skipped — the
+        user previously had ``_commands`` and deleted them, so re-adding
+        from ``remotes`` would resurrect user-deleted commands.  Devices
+        NOT in this set are migrated normally (first-time migration).
+
         :param schema: The schema to enrich.
         :param remotes: The remotes dict from ``.storage`` or in-memory.
+        :param known_command_devices: Device IDs that previously had
+            ``_commands`` in the schema.  Prevents resurrection of
+            user-deleted ``_commands``.
         :return: The schema with ``_commands`` merged in.
         """
         if not remotes or not isinstance(remotes, dict):
@@ -1551,16 +1570,25 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # Create a root entry for this device if it doesn't exist
                 entry = {}
                 new_schema[device_id] = entry
-            if SZ_TR_COMMANDS not in entry:
-                entry[SZ_TR_COMMANDS] = dict(commands)
-                changed = True
-                migrated_count += 1
-                _LOGGER.info(
-                    "SSOT Phase 3a: copied %d command(s) from remotes to "
-                    "schema _commands for %s",
-                    len(commands),
+            if SZ_TR_COMMANDS in entry:
+                continue  # already has _commands — schema is authoritative
+            # Skip if the user previously had _commands and deleted them
+            if known_command_devices is not None and device_id in known_command_devices:
+                _LOGGER.debug(
+                    "SSOT Phase 3a: skipping %s — _commands was previously "
+                    "in schema but is now absent (user deletion)",
                     device_id,
                 )
+                continue
+            entry[SZ_TR_COMMANDS] = dict(commands)
+            changed = True
+            migrated_count += 1
+            _LOGGER.info(
+                "SSOT Phase 3a: copied %d command(s) from remotes to "
+                "schema _commands for %s",
+                len(commands),
+                device_id,
+            )
 
         if changed:
             _LOGGER.info(
@@ -2152,7 +2180,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             self.options.get(SZ_KNOWN_LIST, {}),
                             reason="ssot_phase3a",
                         )
-                    enriched = self._sync_remotes_to_schema(enriched, self._remotes)
+                    enriched = self._sync_remotes_to_schema(
+                        enriched, self._remotes, self._devices_with_commands
+                    )
                 # Phase 3b: migrate REM _commands (packet strings) to FAN
                 # _commands (dict templates).  REM entries are kept for
                 # backward compatibility (downgrade path).
@@ -2214,7 +2244,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # .storage[remotes] or known_list[commands] are migrated to
                 # schema _commands on every save cycle.
                 config_schema = self._sync_remotes_to_schema(
-                    config_schema, self._remotes
+                    config_schema, self._remotes, self._devices_with_commands
                 )
                 # Phase 3b: also migrate REM → FAN dict templates
                 config_schema = self._migrate_rem_commands_to_fan(config_schema)
@@ -2233,7 +2263,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # topology matches the config.
                 if self._remotes:
                     migrated_schema = self._sync_remotes_to_schema(
-                        config_schema, self._remotes
+                        config_schema, self._remotes, self._devices_with_commands
                     )
                     # Phase 3b: also migrate REM → FAN dict templates
                     migrated_schema = self._migrate_rem_commands_to_fan(migrated_schema)
@@ -2262,6 +2292,18 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # from the dying coordinator is stale topology that the user may
             # have just cleared — it must not survive in the cache.
             schema = self.options.get(CONF_SCHEMA, {})
+
+        # Update _devices_with_commands to reflect the current schema state.
+        # This tracks which devices have _commands so that on the next save
+        # cycle, _sync_remotes_to_schema can skip devices that previously
+        # had _commands but no longer do (user deletion → no resurrection).
+        current_schema = self.options.get(CONF_SCHEMA, {})
+        if isinstance(current_schema, dict):
+            self._devices_with_commands = {
+                dev_id
+                for dev_id, entry in current_schema.items()
+                if isinstance(entry, dict) and SZ_TR_COMMANDS in entry
+            }
 
         # Explicitly declare intermediate dict to solve Pylance 'Never is not iterable'
         # Use _commands_for_save (includes _comment metadata) instead of

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -921,7 +921,8 @@ class DiscoveryManager:
         """Build a descriptive comment from scan engine data.
 
         Includes: likely type, confidence, ambiguity notes, binding info,
-        packet codes seen, and battery/RSSI if available.
+        domain_id (appliance_control), packet codes seen, and battery/RSSI
+        if available.
         """
         parts: list[str] = []
 
@@ -942,6 +943,11 @@ class DiscoveryManager:
             parts.append(f"bound to {bound_to}")
         if zone_idx:
             parts.append(f"zone {zone_idx}")
+
+        # Domain ID (FC = appliance_control, issue 834)
+        domain_id = getattr(dev, "domain_id", None) if dev else None
+        if domain_id == "FC":
+            parts.append("domain FC (appliance_control)")
 
         # Packet codes seen
         codes = getattr(dev, "codes_seen", None) if dev else None
@@ -969,6 +975,7 @@ class DiscoveryManager:
         zone_idx: str | None = None,
         ctl_id: str | None = None,
         comment: str | None = None,
+        domain_id: str | None = None,
     ) -> dict[str, Any]:
         """Generate a schema fragment for a discovered device.
 
@@ -993,6 +1000,7 @@ class DiscoveryManager:
         :param zone_idx: Optional zone index (for TRV/THM in a TCS).
         :param ctl_id: Optional CTL device ID (for placing devices in a TCS).
         :param comment: Optional human-readable comment for the ``_comment`` trait.
+        :param domain_id: Optional domain ID (FC=appliance_control, see issue 834).
         :return: A dict that can be deep-merged into the global schema.
         """
         from ramses_rf.schemas import (
@@ -1088,7 +1096,7 @@ class DiscoveryManager:
                 )
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
-        # ── BDR: relay — DHW valve or zone actuator ─────────────────
+        # ── BDR: relay — appliance_control, DHW valve, or zone actuator
         if lt == "BDR":
             if ctl_id and zone_idx:
                 return _merge(
@@ -1100,8 +1108,16 @@ class DiscoveryManager:
                         },
                     }
                 )
+            # domain_id=FC means the BDR broadcasts 3B00/3EF0 (TPI loop) —
+            # it's the boiler relay, not a DHW valve.  See issue 834.
+            if ctl_id and domain_id == "FC":
+                return _merge(
+                    {
+                        ctl_id: {SZ_SYSTEM: {SZ_APPLIANCE_CONTROL: device_id}},
+                    }
+                )
             if ctl_id:
-                # No zone — put in DHW as htg_valve
+                # No zone, no FC domain — assume DHW valve (htg_valve)
                 return _merge(
                     {
                         ctl_id: {SZ_DHW_SYSTEM: {SZ_DHW_VALVE: device_id}},
@@ -1198,6 +1214,7 @@ class DiscoveryManager:
             likely_type = dev.likely_type if dev else "unknown"
             bound_to = dev.bound_to if dev else None
             zone_idx = dev.zone_idx if dev else None
+            domain_id = getattr(dev, "domain_id", None) if dev else None
 
             # Build a descriptive comment from scan engine data so the user
             # can see what the scan engine found and any ambiguity.
@@ -1216,6 +1233,7 @@ class DiscoveryManager:
                 zone_idx=zone_idx,
                 ctl_id=ctl_id,
                 comment=comment,
+                domain_id=domain_id,
             )
 
         self._metadata[device_id] = meta

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -520,20 +520,37 @@ class DiscoveryManager:
             if not isinstance(schema_entry, dict):
                 continue
 
+            # _bound is str (REM/DIS → their FAN) or list[str] (FAN →
+            # its bound REMs, Phase 3b multi-REM format)
             schema_bound = schema_entry.get(SZ_TR_BOUND)
-            if not isinstance(schema_bound, str) or not schema_bound:
+            if isinstance(schema_bound, str):
+                schema_bound_ids = [schema_bound] if schema_bound else []
+            elif isinstance(schema_bound, list):
+                schema_bound_ids = [b for b in schema_bound if isinstance(b, str) and b]
+            else:
+                schema_bound_ids = []
+            if not schema_bound_ids:
                 continue  # no _bound in schema — nothing to compare
 
             scan_bound = dev.bound_to or ""
             if not scan_bound:
                 continue  # scan doesn't know — not a meaningful mismatch
 
-            # Normalize for comparison (case-insensitive)
-            if scan_bound.upper() != schema_bound.upper():
+            # Normalize for comparison (case-insensitive).  For a list,
+            # the scan's single bound_to must be one of the schema's
+            # bound IDs — otherwise it's a mismatch.
+            schema_bound_str = (
+                schema_bound
+                if isinstance(schema_bound, str)
+                else ", ".join(schema_bound_ids)
+            )
+            if scan_bound.upper() not in {b.upper() for b in schema_bound_ids}:
                 meta = self._metadata.get(device_id, DeviceMetadata())
-                meta.bound_mismatch = f"schema={schema_bound}, discovery={scan_bound}"
+                meta.bound_mismatch = (
+                    f"schema={schema_bound_str}, discovery={scan_bound}"
+                )
                 self._metadata[device_id] = meta
-                mismatches.append((device_id, schema_bound, scan_bound))
+                mismatches.append((device_id, schema_bound_str, scan_bound))
                 _LOGGER.debug(
                     "DiscoveryManager: bound mismatch for %s — "
                     "schema has _bound=%s but discovery suggests %s",

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -24,6 +24,7 @@ from homeassistant.components.persistent_notification import (
     async_dismiss as async_dismiss_notification,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .const import (
     DOMAIN,
@@ -88,6 +89,10 @@ class DeviceMetadata:
     # Set when the scan engine has a likely_type but the schema entry
     # has no _class at all.  Cleared when the user adds a _class.
     missing_class: str | None = None
+    # Set when the user explicitly chose "Skip" in the review_discovered
+    # step, dismissing the missing_class suggestion.  Prevents
+    # check_missing_class from re-flagging the same device every cycle.
+    missing_class_dismissed: bool = False
     # Set when a device is in the schema but has not been seen by the
     # scan engine for longer than the orphan threshold.  Cleared when
     # traffic is seen again.
@@ -106,6 +111,7 @@ class DeviceMetadata:
             "class_mismatch_dismissed": self.class_mismatch_dismissed,
             "bound_mismatch": self.bound_mismatch,
             "missing_class": self.missing_class,
+            "missing_class_dismissed": self.missing_class_dismissed,
             "orphaned": self.orphaned,
         }
 
@@ -127,6 +133,7 @@ class DeviceMetadata:
             class_mismatch_dismissed=data.get("class_mismatch_dismissed", False),
             bound_mismatch=data.get("bound_mismatch"),
             missing_class=data.get("missing_class"),
+            missing_class_dismissed=data.get("missing_class_dismissed", False),
             orphaned=data.get("orphaned"),
         )
 
@@ -609,6 +616,11 @@ class DiscoveryManager:
             if not scan_type or scan_type == "DEV":
                 continue  # scan doesn't know either — not actionable
 
+            # Skip if the user already dismissed this missing_class ("Skip")
+            existing_meta = self._metadata.get(device_id)
+            if existing_meta and existing_meta.missing_class_dismissed:
+                continue  # user decided — don't re-flag
+
             meta = self._metadata.get(device_id, DeviceMetadata())
             meta.missing_class = f"discovery={scan_type}"
             self._metadata[device_id] = meta
@@ -654,7 +666,7 @@ class DiscoveryManager:
             threshold_days = self._lost_threshold_days
 
         scan_devices = {d.device_id: d for d in self._scan.get_devices()}
-        now = dt.now()
+        now = dt_util.now()  # tz-aware (HA default timezone)
         threshold = now - td(days=threshold_days)
         orphaned: list[str] = []
 
@@ -681,6 +693,11 @@ class DiscoveryManager:
                 last_seen = dt.fromisoformat(last_seen_str)
             except (ValueError, TypeError):
                 continue
+
+            # Ensure tz-aware for comparison (ramses_rf may store naive
+            # or tz-aware datetimes depending on version/config).
+            if last_seen.tzinfo is None:
+                last_seen = last_seen.replace(tzinfo=dt_util.get_default_time_zone())
 
             if last_seen < threshold:
                 meta = self._metadata.get(device_id, DeviceMetadata())

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -29,7 +29,7 @@ from ramses_tx.command import Command
 from ramses_tx.const import DEFAULT_GAP_DURATION, Priority
 from ramses_tx.exceptions import ProtocolError, ProtocolSendFailed, ProtocolTimeoutError
 
-from .const import ATTR_DEVICE_ID, DOMAIN
+from .const import ATTR_DEVICE_ID, CONF_SCHEMA, DOMAIN
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .schemas import DEFAULT_NUM_REPEATS, DEFAULT_TIMEOUT
@@ -312,7 +312,7 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         """
         if not self.is_fan_entity:
             return []
-        schema = self.coordinator.options.get("schema", {})
+        schema = self.coordinator.options.get(CONF_SCHEMA, {})
         entry = schema.get(self._device.id, {})
         if not isinstance(entry, dict):
             return []

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -1108,6 +1108,25 @@ class RamsesServiceHandler:
                 main_tcs = config_schema.get("main_tcs")
                 if isinstance(main_tcs, str):
                     ctl_id = main_tcs
+        # Fall back to the runtime client's main TCS (issue 834:
+        # main_tcs may not be in the config entry options yet if
+        # sync_topology hasn't run since the last profile reload —
+        # the coordinator only writes main_tcs to the config entry
+        # during async_save_client_state → sync_learned_topology).
+        if not ctl_id and self._coordinator.client:
+            tcs = getattr(self._coordinator.client, "tcs", None)
+            if tcs and isinstance(getattr(tcs, "id", None), str):
+                ctl_id = tcs.id
+        _LOGGER.debug(
+            "accept_discovered_device: device_id=%s, ctl_id=%s, "
+            "client=%s, config_main_tcs=%s",
+            device_id,
+            ctl_id,
+            self._coordinator.client is not None,
+            self._coordinator.options.get(CONF_SCHEMA, {}).get("main_tcs")
+            if isinstance(self._coordinator.options.get(CONF_SCHEMA, {}), dict)
+            else None,
+        )
 
         try:
             entry = self._coordinator.discovery_manager.accept_device(

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1388,6 +1388,101 @@ async def test_hvac_set_fan_mode_falls_back_to_known_list(
     mock_device.set_fan_mode.assert_not_called()
 
 
+async def test_hvac_set_fan_mode_rem_not_faked_raises(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """async_set_fan_mode REM fallback raises if bound REM is not faked."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    # Bound REM device exists but is NOT faked
+    rem_dev = MagicMock()
+    rem_dev.is_faked = False
+    mock_coordinator._get_device = MagicMock(return_value=rem_dev)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    with pytest.raises(HomeAssistantError, match="not configured for faking"):
+        await hvac.async_set_fan_mode("low")
+
+    # Should NOT have sent the command
+    mock_device._gwy.async_send_cmd.assert_not_awaited()
+
+
+async def test_hvac_set_fan_mode_rem_faked_sends(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """async_set_fan_mode REM fallback sends when bound REM IS faked."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    # Bound REM device exists and IS faked
+    rem_dev = MagicMock()
+    rem_dev.is_faked = True
+    mock_coordinator._get_device = MagicMock(return_value=rem_dev)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    await hvac.async_set_fan_mode("low")
+
+    # Should have sent the command
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device.set_fan_mode.assert_not_called()
+
+
+async def test_hvac_set_fan_mode_rem_not_found_sends(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """async_set_fan_mode REM fallback sends when bound REM device not found.
+
+    If _get_device returns None (device not in registry), we can't check
+    is_faked — fall through to sending, matching the remote.py behaviour
+    where the check is only done when the device object is available.
+    """
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    # Bound REM device not found in registry
+    mock_coordinator._get_device = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    await hvac.async_set_fan_mode("low")
+
+    # Should have sent the command (no is_faked check possible)
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Phase 3a: fan_modes property tests
 # ---------------------------------------------------------------------------

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -4600,7 +4600,7 @@ class TestSyncRemotesToSchema:
     """Tests for RamsesCoordinator._sync_remotes_to_schema (Phase 3a)."""
 
     def test_remotes_copied_to_schema(self) -> None:
-        """Commands from remotes are copied to schema _commands."""
+        """Commands from remotes are copied to schema _commands (first-time)."""
         schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
         remotes = {"32:153001": {"turn_on": "I --- 22F1 003 000030"}}
         result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes)
@@ -4609,6 +4609,35 @@ class TestSyncRemotesToSchema:
         }
         # Existing _class preserved
         assert result["32:153001"]["_class"] == "REM"
+
+    def test_remotes_not_resurrected_for_known_command_device(self) -> None:
+        """Commands are NOT re-added if device previously had _commands.
+
+        If known_command_devices includes a device, and that device's
+        schema entry no longer has _commands (user deleted it), the
+        commands are NOT resurrected from remotes.
+        """
+        schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
+        remotes = {"32:153001": {"turn_on": "I --- 22F1 003 000030"}}
+        # Device previously had _commands — user deleted them
+        known = {"32:153001"}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes, known)
+        assert SZ_TR_COMMANDS not in result["32:153001"]
+        assert result["32:153001"]["_class"] == "REM"
+
+    def test_remotes_migrated_for_unknown_command_device(self) -> None:
+        """Commands ARE migrated for devices not in known_command_devices.
+
+        If known_command_devices is provided but the device is NOT in it,
+        the commands are migrated normally (first-time migration).
+        """
+        schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
+        remotes = {"32:153001": {"turn_on": "I --- 22F1 003 000030"}}
+        known: set[str] = set()  # device not known → migrate
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes, known)
+        assert result["32:153001"][SZ_TR_COMMANDS] == {
+            "turn_on": "I --- 22F1 003 000030"
+        }
 
     def test_schema_commands_not_overwritten(self) -> None:
         """Schema _commands is authoritative — remotes don't overwrite."""
@@ -4798,6 +4827,9 @@ async def test_async_save_client_state_else_branch_syncs_remotes(
     When learned topology is NOT richer than config (enriched is None) and
     no comments are refreshed, the else branch still runs
     _sync_remotes_to_schema to migrate commands from .storage[remotes].
+
+    The REM is in the config schema but has no _commands yet (first-time
+    migration).  _devices_with_commands is empty, so migration proceeds.
     """
     assert mock_coordinator.client is not None
 
@@ -4810,6 +4842,7 @@ async def test_async_save_client_state_else_branch_syncs_remotes(
 
     # Remotes has commands that need migrating
     mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._devices_with_commands = set()  # first-time migration
     mock_coordinator._entities = {}
     mock_coordinator._skip_topology_sync = False
 
@@ -4838,6 +4871,54 @@ async def test_async_save_client_state_else_branch_syncs_remotes(
     assert saved_options[CONF_SCHEMA][rem_id][SZ_TR_COMMANDS] == commands
 
 
+async def test_async_save_client_state_no_resurrection_of_deleted_commands(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Save cycle does not resurrect user-deleted _commands from remotes.
+
+    If a device previously had _commands in the schema and the user deleted
+    them, _sync_remotes_to_schema should NOT re-add them from .storage[remotes].
+    """
+    assert mock_coordinator.client is not None
+
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+
+    # Config schema has the REM but _commands was deleted by the user
+    config_schema: dict[str, Any] = {rem_id: {"_class": "REM"}}
+    mock_coordinator.options = {CONF_SCHEMA: config_schema, SZ_KNOWN_LIST: {}}
+
+    # Remotes still has the old commands (from .storage)
+    mock_coordinator._remotes = {rem_id: commands}
+    # Device previously had _commands — should NOT be resurrected
+    mock_coordinator._devices_with_commands = {rem_id}
+    mock_coordinator._entities = {}
+    mock_coordinator._skip_topology_sync = False
+
+    # Learned schema is same as config (no enrichment)
+    learned_schema = dict(config_schema)
+    cast(Any, mock_coordinator.client).get_state = MagicMock(
+        return_value=(learned_schema, {})
+    )
+
+    mock_save = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save = mock_save
+
+    # Patch sync_learned_topology to return None (no enrichment)
+    with (
+        patch(
+            "custom_components.ramses_cc.coordinator.sync_learned_topology",
+            return_value=None,
+        ),
+        patch.object(mock_coordinator, "discovery_manager", None),
+    ):
+        await mock_coordinator.async_save_client_state()
+
+    # _commands should NOT be in the schema (user deleted, not resurrected)
+    saved_schema = mock_coordinator.options[CONF_SCHEMA]
+    assert SZ_TR_COMMANDS not in saved_schema.get(rem_id, {})
+
+
 async def test_async_save_client_state_backup_before_migration(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -4858,6 +4939,7 @@ async def test_async_save_client_state_backup_before_migration(
 
     # Remotes has commands that need migrating
     mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._devices_with_commands = set()  # first-time migration
     mock_coordinator._entities = {}
     mock_coordinator._skip_topology_sync = False
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -4942,6 +4942,61 @@ async def test_async_save_client_state_no_backup_when_already_migrated(
     mock_backup.assert_not_awaited()
 
 
+async def test_async_save_client_state_survives_validation_failure(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Save cycle skips topology sync when _validate_schema_for_ramserf raises.
+
+    If the enriched schema fails validation, the save cycle should log the
+    error and skip the config entry update — NOT abort with an unhandled
+    ValueError, and NOT overwrite the config entry with an invalid schema.
+    The rest of the save (packets, remotes to .storage) should still happen.
+    """
+    assert mock_coordinator.client is not None
+
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+
+    config_schema: dict[str, Any] = {rem_id: {"_class": "REM"}}
+    original_options = {CONF_SCHEMA: config_schema, SZ_KNOWN_LIST: {}}
+    mock_coordinator.options = dict(original_options)
+
+    mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._entities = {}
+    mock_coordinator._skip_topology_sync = False
+
+    # Enriched schema that will fail validation
+    enriched_schema = {rem_id: {"_class": "REM"}, "main_tcs": "01:123456"}
+    cast(Any, mock_coordinator.client).get_state = MagicMock(
+        return_value=(enriched_schema, {})
+    )
+
+    mock_save = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save = mock_save
+    mock_backup = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save_backup = mock_backup
+
+    with (
+        patch(
+            "custom_components.ramses_cc.coordinator.sync_learned_topology",
+            return_value=enriched_schema,
+        ),
+        patch.object(mock_coordinator, "discovery_manager", None),
+        patch.object(
+            mock_coordinator,
+            "_validate_schema_for_ramserf",
+            side_effect=ValueError("Schema validation failed: bad key"),
+        ),
+    ):
+        # Should NOT raise — the ValueError is caught
+        await mock_coordinator.async_save_client_state()
+
+    # Config entry options should NOT be updated with the invalid schema
+    assert mock_coordinator.options[CONF_SCHEMA] == config_schema
+    # The save to .storage should still happen (packets, remotes)
+    mock_save.assert_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Phase 3b: _migrate_rem_commands_to_fan tests
 # ---------------------------------------------------------------------------

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -776,6 +776,43 @@ class TestGenerateSchemaEntryEdgeCases:
         )
         assert result["01:111111"][SZ_DHW_SYSTEM][SZ_DHW_VALVE] == "08:333333"
 
+    def test_bdr_with_ctl_and_fc_domain_is_appliance_control(self) -> None:
+        """BDR with ctl_id and domain_id=FC is the appliance_control (issue 834).
+
+        A BDR broadcasting 3B00/3EF0 (TPI loop) is the boiler relay, not a
+        DHW valve.  The scan engine sets domain_id=FC; generate_schema_entry
+        must place it under system.appliance_control, not stored_hotwater.
+        """
+        from ramses_rf.schemas import SZ_APPLIANCE_CONTROL, SZ_SYSTEM
+
+        result = DiscoveryManager.generate_schema_entry(
+            "13:121025", "BDR", ctl_id="01:046100", domain_id="FC"
+        )
+        assert result["01:046100"][SZ_SYSTEM][SZ_APPLIANCE_CONTROL] == "13:121025"
+
+    def test_bdr_with_fc_domain_no_ctl_goes_to_orphans(self) -> None:
+        """BDR with domain_id=FC but no ctl_id goes to orphans_heat."""
+        from ramses_rf.schemas import SZ_ORPHANS_HEAT
+
+        result = DiscoveryManager.generate_schema_entry(
+            "13:121025", "BDR", domain_id="FC"
+        )
+        assert "13:121025" in result[SZ_ORPHANS_HEAT]
+
+    def test_bdr_with_zone_takes_priority_over_fc_domain(self) -> None:
+        """BDR with both zone_idx and domain_id=FC is a zone actuator.
+
+        zone_idx is a stronger signal (explicit zone binding) than the FC
+        domain (TPI loop).  A BDR could theoretically be both, but zone
+        binding wins.
+        """
+        from ramses_rf.schemas import SZ_ACTUATORS, SZ_ZONES
+
+        result = DiscoveryManager.generate_schema_entry(
+            "13:121025", "BDR", ctl_id="01:046100", zone_idx="02", domain_id="FC"
+        )
+        assert "13:121025" in result["01:046100"][SZ_ZONES]["02"][SZ_ACTUATORS]
+
     def test_bdr_no_ctl(self) -> None:
         """BDR without ctl_id goes to heat orphans."""
         from ramses_rf.schemas import SZ_ORPHANS_HEAT

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1548,6 +1548,86 @@ class TestCheckBoundMismatches:
         count = manager.check_bound_mismatches(schema)
         assert count == 0
 
+    def test_list_bound_no_mismatch_when_scan_in_list(self) -> None:
+        """FAN with list-valued _bound — scan's bound_to is in the list."""
+        dev = make_discovered_device("32:153289", "FAN")
+        # make_discovered_device sets bound_to="01:145038"
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["01:145038", "37:111111"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is None or meta.bound_mismatch is None
+
+    def test_list_bound_mismatch_when_scan_not_in_list(self) -> None:
+        """FAN with list-valued _bound — scan's bound_to NOT in list."""
+        dev = make_discovered_device("32:153289", "FAN")
+        # bound_to="01:145038" but schema says ["22:999999", "37:111111"]
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["22:999999", "37:111111"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 1
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.bound_mismatch is not None
+        assert "22:999999" in meta.bound_mismatch
+        assert "37:111111" in meta.bound_mismatch
+        assert "01:145038" in meta.bound_mismatch
+
+    def test_list_bound_mismatch_cleared_when_resolved(self) -> None:
+        """List-valued _bound mismatch is cleared when scan joins the list."""
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Pre-set a mismatch
+        manager._metadata["32:153289"] = DeviceMetadata(
+            bound_mismatch="schema=22:999999, 37:111111, discovery=01:145038"
+        )
+        # Now schema list includes the scan's bound_to
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["01:145038", "22:999999"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.bound_mismatch is None
+
+    def test_list_bound_case_insensitive(self) -> None:
+        """List-valued _bound comparison is case-insensitive."""
+        dev = make_discovered_device("32:153289", "FAN")
+        # bound_to="01:145038"
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Different case in list — should NOT be a mismatch
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["01:145038".upper(), "37:111111"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+
 
 class TestCheckMissingClass:
     """Tests for DiscoveryManager.check_missing_class."""

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -11,7 +11,7 @@ Tests verify:
 
 from __future__ import annotations
 
-from datetime import datetime as dt, timedelta as td
+from datetime import UTC, datetime as dt, timedelta as td
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1689,6 +1689,37 @@ class TestCheckMissingClass:
         count = manager.check_missing_class(schema)
         assert count == 0
 
+    def test_missing_class_skipped_when_dismissed(self) -> None:
+        """A dismissed missing_class is not re-flagged on the next check."""
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # User previously dismissed the missing_class suggestion
+        manager._metadata["32:153289"] = DeviceMetadata(missing_class_dismissed=True)
+        schema = {"32:153289": {}}  # still no _class
+        count = manager.check_missing_class(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.missing_class is None  # not re-flagged
+
+    def test_missing_class_dismissed_serialization(self) -> None:
+        """missing_class_dismissed is serialized/deserialized correctly."""
+        meta = DeviceMetadata(missing_class_dismissed=True)
+        d = meta.to_dict()
+        assert d["missing_class_dismissed"] is True
+
+        restored = DeviceMetadata.from_dict(d)
+        assert restored.missing_class_dismissed is True
+
+    def test_missing_class_dismissed_default_false(self) -> None:
+        """missing_class_dismissed defaults to False."""
+        meta = DeviceMetadata()
+        assert meta.missing_class_dismissed is False
+        d = meta.to_dict()
+        assert d["missing_class_dismissed"] is False
+
 
 class TestCheckOrphanedDevices:
     """Tests for DiscoveryManager.check_orphaned_devices."""
@@ -1767,6 +1798,33 @@ class TestCheckOrphanedDevices:
 
         schema = {"main_tcs": "01:145038", "_owner": "me"}
         count = manager.check_orphaned_devices(schema)
+        assert count == 0
+
+    def test_orphaned_with_tz_aware_last_seen(self) -> None:
+        """Tz-aware last_seen (e.g. from ramses_rf) is compared correctly."""
+
+        old_date = (dt.now(UTC) - td(days=30)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 1
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is not None
+
+    def test_not_orphaned_with_tz_aware_recent(self) -> None:
+        """Tz-aware recent last_seen is not flagged as orphaned."""
+
+        recent_date = (dt.now(UTC) - td(days=1)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=recent_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
         assert count == 0
 
 


### PR DESCRIPTION
fix: classify BDR as appliance_control when domain_id=FC (issue [834](https://github.com/ramses-rf/ramses_cc/issues/834))
 
A BDR broadcasting 3B00/3EF0 (TPI loop) is the boiler relay, not a DHW
valve.  generate_schema_entry now checks domain_id=FC before falling
back to hotwater_valve, placing the BDR under system.appliance_control.
 
- Add domain_id param to generate_schema_entry + appliance_control branch
- Pass dev.domain_id through in accept_device
- Include "domain FC (appliance_control)" in device comment
- Fall back to runtime client.tcs for ctl_id when main_tcs not yet in
  config entry options (after profile reload, before sync_topology)
- 3 new tests for the BDR branch (FC→appliance, FC+zone→zone, FC no ctl)

AI used: GLM 5.2 high