### PR TITLE
fix: active_fault sensor reports `off` instead of `unknown` when no faults (issue 841)

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -224,12 +224,15 @@ class RamsesLogbookBinarySensor(RamsesBinarySensor):
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor.
 
-        :return: True if faults are active, None if unknown.
+        ``active_faults`` returns ``None`` when the fault log is empty or not
+        yet loaded — both mean 'no active faults', so report ``False`` (off)
+        rather than ``unknown`` (issue 841).
+
+        :return: True if faults are active, False otherwise.
         :rtype: bool | None
         """
         faults = resolve_async_attr(self, self._device, "active_faults")
-        if faults is not None:
-            self._last_known_state = bool(faults)
+        self._last_known_state = bool(faults)
         return self._last_known_state
 
 

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -41,7 +41,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'unknown',
+      'state': 'off',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -277,6 +277,15 @@ async def test_logbook_binary_sensor_state(
     # Assert
     assert final_state is True
 
+    # Act (is_on = False, issue 841)
+    # 3. Test is_on = False when active_faults is None (empty/unloaded log)
+    #    must report off, not unknown (regression vs 0.54.3)
+    mock_resolve_async_attr.return_value = None
+    none_state = sensor.is_on
+
+    # Assert
+    assert none_state is False
+
 
 async def test_system_binary_sensor_availability(
     mock_coordinator: MagicMock,


### PR DESCRIPTION
RamsesLogbookBinarySensor.is_on kept _last_known_state at its initial None when ramses_rf's active_faults returned None (empty/unloaded fault log), so the sensor showed 'unknown' instead of 'off'. This was a regression introduced by the _last_known_state refactor (commit 51eaddf) — 0.54.3 returned bool(active_faults), which mapped None to False.

Coerce faults to bool unconditionally so None/() both report off, matching the 0.54.3 truth table and the BinarySensorDeviceClass.PROBLEM semantic.


see https://github.com/ramses-rf/ramses_cc/issues/841
AI used: GLM 5.2 high
