### PR TITLE
docs: add TODO noting dev hook is superseded by PYTHONPATH approach

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -23,6 +23,13 @@ from typing import Any
 # --- DEVELOPMENT HOOK ---
 # If a local copy of ramses_rf exists, use it instead of the system installed version.
 # This allows for testing changes without rebuilding the container.
+#
+# TODO: The dev hook below is superseded by the PYTHONPATH approach — see the
+# "Testing with a local ramses_rf" section in ramses_extras/docs/HA_SIM_TEST_TOOL.md.
+# The PYTHONPATH approach is simpler (no ramses_cc modification, no /config/deps
+# copy needed) and works with any docker-compose that bind-mounts the ramses_rf
+# source tree.  The dev hook is kept for backward compatibility but should not
+# be needed for new development.
 
 ENABLE_DEV_HOOK = False  # Set to true to enable the dev hook
 DEV_LIB_PATH = "/config/deps/ramses_rf/src"


### PR DESCRIPTION
I ran into this tweak. No real need to merge, but you might anyway. But maybe something for the wiki ?

The dev hook (ENABLE_DEV_HOOK) requires copying ramses_rf into /config/deps/ramses_rf/src and modifying this file.  The PYTHONPATH approach is simpler: just add the bind mount + PYTHONPATH=/config/ ramses_rf/src to docker-compose.yml — no ramses_cc modification needed.

Testing with a local ramses_rf (PYTHONPATH)

HA installs `ramses_rf` from the ramses_cc `manifest.json` (`ramses-rf==0.58.4`)
on every startup, overriding any manually `pip install`ed version.  To test a
local/fixed ramses_rf, the ha-sim docker-compose already bind-mounts
`/home/willem/dev/ramses_rf` to `/config/ramses_rf`.  Adding
`PYTHONPATH=/config/ramses_rf/src` to the container environment makes Python
load the local copy before site-packages (where the pip-installed 0.58.4
lives) — no modification to ramses_cc needed.

The `docker-compose.yml` at `/home/willem/docker_files/ha-sim/docker-compose.yml`
should have:

```yaml
    environment:
      - TZ=Europe/Amsterdam
      - HASSIO_PORT=8124
      - PYTHONPATH=/config/ramses_rf/src
```

After changing the environment, recreate the container (a plain `restart` is
not enough — environment changes require recreation):

```bash
cd /home/willem/docker_files/ha-sim
docker compose up -d
```

To verify the local copy is loaded:

```bash
docker exec ha-sim python3 -c 'import sys; print([p for p in sys.path if "ramses_rf" in p])'
# Should show: ['/config/ramses_rf/src']
```

To revert, remove the `PYTHONPATH` line and `docker compose up -d` again.

