### PR TITLE
Fix/851 fan param services

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -23,6 +23,13 @@ from typing import Any
 # --- DEVELOPMENT HOOK ---
 # If a local copy of ramses_rf exists, use it instead of the system installed version.
 # This allows for testing changes without rebuilding the container.
+#
+# TODO: The dev hook below is superseded by the PYTHONPATH approach — see the
+# "Testing with a local ramses_rf" section in ramses_extras/docs/HA_SIM_TEST_TOOL.md.
+# The PYTHONPATH approach is simpler (no ramses_cc modification, no /config/deps
+# copy needed) and works with any docker-compose that bind-mounts the ramses_rf
+# source tree.  The dev hook is kept for backward compatibility but should not
+# be needed for new development.
 
 ENABLE_DEV_HOOK = False  # Set to true to enable the dev hook
 DEV_LIB_PATH = "/config/deps/ramses_rf/src"

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1335,21 +1335,11 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to set fan param: {err}") from err
 
-    @callback
-    async def async_update_fan_params(self, **kwargs: Any) -> None:
-        """Handle 'update_fan_params' service call.
-
-        :param kwargs: Service arguments.
-        """
-        _LOGGER.info(
-            "Fan read all params from climate entity %s (%s)",
-            self.entity_id,
-            self.__class__.__name__,
-        )
-        kwargs[ATTR_DEVICE_ID] = self._device.id
-        # Note: This spawns a task and is not awaited, so simple try/except
-        # here won't catch exceptions from the task.
-        self.coordinator.get_all_fan_params(kwargs)  # don't await
+    # NOTE: async_update_fan_params was removed.  The 'update_fan_params'
+    # service is registered once as a domain service (see schemas.py
+    # SVCS_RAMSES_CLIMATE comment) and resolves the FAN device_id from either
+    # an explicit device_id field or a target entity selector.  See
+    # ramses_cc issue 851.
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -739,26 +739,11 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         else:
             _LOGGER.warning("REM %s not bound to a FAN", self._device.id)
 
-    async def async_update_fan_rem_params(self, **kwargs: Any) -> None:
-        """Handle 'update_fan_params' service call.
-
-        :param kwargs: Arbitrary keyword arguments.
-        """
-        _LOGGER.info(
-            "Fan read all params via remote entity %s (%s)",
-            self.entity_id,
-            self.__class__.__name__,
-        )
-        parent = self.coordinator.fan_handler._fan_bound_to_remote.get(self._device.id)
-        if parent:
-            kwargs[ATTR_DEVICE_ID] = parent
-            kwargs["from_id"] = self._device.id  # replaces manual from_id entry
-            # Call coordinator method directly on the loop.
-            # coordinator.get_all_fan_params internally calls loop.create_task().
-            # It is NOT blocking and must NOT be run in an executor.
-            self.coordinator.get_all_fan_params(kwargs)
-        else:
-            _LOGGER.warning("REM %s not bound to a FAN", self._device.id)
+    # NOTE: async_update_fan_rem_params was removed.  It was never registered
+    # in SVCS_RAMSES_REMOTE (only get_fan_rem_param / set_fan_rem_param are),
+    # so it was unreachable dead code.  The domain 'update_fan_params' service
+    # covers the bulk-read use case (with an explicit from_id for the bound
+    # REM if needed).  See ramses_cc issue 851.
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2602,7 +2602,14 @@ SCH_SET_FAN_PARAM_DOMAIN = vol.Schema(
     },
     extra=vol.PREVENT_EXTRA,
 )
-SCH_UPDATE_FAN_PARAMS_DOMAIN = SCH_UPDATE_FAN_PARAMS
+SCH_UPDATE_FAN_PARAMS_DOMAIN = vol.Schema(
+    {
+        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
+        vol.Optional("device_id"): vol.Any(None, cv.string),
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
+    },
+    extra=vol.PREVENT_EXTRA,
+)
 
 
 # services without their own schema
@@ -2625,7 +2632,13 @@ SVCS_RAMSES_CLIMATE = {
     SVC_GET_SYSTEM_FAULTS: SCH_GET_SYSTEM_FAULTS,
     SVC_GET_FAN_CLIM_PARAM: SCH_GET_FAN_PARAM,  # UI fan_param actions
     SVC_SET_FAN_CLIM_PARAM: SCH_SET_FAN_PARAM,
-    SVC_UPDATE_FAN_PARAMS: SCH_UPDATE_FAN_PARAMS,
+    # NOTE: SVC_UPDATE_FAN_PARAMS is intentionally NOT registered here as a
+    # climate entity service.  It is registered once as a domain service in
+    # async_register_domain_services (with SCH_UPDATE_FAN_PARAMS_DOMAIN, which
+    # accepts both a target entity selector and an explicit device_id).  The
+    # previous duplicate entity-service registration was overwritten by the
+    # domain service anyway, and keeping both caused confusion about which
+    # handler + schema was authoritative.  See ramses_cc issue 851.
 }
 
 # services for water_heater platform

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -14,7 +14,6 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_call_later
 
 from ramses_rf.address import Address
-from ramses_rf.commands.builders import build_dto
 from ramses_rf.commands.core import Command as Intent
 from ramses_rf.devices import Fakeable
 from ramses_rf.enums import Action
@@ -362,11 +361,14 @@ class RamsesServiceHandler:
                 action=Action.GET_FAN_PARAM,
                 data={"param_id": param_id},
             )
-            cmd = build_dto(intent)
-            _LOGGER.debug("Sending command: %s", cmd)
-
-            # Send the command directly using the gateway
-            await self._coordinator.client.async_send_cmd(cmd)
+            # Use the CQRS CommandDispatcher, which translates the intent
+            # to a CommandDTO and shims it back to a legacy Command that
+            # async_send_cmd accepts.  Calling build_dto() + async_send_cmd()
+            # directly passes a CommandDTO (positional addr1/addr2/addr3) to
+            # a code path that expects cmd.src.id, raising AttributeError.
+            # See ramses_cc issue 851.
+            _LOGGER.debug("Sending get_fan_param intent: %s", intent)
+            await self._coordinator.client.dispatcher.send(intent)
 
             # Clear pending state after timeout (non-blocking)
             self._schedule_clear_pending(entity, 30)
@@ -555,8 +557,10 @@ class RamsesServiceHandler:
                 action=Action.SET_FAN_PARAM,
                 data={"param_id": param_id, "value": value},
             )
-            cmd = build_dto(intent)
-            await self._coordinator.client.async_send_cmd(cmd)
+            # Use the CQRS CommandDispatcher (translates intent → CommandDTO
+            # → legacy Command).  See get_fan_param above / issue 851.
+            _LOGGER.debug("Sending set_fan_param intent: %s", intent)
+            await self._coordinator.client.dispatcher.send(intent)
             await asyncio.sleep(0.2)
 
             self._schedule_clear_pending(entity, 30)

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -179,6 +179,11 @@ update_fan_params:
           - climate
 
   fields:
