### PR TITLE
Feature/phase3d alignment

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1166,7 +1166,15 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                     fan_mode,
                     packet_str,
                 )
-                cmd = Command(packet_str)
+
+                # Users might enter a CLI shorthand OR a raw frame string;
+                # _build_packet_from_template returns a full packet frame
+                # (W --- src dst --:------ code len payload) which
+                # Command.from_cli() parses, but Command() does not.
+                try:
+                    cmd = Command.from_cli(packet_str)
+                except (ValueError, RamsesException):
+                    cmd = Command(packet_str)
                 await self._device._gwy.async_send_cmd(
                     cmd, num_repeats=2, priority=Priority.HIGH
                 )

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1060,8 +1060,13 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                     base_modes.append(cmd_name)
 
         # Phase 3a: bound REM's _commands (packet strings, fallback)
+        # Only offer REM commands if the REM is faked — sending as a
+        # non-faked REM would collide with the physical remote's transmissions.
         bound_rem = self._bound_rem or self._device.get_bound_rem()
         if bound_rem:
+            rem_dev = self.coordinator._get_device(str(bound_rem))
+            if rem_dev is not None and not rem_dev.is_faked:
+                return base_modes  # REM not faked — don't offer its commands
             rem_commands = remotes.get(str(bound_rem), {})
             if isinstance(rem_commands, dict):
                 cmds, _ = _split_commands(rem_commands)
@@ -1170,6 +1175,18 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
             # Check REM packet strings (Phase 3a fallback)
             if fan_mode in rem_commands:
+                # Verify the bound REM is faked — we're sending a packet
+                # as if it came from that REM, which only makes sense if
+                # the REM is configured for faking.  This mirrors the
+                # check in remote.py's async_send_command.
+                if bound_rem:
+                    rem_dev = self.coordinator._get_device(str(bound_rem))
+                    if rem_dev is not None and not rem_dev.is_faked:
+                        raise HomeAssistantError(
+                            f"Bound REM {bound_rem} is not configured for "
+                            f"faking — cannot send custom command"
+                        )
+
                 cmd_str = rem_commands[fan_mode]
                 _LOGGER.info(
                     "Intercepted fan_mode '%s'; sending custom command: %s",

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1725,12 +1725,19 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         )
                 # Clear the missing_class flag for both "add_class" and "skip"
                 # so the notification doesn't re-fire immediately.  For "skip"
-                # the flag will be re-set on the next checkpoint if the schema
-                # still lacks _class — but that's the next review cycle.
+                # also set missing_class_dismissed to prevent check_missing_class
+                # from re-flagging the same device on the next checkpoint.
                 if action in ("add_class", "skip"):
                     meta = coordinator.discovery_manager._metadata.get(device_id)
                     if meta:
                         meta.missing_class = None
+                        if action == "skip":
+                            # Persist the dismissal so check_missing_class
+                            # doesn't re-flag this device on the next checkpoint
+                            meta.missing_class_dismissed = True
+                        elif action == "add_class":
+                            # User added a class — clear any prior dismissal
+                            meta.missing_class_dismissed = False
 
             if changed:
                 self.options[CONF_SCHEMA] = order_schema(config_schema)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1138,16 +1138,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 if mapped.get("faked") is True:
                     traits["faked"] = True
                 if mapped.get("bound"):
-                    # ramses_rf's SCH_TRAITS only accepts 'bound' as a
-                    # string (single device ID) for REM/DIS devices.  The
-                    # _bound trait on a FAN is a ramses_cc concept (used by
-                    # fan_handler to route 2411 commands) and may be a list
-                    # for multi-REM binding — ramses_rf doesn't need it.
-                    # Only pass bound to ramses_rf if it's a string (REM/DIS
-                    # pointing to their FAN), not if it's a list (FAN
-                    # pointing to its REMs).
-                    if isinstance(mapped["bound"], str):
-                        traits["bound"] = mapped["bound"]
+                    # ramses_rf 0.58.2+ accepts 'bound' as str | list[str]
+                    # (verified config.py:89-93).  str is for REM/DIS pointing
+                    # to their FAN; list is for FAN pointing to its REMs
+                    # (multi-REM binding).  Both are passed through.
+                    traits["bound"] = mapped["bound"]
                 if mapped.get("scheme"):
                     traits["scheme"] = mapped["scheme"]
             known_list[device_id] = traits
@@ -1187,14 +1182,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             if isinstance(traits, dict) and isinstance(traits.get("class"), str):
                 traits["class"] = _normalize_class_slug(traits["class"])
 