+    device_id:
+      example: '"32:153289"'
+      required: false
+      selector:
+        text:
     from_id:
       example: '"18:123456"'
       required: false

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -493,11 +493,15 @@
 
         "update_fan_params": {
             "name": "Update Fan Parameters",
-            "description": "Request all available configuration parameters (2411) from a FAN. Will update all parameter entities for the device.",
+            "description": "Request all available configuration parameters (2411) from a FAN. Will update all parameter entities for the device. Select the FAN climate entity as the target, or provide a RAMSES device_id (XX:XXXXXX).",
             "fields": {
+                "device_id": {
+                    "name": "Target device_id",
+                    "description": "Optional RAMSES device ID of the FAN (XX:XXXXXX). If omitted, select the FAN climate entity as the target."
+                },
                 "from_id": {
                     "name": "Source Device ID",
-                    "description": "Optional source device ID to use for the request (defaults to Bound REM). Enter any device ID in format XX:XXXXXX"
+                    "description": "Optional source device ID to use for the request (defaults to the bound REM, else the gateway). Enter a device ID in format XX:XXXXXX"
                 }
             }
         },

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -493,11 +493,15 @@
 
         "update_fan_params": {
             "name": "Fan-parameters bijwerken",
-            "description": "Vraag alle beschikbare instellingen (2411) op van een FAN. Werkt alle parameter entiteiten bij voor het apparaat.",
+            "description": "Vraag alle beschikbare instellingen (2411) op van een FAN. Werkt alle parameter entiteiten bij voor het apparaat. Selecteer de FAN climate-entiteit als doel, of geef een RAMSES device_id (XX:XXXXXX) op.",
             "fields": {
+                "device_id": {
+                    "name": "Doelapparaat-ID",
+                    "description": "Optioneel: RAMSES apparaat-ID van de FAN (XX:XXXXXX). Laat leeg en selecteer de FAN climate-entiteit als doel."
+                },
                 "from_id": {
                     "name": "Bronapparaat-ID",
-                    "description": "Optioneel: bronapparaat-ID voor het verzoek (laat leeg voor 'bound' REM). Vul een apparaat-ID in als XX:XXXXXX"
+                    "description": "Optioneel: bronapparaat-ID voor het verzoek (standaard de 'bound' REM, anders de gateway). Vul een apparaat-ID in als XX:XXXXXX"
                 }
             }
         },

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -775,11 +775,10 @@ async def test_hvac_services(
         {"param": "p1", "value": 1, ATTR_DEVICE_ID: mock_device.id}
     )
 
-    # async_update_fan_params
-    await hvac.async_update_fan_params()
-    mock_coordinator.get_all_fan_params.assert_called_with(
-        {ATTR_DEVICE_ID: mock_device.id}
-    )
+    # NOTE: async_update_fan_params was removed from the climate entity (it
+    # was a duplicate of the domain service).  The domain service
+    # 'update_fan_params' resolves device_id from the target/entity selector
+    # or an explicit device_id field.  See ramses_cc issue 851.
 
 
 async def test_error_handling(
@@ -1106,22 +1105,6 @@ async def test_zone_immediate_update_on_commands(
     mock_device.set_schedule.assert_awaited()
     zone.async_write_ha_state.assert_called()
     zone.async_write_ha_state.reset_mock()
-
-
-async def test_hvac_update_fan_params_coverage(
-    mock_coordinator: MagicMock, mock_description: MagicMock
-) -> None:
-    """Test update_fan_params specifically to guarantee coverage of args."""
-    mock_device = MagicMock(spec=HvacVentilator)
-    mock_device.id = "30:COVERAGE"
-    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
-
-    # Pass specific kwargs to trace the flow through lines 557-558
-    await hvac.async_update_fan_params(explicit_arg=True)
-
-    mock_coordinator.get_all_fan_params.assert_called_with(
-        {"explicit_arg": True, ATTR_DEVICE_ID: "30:COVERAGE"}
-    )
 
 
 async def test_zone_set_hvac_mode_error(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -132,6 +132,8 @@ def mock_coordinator(mock_hass: MagicMock, mock_entry: MagicMock) -> RamsesCoord
     coordinator = RamsesCoordinator(mock_hass, mock_entry)
     coordinator.client = MagicMock()
     cast(Any, coordinator.client).async_send_cmd = AsyncMock()
+    cast(Any, coordinator.client).dispatcher = MagicMock()
+    cast(Any, coordinator.client).dispatcher.send = AsyncMock()
     coordinator._device_info = {}
     coordinator.platforms = {}
     coordinator._devices = []
@@ -1551,14 +1553,13 @@ async def test_coordinator_get_fan_param(
         mock_dev.id = FAN_ID
         mock_get_dev.return_value = mock_dev
 
-        cast(Any, mock_coordinator.client).async_send_cmd = mock_send
+        cast(Any, mock_coordinator.client).dispatcher.send = mock_send
 
         await mock_coordinator.async_get_fan_param(call_data)
 
         assert cast(Any, mock_send).called
-        cmd = mock_send.call_args[0][0]
-        # Check command attributes if possible, or just that it was sent
-        assert cmd is not None
+        intent = mock_send.call_args[0][0]
+        assert intent.action.name == "GET_FAN_PARAM"
 
 
 async def test_coordinator_set_fan_param(
@@ -1585,7 +1586,7 @@ async def test_coordinator_set_fan_param(
         mock_dev.id = FAN_ID
         mock_get_dev.return_value = mock_dev
 
-        cast(Any, mock_coordinator.client).async_send_cmd = mock_send
+        cast(Any, mock_coordinator.client).dispatcher.send = mock_send
 
         await mock_coordinator.async_set_fan_param(call_data)
 
@@ -1632,7 +1633,7 @@ async def test_coordinator_set_fan_param_no_binding(
     cast(Any, mock_fan_device).get_bound_rem = MagicMock(return_value=None)
     mock_send = AsyncMock()
 
-    cast(Any, mock_coordinator.client).async_send_cmd = mock_send
+    cast(Any, mock_coordinator.client).dispatcher.send = mock_send
 
     call_data = {"device_id": FAN_ID, "param_id": PARAM_ID_HEX, "value": 21.5}
 
@@ -1668,7 +1669,7 @@ async def test_get_fan_param_fallback_hgi(
     call_data = {"device_id": FAN_ID, "param_id": PARAM_ID_HEX}
 
     cast(Any, mock_coordinator.client).hgi = MagicMock(id=hgi_id)
-    cast(Any, mock_coordinator.client).async_send_cmd = mock_send
+    cast(Any, mock_coordinator.client).dispatcher.send = mock_send
 
     # 4. Run with log capture to verify the debug logic
     with caplog.at_level(logging.DEBUG):
@@ -1681,10 +1682,10 @@ async def test_get_fan_param_fallback_hgi(
         in caplog.text
     )
 
-    # Check the command was actually sent with the HGI ID as the source
+    # Check the intent was actually sent via the dispatcher with HGI as source
     assert cast(Any, mock_send).called
-    mock_send.call_args[0][0]
-    # removed cmd.src.id assert
+    intent = mock_send.call_args[0][0]
+    assert intent.src.id == hgi_id
 
 
 # --- Tests migrated from test_fan_param.py ---
@@ -1709,7 +1710,7 @@ class TestFanParameterGet:
         This fixture runs before each test method and sets up:
         - A real RamsesCoordinator instance
         - A mock client with an HGI device
-        - Patches for build_dto
+        - A mock CQRS dispatcher (dispatcher.send replaces build_dto + async_send_cmd)
         - Test command objects for GET operations
 
         Args:
@@ -1741,17 +1742,12 @@ class TestFanParameterGet:
         self.mock_device.id = TEST_DEVICE_ID
         cast(Any, self.mock_device).get_bound_rem.return_value = None
 
-        # Patch build_dto to control command creation
-        self.patcher = patch("custom_components.ramses_cc.services.build_dto")
-        self.mock_get_fan_param = self.patcher.start()
-
-        # Create a test command that will be returned by the patched method
-        self.mock_cmd = MagicMock()
-        self.mock_cmd.code = "2411"
-        self.mock_cmd.verb = "RQ"
-        self.mock_cmd.src = MagicMock(id=TEST_FROM_ID)
-        self.mock_cmd.dst = MagicMock(id=TEST_DEVICE_ID)
-        cast(Any, self.mock_get_fan_param).return_value = self.mock_cmd
+        # Mock the CQRS dispatcher — fan_param services call
+        # client.dispatcher.send(intent) instead of build_dto + async_send_cmd.
+        # See ramses_cc issue 851.
+        self.mock_dispatcher_send = AsyncMock()
+        cast(Any, self.coordinator.client).dispatcher = MagicMock()
+        cast(Any, self.coordinator.client).dispatcher.send = self.mock_dispatcher_send
 
         cast(Any, self.coordinator.client).hgi = MagicMock(id=TEST_FROM_ID)
         cast(Any, self.coordinator.client.device_registry).device_by_id = {
@@ -1760,17 +1756,13 @@ class TestFanParameterGet:
 
         yield  # Test runs here
 
-        # Cleanup - stop all patches
-        self.patcher.stop()
-
     @pytest.mark.asyncio
     async def test_basic_fan_param_request(self, hass: HomeAssistant) -> None:
         """Test basic fan parameter request.
 
         Verifies that:
-        1. The command is constructed with correct parameters
-        2. The command is sent via the client
-        3. No errors are raised
+        1. The intent is sent via the CQRS dispatcher
+        2. No errors are raised
         """
         # Setup service call data with all required parameters
         service_data = {
@@ -1783,13 +1775,10 @@ class TestFanParameterGet:
         # Act - Call the method under test
         await self.coordinator.async_get_fan_param(call)
 
-        # Assert - Verify command construction
-        self.mock_get_fan_param.assert_called_once()
-
-        # Verify command was sent via the client
-        cast(Any, self.mock_client.async_send_cmd).assert_awaited_once_with(
-            self.mock_cmd
-        )
+        # Assert - Verify intent was sent via the CQRS dispatcher
+        self.mock_dispatcher_send.assert_awaited_once()
+        intent = self.mock_dispatcher_send.call_args[0][0]
+        assert intent.action.name == "GET_FAN_PARAM"
 
     @pytest.mark.asyncio
     async def test_missing_required_param_id(
@@ -1814,7 +1803,7 @@ class TestFanParameterGet:
             await self.coordinator.async_get_fan_param(call)
 
         # Verify no command was sent
-        cast(Any, self.mock_client.async_send_cmd).assert_not_called()
+        self.mock_dispatcher_send.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_custom_fan_id(self, hass: HomeAssistant) -> None:
@@ -1836,11 +1825,8 @@ class TestFanParameterGet:
         # Act - Call the method under test
         await self.coordinator.async_get_fan_param(call)
 
-        # Assert - Verify command was constructed with custom fan_id
-        self.mock_get_fan_param.assert_called_once()
-
-        # Verify command was sent
-        cast(Any, self.mock_client.async_send_cmd).assert_awaited_once()
+        # Assert - Verify intent was sent via the CQRS dispatcher
+        self.mock_dispatcher_send.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_get_fan_param_with_ha_device_selector_resolves_device_id(
@@ -1865,7 +1851,7 @@ class TestFanParameterGet:
 
         await self.coordinator.async_get_fan_param(call)
 
-        self.mock_get_fan_param.assert_called_once()
+        self.mock_dispatcher_send.assert_awaited_once()
 
 
 async def test_get_fan_param_service_schema_accepts_ha_device_selector(
@@ -1906,7 +1892,7 @@ class TestFanParameterSet:
 
     Safety measures in place:
     - build_dto is patched with mock
-    - Client.async_send_cmd is mocked
+    - Client.dispatcher.send is mocked (CQRS path)
     - Coordinator uses mock client, not real hardware
     - All assertions verify mock behaviour only
     - No real hardware communication can occur
@@ -1923,7 +1909,7 @@ class TestFanParameterSet:
         This fixture runs before each test method and sets up:
         - A real RamsesCoordinator instance
         - A mock client with an HGI device
-        - Patches for build_dto
+        - A mock CQRS dispatcher (dispatcher.send replaces build_dto + async_send_cmd)
         - Test command objects for SET operations
 
         Args:
@@ -1953,17 +1939,12 @@ class TestFanParameterSet:
         self.mock_device.id = TEST_DEVICE_ID
         cast(Any, self.mock_device).get_bound_rem.return_value = None
 
-        # Patch build_dto to control command creation
-        self.patcher = patch("custom_components.ramses_cc.services.build_dto")
-        self.mock_set_fan_param = self.patcher.start()
-
-        # Create a test command that will be returned by the patched method
-        self.mock_cmd = MagicMock()
-        self.mock_cmd.code = "2411"
-        self.mock_cmd.verb = "W"
-        self.mock_cmd.src = MagicMock(id=TEST_FROM_ID)
-        self.mock_cmd.dst = MagicMock(id=TEST_DEVICE_ID)
-        cast(Any, self.mock_set_fan_param).return_value = self.mock_cmd
+        # Mock the CQRS dispatcher — fan_param services call
+        # client.dispatcher.send(intent) instead of build_dto + async_send_cmd.
+        # See ramses_cc issue 851.
+        self.mock_dispatcher_send = AsyncMock()
+        cast(Any, self.coordinator.client).dispatcher = MagicMock()
+        cast(Any, self.coordinator.client).dispatcher.send = self.mock_dispatcher_send
 
         # PERFORMANCE OPTIMIZATION:
         # Patch asyncio.sleep to be instant for set operations which use sleep
@@ -1978,7 +1959,6 @@ class TestFanParameterSet:
         yield  # Test runs here
 
         # Cleanup - stop all patches
-        self.patcher.stop()
         self.sleep_patcher.stop()
 
     @pytest.mark.asyncio
@@ -1986,9 +1966,8 @@ class TestFanParameterSet:
         """Test basic fan parameter set with all required parameters.
 
         Verifies that:
-        1. The command is constructed with correct parameters
-        2. The command is sent via the client
-        3. No errors are raised
+        1. The intent is sent via the CQRS dispatcher
+        2. No errors are raised
         """
         # Setup service call data with all required parameters
         service_data = {
@@ -2002,13 +1981,10 @@ class TestFanParameterSet:
         # Act - Call the method under test
         await self.coordinator.async_set_fan_param(call)
 
-        # Assert - Verify command construction
-        self.mock_set_fan_param.assert_called_once()
-
-        # Verify command was sent via the client
-        cast(Any, self.mock_client.async_send_cmd).assert_awaited_once_with(
-            self.mock_cmd
-        )
+        # Assert - Verify intent was sent via the CQRS dispatcher
+        self.mock_dispatcher_send.assert_awaited_once()
+        intent = self.mock_dispatcher_send.call_args[0][0]
+        assert intent.action.name == "SET_FAN_PARAM"
 
     @pytest.mark.asyncio
     async def test_set_fan_param_with_ha_device_selector(
@@ -2034,10 +2010,8 @@ class TestFanParameterSet:
 
         await self.coordinator.async_set_fan_param(call)
 
-        self.mock_set_fan_param.assert_called_once()
-
-        # Verify command was sent
-        cast(Any, self.mock_client.async_send_cmd).assert_awaited_once()
+        # Verify intent was sent via the CQRS dispatcher
+        self.mock_dispatcher_send.assert_awaited_once()
 
 
 class TestFanParameterUpdate:
@@ -2054,7 +2028,7 @@ class TestFanParameterUpdate:
         This fixture runs before each test method and sets up:
         - A real RamsesCoordinator instance
         - A mock client with an HGI device
-        - Patches for build_dto
+        - A mock CQRS dispatcher (dispatcher.send replaces build_dto + async_send_cmd)
         - Test command objects for UPDATE operations
 
         Args:
@@ -2084,17 +2058,12 @@ class TestFanParameterUpdate:
         self.mock_device.id = TEST_DEVICE_ID
         cast(Any, self.mock_device).get_bound_rem.return_value = None
 
-        # Patch build_dto to control command creation
-        self.patcher = patch("custom_components.ramses_cc.services.build_dto")
-        self.mock_get_fan_param = self.patcher.start()
-
-        # Create a test command that will be returned by the patched method
-        self.mock_cmd = MagicMock()
-        self.mock_cmd.code = "2411"
-        self.mock_cmd.verb = "RQ"
-        self.mock_cmd.src = MagicMock(id=TEST_FROM_ID)
-        self.mock_cmd.dst = MagicMock(id=TEST_DEVICE_ID)
-        cast(Any, self.mock_get_fan_param).return_value = self.mock_cmd
+        # Mock the CQRS dispatcher — fan_param services call
+        # client.dispatcher.send(intent) instead of build_dto + async_send_cmd.
+        # See ramses_cc issue 851.
+        self.mock_dispatcher_send = AsyncMock()
+        cast(Any, self.coordinator.client).dispatcher = MagicMock()
+        cast(Any, self.coordinator.client).dispatcher.send = self.mock_dispatcher_send
 
         # PERFORMANCE OPTIMIZATION:
         # Patch asyncio.sleep to be instant for set operations which use sleep
@@ -2109,7 +2078,6 @@ class TestFanParameterUpdate:
         yield  # Test runs here
 
         # Cleanup - stop all patches
-        self.patcher.stop()
         self.sleep_patcher.stop()
 
     @pytest.mark.asyncio
@@ -2117,8 +2085,8 @@ class TestFanParameterUpdate:
         """Test basic fan parameter update with all required parameters.
 
         Verifies that:
-        1. Commands are constructed for all parameters in the schema
-        2. All commands are sent via the client
+        1. Intents are sent for all parameters in the schema
+        2. All intents are sent via the CQRS dispatcher
         3. No errors are raised
         """
         # Setup service call data with all required parameters
@@ -2131,14 +2099,9 @@ class TestFanParameterUpdate:
         # Act - Call the method under test
         await self.coordinator.service_handler._async_run_fan_param_sequence(call)
 
-        # Verify all parameters in the schema were requested
-        assert cast(Any, self.mock_get_fan_param).call_count > 0, (
+        # Verify all parameters in the schema were requested via the dispatcher
+        assert self.mock_dispatcher_send.call_count > 0, (
             "Expected multiple parameter requests"
-        )
-
-        # Verify commands were sent via the client
-        assert cast(Any, self.mock_client.async_send_cmd).call_count > 0, (
-            "Expected multiple commands sent"
         )
 
 

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -747,9 +747,11 @@ async def test_fan_param_methods(
 ) -> None:
     """Test fan parameter methods for bound and unbound scenarios.
 
-    This test consolidates bound, unbound, set, get, and update
-    verifications, including the recent thread-safety fix for
-    async_update_fan_rem_params.
+    This test consolidates bound, unbound, set, and get verifications.
+    async_update_fan_rem_params was removed (it was never registered in
+    SVCS_RAMSES_REMOTE, so it was unreachable dead code); the bulk-read
+    use case is covered by the domain 'update_fan_params' service.  See
+    ramses_cc issue 851.
     """
     entity_id = "remote.test_remote"
     device_id = "12:123456"
@@ -789,39 +791,13 @@ async def test_fan_param_methods(
     await remote.async_set_fan_rem_param(**kwargs)
     mock_coordinator.async_set_fan_param.assert_awaited()
 
-    # --- Test 3: Update Params (Bound + Thread Safety Check) ---
-    # Create a completed Future to simulate the return value of
-    # async_add_executor_job if it were improperly used. We assert
-    # that it is NOT used.
-    future: asyncio.Future[None] = asyncio.Future()
-    future.set_result(None)
-
-    with patch.object(hass, "async_add_executor_job", return_value=future) as mock_exec:
-        await remote.async_update_fan_rem_params(**kwargs)
-
-        # VERIFICATION: Ensure async_add_executor_job was NOT called.
-        # The method should now run directly on the event loop.
-        mock_exec.assert_not_called()
-
-        # Check that coordinator.get_all_fan_params was called directly
-        expected_kwargs = {
-            "key": "value",
-            "device_id": fan_id,
-            "from_id": device_id,
-        }
-        mock_coordinator.get_all_fan_params.assert_called_with(expected_kwargs)
-
-    # --- Test 4: Unbound Scenarios ---
+    # --- Test 3: Unbound Scenarios ---
     mock_coordinator.fan_handler._fan_bound_to_remote = {}
     mock_coordinator.get_all_fan_params.reset_mock()
     mock_coordinator.async_get_fan_param.reset_mock()
     mock_coordinator.async_set_fan_param.reset_mock()
 
     with caplog.at_level(logging.WARNING):
-        # Update
-        await remote.async_update_fan_rem_params(**kwargs)
-        assert f"REM {device_id} not bound to a FAN" in caplog.text
-
         # Get
         await remote.async_get_fan_rem_param(**kwargs)
         # Set

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -97,6 +97,10 @@ def mock_coordinator(hass: HomeAssistant) -> RamsesCoordinator:
     coordinator.client = MagicMock()
     mock_client = cast(Any, coordinator.client)
     mock_client.async_send_cmd = AsyncMock()
+    # CQRS CommandDispatcher — the fan_param services call
+    # client.dispatcher.send(intent) instead of build_dto + async_send_cmd.
+    mock_client.dispatcher = MagicMock()
+    mock_client.dispatcher.send = AsyncMock()
     # Initialize device_by_id as a dict for lookups
     mock_client.device_registry.device_by_id = {}
     coordinator.platforms = {}
@@ -484,16 +488,12 @@ async def test_async_set_fan_param_success_clear_pending(
     mock_entity.set_pending = MagicMock()
     mock_entity._clear_pending_after_timeout = AsyncMock()
 
-    # Mock build_dto to avoid validation errors
+    # dispatcher.send is already mocked on mock_coordinator.client
     with (
         patch.object(
             mock_coordinator.fan_handler, "find_param_entity", return_value=mock_entity
         ),
-        patch("custom_components.ramses_cc.services.build_dto") as mock_cmd_cls,
     ):
-        mock_cmd = MagicMock()
-        mock_cmd_cls.return_value = mock_cmd
-
         call = {
             "device_id": FAN_ID,
             "param_id": "01",
@@ -502,10 +502,9 @@ async def test_async_set_fan_param_success_clear_pending(
         }
         await mock_coordinator.async_set_fan_param(call)
 
-        # Verify command sent
+        # Verify command sent via CQRS dispatcher
         mock_client = cast(Any, mock_coordinator.client)
-        assert mock_client.async_send_cmd.called
-        assert mock_client.async_send_cmd.call_args[0][0] == mock_cmd
+        assert mock_client.dispatcher.send.called
         # Verify pending set
         assert mock_entity.set_pending.called
 
@@ -600,9 +599,9 @@ async def test_set_fan_param_generic_exception(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
     """Test the generic exception handler coverage in async_set_fan_param."""
-    # 1. Setup the transport failure
+    # 1. Setup the transport failure on the CQRS dispatcher
     mock_client = cast(Any, mock_coordinator.client)
-    mock_client.async_send_cmd.side_effect = Exception("Transport Failure")
+    mock_client.dispatcher.send.side_effect = Exception("Transport Failure")
 
     # 2. Setup the entity and its cleanup mock
     mock_entity = MagicMock()
@@ -616,17 +615,14 @@ async def test_set_fan_param_generic_exception(
         "from_id": "18:000000",
     }
 
-    # 3. Patch necessary internal methods and the Command builder
+    # 3. Patch necessary internal methods
     with (
         patch.object(
             mock_coordinator.service_handler,
             "_get_device_and_from_id",
             return_value=("30:111111", "30_111111", "18:000000"),
         ),
-        patch("custom_components.ramses_cc.services.build_dto") as mock_cmd,
     ):
-        mock_cmd.set_fan_param.return_value = MagicMock()
-
         # 4. Verify that HomeAssistantError is raised with the correct message
         with pytest.raises(HomeAssistantError, match="Failed to set fan parameter"):
             await mock_coordinator.async_set_fan_param(call_data)
@@ -713,7 +709,6 @@ async def test_set_fan_param_exception_handling(
         patch.object(
             mock_coordinator.fan_handler, "find_param_entity", return_value=mock_entity
         ),
-        patch("custom_components.ramses_cc.services.build_dto") as mock_cmd,
         # Patch device lookup to ensure we reach the logic
         patch.object(
             mock_coordinator.service_handler,
@@ -721,11 +716,9 @@ async def test_set_fan_param_exception_handling(
             return_value=("30:111111", "30_111111", "18:000000"),
         ),
     ):
-        # Mock send_cmd to raise Exception
+        # Mock dispatcher.send to raise Exception
         mock_client = cast(Any, mock_coordinator.client)
-        mock_client.async_send_cmd.side_effect = Exception("Boom")
-        # Mock cmd creation to succeed so we reach send_cmd
-        mock_cmd.set_fan_param.return_value = MagicMock()
+        mock_client.dispatcher.send.side_effect = Exception("Boom")
 
         call = {
             "device_id": "30:111111",
@@ -810,7 +803,6 @@ async def test_set_fan_param_exception_clears_pending(
         patch.object(
             mock_coordinator.fan_handler, "find_param_entity", return_value=mock_entity
         ),
-        patch("custom_components.ramses_cc.services.build_dto") as mock_cmd_cls,
         # Patch device lookup so we don't fail early with 'No valid source'
         patch.object(
             mock_coordinator.service_handler,
@@ -818,11 +810,9 @@ async def test_set_fan_param_exception_clears_pending(
             return_value=("30:111111", "30_111111", "18:000000"),
         ),
     ):
-        mock_cmd = MagicMock()
-        mock_cmd_cls.return_value = mock_cmd
-        # Mock send_cmd to raise Exception
+        # Mock dispatcher.send to raise Exception
         mock_client = cast(Any, mock_coordinator.client)
-        mock_client.async_send_cmd.side_effect = Exception("Boom")
+        mock_client.dispatcher.send.side_effect = Exception("Boom")
 
         call = {
             "device_id": "30:111111",
@@ -1073,10 +1063,10 @@ async def test_get_fan_param_generic_exception(
         patch.object(
             mock_coordinator.fan_handler, "find_param_entity", return_value=mock_entity
         ),
-        patch("custom_components.ramses_cc.services.build_dto") as mock_cmd_cls,
     ):
-        # Configure the side effect on the method, not the class constructor
-        mock_cmd_cls.side_effect = Exception("Unexpected Error")
+        # Configure dispatcher.send to raise
+        mock_client = cast(Any, mock_coordinator.client)
+        mock_client.dispatcher.send.side_effect = Exception("Unexpected Error")
 
         # Now we expect HomeAssistantError because coordinator wraps the generic exception
         with pytest.raises(HomeAssistantError, match="Failed to get fan parameter"):
@@ -1106,9 +1096,10 @@ async def test_set_fan_param_value_error_in_command(
             "_get_device_and_from_id",
             return_value=("30:111111", "30_111111", "18:000000"),
         ),
-        patch("custom_components.ramses_cc.services.build_dto") as mock_cmd,
     ):
-        mock_cmd.side_effect = ValueError("Value out of range")
+        # dispatcher.send calls build_dto internally; simulate its ValueError
+        mock_client = cast(Any, mock_coordinator.client)
+        mock_client.dispatcher.send.side_effect = ValueError("Value out of range")
 
         with pytest.raises(
             HomeAssistantError, match="Invalid parameter for set_fan_param"
@@ -1578,9 +1569,9 @@ async def test_get_fan_param_no_source(
 
     assert "No valid source device available" in caplog.text
 
-    # Verify client.async_send_cmd was NOT called
+    # Verify client.dispatcher.send was NOT called
     mock_client = cast(Any, coordinator.client)
-    mock_client.async_send_cmd.assert_not_called()
+    mock_client.dispatcher.send.assert_not_called()
 
 
 async def test_get_fan_param_sets_pending(hass: HomeAssistant) -> None:
@@ -1590,6 +1581,8 @@ async def test_get_fan_param_sets_pending(hass: HomeAssistant) -> None:
     coordinator.client = MagicMock()
     mock_client = cast(Any, coordinator.client)
     mock_client.async_send_cmd = AsyncMock()
+    mock_client.dispatcher = MagicMock()
+    mock_client.dispatcher.send = AsyncMock()
 
     # Setup happy path for IDs using valid RAMSES ID format (XX:YYYYYY)
     coordinator.service_handler._get_device_and_from_id = MagicMock(
@@ -1637,6 +1630,9 @@ async def test_set_fan_param_errors(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(domain=DOMAIN, options={CONF_SCAN_INTERVAL: 60})
     coordinator = RamsesCoordinator(hass, entry)
     coordinator.client = MagicMock()
+    mock_client = cast(Any, coordinator.client)
+    mock_client.dispatcher = MagicMock()
+    mock_client.dispatcher.send = AsyncMock()
 
     # 1. Missing Source (from_id)
     device = MagicMock()
@@ -1654,22 +1650,15 @@ async def test_set_fan_param_errors(hass: HomeAssistant) -> None:
     coordinator.service_handler._get_device_and_from_id = MagicMock(
         return_value=("32:111111", "32_111111", "18:000000")
     )
-    # Mock Send to raise generic Exception
+    # Mock dispatcher.send to raise generic Exception
     mock_client = cast(Any, coordinator.client)
-    mock_client.async_send_cmd.side_effect = RuntimeError("Transport fail")
+    mock_client.dispatcher.send.side_effect = RuntimeError("Transport fail")
 
     mock_entity = MagicMock()
     mock_entity._clear_pending_after_timeout = AsyncMock()
     coordinator.fan_handler.find_param_entity = MagicMock(return_value=mock_entity)
 
-    # Patch build_dto to skip validation for this test
-    with (
-        patch(
-            "custom_components.ramses_cc.services.build_dto",
-            return_value="MOCK_CMD",
-        ),
-        pytest.raises(HomeAssistantError, match="Failed to set fan parameter"),
-    ):
+    with pytest.raises(HomeAssistantError, match="Failed to set fan parameter"):
         await coordinator.async_set_fan_param(call)
 
     # Verify pending was cleared
@@ -1812,6 +1801,9 @@ async def test_get_fan_param_value_error_clears_pending(hass: HomeAssistant) -> 
     entry = MockConfigEntry(domain=DOMAIN, options={CONF_SCAN_INTERVAL: 60})
     coordinator = RamsesCoordinator(hass, entry)
     coordinator.client = MagicMock()
+    mock_client = cast(Any, coordinator.client)
+    mock_client.dispatcher = MagicMock()
+    mock_client.dispatcher.send = AsyncMock()
 
     # 1. Setup valid IDs to ensure we get past initial checks
     coordinator.service_handler._get_device_and_from_id = MagicMock(
@@ -1824,15 +1816,11 @@ async def test_get_fan_param_value_error_clears_pending(hass: HomeAssistant) -> 
     mock_entity._clear_pending_after_timeout = AsyncMock()
     coordinator.fan_handler.find_param_entity = MagicMock(return_value=mock_entity)
 
-    # 3. Patch build_dto to raise ValueError
+    # 3. Patch dispatcher.send to raise ValueError
     # This ensures 'entity' is already assigned before the exception is raised
-    with (
-        patch(
-            "custom_components.ramses_cc.services.build_dto",
-            side_effect=ValueError("Simulated Error"),
-        ),
-        pytest.raises(ServiceValidationError, match="service_param_invalid"),
-    ):
+    mock_client = cast(Any, coordinator.client)
+    mock_client.dispatcher.send.side_effect = ValueError("Simulated Error")
+    with pytest.raises(ServiceValidationError, match="service_param_invalid"):
         call = {"device_id": "32:111111", "param_id": "01"}
 
         await coordinator.async_get_fan_param(call)
@@ -1868,6 +1856,9 @@ async def test_set_fan_param_value_error_clears_pending(hass: HomeAssistant) -> 
     entry = MockConfigEntry(domain=DOMAIN, options={CONF_SCAN_INTERVAL: 60})
     coordinator = RamsesCoordinator(hass, entry)
     coordinator.client = MagicMock()
+    mock_client = cast(Any, coordinator.client)
+    mock_client.dispatcher = MagicMock()
+    mock_client.dispatcher.send = AsyncMock()
 
     # 1. Setup valid IDs so execution proceeds past initial checks
     coordinator.service_handler._get_device_and_from_id = MagicMock(
@@ -1879,18 +1870,13 @@ async def test_set_fan_param_value_error_clears_pending(hass: HomeAssistant) -> 
     mock_entity._clear_pending_after_timeout = AsyncMock()
     coordinator.fan_handler.find_param_entity = MagicMock(return_value=mock_entity)
 
-    # 3. Patch build_dto to raise ValueError
-    with patch(
-        "custom_components.ramses_cc.services.build_dto",
-        side_effect=ValueError("Simulated Validation Error"),
-    ):
-        call = {"device_id": "32:111111", "param_id": "01", "value": 10}
+    # 3. Patch dispatcher.send to raise ValueError
+    mock_client.dispatcher.send.side_effect = ValueError("Simulated Validation Error")
+    call = {"device_id": "32:111111", "param_id": "01", "value": 10}
 
-        # The coordinator catches ValueError and re-raises it as HomeAssistantError
-        with pytest.raises(
-            HomeAssistantError, match="Invalid parameter for set_fan_param"
-        ):
-            await coordinator.async_set_fan_param(call)
+    # The coordinator catches ValueError and re-raises it as HomeAssistantError
+    with pytest.raises(HomeAssistantError, match="Invalid parameter for set_fan_param"):
+        await coordinator.async_set_fan_param(call)
 
     # 4. Verify _clear_pending_after_timeout(0) was called in the except block
     mock_entity._clear_pending_after_timeout.assert_called_with(0)
@@ -2052,24 +2038,17 @@ async def test_get_fan_param_service_validation_error_clears_pending(
     mock_entity._clear_pending_after_timeout = AsyncMock()
     mock_coordinator.fan_handler.find_param_entity = MagicMock(return_value=mock_entity)
 
-    # 3. Patch build_dto to succeed, but Client to raise ServiceValidationError
-    with patch(
-        "custom_components.ramses_cc.services.build_dto",
-        return_value=MagicMock(),
-    ):
-        # Simulate a downstream validation error (e.g. from the transport layer)
-        mock_client = cast(Any, mock_coordinator.client)
-        mock_client.async_send_cmd.side_effect = ServiceValidationError(
-            "Downstream Validation Failure"
-        )
+    # 3. Patch dispatcher.send to raise ServiceValidationError
+    mock_client = cast(Any, mock_coordinator.client)
+    mock_client.dispatcher.send.side_effect = ServiceValidationError(
+        "Downstream Validation Failure"
+    )
 
-        call = {"device_id": "30:111111", "param_id": "01"}
+    call = {"device_id": "30:111111", "param_id": "01"}
 
-        # 4. Assert the specific exception bubbles up
-        with pytest.raises(
-            ServiceValidationError, match="Downstream Validation Failure"
-        ):
-            await mock_coordinator.async_get_fan_param(call)
+    # 4. Assert the specific exception bubbles up
+    with pytest.raises(ServiceValidationError, match="Downstream Validation Failure"):
+        await mock_coordinator.async_get_fan_param(call)
 
     # 5. Verify _clear_pending_after_timeout(0) was called
     mock_entity._clear_pending_after_timeout.assert_called_with(0)
@@ -2091,14 +2070,14 @@ async def test_coordinator_get_fan_param(
 
     await mock_coordinator.async_get_fan_param(call_data)
 
-    # Verify command sent
+    # Verify intent sent via CQRS dispatcher
     mock_client = cast(Any, mock_coordinator.client)
-    assert mock_client.async_send_cmd.called
-    cmd = mock_client.async_send_cmd.call_args[0][0]
-    # Check command details (RQ 2411)
-    assert cmd.addr2 == FAN_ID
-    assert cmd.verb == "RQ"
-    assert cmd.code == "2411"
+    assert mock_client.dispatcher.send.called
+    intent = mock_client.dispatcher.send.call_args[0][0]
+    # Intent has src/dst/action/data; the dispatcher translates it to a
+    # CommandDTO with addr1=src, addr2=dst, verb=RQ, code=2411
+    assert intent.dst.id == FAN_ID
+    assert intent.action.name == "GET_FAN_PARAM"
 
 
 async def test_coordinator_set_fan_param(
@@ -2117,14 +2096,12 @@ async def test_coordinator_set_fan_param(
 
     await mock_coordinator.async_set_fan_param(call_data)
 
-    # Verify command sent
+    # Verify intent sent via CQRS dispatcher
     mock_client = cast(Any, mock_coordinator.client)
-    assert mock_client.async_send_cmd.called
-    cmd = mock_client.async_send_cmd.call_args[0][0]
-    # Check command details (W 2411)
-    assert cmd.addr2 == FAN_ID
-    assert cmd.verb == " W"
-    assert cmd.code == "2411"
+    assert mock_client.dispatcher.send.called
+    intent = mock_client.dispatcher.send.call_args[0][0]
+    assert intent.dst.id == FAN_ID
+    assert intent.action.name == "SET_FAN_PARAM"
 
 
 async def test_update_fan_params_sequence(
@@ -2150,14 +2127,14 @@ async def test_update_fan_params_sequence(
         # Call the method on service_handler, NOT directly on coordinator
         await mock_coordinator.service_handler._async_run_fan_param_sequence(call_data)
 
-    # Verify that exactly 2 commands were sent (one for each param in tiny_schema)
+    # Verify that exactly 2 intents were sent via the CQRS dispatcher
     mock_client = cast(Any, mock_coordinator.client)
-    assert mock_client.async_send_cmd.call_count == 2
+    assert mock_client.dispatcher.send.call_count == 2
 
-    # Optional: Verify the calls were correct
-    calls = mock_client.async_send_cmd.call_args_list
-    assert calls[0][0][0].code == "2411"  # First command
-    assert calls[1][0][0].code == "2411"  # Second command
+    # Optional: Verify the calls were correct (GET_FAN_PARAM intents)
+    calls = mock_client.dispatcher.send.call_args_list
+    assert calls[0][0][0].action.name == "GET_FAN_PARAM"
+    assert calls[1][0][0].action.name == "GET_FAN_PARAM"
 
 
 async def test_set_fan_param_no_bound_remote(
@@ -2187,7 +2164,7 @@ async def test_set_fan_param_no_bound_remote(
 
     # Verify NO command was sent (because there is no source ID)
     mock_client = cast(Any, mock_coordinator.client)
-    mock_client.async_send_cmd.assert_not_called()
+    mock_client.dispatcher.send.assert_not_called()
 
 
 async def test_set_fan_param_explicit_id_precedence(
@@ -2219,13 +2196,13 @@ async def test_set_fan_param_explicit_id_precedence(
     # We rely on the real method in RamsesServiceHandler.
     await mock_coordinator.async_set_fan_param(call_data)
 
-    # 3. Assert: The command should use the EXPLICIT ID (32:222222), not the bound one (32:111111)
+    # 3. Assert: The intent should use the EXPLICIT ID (32:222222), not the bound one
     mock_client = cast(Any, mock_coordinator.client)
-    assert mock_client.async_send_cmd.called
-    cmd = mock_client.async_send_cmd.call_args[0][0]
+    assert mock_client.dispatcher.send.called
+    intent = mock_client.dispatcher.send.call_args[0][0]
 
-    # removed cmd.src.id assert
-    assert cmd.addr1 != "32:111111"
+    # intent.src is an Address; the explicit from_id should be used, not the bound one
+    assert intent.src.id != "32:111111"
 
 
 async def test_get_fan_param_uses_hgi_fallback(
@@ -2257,10 +2234,10 @@ async def test_get_fan_param_uses_hgi_fallback(
         # Check that the fallback log was triggered
         assert "using gateway id" in caplog.text
 
-    # 5. Verify Command was sent with HGI ID as source
-    assert mock_client.async_send_cmd.called
-    mock_client.async_send_cmd.call_args[0][0]
-    # removed cmd.src.id assert
+    # 5. Verify intent was sent via dispatcher with HGI ID as source
+    assert mock_client.dispatcher.send.called
+    intent = mock_client.dispatcher.send.call_args[0][0]
+    assert intent.src.id == "18:999999"
 
 
 async def test_target_to_device_id_internals_coverage(
@@ -2467,18 +2444,14 @@ async def test_get_fan_param_transport_error(
     mock_entity._clear_pending_after_timeout = AsyncMock()
     mock_coordinator.fan_handler.find_param_entity = MagicMock(return_value=mock_entity)
 
-    # 3. Patch build_dto to succeed, but Client to raise ProtocolSendFailed
-    with patch(
-        "custom_components.ramses_cc.services.build_dto",
-        return_value=MagicMock(),
-    ):
-        mock_client = cast(Any, mock_coordinator.client)
-        mock_client.async_send_cmd.side_effect = ProtocolSendFailed("RF Error")
+    # 3. Patch dispatcher.send to raise ProtocolSendFailed
+    mock_client = cast(Any, mock_coordinator.client)
+    mock_client.dispatcher.send.side_effect = ProtocolSendFailed("RF Error")
 
-        call = {"device_id": "30:111111", "param_id": "01"}
+    call = {"device_id": "30:111111", "param_id": "01"}
 
-        with pytest.raises(HomeAssistantError, match="Failed to get fan parameter"):
-            await mock_coordinator.async_get_fan_param(call)
+    with pytest.raises(HomeAssistantError, match="Failed to get fan parameter"):
+        await mock_coordinator.async_get_fan_param(call)
 
     # 4. Verify cleanup called
     mock_entity._clear_pending_after_timeout.assert_called_with(0)
@@ -2498,18 +2471,14 @@ async def test_set_fan_param_transport_error(
     mock_entity._clear_pending_after_timeout = AsyncMock()
     mock_coordinator.fan_handler.find_param_entity = MagicMock(return_value=mock_entity)
 
-    # 3. Patch Command
-    with patch(
-        "custom_components.ramses_cc.services.build_dto",
-        return_value=MagicMock(),
-    ):
-        mock_client = cast(Any, mock_coordinator.client)
-        mock_client.async_send_cmd.side_effect = TimeoutError("Tx Timeout")
+    # 3. Patch dispatcher.send to raise TimeoutError
+    mock_client = cast(Any, mock_coordinator.client)
+    mock_client.dispatcher.send.side_effect = TimeoutError("Tx Timeout")
 
-        call = {"device_id": "30:111111", "param_id": "01", "value": 10}
+    call = {"device_id": "30:111111", "param_id": "01", "value": 10}
 
-        with pytest.raises(HomeAssistantError, match="Failed to set fan parameter"):
-            await mock_coordinator.async_set_fan_param(call)
+    with pytest.raises(HomeAssistantError, match="Failed to set fan parameter"):
+        await mock_coordinator.async_set_fan_param(call)
 
     # 4. Verify cleanup called
     mock_entity._clear_pending_after_timeout.assert_called_with(0)


### PR DESCRIPTION
## Summary

Two bugs and one cleanup, all related to FAN 2411 parameter handling.

### 1. `AttributeError: 'CommandDTO' object has no attribute 'src'`
`get_fan_param` and `set_fan_param` called `build_dto(intent)` to produce a `CommandDTO` (positional `addr1`/`addr2`/`addr3` per the issue 639 CQRS refactor), then passed it directly to `client.async_send_cmd()`. But `async_send_cmd` expects a legacy `ramses_tx.Command` with `.src.id` — the protocol layer's `_patch_cmd_if_needed` accesses `cmd.src.id`, raising `AttributeError`.

**Fix:** Switched both call sites to `client.dispatcher.send(intent)`, which is the CQRS `CommandDispatcher` that internally calls `build_dto(intent)` and shims the resulting `CommandDTO` back into a legacy `Command` via `LegacyCommand._from_attrs(...)`.

### 2. Duplicate `update_fan_params` registration
`SVC_UPDATE_FAN_PARAMS` was registered both as a climate entity service (`SVCS_RAMSES_CLIMATE`) and as a domain service (`async_register_domain_services`). The domain service registration overwrote the entity service, making the entity-service schema/handler dead code. Removed it from `SVCS_RAMSES_CLIMATE` and kept the single domain service registration.

### 3. Schema + dead code cleanup
- `SCH_UPDATE_FAN_PARAMS_DOMAIN` was just an alias for the entity-service schema. Made it a proper domain schema accepting `device_id` (string) + `device` (HA selector) + `from_id`, consistent with `set_fan_param`/`get_fan_param`. Updated `services.yaml` and en/nl translations.
- Removed `async_update_fan_params` from `RamsesHvac` (climate.py) and `async_update_fan_rem_params` from `RamsesRemote` (remote.py). The latter was never registered in `SVCS_RAMSES_REMOTE`. The domain `update_fan_params` service covers the bulk-read use case.

## Files changed
- `custom_components/ramses_cc/services.py` — dispatcher.send fix, removed build_dto import
- `custom_components/ramses_cc/schemas.py` — proper domain schema, removed duplicate from SVCS_RAMSES_CLIMATE
- `custom_components/ramses_cc/services.yaml` — added device_id field to update_fan_params
- `custom_components/ramses_cc/translations/en.json` + `nl.json` — device_id field descriptions
- `custom_components/ramses_cc/climate.py` — removed dead async_update_fan_params
- `custom_components/ramses_cc/remote.py` — removed dead async_update_fan_rem_params
- `tests/tests_new/test_services.py` — ~20 tests updated to mock/assert on dispatcher.send
- `tests/tests_new/test_coordinator.py` — 3 test classes updated for dispatcher.send
- `tests/tests_new/test_climate.py` — removed tests for deleted method
- `tests/tests_new/test_remote.py` — removed tests for deleted method

#### Test plan
- [x] `ruff check` + `ruff format` — all pass
- [x] `pytest` — 1208 passed, 10 skipped (1 pre-existing failure in `test_evo_control.py::test_namespace` from the ramses_rf `fix/843` DHW hydration branch, unrelated to this PR)
- [x] Live test on HASS: call `update_fan_params` with `device_id: "32:153289"` and verify the 15 parameter entities are created and populated

Requires: ramses_rf PR https://github.com/ramses-rf/ramses_rf/pull/870 (fix/851-fan-2411-routing) to be merged first — without the 2411 routing re-wire, `supports_2411` never becomes True and `create_parameter_entities` returns `[]`.

Refs: https://github.com/ramses-rf/ramses_cc/issues/851