-        # Sanitize: ramses_rf's SCH_TRAITS only accepts 'bound' for HVAC
-        # devices with an explicit class.  Remove 'bound' from entries that
-        # don't have 'class' to prevent validation errors.
+        # Sanitize: ramses_rf's SCH_TRAITS_HEAT does not accept 'bound'
+        # (only SCH_TRAITS_HVAC has it).  Remove 'bound' from heat devices
+        # that don't have an explicit class.  HVAC devices without class are
+        # fine — SCH_TRAITS_HVAC defaults class to 'HVC' (ramses_rf 0.58.2+).
         for _device_id, traits in known_list.items():
             if (
                 isinstance(traits, dict)
                 and "bound" in traits
                 and not traits.get("class")
+                and _device_id[:3] in _HEAT_PREFIXES
             ):
                 traits.pop("bound", None)
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -32,10 +32,7 @@ from homeassistant.helpers.event import async_call_later, async_track_time_inter
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from ramses_rf.config import (
-    strip_and_map_traits as _strip_and_map_traits,
-    strip_traits as _strip_traits_rf,
-)
+from ramses_rf.config import strip_and_map_traits as _strip_and_map_traits
 from ramses_rf.devices import (
     _CLASS_BY_SLUG,
     DEV_TYPE_MAP,
@@ -117,6 +114,9 @@ from .discovery import DiscoveryManager
 from .fan_handler import RamsesFanHandler
 from .mqtt_bridge import RamsesMqttBridge
 from .schemas import (
+    _HEAT_PREFIXES,
+    _SCHEMA_EXTENSION_KEYS,
+    _strip_and_orchestrate,
     extract_hvac_schema,
     merge_hvac_schema,
     merge_schemas,
@@ -133,17 +133,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SAVE_STATE_INTERVAL: Final[td] = td(minutes=5)
 _DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9A-F]{2}:[0-9A-F]{6}$", re.I)
-# Heat-side prefixes that should never be treated as VCS at root level.
-# Any non-01: device NOT in this set is assumed to be HVAC and gets
-# remotes: [] injected if missing.  Pragmatic — proper HVAC prefix
-# classification is deferred (see schema_architecture.md,
-# "Device ID prefixes for HVAC").
-_HEAT_PREFIXES: Final[frozenset[str]] = frozenset(
-    ("01:", "04:", "07:", "08:", "10:", "13:", "22:", "34:")
-)
-# Device-id prefixes allowed in a TCS-level ``orphans`` list (ramses_rf's
-# PARENT_RULES only accepts BdrSwitch / OtbGateway / UfhController there).
-_TCS_ORPHAN_PREFIXES: Final[frozenset[str]] = frozenset(("02:", "10:", "13:"))
+# _HEAT_PREFIXES and _TCS_ORPHAN_PREFIXES are imported from .schemas
+# (single definition shared with strip_traits_for_validation).
 _EXTRACT_DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(
     r"[0-9A-F]{2}:[0-9A-F]{6}", re.I
 )
@@ -847,9 +838,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
     # Keys that ramses_cc adds to the schema dict but ramses_rf doesn't
     # understand.  They are stripped before passing the schema to the Gateway.
-    _SCHEMA_EXTENSION_KEYS: Final[frozenset[str]] = frozenset(
-        {SZ_DEVICE_COMMENTS, SZ_OWNER}
-    )
+    # _SCHEMA_EXTENSION_KEYS is imported from .schemas (shared definition).
 
     @staticmethod
     def _validate_schema_for_ramserf(schema: dict[str, Any]) -> None:
@@ -916,200 +905,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
     def _strip_schema_extensions(schema: dict[str, Any]) -> dict[str, Any]:
         """Return a copy of *schema* with ramses_cc-only keys removed.
 
-        ramses_rf's ``SCH_GLOBAL_SCHEMAS`` validator would reject our
-        extension keys (``device_comments``) and ``_`` prefixed user traits
-        (``_disabled``, ``_name``, etc.), so we strip them before passing
-        the schema to the Gateway.
+        Thin wrapper around ``_strip_and_orchestrate()`` (in schemas.py) —
+        the shared stage-1 + stage-3 stripping logic used by both the
+        coordinator (gateway feeding) and config_flow (validation).
 
-        Stage 1 (strip ``_`` keys) is delegated to ramses_rf's
-        ``strip_traits`` — no duplicate logic.  Stage 2 (mapping
-        ``_bound``→``bound``, etc.) is done in
-        ``_derive_known_list_from_schema`` via ``strip_and_map_traits``.
-        This function handles stage 3 only: orchestration
-        (disabled/skipped filtering, orphan routing, HGI dropping,
-        foreign-owner handling).
-
-        Also strips ``None`` values for known optional keys like
-        ``main_tcs`` — ramses_rf's validator rejects ``null`` even though
-        the key is ``vol.Optional``.
-
-        For HVAC (ventilation) devices (any non-heat device at root level,
-        e.g. FAN ``29:``, ``30:``, HRU ``32:``, ``37:``), ramses_rf's
-        ``SCH_GLOBAL_SCHEMAS`` treats them as VCS and requires at least one
-        of ``remotes``/``sensors`` keys to be present.  Instead of injecting
-        a fake ``remotes: []``, we move such devices to ``orphans_hvac``
-        where they belong until we know enough to place them as VCS.
-        Heat-side prefixes (``04:``, ``07:``, etc.) are excluded — they go
-        to ``orphans_heat``.
+        See ``_strip_and_orchestrate`` for the full documentation of what
+        stage 3 orchestration does (orphan routing, disabled/skipped/foreign
+        filtering, HGI dropping, ``None`` stripping, TCS orphan safety net).
         """
-
-        # First pass: collect _disabled/_skipped device IDs so we can remove
-        # them from orphan lists, and collect un-disabled trait-only devices
-        # so we can add them to orphans (so ramses_rf creates them)
-        ctl_id = schema.get(SZ_MAIN_TCS)
-        root_owner = schema.get(SZ_OWNER)
-        disabled_ids: set[str] = set()
-        skipped_ids: set[str] = set()
-        foreign_ids: set[str] = set()
-        undisabled_ids: set[str] = set()
-        for k, v in schema.items():
-            if isinstance(v, dict) and _DEVICE_ID_RE.match(str(k)) and str(k) != ctl_id:
-                if v.get(SZ_TR_DISABLED) is True:
-                    disabled_ids.add(str(k))
-                elif v.get(SZ_TR_SKIPPED) is True:
-                    skipped_ids.add(str(k))
-                elif v.get(SZ_TR_DISABLED) is False or v.get(SZ_TR_SKIPPED) is False:
-                    # Explicitly un-disabled or un-skipped — needs to be in
-                    # orphans so ramses_rf creates it
-                    undisabled_ids.add(str(k))
-                # Check ownership: foreign devices go to block_list, not orphans
-                if (
-                    root_owner
-                    and isinstance(v.get(SZ_TR_OWNER), str)
-                    and v[SZ_TR_OWNER] != root_owner
-                ):
-                    foreign_ids.add(str(k))
-
-        result: dict[str, Any] = {}
-        for k, v in schema.items():
-            # Skip all root-level _ prefixed keys (root _owner, _bound, _class,
-            # _faked, etc.) — these are ramses_cc-only traits that ramses_rf's
-            # schema validator would reject.
-            if isinstance(k, str) and k.startswith("_"):
-                continue
-            if k in RamsesCoordinator._SCHEMA_EXTENSION_KEYS or v is None:
-                continue
-            # Drop HGI (18:) entries — they are gateways, not heating devices.
-            # ramses_rf doesn't need them in the schema (the HGI is the gateway
-            # itself, not a controlled device).  Keeping them here would cause
-            # ramses_rf to try loading them as TCS/VCS entries.
-            if isinstance(k, str) and k.startswith("18:"):
-                continue
-            # Remove _disabled, _skipped, and foreign-owner devices from orphan lists
-            if k in (SZ_ORPHANS_HEAT, SZ_ORPHANS_HVAC) and isinstance(v, list):
-                v = [
-                    d
-                    for d in v
-                    if d not in disabled_ids
-                    and d not in skipped_ids
-                    and d not in foreign_ids
-                ]
-            # Track if the original had _ keys before stripping
-            had_traits = isinstance(v, dict) and any(
-                str(k2).startswith("_") for k2 in v
-            )
-            # Stage 1: delegate to ramses_rf's strip_traits
-            # (recursive — strips all _ keys, no mapping)
-            # Mapping (_bound→bound, etc.) is done separately in
-            # _derive_known_list_from_schema via strip_and_map_traits.
-            if isinstance(v, dict):
-                v = _strip_traits_rf(v)
-            # Non-heat device at root level without remotes/sensors — move
-            # to orphans_hvac instead of keeping as an invalid VCS entry.
-            # ramses_rf's SCH_GLOBAL_SCHEMAS treats root-level non-CTL
-            # devices as VCS, requiring remotes or sensors.  We don't know
-            # enough about the device yet (prefix is ambiguous: 29:/37:/32:
-            # can be FAN/REM/CO2/HUM), so orphans_hvac is the safe place.
-            # Skip disabled/skipped devices (they'll be dropped below).
-            # TODO: proper HVAC prefix classification — see
-            # schema_architecture.md, "Device ID prefixes for HVAC".
-            if (
-                isinstance(v, dict)
-                and _DEVICE_ID_RE.match(str(k))
-                and str(k)[:3] not in _HEAT_PREFIXES
-                and str(k) not in disabled_ids
-                and str(k) not in skipped_ids
-                and str(k) not in foreign_ids
-                and "remotes" not in v
-                and "sensors" not in v
-            ):
-                undisabled_ids.add(str(k))
-                continue
-            # Drop trait-only entries (had _ keys, now empty after stripping)
-            if (
-                had_traits
-                and isinstance(v, dict)
-                and _DEVICE_ID_RE.match(str(k))
-                and not v
-            ):
-                # Un-disabled trait-only entry: add to orphans instead
-                # (ramses_rf would reject the empty dict)
-                continue
-            # Drop empty device entries (no traits, no topology) —
-            # ramses_rf rejects empty dicts for device IDs.  Add to orphans
-            # instead so the device is still created.
-            if (
-                not had_traits
-                and isinstance(v, dict)
-                and _DEVICE_ID_RE.match(str(k))
-                and str(k) != ctl_id
-                and not v
-                and str(k) not in disabled_ids
-                and str(k) not in skipped_ids
-            ):
-                undisabled_ids.add(str(k))
-                continue
-            # Skip foreign-owner devices — they go to block_list, not the schema
-            if str(k) in foreign_ids:
-                continue
-            result[k] = v
-
-        # Add un-disabled trait-only devices to orphans so ramses_rf creates them.
-        # When a user changes _disabled from true to false, the device entry
-        # becomes trait-only (no topology keys).  Without this, the device would
-        # be dropped entirely and ramses_rf would not create it.
-        if undisabled_ids:
-            heat_orphans = set(result.get(SZ_ORPHANS_HEAT, []))
-            hvac_orphans = set(result.get(SZ_ORPHANS_HVAC, []))
-            for dev_id in undisabled_ids:
-                # Skip HGI gateways — they are not heating or HVAC devices
-                # and should not be in any orphan list.
-                if dev_id.startswith("18:"):
-                    continue
-                if dev_id[:3] not in _HEAT_PREFIXES:
-                    hvac_orphans.add(dev_id)
-                    heat_orphans.discard(dev_id)  # avoid heat+hvac duplicates
-                else:
-                    heat_orphans.add(dev_id)
-            if heat_orphans:
-                result[SZ_ORPHANS_HEAT] = sorted(heat_orphans)
-            if hvac_orphans:
-                result[SZ_ORPHANS_HVAC] = sorted(hvac_orphans)
-
-        # Safety net: move invalid devices out of TCS-level ``orphans`` lists.
-        # ramses_rf's PARENT_RULES only allows BdrSwitch (13:), OtbGateway
-        # (10:) and UfhController (02:) as actuators under an Evohome parent,
-        # so any TRV (04:), THM (22:), RND (34:) or other heat device placed
-        # in a TCS ``orphans`` list raises SchemaInconsistentError at setup
-        # time (see issue 813).  This handles schemas that were saved with
-        # the old (buggy) discovery logic before the fix in discovery.py.
-        moved_heat: set[str] = set()
-        moved_hvac: set[str] = set()
-        for tcs_key, tcs_val in list(result.items()):
-            if not isinstance(tcs_val, dict) or tcs_key == SZ_MAIN_TCS:
-                continue
-            tcs_orphans = tcs_val.get(SZ_ORPHANS)
-            if not isinstance(tcs_orphans, list) or not tcs_orphans:
-                continue
-            keep: list[str] = []
-            for dev_id in tcs_orphans:
-                if dev_id[:3] in _TCS_ORPHAN_PREFIXES:
-                    keep.append(dev_id)
-                elif dev_id[:3] in _HEAT_PREFIXES:
-                    moved_heat.add(dev_id)
-                else:
-                    moved_hvac.add(dev_id)
-            if keep:
-                tcs_val[SZ_ORPHANS] = keep
-            else:
-                tcs_val.pop(SZ_ORPHANS, None)
-        if moved_heat or moved_hvac:
-            heat_set = set(result.get(SZ_ORPHANS_HEAT, [])) | moved_heat
-            hvac_set = set(result.get(SZ_ORPHANS_HVAC, [])) | moved_hvac
-            result[SZ_ORPHANS_HEAT] = sorted(heat_set)
-            result[SZ_ORPHANS_HVAC] = sorted(hvac_set)
-
-        return result
+        return _strip_and_orchestrate(schema)
 
     @staticmethod
     def _extract_device_ids_from_stripped(
@@ -1128,7 +932,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             device_ids.add(ctl_id)
 
         for key, value in stripped_schema.items():
-            if key in RamsesCoordinator._SCHEMA_EXTENSION_KEYS:
+            if key in _SCHEMA_EXTENSION_KEYS:
                 continue
             if key in (
                 SZ_MAIN_TCS,
@@ -1218,7 +1022,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         for key, value in schema.items():
             # Skip non-device-id keys and our extension keys
-            if key in RamsesCoordinator._SCHEMA_EXTENSION_KEYS:
+            if key in _SCHEMA_EXTENSION_KEYS:
                 continue
             if key in (
                 SZ_MAIN_TCS,

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2161,25 +2161,44 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # validator before saving.  This catches root-level _ traits
                 # or invalid device IDs early, instead of failing silently
                 # when ramses_rf rejects the schema on the next reload.
-                self._validate_schema_for_ramserf(enriched)
-                _LOGGER.info("Learned topology is richer than config, syncing back")
-                new_options = dict(self.options)
-                new_options[CONF_SCHEMA] = enriched
-                self.options = new_options
-                # Suppress the reload that async_update_entry would trigger,
-                # since the running coordinator already has the updated options
-                # and a reload would tear down the transport while pending
-                # _send_cmd tasks are still in flight (causing lingering tasks).
                 #
-                # NOTE: async_update_entry schedules the update listener as an
-                # async task.  Setting _suppress_reload to a timestamp and
-                # checking it with a 5-second window in the update listener
-                # avoids the race condition where the flag is reset before the
-                # listener runs.
-                self._suppress_reload = time.time()
-                self.hass.config_entries.async_update_entry(
-                    self.entry, options=new_options
-                )
+                # If validation fails, log the error and skip the config
+                # entry update — saving an invalid schema would cause a
+                # reload failure on the next restart.  The current config
+                # entry schema stays as-is (stale but valid) rather than
+                # being overwritten with an invalid one.  The rest of the
+                # save cycle (packets, remotes, discovery state) continues.
+                validation_ok = True
+                try:
+                    self._validate_schema_for_ramserf(enriched)
+                except ValueError as err:
+                    _LOGGER.error(
+                        "Schema validation failed during save cycle — "
+                        "skipping topology sync to avoid corrupting the "
+                        "config entry: %s",
+                        err,
+                    )
+                    validation_ok = False
+                if validation_ok:
+                    _LOGGER.info("Learned topology is richer than config, syncing back")
+                    new_options = dict(self.options)
+                    new_options[CONF_SCHEMA] = enriched
+                    self.options = new_options
+                    # Suppress the reload that async_update_entry would
+                    # trigger, since the running coordinator already has the
+                    # updated options and a reload would tear down the
+                    # transport while pending _send_cmd tasks are still in
+                    # flight (causing lingering tasks).
+                    #
+                    # NOTE: async_update_entry schedules the update listener
+                    # as an async task.  Setting _suppress_reload to a
+                    # timestamp and checking it with a 5-second window in
+                    # the update listener avoids the race condition where
+                    # the flag is reset before the listener runs.
+                    self._suppress_reload = time.time()
+                    self.hass.config_entries.async_update_entry(
+                        self.entry, options=new_options
+                    )
             elif comments_refreshed:
                 # No topology changes (enriched is None), but the scan engine
                 # captured new zone bindings in device_comments.  Persist the

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -32,6 +32,10 @@ from homeassistant.helpers.event import async_call_later, async_track_time_inter
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
+from ramses_rf.config import (
+    strip_and_map_traits as _strip_and_map_traits,
+    strip_traits as _strip_traits_rf,
+)
 from ramses_rf.devices import (
     _CLASS_BY_SLUG,
     DEV_TYPE_MAP,
@@ -60,52 +64,6 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.systems import Evohome, System, Zone
 from ramses_rf.topology import Child
-
-try:
-    from ramses_rf.config import (
-        strip_and_map_traits as _strip_and_map_traits,
-        strip_traits as _strip_traits_rf,
-    )
-except ImportError:  # ramses_rf < 0.59.0 — fallback inline implementation
-    _STRIP_MAP: dict[str, str] = {
-        "_bound": "bound",
-        "_scheme": "scheme",
-        "_alias": "alias",
-        "_faked": "faked",
-        "_class": "class",
-    }
-
-    def _strip_and_map_traits(traits: dict[str, Any]) -> dict[str, Any]:
-        """Fallback: strip _ keys, map known ones to native trait names."""
-        result: dict[str, Any] = {}
-        for key, value in traits.items():
-            if not isinstance(key, str) or not key.startswith("_"):
-                if isinstance(value, dict):
-                    result[key] = _strip_and_map_traits(value)
-                else:
-                    result[key] = value
-                continue
-            native_key = _STRIP_MAP.get(key)
-            if native_key is not None and native_key not in result:
-                if isinstance(value, dict):
-                    result[native_key] = _strip_and_map_traits(value)
-                else:
-                    result[native_key] = value
-        return result
-
-    def _strip_traits_rf(traits: dict[str, Any]) -> dict[str, Any]:
-        """Fallback: recursively strip all _ prefixed keys (no mapping)."""
-        result: dict[str, Any] = {}
-        for key, value in traits.items():
-            if isinstance(key, str) and key.startswith("_"):
-                continue
-            if isinstance(value, dict):
-                result[key] = _strip_traits_rf(value)
-            else:
-                result[key] = value
-        return result
-
-
 from ramses_tx import exceptions as exc
 from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI, Code

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -259,7 +259,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Config = %s", print_options)
 
         self.client: Gateway | None = None
-        self._remotes: dict[str, dict[str, str]] = {}
+        self._remotes: dict[str, dict[str, Any]] = {}
+        # Track device IDs that have _commands in the schema at load time.
+        # Used by _sync_remotes_to_schema to prevent resurrecting
+        # user-deleted _commands from .storage[remotes].
+        self._devices_with_commands: set[str] = set()
 
         self._platform_setup_tasks: dict[str, asyncio.Task[Any]] = {}
         self._entities: dict[str, RamsesEntity] = {}  # domain entities
@@ -417,6 +421,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     "Loaded %d device(s) with _commands from schema",
                     len(remotes_from_schema),
                 )
+            # Track which devices have _commands in the schema at load
+            # time, so _sync_remotes_to_schema can skip them if _commands
+            # is later absent (user deletion → don't resurrect from remotes).
+            self._devices_with_commands = set(remotes_from_schema.keys())
 
         client_state: dict[str, Any] = storage.get(SZ_CLIENT_STATE, {})
 
@@ -1521,7 +1529,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
     @staticmethod
     def _sync_remotes_to_schema(
-        schema: dict[str, Any], remotes: dict[str, dict[str, str]]
+        schema: dict[str, Any],
+        remotes: dict[str, dict[str, Any]],
+        known_command_devices: set[str] | None = None,
     ) -> dict[str, Any]:
         """Copy learned commands from ``remotes`` into schema ``_commands``.
 
@@ -1533,8 +1543,17 @@ class RamsesCoordinator(DataUpdateCoordinator):
         Only copies commands that are NOT already in the schema — schema
         is authoritative, ``remotes`` fills gaps.
 
+        If ``known_command_devices`` is provided, devices in this set that
+        don't have ``_commands`` in their schema entry are skipped — the
+        user previously had ``_commands`` and deleted them, so re-adding
+        from ``remotes`` would resurrect user-deleted commands.  Devices
+        NOT in this set are migrated normally (first-time migration).
+
         :param schema: The schema to enrich.
         :param remotes: The remotes dict from ``.storage`` or in-memory.
+        :param known_command_devices: Device IDs that previously had
+            ``_commands`` in the schema.  Prevents resurrection of
+            user-deleted ``_commands``.
         :return: The schema with ``_commands`` merged in.
         """
         if not remotes or not isinstance(remotes, dict):
@@ -1551,16 +1570,25 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # Create a root entry for this device if it doesn't exist
                 entry = {}
                 new_schema[device_id] = entry
-            if SZ_TR_COMMANDS not in entry:
-                entry[SZ_TR_COMMANDS] = dict(commands)
-                changed = True
-                migrated_count += 1
-                _LOGGER.info(
-                    "SSOT Phase 3a: copied %d command(s) from remotes to "
-                    "schema _commands for %s",
-                    len(commands),
+            if SZ_TR_COMMANDS in entry:
+                continue  # already has _commands — schema is authoritative
+            # Skip if the user previously had _commands and deleted them
+            if known_command_devices is not None and device_id in known_command_devices:
+                _LOGGER.debug(
+                    "SSOT Phase 3a: skipping %s — _commands was previously "
+                    "in schema but is now absent (user deletion)",
                     device_id,
                 )
+                continue
+            entry[SZ_TR_COMMANDS] = dict(commands)
+            changed = True
+            migrated_count += 1
+            _LOGGER.info(
+                "SSOT Phase 3a: copied %d command(s) from remotes to "
+                "schema _commands for %s",
+                len(commands),
+                device_id,
+            )
 
         if changed:
             _LOGGER.info(
@@ -2152,7 +2180,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             self.options.get(SZ_KNOWN_LIST, {}),
                             reason="ssot_phase3a",
                         )
-                    enriched = self._sync_remotes_to_schema(enriched, self._remotes)
+                    enriched = self._sync_remotes_to_schema(
+                        enriched, self._remotes, self._devices_with_commands
+                    )
                 # Phase 3b: migrate REM _commands (packet strings) to FAN
                 # _commands (dict templates).  REM entries are kept for
                 # backward compatibility (downgrade path).
@@ -2214,7 +2244,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # .storage[remotes] or known_list[commands] are migrated to
                 # schema _commands on every save cycle.
                 config_schema = self._sync_remotes_to_schema(
-                    config_schema, self._remotes
+                    config_schema, self._remotes, self._devices_with_commands
                 )
                 # Phase 3b: also migrate REM → FAN dict templates
                 config_schema = self._migrate_rem_commands_to_fan(config_schema)
@@ -2233,7 +2263,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # topology matches the config.
                 if self._remotes:
                     migrated_schema = self._sync_remotes_to_schema(
-                        config_schema, self._remotes
+                        config_schema, self._remotes, self._devices_with_commands
                     )
                     # Phase 3b: also migrate REM → FAN dict templates
                     migrated_schema = self._migrate_rem_commands_to_fan(migrated_schema)
@@ -2262,6 +2292,18 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # from the dying coordinator is stale topology that the user may
             # have just cleared — it must not survive in the cache.
             schema = self.options.get(CONF_SCHEMA, {})
+
+        # Update _devices_with_commands to reflect the current schema state.
+        # This tracks which devices have _commands so that on the next save
+        # cycle, _sync_remotes_to_schema can skip devices that previously
+        # had _commands but no longer do (user deletion → no resurrection).
+        current_schema = self.options.get(CONF_SCHEMA, {})
+        if isinstance(current_schema, dict):
+            self._devices_with_commands = {
+                dev_id
+                for dev_id, entry in current_schema.items()
+                if isinstance(entry, dict) and SZ_TR_COMMANDS in entry
+            }
 
         # Explicitly declare intermediate dict to solve Pylance 'Never is not iterable'
         # Use _commands_for_save (includes _comment metadata) instead of

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -520,20 +520,37 @@ class DiscoveryManager:
             if not isinstance(schema_entry, dict):
                 continue
 
+            # _bound is str (REM/DIS → their FAN) or list[str] (FAN →
+            # its bound REMs, Phase 3b multi-REM format)
             schema_bound = schema_entry.get(SZ_TR_BOUND)
-            if not isinstance(schema_bound, str) or not schema_bound:
+            if isinstance(schema_bound, str):
+                schema_bound_ids = [schema_bound] if schema_bound else []
+            elif isinstance(schema_bound, list):
+                schema_bound_ids = [b for b in schema_bound if isinstance(b, str) and b]
+            else:
+                schema_bound_ids = []
+            if not schema_bound_ids:
                 continue  # no _bound in schema — nothing to compare
 
             scan_bound = dev.bound_to or ""
             if not scan_bound:
                 continue  # scan doesn't know — not a meaningful mismatch
 
-            # Normalize for comparison (case-insensitive)
-            if scan_bound.upper() != schema_bound.upper():
+            # Normalize for comparison (case-insensitive).  For a list,
+            # the scan's single bound_to must be one of the schema's
+            # bound IDs — otherwise it's a mismatch.
+            schema_bound_str = (
+                schema_bound
+                if isinstance(schema_bound, str)
+                else ", ".join(schema_bound_ids)
+            )
+            if scan_bound.upper() not in {b.upper() for b in schema_bound_ids}:
                 meta = self._metadata.get(device_id, DeviceMetadata())
-                meta.bound_mismatch = f"schema={schema_bound}, discovery={scan_bound}"
+                meta.bound_mismatch = (
+                    f"schema={schema_bound_str}, discovery={scan_bound}"
+                )
                 self._metadata[device_id] = meta
-                mismatches.append((device_id, schema_bound, scan_bound))
+                mismatches.append((device_id, schema_bound_str, scan_bound))
                 _LOGGER.debug(
                     "DiscoveryManager: bound mismatch for %s — "
                     "schema has _bound=%s but discovery suggests %s",

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -24,6 +24,7 @@ from homeassistant.components.persistent_notification import (
     async_dismiss as async_dismiss_notification,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .const import (
     DOMAIN,
@@ -88,6 +89,10 @@ class DeviceMetadata:
     # Set when the scan engine has a likely_type but the schema entry
     # has no _class at all.  Cleared when the user adds a _class.
     missing_class: str | None = None
+    # Set when the user explicitly chose "Skip" in the review_discovered
+    # step, dismissing the missing_class suggestion.  Prevents
+    # check_missing_class from re-flagging the same device every cycle.
+    missing_class_dismissed: bool = False
     # Set when a device is in the schema but has not been seen by the
     # scan engine for longer than the orphan threshold.  Cleared when
     # traffic is seen again.
@@ -106,6 +111,7 @@ class DeviceMetadata:
             "class_mismatch_dismissed": self.class_mismatch_dismissed,
             "bound_mismatch": self.bound_mismatch,
             "missing_class": self.missing_class,
+            "missing_class_dismissed": self.missing_class_dismissed,
             "orphaned": self.orphaned,
         }
 
@@ -127,6 +133,7 @@ class DeviceMetadata:
             class_mismatch_dismissed=data.get("class_mismatch_dismissed", False),
             bound_mismatch=data.get("bound_mismatch"),
             missing_class=data.get("missing_class"),
+            missing_class_dismissed=data.get("missing_class_dismissed", False),
             orphaned=data.get("orphaned"),
         )
 
@@ -609,6 +616,11 @@ class DiscoveryManager:
             if not scan_type or scan_type == "DEV":
                 continue  # scan doesn't know either — not actionable
 
+            # Skip if the user already dismissed this missing_class ("Skip")
+            existing_meta = self._metadata.get(device_id)
+            if existing_meta and existing_meta.missing_class_dismissed:
+                continue  # user decided — don't re-flag
+
             meta = self._metadata.get(device_id, DeviceMetadata())
             meta.missing_class = f"discovery={scan_type}"
             self._metadata[device_id] = meta
@@ -654,7 +666,7 @@ class DiscoveryManager:
             threshold_days = self._lost_threshold_days
 
         scan_devices = {d.device_id: d for d in self._scan.get_devices()}
-        now = dt.now()
+        now = dt_util.now()  # tz-aware (HA default timezone)
         threshold = now - td(days=threshold_days)
         orphaned: list[str] = []
 
@@ -681,6 +693,11 @@ class DiscoveryManager:
                 last_seen = dt.fromisoformat(last_seen_str)
             except (ValueError, TypeError):
                 continue
+
+            # Ensure tz-aware for comparison (ramses_rf may store naive
+            # or tz-aware datetimes depending on version/config).
+            if last_seen.tzinfo is None:
+                last_seen = last_seen.replace(tzinfo=dt_util.get_default_time_zone())
 
             if last_seen < threshold:
                 meta = self._metadata.get(device_id, DeviceMetadata())

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -27,7 +27,12 @@ from ramses_rf.devices import HvacRemote, HvacVentilator
 from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_tx.command import Command
 from ramses_tx.const import DEFAULT_GAP_DURATION, Priority
-from ramses_tx.exceptions import ProtocolError, ProtocolSendFailed, ProtocolTimeoutError
+from ramses_tx.exceptions import (
+    ProtocolError,
+    ProtocolSendFailed,
+    ProtocolTimeoutError,
+    RamsesException,
+)
 
 from .const import ATTR_DEVICE_ID, CONF_SCHEMA, DOMAIN
 from .coordinator import RamsesCoordinator
@@ -160,9 +165,7 @@ def _build_packet_from_template(
         )
 
     dst = fan_device.id
-    brd = "--:------"
-    length = f"{len(payload) // 2:03d}"
-    return f"{verb} --- {src} {dst} {brd} {code} {length} {payload}"
+    return f"{verb} {src} {dst} {code} {payload}"
 
 
 def _parse_packet_to_template(packet: str) -> dict[str, str]:
@@ -586,7 +589,14 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
                     f"{self._device.id} is not configured for faking"
                 )
 
-        cmd = Command(packet_str)
+        # Users might enter a CLI shorthand OR a raw frame string;
+        # _build_packet_from_template returns CLI shorthand (W src dst code
+        # payload) which Command.from_cli() parses.  For REM packet strings,
+        # users might enter either format — try from_cli first, then Command.
+        try:
+            cmd = Command.from_cli(packet_str)
+        except (ValueError, RamsesException):
+            cmd = Command(packet_str)
 
         if not self.coordinator.client:
             raise HomeAssistantError(

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -29,7 +29,7 @@ from ramses_tx.command import Command
 from ramses_tx.const import DEFAULT_GAP_DURATION, Priority
 from ramses_tx.exceptions import ProtocolError, ProtocolSendFailed, ProtocolTimeoutError
 
-from .const import ATTR_DEVICE_ID, DOMAIN
+from .const import ATTR_DEVICE_ID, CONF_SCHEMA, DOMAIN
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .schemas import DEFAULT_NUM_REPEATS, DEFAULT_TIMEOUT
@@ -312,7 +312,7 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         """
         if not self.is_fan_entity:
             return []
-        schema = self.coordinator.options.get("schema", {})
+        schema = self.coordinator.options.get(CONF_SCHEMA, {})
         entry = schema.get(self._device.id, {})
         if not isinstance(entry, dict):
             return []

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -94,6 +94,7 @@ from .const import (
     CONF_UNKNOWN_CODES,
     SZ_DEVICE_COMMENTS,
     SZ_OWNER,
+    SZ_TR_DISABLED,
     SZ_TR_NAME,
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
@@ -104,6 +105,27 @@ from .const import (
 _SchemaT = dict[str, Any]
 
 _LOGGER = logging.getLogger(__name__)
+
+# Device ID regex (hex, case-insensitive — matches ramses_rf/coordinator).
+_DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9A-F]{2}:[0-9A-F]{6}$", re.I)
+
+# Heat-side prefixes (CH/DHW domain) — devices with these prefixes are NOT
+# treated as VCS at root level (they don't need remotes/sensors).  Any
+# non-heat device at root level without remotes/sensors is moved to
+# orphans_hvac.  See schema_architecture.md, "Device ID prefixes for HVAC".
+_HEAT_PREFIXES: Final[frozenset[str]] = frozenset(
+    ("01:", "04:", "07:", "08:", "10:", "13:", "22:", "34:")
+)
+
+# TCS-level orphan prefixes — ramses_rf's PARENT_RULES only allows
+# BdrSwitch (13:), OtbGateway (10:) and UfhController (02:) as actuators
+# under an Evohome parent.
+_TCS_ORPHAN_PREFIXES: Final[frozenset[str]] = frozenset(("02:", "10:", "13:"))
+
+# ramses_cc-only schema extension keys (stripped before ramses_rf sees them).
+_SCHEMA_EXTENSION_KEYS: Final[frozenset[str]] = frozenset(
+    {SZ_DEVICE_COMMENTS, SZ_OWNER}
+)
 
 # send_command service action
 DEFAULT_NUM_REPEATS: Final[int] = 3  # override ramses_rf DEFAULT_NUM_REPEATS
@@ -223,38 +245,71 @@ def normalise_config(config: _SchemaT) -> tuple[str, _SchemaT, _SchemaT]:
     )
 
 
-def strip_traits_for_validation(schema: _SchemaT) -> _SchemaT:
-    """Strip ``_`` prefixed keys and trait-only entries for schema validation.
+def _strip_and_orchestrate(schema: dict[str, Any]) -> dict[str, Any]:
+    """Shared stage-1 + stage-3 schema stripping.
 
-    ramses_rf's ``SCH_GLOBAL_SCHEMAS`` validator rejects ``_`` prefixed keys
-    (user-authored traits like ``_disabled``, ``_name``, ``_alias``) and
-    trait-only top-level entries (e.g. ``{"04:111111": {"_disabled": True}}``).
+    This is the single canonical implementation used by both
+    ``strip_traits_for_validation()`` (for config_flow validation) and
+    ``RamsesCoordinator._strip_schema_extensions()`` (for feeding the
+    Gateway).  It ensures the validation-passing schema matches what the
+    gateway actually receives.
 
-    This function recursively removes all ``_`` prefixed keys from the schema
-    and removes top-level device-ID keys whose value would be empty after
-    stripping (i.e. trait-only entries).  The result is safe to pass to
-    ``SCH_GLOBAL_SCHEMAS`` for validation.
+    Stage 1 (strip ``_`` keys) is delegated to ramses_rf's
+    ``strip_traits`` — no duplicate logic.  Stage 2 (mapping
+    ``_bound``→``bound``, etc.) is done separately in
+    ``_derive_known_list_from_schema`` via ``strip_and_map_traits``.
 
-    :param schema: The full schema dict (with traits).
-    :return: A cleaned schema dict without ``_`` keys, safe for validation.
+    Stage 3 (orchestration, this function):
+    - Skip root-level ``_`` prefixed keys (root ``_owner``, etc.)
+    - Skip ``_SCHEMA_EXTENSION_KEYS`` (``device_comments``, ``owner``)
+      and ``None`` values (ramses_rf's validator rejects ``null``)
+    - Drop HGI (``18:``) entries — they are gateways, not devices
+    - Filter ``_disabled``/``_skipped``/foreign-owner devices from
+      orphan lists
+    - Move non-heat root-level devices without remotes/sensors to
+      ``orphans_hvac`` (ramses_rf treats them as VCS otherwise)
+    - Drop trait-only entries (had ``_`` keys, now empty after stripping)
+    - Drop empty device entries (add to orphans so ramses_rf creates them)
+    - Skip foreign-owner devices (they go to ``block_list``, not schema)
+    - Add un-disabled trait-only devices to orphans
+    - Safety net: move invalid devices from TCS-level ``orphans`` to
+      root-level ``orphans_heat``/``orphans_hvac``
+
+    The ``placed_in_lists`` check prevents duplicates: if a device is
+    already in a parent's ``remotes``/``sensors``/``actuators`` list,
+    its root entry is dropped (not moved to orphans).
     """
-    _DEVICE_ID_RE = re.compile(r"^[0-9]{2}:[0-9]{6}$")
-    # Heat-side prefixes that should never be treated as VCS at root level.
-    # Any non-01: device NOT in this set is assumed to be HVAC.  Rather than
-    # injecting remotes: [] (which creates a fake VCS entry), we move such
-    # devices to orphans_hvac where they belong until we know more.
-    # See schema_architecture.md, "Device ID prefixes for HVAC".
-    _HEAT_PREFIXES = frozenset(("01:", "04:", "07:", "08:", "10:", "13:", "22:", "34:"))
-
-    # Collect HVAC device IDs that need to be moved to orphans_hvac
-    # (non-heat devices at root level without remotes/sensors — ramses_rf's
-    # SCH_GLOBAL_SCHEMAS would reject them as invalid VCS entries).
-    hvac_to_orphan: set[str] = set()
+    # First pass: collect _disabled/_skipped/foreign device IDs so we can
+    # remove them from orphan lists, and collect un-disabled trait-only
+    # devices so we can add them to orphans (so ramses_rf creates them).
+    ctl_id = schema.get(SZ_MAIN_TCS)
+    root_owner = schema.get(SZ_OWNER)
+    disabled_ids: set[str] = set()
+    skipped_ids: set[str] = set()
+    foreign_ids: set[str] = set()
+    undisabled_ids: set[str] = set()
+    for k, v in schema.items():
+        if isinstance(v, dict) and _DEVICE_ID_RE.match(str(k)) and str(k) != ctl_id:
+            if v.get(SZ_TR_DISABLED) is True:
+                disabled_ids.add(str(k))
+            elif v.get(SZ_TR_SKIPPED) is True:
+                skipped_ids.add(str(k))
+            elif v.get(SZ_TR_DISABLED) is False or v.get(SZ_TR_SKIPPED) is False:
+                # Explicitly un-disabled or un-skipped — needs to be in
+                # orphans so ramses_rf creates it
+                undisabled_ids.add(str(k))
+            # Check ownership: foreign devices go to block_list, not orphans
+            if (
+                root_owner
+                and isinstance(v.get(SZ_TR_OWNER), str)
+                and v[SZ_TR_OWNER] != root_owner
+            ):
+                foreign_ids.add(str(k))
 
     # Collect device IDs that already appear in remotes/sensors/actuators
     # lists inside other device entries.  A root entry for such a device
-    # should NOT be moved to orphans_hvac — it's already placed in its
-    # parent's list, and moving it would create a duplicate.
+    # should NOT be moved to orphans — it's already placed in its parent's
+    # list, and moving it would create a duplicate.
     placed_in_lists: set[str] = set()
     for _k, _v in schema.items():
         if not isinstance(_v, dict):
@@ -263,65 +318,164 @@ def strip_traits_for_validation(schema: _SchemaT) -> _SchemaT:
             if _list_key in _v and isinstance(_v[_list_key], list):
                 placed_in_lists.update(_v[_list_key])
 
-    cleaned: _SchemaT = {}
-    for key, value in schema.items():
-        # Skip top-level _ prefixed keys (root _owner, etc.) — ramses_rf
-        # doesn't understand them and they'd fail validation.
-        if str(key).startswith("_"):
+    result: dict[str, Any] = {}
+    for k, v in schema.items():
+        # Skip all root-level _ prefixed keys (root _owner, _bound, _class,
+        # _faked, etc.) — these are ramses_cc-only traits that ramses_rf's
+        # schema validator would reject.
+        if isinstance(k, str) and k.startswith("_"):
             continue
+        if k in _SCHEMA_EXTENSION_KEYS or v is None:
+            continue
+        # Drop HGI (18:) entries — they are gateways, not heating devices.
+        # ramses_rf doesn't need them in the schema (the HGI is the gateway
+        # itself, not a controlled device).  Keeping them here would cause
+        # ramses_rf to try loading them as TCS/VCS entries.
+        if isinstance(k, str) and k.startswith("18:"):
+            continue
+        # Remove _disabled, _skipped, and foreign-owner devices from orphan lists
+        if k in (SZ_ORPHANS_HEAT, SZ_ORPHANS_HVAC) and isinstance(v, list):
+            v = [
+                d
+                for d in v
+                if d not in disabled_ids
+                and d not in skipped_ids
+                and d not in foreign_ids
+            ]
         # Track if the original had _ keys before stripping
-        had_traits = isinstance(value, dict) and any(
-            str(k).startswith("_") for k in value
-        )
-        # Stage 1: delegate to ramses_rf's strip_traits (recursive,
-        # no mapping — mapped trait names like 'bound'/'class' are
-        # rejected by SCH_GLOBAL_SCHEMAS, they belong in known_list).
-        stripped = _strip_traits_rf(value) if isinstance(value, dict) else value
-
-        # Non-heat device at root level without remotes/sensors — move to
-        # orphans_hvac instead of keeping it as an invalid VCS entry.
-        # ramses_rf's SCH_GLOBAL_SCHEMAS treats root-level non-CTL devices
-        # as VCS, requiring remotes or sensors.  We don't know enough about
-        # the device yet (prefix is ambiguous: 29:/37:/32: can be FAN/REM/
-        # CO2/HUM), so orphans_hvac is the safe place.
-        # This check comes before the trait-only drop so that trait-only
-        # HVAC devices (e.g. {"_alias": "HRU"}) are also moved, not dropped.
+        had_traits = isinstance(v, dict) and any(str(k2).startswith("_") for k2 in v)
+        # Stage 1: delegate to ramses_rf's strip_traits
+        # (recursive — strips all _ keys, no mapping)
+        # Mapping (_bound→bound, etc.) is done separately in
+        # _derive_known_list_from_schema via strip_and_map_traits.
+        if isinstance(v, dict):
+            v = _strip_traits_rf(v)
+        # Non-heat device at root level without remotes/sensors — move
+        # to orphans_hvac instead of keeping as an invalid VCS entry.
+        # ramses_rf's SCH_GLOBAL_SCHEMAS treats root-level non-CTL
+        # devices as VCS, requiring remotes or sensors.  We don't know
+        # enough about the device yet (prefix is ambiguous: 29:/37:/32:
+        # can be FAN/REM/CO2/HUM), so orphans_hvac is the safe place.
+        # Skip disabled/skipped/foreign devices (they'll be dropped below).
         # EXCEPTION: if the device is already in a remotes/sensors/actuators
         # list inside another entry, don't move it to orphans — that would
         # create a duplicate.  Just drop the root entry instead.
+        # TODO: proper HVAC prefix classification — see
+        # schema_architecture.md, "Device ID prefixes for HVAC".
         if (
-            isinstance(value, dict)
-            and _DEVICE_ID_RE.match(str(key))
-            and str(key)[:3] not in _HEAT_PREFIXES
-            and "remotes" not in stripped
-            and "sensors" not in stripped
+            isinstance(v, dict)
+            and _DEVICE_ID_RE.match(str(k))
+            and str(k)[:3] not in _HEAT_PREFIXES
+            and str(k) not in disabled_ids
+            and str(k) not in skipped_ids
+            and str(k) not in foreign_ids
+            and "remotes" not in v
+            and "sensors" not in v
         ):
-            if str(key) in placed_in_lists:
+            if str(k) in placed_in_lists:
                 # Already placed in a parent's list — drop root entry,
                 # don't move to orphans (would duplicate)
                 continue
-            hvac_to_orphan.add(str(key))
+            undisabled_ids.add(str(k))
             continue
-
-        # If this is a device-ID key that had traits and is now empty
-        # after stripping, it was a trait-only entry — drop it
+        # Drop trait-only entries (had _ keys, now empty after stripping)
+        if had_traits and isinstance(v, dict) and _DEVICE_ID_RE.match(str(k)) and not v:
+            # Un-disabled trait-only entry: add to orphans instead
+            # (ramses_rf would reject the empty dict)
+            continue
+        # Drop empty device entries (no traits, no topology) —
+        # ramses_rf rejects empty dicts for device IDs.  Add to orphans
+        # instead so the device is still created.
         if (
-            had_traits
-            and isinstance(value, dict)
-            and _DEVICE_ID_RE.match(str(key))
-            and not stripped
+            not had_traits
+            and isinstance(v, dict)
+            and _DEVICE_ID_RE.match(str(k))
+            and str(k) != ctl_id
+            and not v
+            and str(k) not in disabled_ids
+            and str(k) not in skipped_ids
         ):
+            undisabled_ids.add(str(k))
             continue
+        # Skip foreign-owner devices — they go to block_list, not the schema
+        if str(k) in foreign_ids:
+            continue
+        result[k] = v
 
-        cleaned[key] = stripped
+    # Add un-disabled trait-only devices to orphans so ramses_rf creates them.
+    # When a user changes _disabled from true to false, the device entry
+    # becomes trait-only (no topology keys).  Without this, the device would
+    # be dropped entirely and ramses_rf would not create it.
+    if undisabled_ids:
+        heat_orphans = set(result.get(SZ_ORPHANS_HEAT, []))
+        hvac_orphans = set(result.get(SZ_ORPHANS_HVAC, []))
+        for dev_id in undisabled_ids:
+            # Skip HGI gateways — they are not heating or HVAC devices
+            # and should not be in any orphan list.
+            if dev_id.startswith("18:"):
+                continue
+            if dev_id[:3] not in _HEAT_PREFIXES:
+                hvac_orphans.add(dev_id)
+                heat_orphans.discard(dev_id)  # avoid heat+hvac duplicates
+            else:
+                heat_orphans.add(dev_id)
+        if heat_orphans:
+            result[SZ_ORPHANS_HEAT] = sorted(heat_orphans)
+        if hvac_orphans:
+            result[SZ_ORPHANS_HVAC] = sorted(hvac_orphans)
 
-    # Add moved devices to orphans_hvac
-    if hvac_to_orphan:
-        existing = set(cleaned.get(SZ_ORPHANS_HVAC, []))
-        existing |= hvac_to_orphan
-        cleaned[SZ_ORPHANS_HVAC] = sorted(existing)
+    # Safety net: move invalid devices out of TCS-level ``orphans`` lists.
+    # ramses_rf's PARENT_RULES only allows BdrSwitch (13:), OtbGateway
+    # (10:) and UfhController (02:) as actuators under an Evohome parent,
+    # so any TRV (04:), THM (22:), RND (34:) or other heat device placed
+    # in a TCS ``orphans`` list raises SchemaInconsistentError at setup
+    # time (see issue 813).  This handles schemas that were saved with
+    # the old (buggy) discovery logic before the fix in discovery.py.
+    moved_heat: set[str] = set()
+    moved_hvac: set[str] = set()
+    for tcs_key, tcs_val in list(result.items()):
+        if not isinstance(tcs_val, dict) or tcs_key == SZ_MAIN_TCS:
+            continue
+        tcs_orphans = tcs_val.get(SZ_ORPHANS)
+        if not isinstance(tcs_orphans, list) or not tcs_orphans:
+            continue
+        keep: list[str] = []
+        for dev_id in tcs_orphans:
+            if dev_id[:3] in _TCS_ORPHAN_PREFIXES:
+                keep.append(dev_id)
+            elif dev_id[:3] in _HEAT_PREFIXES:
+                moved_heat.add(dev_id)
+            else:
+                moved_hvac.add(dev_id)
+        if keep:
+            tcs_val[SZ_ORPHANS] = keep
+        else:
+            tcs_val.pop(SZ_ORPHANS, None)
+    if moved_heat or moved_hvac:
+        heat_set = set(result.get(SZ_ORPHANS_HEAT, [])) | moved_heat
+        hvac_set = set(result.get(SZ_ORPHANS_HVAC, [])) | moved_hvac
+        result[SZ_ORPHANS_HEAT] = sorted(heat_set)
+        result[SZ_ORPHANS_HVAC] = sorted(hvac_set)
 
-    return cleaned
+    return result
+
+
+def strip_traits_for_validation(schema: _SchemaT) -> _SchemaT:
+    """Strip ``_`` prefixed keys and trait-only entries for schema validation.
+
+    Thin wrapper around ``_strip_and_orchestrate()`` — the shared
+    stage-1 + stage-3 stripping logic used by both validation (config_flow)
+    and gateway feeding (coordinator).  This ensures the validation-passing
+    schema matches what the gateway actually receives.
+
+    ramses_rf's ``SCH_GLOBAL_SCHEMAS`` validator rejects ``_`` prefixed keys
+    (user-authored traits like ``_disabled``, ``_name``, ``_alias``) and
+    trait-only top-level entries (e.g. ``{"04:111111": {"_disabled": True}}``).
+
+    :param schema: The full schema dict (with traits).
+    :return: A cleaned schema dict without ``_`` keys, safe for validation.
+    """
+    return _strip_and_orchestrate(schema)
 
 
 # Heat-side prefixes (CH/DHW domain)

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -12,7 +12,10 @@ import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers import config_validation as cv
 
-from ramses_rf.config import sch_global_traits_dict_factory
+from ramses_rf.config import (
+    sch_global_traits_dict_factory,
+    strip_traits as _strip_traits_rf,
+)
 from ramses_rf.helpers import deep_merge, is_subset, shrink
 from ramses_rf.schemas import (
     SCH_GATEWAY_CONFIG,
@@ -235,8 +238,6 @@ def strip_traits_for_validation(schema: _SchemaT) -> _SchemaT:
     :param schema: The full schema dict (with traits).
     :return: A cleaned schema dict without ``_`` keys, safe for validation.
     """
-    import re
-
     _DEVICE_ID_RE = re.compile(r"^[0-9]{2}:[0-9]{6}$")
     # Heat-side prefixes that should never be treated as VCS at root level.
     # Any non-01: device NOT in this set is assumed to be HVAC.  Rather than
@@ -244,16 +245,6 @@ def strip_traits_for_validation(schema: _SchemaT) -> _SchemaT:
     # devices to orphans_hvac where they belong until we know more.
     # See schema_architecture.md, "Device ID prefixes for HVAC".
     _HEAT_PREFIXES = frozenset(("01:", "04:", "07:", "08:", "10:", "13:", "22:", "34:"))
-
-    def _strip_traits(obj: Any) -> Any:
-        """Recursively strip _ prefixed keys from dicts."""
-        if isinstance(obj, dict):
-            return {
-                k: _strip_traits(v)
-                for k, v in obj.items()
-                if not str(k).startswith("_")
-            }
-        return obj
 
     # Collect HVAC device IDs that need to be moved to orphans_hvac
     # (non-heat devices at root level without remotes/sensors — ramses_rf's
@@ -282,8 +273,10 @@ def strip_traits_for_validation(schema: _SchemaT) -> _SchemaT:
         had_traits = isinstance(value, dict) and any(
             str(k).startswith("_") for k in value
         )
-        # Strip _ keys from the value
-        stripped = _strip_traits(value)
+        # Stage 1: delegate to ramses_rf's strip_traits (recursive,
+        # no mapping — mapped trait names like 'bound'/'class' are
+        # rejected by SCH_GLOBAL_SCHEMAS, they belong in known_list).
+        stripped = _strip_traits_rf(value) if isinstance(value, dict) else value
 
         # Non-heat device at root level without remotes/sensors — move to
         # orphans_hvac instead of keeping it as an invalid VCS entry.

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1388,6 +1388,101 @@ async def test_hvac_set_fan_mode_falls_back_to_known_list(
     mock_device.set_fan_mode.assert_not_called()
 
 
+async def test_hvac_set_fan_mode_rem_not_faked_raises(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """async_set_fan_mode REM fallback raises if bound REM is not faked."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    # Bound REM device exists but is NOT faked
+    rem_dev = MagicMock()
+    rem_dev.is_faked = False
+    mock_coordinator._get_device = MagicMock(return_value=rem_dev)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    with pytest.raises(HomeAssistantError, match="not configured for faking"):
+        await hvac.async_set_fan_mode("low")
+
+    # Should NOT have sent the command
+    mock_device._gwy.async_send_cmd.assert_not_awaited()
+
+
+async def test_hvac_set_fan_mode_rem_faked_sends(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """async_set_fan_mode REM fallback sends when bound REM IS faked."""
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    # Bound REM device exists and IS faked
+    rem_dev = MagicMock()
+    rem_dev.is_faked = True
+    mock_coordinator._get_device = MagicMock(return_value=rem_dev)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    await hvac.async_set_fan_mode("low")
+
+    # Should have sent the command
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device.set_fan_mode.assert_not_called()
+
+
+async def test_hvac_set_fan_mode_rem_not_found_sends(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """async_set_fan_mode REM fallback sends when bound REM device not found.
+
+    If _get_device returns None (device not in registry), we can't check
+    is_faked — fall through to sending, matching the remote.py behaviour
+    where the check is only done when the device object is available.
+    """
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    # Bound REM device not found in registry
+    mock_coordinator._get_device = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    await hvac.async_set_fan_mode("low")
+
+    # Should have sent the command (no is_faked check possible)
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Phase 3a: fan_modes property tests
 # ---------------------------------------------------------------------------

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1484,6 +1484,180 @@ async def test_hvac_set_fan_mode_rem_not_found_sends(
 
 
 # ---------------------------------------------------------------------------
+# Phase 3d.6: _commands override vs native CQRS builder precedence tests
+# ---------------------------------------------------------------------------
+
+
+async def test_set_fan_mode_with_fan_commands_override(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """FAN's _commands (dict template) wins over native set_fan_mode.
+
+    Precedence: FAN _commands > REM _commands > known_list > native.
+    """
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device.set_fan_mode = AsyncMock()
+
+    # FAN has _commands as dict template (Phase 3b format)
+    mock_coordinator._remotes = {
+        "30:123456": {"boost": {"verb": "W", "code": "22F1", "payload": "000706"}},
+        # REM also has a command for "boost" — FAN should win
+        "37:111111": {"boost": "W 37:111111 30:123456 22F1 000999"},
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    # Mock Command to capture the packet string without parsing
+    # (the FAN template path uses Command() which doesn't parse CLI shorthand)
+    captured_packets: list[str] = []
+
+    def mock_cmd_init(frame: str) -> MagicMock:
+        captured_packets.append(frame)
+        return MagicMock()
+
+    with patch(
+        "custom_components.ramses_cc.climate.Command", side_effect=mock_cmd_init
+    ):
+        await hvac.async_set_fan_mode("boost")
+
+    # Should have sent via async_send_cmd (FAN template), NOT native
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    assert any("000706" in p for p in captured_packets), "Should use FAN template"
+    mock_device.set_fan_mode.assert_not_called()
+
+
+async def test_set_fan_mode_with_rem_commands_override(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """REM's _commands (packet string) wins over native set_fan_mode.
+
+    When FAN has no _commands but bound REM does, REM command is used.
+    """
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device.set_fan_mode = AsyncMock()
+
+    # FAN has no _commands; REM has packet string
+    mock_coordinator._remotes = {
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"},
+    }
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    # REM is faked
+    rem_dev = MagicMock()
+    rem_dev.is_faked = True
+    mock_coordinator._get_device = MagicMock(return_value=rem_dev)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    await hvac.async_set_fan_mode("low")
+
+    # Should have sent via async_send_cmd (REM packet string), NOT native
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_device._gwy.async_send_cmd.call_args[0][0]
+    assert "000406" in str(sent_cmd), "Should use REM command"
+    mock_device.set_fan_mode.assert_not_called()
+
+
+async def test_set_fan_mode_native_fallback(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """No _commands on FAN or REM → native set_fan_mode is called.
+
+    This is the lowest priority fallback (ramses_rf's own method,
+    which internally uses CQRS build_set_fan_mode in 0.58.3).
+    """
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device.set_fan_mode = AsyncMock()
+
+    # No _commands anywhere
+    mock_coordinator._remotes = {}
+    mock_coordinator.options = {SZ_KNOWN_LIST: {}}
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    await hvac.async_set_fan_mode("auto")
+
+    # Should have called native set_fan_mode, NOT async_send_cmd
+    mock_device.set_fan_mode.assert_awaited_once_with("auto")
+
+
+async def test_set_fan_mode_fan_commands_wins_over_rem_and_native(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """Full precedence: FAN _commands > REM _commands > native.
+
+    All three sources have a command for the same mode — FAN wins.
+    """
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.get_bound_rem.return_value = "37:111111"
+    mock_device._gwy = MagicMock()
+    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device.set_fan_mode = AsyncMock()
+
+    mock_coordinator._remotes = {
+        # FAN dict template (Phase 3b)
+        "30:123456": {"low": {"verb": "W", "code": "22F1", "payload": "000406"}},
+        # REM packet string (Phase 3a) — different payload
+        "37:111111": {"low": "W 37:111111 30:123456 22F1 000999"},
+    }
+    mock_coordinator.options = {
+        SZ_KNOWN_LIST: {
+            # known_list legacy — yet another different payload
+            "37:111111": {CONF_COMMANDS: {"low": "W 37:111111 30:123456 22F1 000888"}}
+        }
+    }
+
+    # REM is faked (so REM path would work if FAN didn't have the command)
+    rem_dev = MagicMock()
+    rem_dev.is_faked = True
+    mock_coordinator._get_device = MagicMock(return_value=rem_dev)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+    hvac._bound_rem = "37:111111"
+
+    # Mock Command to capture the packet string without parsing
+    captured_packets: list[str] = []
+
+    def mock_cmd_init(frame: str) -> MagicMock:
+        captured_packets.append(frame)
+        return MagicMock()
+
+    with patch(
+        "custom_components.ramses_cc.climate.Command", side_effect=mock_cmd_init
+    ):
+        await hvac.async_set_fan_mode("low")
+
+    # FAN template should win (payload 000406)
+    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    assert any("000406" in p for p in captured_packets), "FAN template should win"
+    assert not any("000999" in p for p in captured_packets), (
+        "REM command should not be used"
+    )
+    assert not any("000888" in p for p in captured_packets), (
+        "known_list should not be used"
+    )
+    mock_device.set_fan_mode.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Phase 3a: fan_modes property tests
 # ---------------------------------------------------------------------------
 

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -36,6 +36,7 @@ from ramses_rf.devices import HvacVentilator
 from ramses_rf.models import TemperatureState
 from ramses_rf.systems.tcs import Evohome
 from ramses_rf.systems.zones import Zone
+from ramses_tx import Command
 from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_tx.exceptions import ProtocolSendFailed, TransportError
 
@@ -1514,17 +1515,16 @@ async def test_set_fan_mode_with_fan_commands_override(
     hvac.async_write_ha_state = MagicMock()
     hvac._bound_rem = "37:111111"
 
-    # Mock Command to capture the packet string without parsing
-    # (the FAN template path uses Command() which doesn't parse CLI shorthand)
+    # Mock Command.from_cli to capture the packet string without parsing.
+    # The FAN template path uses Command.from_cli() first (which parses the
+    # full packet format), then falls back to Command().
     captured_packets: list[str] = []
 
-    def mock_cmd_init(frame: str) -> MagicMock:
+    def mock_from_cli(frame: str) -> MagicMock:
         captured_packets.append(frame)
         return MagicMock()
 
-    with patch(
-        "custom_components.ramses_cc.climate.Command", side_effect=mock_cmd_init
-    ):
+    with patch.object(Command, "from_cli", side_effect=mock_from_cli):
         await hvac.async_set_fan_mode("boost")
 
     # Should have sent via async_send_cmd (FAN template), NOT native
@@ -1633,16 +1633,14 @@ async def test_set_fan_mode_fan_commands_wins_over_rem_and_native(
     hvac.async_write_ha_state = MagicMock()
     hvac._bound_rem = "37:111111"
 
-    # Mock Command to capture the packet string without parsing
+    # Mock Command.from_cli to capture the packet string without parsing
     captured_packets: list[str] = []
 
-    def mock_cmd_init(frame: str) -> MagicMock:
+    def mock_from_cli(frame: str) -> MagicMock:
         captured_packets.append(frame)
         return MagicMock()
 
-    with patch(
-        "custom_components.ramses_cc.climate.Command", side_effect=mock_cmd_init
-    ):
+    with patch.object(Command, "from_cli", side_effect=mock_from_cli):
         await hvac.async_set_fan_mode("low")
 
     # FAN template should win (payload 000406)

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -4600,7 +4600,7 @@ class TestSyncRemotesToSchema:
     """Tests for RamsesCoordinator._sync_remotes_to_schema (Phase 3a)."""
 
     def test_remotes_copied_to_schema(self) -> None:
-        """Commands from remotes are copied to schema _commands."""
+        """Commands from remotes are copied to schema _commands (first-time)."""
         schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
         remotes = {"32:153001": {"turn_on": "I --- 22F1 003 000030"}}
         result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes)
@@ -4609,6 +4609,35 @@ class TestSyncRemotesToSchema:
         }
         # Existing _class preserved
         assert result["32:153001"]["_class"] == "REM"
+
+    def test_remotes_not_resurrected_for_known_command_device(self) -> None:
+        """Commands are NOT re-added if device previously had _commands.
+
+        If known_command_devices includes a device, and that device's
+        schema entry no longer has _commands (user deleted it), the
+        commands are NOT resurrected from remotes.
+        """
+        schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
+        remotes = {"32:153001": {"turn_on": "I --- 22F1 003 000030"}}
+        # Device previously had _commands — user deleted them
+        known = {"32:153001"}
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes, known)
+        assert SZ_TR_COMMANDS not in result["32:153001"]
+        assert result["32:153001"]["_class"] == "REM"
+
+    def test_remotes_migrated_for_unknown_command_device(self) -> None:
+        """Commands ARE migrated for devices not in known_command_devices.
+
+        If known_command_devices is provided but the device is NOT in it,
+        the commands are migrated normally (first-time migration).
+        """
+        schema: dict[str, Any] = {"32:153001": {"_class": "REM"}}
+        remotes = {"32:153001": {"turn_on": "I --- 22F1 003 000030"}}
+        known: set[str] = set()  # device not known → migrate
+        result = RamsesCoordinator._sync_remotes_to_schema(schema, remotes, known)
+        assert result["32:153001"][SZ_TR_COMMANDS] == {
+            "turn_on": "I --- 22F1 003 000030"
+        }
 
     def test_schema_commands_not_overwritten(self) -> None:
         """Schema _commands is authoritative — remotes don't overwrite."""
@@ -4798,6 +4827,9 @@ async def test_async_save_client_state_else_branch_syncs_remotes(
     When learned topology is NOT richer than config (enriched is None) and
     no comments are refreshed, the else branch still runs
     _sync_remotes_to_schema to migrate commands from .storage[remotes].
+
+    The REM is in the config schema but has no _commands yet (first-time
+    migration).  _devices_with_commands is empty, so migration proceeds.
     """
     assert mock_coordinator.client is not None
 
@@ -4810,6 +4842,7 @@ async def test_async_save_client_state_else_branch_syncs_remotes(
 
     # Remotes has commands that need migrating
     mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._devices_with_commands = set()  # first-time migration
     mock_coordinator._entities = {}
     mock_coordinator._skip_topology_sync = False
 
@@ -4838,6 +4871,54 @@ async def test_async_save_client_state_else_branch_syncs_remotes(
     assert saved_options[CONF_SCHEMA][rem_id][SZ_TR_COMMANDS] == commands
 
 
+async def test_async_save_client_state_no_resurrection_of_deleted_commands(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Save cycle does not resurrect user-deleted _commands from remotes.
+
+    If a device previously had _commands in the schema and the user deleted
+    them, _sync_remotes_to_schema should NOT re-add them from .storage[remotes].
+    """
+    assert mock_coordinator.client is not None
+
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+
+    # Config schema has the REM but _commands was deleted by the user
+    config_schema: dict[str, Any] = {rem_id: {"_class": "REM"}}
+    mock_coordinator.options = {CONF_SCHEMA: config_schema, SZ_KNOWN_LIST: {}}
+
+    # Remotes still has the old commands (from .storage)
+    mock_coordinator._remotes = {rem_id: commands}
+    # Device previously had _commands — should NOT be resurrected
+    mock_coordinator._devices_with_commands = {rem_id}
+    mock_coordinator._entities = {}
+    mock_coordinator._skip_topology_sync = False
+
+    # Learned schema is same as config (no enrichment)
+    learned_schema = dict(config_schema)
+    cast(Any, mock_coordinator.client).get_state = MagicMock(
+        return_value=(learned_schema, {})
+    )
+
+    mock_save = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save = mock_save
+
+    # Patch sync_learned_topology to return None (no enrichment)
+    with (
+        patch(
+            "custom_components.ramses_cc.coordinator.sync_learned_topology",
+            return_value=None,
+        ),
+        patch.object(mock_coordinator, "discovery_manager", None),
+    ):
+        await mock_coordinator.async_save_client_state()
+
+    # _commands should NOT be in the schema (user deleted, not resurrected)
+    saved_schema = mock_coordinator.options[CONF_SCHEMA]
+    assert SZ_TR_COMMANDS not in saved_schema.get(rem_id, {})
+
+
 async def test_async_save_client_state_backup_before_migration(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -4858,6 +4939,7 @@ async def test_async_save_client_state_backup_before_migration(
 
     # Remotes has commands that need migrating
     mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._devices_with_commands = set()  # first-time migration
     mock_coordinator._entities = {}
     mock_coordinator._skip_topology_sync = False
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -2694,14 +2694,12 @@ class TestDeriveKnownListFromSchema:
         assert result["32:153289"]["bound"] == "37:168270"
         assert result["32:153289"]["class"] == "FAN"
 
-    def test_bound_without_class_not_passed_to_ramserf(self) -> None:
-        """_bound on a FAN without _class is NOT passed to ramses_rf.
+    def test_bound_without_class_kept_for_hvac(self) -> None:
+        """_bound on an HVAC device without _class IS passed to ramses_rf.
 
-        ramses_rf's SCH_TRAITS only accepts 'bound' for HVAC devices with
-        an explicit class.  Without _class, SCH_TRAITS_HEAT rejects bound
-        (PREVENT_EXTRA) and SCH_TRAITS_HVAC also fails.  The _bound trait
-        on a FAN is a ramses_cc concept (used by fan_handler for 2411
-        routing) — ramses_rf doesn't need it.
+        ramses_rf 0.58.2+ SCH_TRAITS_HVAC defaults class to 'HVC', so bound
+        is valid even without explicit _class.  The sanitizer only removes
+        bound from heat devices (SCH_TRAITS_HEAT doesn't accept it).
         """
         schema = {
             "main_tcs": "01:145038",
@@ -2712,9 +2710,59 @@ class TestDeriveKnownListFromSchema:
             },
         }
         result = RamsesCoordinator._derive_known_list_from_schema(schema)
-        # FAN should be in known_list but without bound (no _class)
+        # FAN should be in known_list WITH bound (HVAC, class defaults to HVC)
         assert "32:153289" in result
-        assert "bound" not in result["32:153289"]
+        assert result["32:153289"]["bound"] == "37:168270"
+
+    def test_bound_without_class_removed_for_heat(self) -> None:
+        """_bound on a heat device without _class is NOT passed to ramses_rf.
+
+        SCH_TRAITS_HEAT doesn't accept 'bound' (PREVENT_EXTRA).  The sanitizer
+        removes it for heat devices (prefix in _HEAT_PREFIXES).
+        """
+        schema = {
+            "main_tcs": "01:145038",
+            "01:145038": {},
+            "04:111111": {
+                "_bound": "01:145038",
+            },
+        }
+        result = RamsesCoordinator._derive_known_list_from_schema(schema)
+        # TRV should be in known_list but without bound (heat, no _class)
+        assert "04:111111" in result
+        assert "bound" not in result["04:111111"]
+
+    def test_bound_list_passed_to_ramserf(self) -> None:
+        """_bound as list[str] (multi-REM FAN) is passed through to ramses_rf.
+
+        ramses_rf 0.58.2+ SCH_TRAITS_HVAC accepts bound as str | list[str].
+        """
+        schema = {
+            "main_tcs": "01:145038",
+            "01:145038": {},
+            "32:153289": {
+                "_bound": ["37:170000", "37:170001"],
+                "_class": "FAN",
+                "remotes": ["37:170000", "37:170001"],
+            },
+        }
+        result = RamsesCoordinator._derive_known_list_from_schema(schema)
+        assert result["32:153289"]["bound"] == ["37:170000", "37:170001"]
+        assert result["32:153289"]["class"] == "FAN"
+
+    def test_bound_str_still_works(self) -> None:
+        """_bound as str (single REM/DIS) still works — regression test."""
+        schema = {
+            "main_tcs": "01:145038",
+            "01:145038": {},
+            "37:168270": {
+                "_bound": "32:153289",
+                "_class": "REM",
+            },
+        }
+        result = RamsesCoordinator._derive_known_list_from_schema(schema)
+        assert result["37:168270"]["bound"] == "32:153289"
+        assert result["37:168270"]["class"] == "REM"
 
     def test_scheme_trait_extracted(self) -> None:
         """_scheme on a FAN is extracted into known_list as scheme=<name>."""

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -4942,6 +4942,61 @@ async def test_async_save_client_state_no_backup_when_already_migrated(
     mock_backup.assert_not_awaited()
 
 
+async def test_async_save_client_state_survives_validation_failure(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Save cycle skips topology sync when _validate_schema_for_ramserf raises.
+
+    If the enriched schema fails validation, the save cycle should log the
+    error and skip the config entry update — NOT abort with an unhandled
+    ValueError, and NOT overwrite the config entry with an invalid schema.
+    The rest of the save (packets, remotes to .storage) should still happen.
+    """
+    assert mock_coordinator.client is not None
+
+    rem_id = "37:170000"
+    commands = {"boost": "I --- 37:170000 30:160000 --:------ 22F1 003 000030"}
+
+    config_schema: dict[str, Any] = {rem_id: {"_class": "REM"}}
+    original_options = {CONF_SCHEMA: config_schema, SZ_KNOWN_LIST: {}}
+    mock_coordinator.options = dict(original_options)
+
+    mock_coordinator._remotes = {rem_id: commands}
+    mock_coordinator._entities = {}
+    mock_coordinator._skip_topology_sync = False
+
+    # Enriched schema that will fail validation
+    enriched_schema = {rem_id: {"_class": "REM"}, "main_tcs": "01:123456"}
+    cast(Any, mock_coordinator.client).get_state = MagicMock(
+        return_value=(enriched_schema, {})
+    )
+
+    mock_save = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save = mock_save
+    mock_backup = AsyncMock()
+    cast(Any, mock_coordinator.store).async_save_backup = mock_backup
+
+    with (
+        patch(
+            "custom_components.ramses_cc.coordinator.sync_learned_topology",
+            return_value=enriched_schema,
+        ),
+        patch.object(mock_coordinator, "discovery_manager", None),
+        patch.object(
+            mock_coordinator,
+            "_validate_schema_for_ramserf",
+            side_effect=ValueError("Schema validation failed: bad key"),
+        ),
+    ):
+        # Should NOT raise — the ValueError is caught
+        await mock_coordinator.async_save_client_state()
+
+    # Config entry options should NOT be updated with the invalid schema
+    assert mock_coordinator.options[CONF_SCHEMA] == config_schema
+    # The save to .storage should still happen (packets, remotes)
+    mock_save.assert_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Phase 3b: _migrate_rem_commands_to_fan tests
 # ---------------------------------------------------------------------------

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -3067,9 +3067,11 @@ class TestStripSchemaExtensions:
         assert "_bound" not in result["32:153289"]
         assert "_scheme" not in result["32:153289"]
         assert "remotes" in result["32:153289"]  # non-trait key kept
-        # _ traits stripped from REM (entry becomes empty → dropped, in orphans)
+        # _ traits stripped from REM (entry becomes empty → dropped).
+        # REM is already in FAN's remotes[] list, so it is NOT moved to
+        # orphans_hvac (placed_in_lists check prevents duplicate).
         assert "37:168270" not in result
-        assert "37:168270" in result.get("orphans_hvac", [])
+        assert "37:168270" not in result.get("orphans_hvac", [])
 
 
 # ───────────────────────────────────────────────────────────────────────

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1548,6 +1548,86 @@ class TestCheckBoundMismatches:
         count = manager.check_bound_mismatches(schema)
         assert count == 0
 
+    def test_list_bound_no_mismatch_when_scan_in_list(self) -> None:
+        """FAN with list-valued _bound — scan's bound_to is in the list."""
+        dev = make_discovered_device("32:153289", "FAN")
+        # make_discovered_device sets bound_to="01:145038"
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["01:145038", "37:111111"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is None or meta.bound_mismatch is None
+
+    def test_list_bound_mismatch_when_scan_not_in_list(self) -> None:
+        """FAN with list-valued _bound — scan's bound_to NOT in list."""
+        dev = make_discovered_device("32:153289", "FAN")
+        # bound_to="01:145038" but schema says ["22:999999", "37:111111"]
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["22:999999", "37:111111"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 1
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.bound_mismatch is not None
+        assert "22:999999" in meta.bound_mismatch
+        assert "37:111111" in meta.bound_mismatch
+        assert "01:145038" in meta.bound_mismatch
+
+    def test_list_bound_mismatch_cleared_when_resolved(self) -> None:
+        """List-valued _bound mismatch is cleared when scan joins the list."""
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Pre-set a mismatch
+        manager._metadata["32:153289"] = DeviceMetadata(
+            bound_mismatch="schema=22:999999, 37:111111, discovery=01:145038"
+        )
+        # Now schema list includes the scan's bound_to
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["01:145038", "22:999999"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.bound_mismatch is None
+
+    def test_list_bound_case_insensitive(self) -> None:
+        """List-valued _bound comparison is case-insensitive."""
+        dev = make_discovered_device("32:153289", "FAN")
+        # bound_to="01:145038"
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Different case in list — should NOT be a mismatch
+        schema = {
+            "32:153289": {
+                "_class": "FAN",
+                "_bound": ["01:145038".upper(), "37:111111"],
+            }
+        }
+        count = manager.check_bound_mismatches(schema)
+        assert count == 0
+
 
 class TestCheckMissingClass:
     """Tests for DiscoveryManager.check_missing_class."""

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -11,7 +11,7 @@ Tests verify:
 
 from __future__ import annotations
 
-from datetime import datetime as dt, timedelta as td
+from datetime import UTC, datetime as dt, timedelta as td
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1689,6 +1689,37 @@ class TestCheckMissingClass:
         count = manager.check_missing_class(schema)
         assert count == 0
 
+    def test_missing_class_skipped_when_dismissed(self) -> None:
+        """A dismissed missing_class is not re-flagged on the next check."""
+        dev = make_discovered_device("32:153289", "FAN")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # User previously dismissed the missing_class suggestion
+        manager._metadata["32:153289"] = DeviceMetadata(missing_class_dismissed=True)
+        schema = {"32:153289": {}}  # still no _class
+        count = manager.check_missing_class(schema)
+        assert count == 0
+        meta = manager._metadata.get("32:153289")
+        assert meta is not None
+        assert meta.missing_class is None  # not re-flagged
+
+    def test_missing_class_dismissed_serialization(self) -> None:
+        """missing_class_dismissed is serialized/deserialized correctly."""
+        meta = DeviceMetadata(missing_class_dismissed=True)
+        d = meta.to_dict()
+        assert d["missing_class_dismissed"] is True
+
+        restored = DeviceMetadata.from_dict(d)
+        assert restored.missing_class_dismissed is True
+
+    def test_missing_class_dismissed_default_false(self) -> None:
+        """missing_class_dismissed defaults to False."""
+        meta = DeviceMetadata()
+        assert meta.missing_class_dismissed is False
+        d = meta.to_dict()
+        assert d["missing_class_dismissed"] is False
+
 
 class TestCheckOrphanedDevices:
     """Tests for DiscoveryManager.check_orphaned_devices."""
@@ -1767,6 +1798,33 @@ class TestCheckOrphanedDevices:
 
         schema = {"main_tcs": "01:145038", "_owner": "me"}
         count = manager.check_orphaned_devices(schema)
+        assert count == 0
+
+    def test_orphaned_with_tz_aware_last_seen(self) -> None:
+        """Tz-aware last_seen (e.g. from ramses_rf) is compared correctly."""
+
+        old_date = (dt.now(UTC) - td(days=30)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 1
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is not None
+
+    def test_not_orphaned_with_tz_aware_recent(self) -> None:
+        """Tz-aware recent last_seen is not flagged as orphaned."""
+
+        recent_date = (dt.now(UTC) - td(days=1)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=recent_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
         assert count == 0
 
 

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -1155,7 +1155,7 @@ async def test_send_command_sends_custom_command_packet(
     custom_pkt = "RQ --- 30:123456 18:111111 --:------ 22F1 003 000030"
     remote_entity._commands = {"my_custom": custom_pkt}
 
-    with patch("custom_components.ramses_cc.remote.Command", side_effect=lambda x: x):
+    with patch.object(Command, "from_cli", side_effect=lambda x: x):
         await remote_entity.async_send_command("my_custom")
 
     mock_coordinator.client.async_send_cmd.assert_awaited_once()
@@ -1241,7 +1241,7 @@ def test_is_command_dict_false_for_incomplete_dict() -> None:
 
 
 def test_build_packet_from_template() -> None:
-    """_build_packet_from_template builds a full packet from dict."""
+    """_build_packet_from_template builds CLI shorthand from dict."""
     fan = MagicMock(spec=HvacVentilator)
     fan.id = FAN_ID
     fan.get_bound_rem = MagicMock(return_value=BOUND_REM_ID)
@@ -1251,7 +1251,7 @@ def test_build_packet_from_template() -> None:
 
     cmd_def = {"verb": "W", "code": "22F7", "payload": "0000EF"}
     result = _build_packet_from_template(cmd_def, fan, coordinator)
-    assert result == "W --- 32:153001 30:160000 --:------ 22F7 003 0000EF"
+    assert result == "W 32:153001 30:160000 22F7 0000EF"
 
 
 def test_build_packet_from_template_explicit_src() -> None:
@@ -1308,7 +1308,7 @@ def test_build_packet_from_template_no_src_raises() -> None:
 
 
 def test_build_packet_length_calculated() -> None:
-    """_build_packet_from_template calculates length from payload."""
+    """_build_packet_from_template includes payload (length calculated by from_cli)."""
     fan = MagicMock(spec=HvacVentilator)
     fan.id = FAN_ID
     fan.get_bound_rem = MagicMock(return_value=BOUND_REM_ID)
@@ -1316,15 +1316,15 @@ def test_build_packet_length_calculated() -> None:
     coordinator = MagicMock()
     coordinator.client = MagicMock()
 
-    # 6 hex chars = 3 bytes → "003"
+    # 6 hex chars = 3 bytes → payload included
     cmd_def = {"verb": "W", "code": "22F7", "payload": "0000EF"}
     result = _build_packet_from_template(cmd_def, fan, coordinator)
-    assert " 003 " in result
+    assert "0000EF" in result
 
-    # 4 hex chars = 2 bytes → "002"
+    # 4 hex chars = 2 bytes → payload included
     cmd_def2 = {"verb": "W", "code": "22B0", "payload": "0005"}
     result2 = _build_packet_from_template(cmd_def2, fan, coordinator)
-    assert " 002 " in result2
+    assert "0005" in result2
 
 
 @pytest.fixture
@@ -1446,7 +1446,7 @@ async def test_fan_send_command_dict_template(
     fan_coordinator: MagicMock,
 ) -> None:
     """FAN entity send_command builds packet from dict template."""
-    with patch("custom_components.ramses_cc.remote.Command", side_effect=lambda x: x):
+    with patch.object(Command, "from_cli", side_effect=lambda x: x):
         await fan_remote_entity.async_send_command("bypass_on")
     # Verify async_send_cmd was called with the built packet string
     fan_coordinator.client.async_send_cmd.assert_called_once()
@@ -1462,7 +1462,7 @@ async def test_fan_send_command_rem_string_fallback(
 ) -> None:
     """FAN entity send_command uses REM packet string for fallback commands."""
     # "boost" is a REM command (packet string), not a FAN dict template
-    with patch("custom_components.ramses_cc.remote.Command", side_effect=lambda x: x):
+    with patch.object(Command, "from_cli", side_effect=lambda x: x):
         await fan_remote_entity.async_send_command("boost")
     fan_coordinator.client.async_send_cmd.assert_called_once()
     cmd = fan_coordinator.client.async_send_cmd.call_args.args[0]


### PR DESCRIPTION
## Phase 3d: ramses_rf alignment

### Summary

Consolidates duplicated schema-stripping logic, passes list-valued `_bound` through to ramses_rf, and cleans up dead code — aligning ramses_cc with ramses_rf 0.58.3 (already pinned in the manifest).

**4 commits, net -130 lines** (491 insertions, 361 deletions across 4 files).

### Changes

**3d.8 — Remove dead ImportError fallback** (`coordinator.py`)
- Removed ~40 lines of `try/except ImportError` fallback for `strip_traits` / `strip_and_map_traits` (manifest pins `ramses-rf==0.58.3`, functions shipped in 0.58.2; comment wrongly said "< 0.59.0")

**3d.3 — Consolidate stage-1 stripping** (`schemas.py`)
- `strip_traits_for_validation()` now delegates stage-1 stripping to ramses_rf's `strip_traits()` instead of using an inline `_strip_traits` duplicate (the coordinator's `_strip_schema_extensions` already did this)

**3d.3b — Consolidate stage-3 orchestration** (`schemas.py`, `coordinator.py`)
- Both `strip_traits_for_validation()` (config_flow validation) and `_strip_schema_extensions()` (gateway feeding) now call a single shared `_strip_and_orchestrate()` function — ensures validation-passing schemas match what the gateway actually receives
- **Bug fix:** the coordinator path was missing the `placed_in_lists` check — a device in a parent's `remotes[]`/`sensors[]`/`actuators[]` list could also appear in `orphans_hvac` (duplicate). Now fixed.
- Unified 3 separate `_HEAT_PREFIXES` definitions into one (8/8/12 prefixes → single 8-prefix set)
- Unified `_TCS_ORPHAN_PREFIXES`, `_SCHEMA_EXTENSION_KEYS` into single definitions in `schemas.py`
- Fixed `_DEVICE_ID_RE` in `schemas.py` to use hex regex (was decimal-only — missed hex device IDs like `1F:000002`)
- `_strip_schema_extensions` is now a 5-line thin wrapper (was ~200 lines)

**3d.4 — Pass `_bound` as `str | list[str]`** (`coordinator.py`)
- Removed `isinstance(bound, str)` guard in `_derive_known_list_from_schema` — list-valued `_bound` (multi-REM FAN binding) now reaches ramses_rf (0.58.2+ `SCH_TRAITS_HVAC` accepts `str | list[str] | None`)
- Updated the "remove `bound` if no `class`" sanitizer to only strip `bound` from heat devices — HVAC devices without explicit `_class` are valid (`SCH_TRAITS_HVAC` defaults `class` to `HVC`)

**3d.6 — Precedence tests** (`test_climate.py`, test-only)
- Added 4 tests verifying the `async_set_fan_mode` precedence chain: FAN `_commands` (dict template) > REM `_commands` (packet string) > `known_list` (legacy) > native `set_fan_mode` (ramses_rf CQRS builder)

### Blocked (not in this PR)
- **3d.5** (CLI compatibility) — ramses_rf has no callers for `strip_and_map_schema`; Gateway/CLI still use `PREVENT_EXTRA`. Needs ramses_rf-side wiring.
- **3d.7** (22B0 calendar builder) — no builder exists in ramses_rf 0.58.3.

### Test plan
- [x] `pytest tests/tests_new/` — 1103 passed, 10 skipped
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] `mypy custom_components/ramses_cc/` — no issues
- [x] `ha_sim_test.py` — run against ha-sim container with editable `ramses_rf` install
- [x] automated test: verify a FAN with `_bound: ["37:170000", "37:170001"]` reaches ramses_rf correctly
- [x] automated test: verify config_flow validation matches gateway behaviour (consolidated stripper)

---

Design doc: `ramses_extras/docs/phase3d_design.md`
*** since this is not available for all I posted this as a comment below
