### PR TITLE
feat: add device health tracking — orphaned/lost device review

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1446,6 +1446,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 "advanced_features",
                 "packet_log",
                 "review_discovered",
+                "review_device_health",
                 "clear_cache",
             ],
         )
@@ -1967,6 +1968,213 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="review_discovered",
+            data_schema=vol.Schema(form_fields),
+            description_placeholders={"message": summary},
+            last_step=True,
+        )
+
+    async def async_step_review_device_health(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Review devices that haven't been seen recently.
+
+        Shows orphaned devices (in schema but not seen by scan for >threshold)
+        and lost devices (ACCEPTED, not seen for >threshold).  The user can
+        keep (dismiss the flag) or remove (full cleanup via remove_device
+        service) each device individually.
+        """
+        self.get_options()
+
+        coordinators = self.hass.data.get(DOMAIN, {})
+        coordinator = None
+        for coord in coordinators.values():
+            if hasattr(coord, "discovery_manager"):
+                coordinator = coord
+                break
+
+        if not coordinator or not coordinator.discovery_manager:
+            return self.async_show_form(
+                step_id="review_device_health",
+                description_placeholders={
+                    "message": "Passive device scan is not enabled."
+                },
+                last_step=True,
+            )
+
+        from .discovery import DiscoveryStatus
+
+        # Run an immediate check so the flags are up to date
+        config_schema_check = self.options.get(CONF_SCHEMA, {})
+        if isinstance(config_schema_check, dict):
+            coordinator.discovery_manager.check_orphaned_devices(config_schema_check)
+            coordinator.discovery_manager.check_for_lost_devices()
+
+        orphaned_devices = coordinator.discovery_manager.get_orphaned_devices()
+        lost_devices = coordinator.discovery_manager.get_lost_devices()
+
+        # Deduplicate: a device could be both orphaned and lost — only
+        # show it once, prioritising LOST (more severe).
+        lost_ids = {e.device.device_id for e in lost_devices}
+        orphaned_only = [
+            e for e in orphaned_devices if e.device.device_id not in lost_ids
+        ]
+
+        if not orphaned_only and not lost_devices:
+            if user_input is not None:
+                return self._async_save()
+            return self.async_show_form(
+                step_id="review_device_health",
+                description_placeholders={"message": "No orphaned or lost devices."},
+                last_step=True,
+            )
+
+        if user_input is not None:
+            # Process each device — "keep" clears the flag, "remove" calls
+            # the remove_device service for full cleanup.
+            removed_any = False
+            for entry in lost_devices:
+                device_id = entry.device.device_id
+                action = user_input.get(f"lost_{device_id}", "keep")
+                if action == "remove":
+                    await self.hass.services.async_call(
+                        DOMAIN,
+                        "remove_device",
+                        {"device_id": device_id},
+                        blocking=True,
+                    )
+                    removed_any = True
+                    _LOGGER.info(
+                        "review_device_health: removed lost device %s",
+                        device_id,
+                    )
+                elif action == "keep":
+                    # Clear LOST status → back to ACCEPTED, clear orphaned
+                    meta = coordinator.discovery_manager._metadata.get(device_id)
+                    if meta:
+                        meta.status = DiscoveryStatus.ACCEPTED
+                        meta.orphaned = None
+
+            for entry in orphaned_only:
+                device_id = entry.device.device_id
+                action = user_input.get(f"orphaned_{device_id}", "keep")
+                if action == "remove":
+                    await self.hass.services.async_call(
+                        DOMAIN,
+                        "remove_device",
+                        {"device_id": device_id},
+                        blocking=True,
+                    )
+                    removed_any = True
+                    _LOGGER.info(
+                        "review_device_health: removed orphaned device %s",
+                        device_id,
+                    )
+                elif action == "keep":
+                    # Clear the orphaned flag — device is still there, just quiet
+                    meta = coordinator.discovery_manager._metadata.get(device_id)
+                    if meta:
+                        meta.orphaned = None
+
+            # Save discovery metadata to .storage via the coordinator's
+            # save cycle (export_state is called inside async_save_client_state)
+            await coordinator.async_save_client_state()
+
+            if removed_any:
+                # remove_device service already updated the config entry,
+                # so refresh self.options from the coordinator to avoid
+                # overwriting with stale data, then save normally
+                self.options = dict(coordinator.options)
+
+            return self._async_save()
+
+        # Build summary table
+        lines: list[str] = []
+        if lost_devices:
+            lines.append(
+                f"**{len(lost_devices)} lost device(s)** "
+                "(accepted but not seen for >7 days):\n"
+            )
+            lines.append("| Device | Type | Last seen | Status |")
+            lines.append("|--------|------|-----------|--------|")
+            for entry in lost_devices:
+                d = entry.device
+                last_seen = getattr(d, "last_seen", "—")
+                lines.append(
+                    f"| `{d.device_id}` | {d.likely_type or '?'} | {last_seen} | LOST |"
+                )
+
+        if orphaned_only:
+            if lines:
+                lines.append("\n")
+            lines.append(
+                f"**{len(orphaned_only)} orphaned device(s)** "
+                "(in schema but not seen recently):\n"
+            )
+            lines.append("| Device | Type | Last seen | Note |")
+            lines.append("|--------|------|-----------|------|")
+            for entry in orphaned_only:
+                d = entry.device
+                last_seen = getattr(d, "last_seen", "—")
+                note = entry.metadata.orphaned or ""
+                lines.append(
+                    f"| `{d.device_id}` | {d.likely_type or '?'} "
+                    f"| {last_seen} | {note} |"
+                )
+
+        if not lines:
+            lines.append("No orphaned or lost devices.")
+        summary = "\n".join(lines)
+
+        # Build form with per-device Keep/Remove selectors
+        form_fields: dict[Any, Any] = {}
+
+        for entry in lost_devices:
+            d = entry.device
+            device_id = d.device_id
+            last_seen = getattr(d, "last_seen", "—")
+            field_label = (
+                f"{device_id} | {d.likely_type or '?'} | last seen: {last_seen} | LOST"
+            )
+            form_fields[
+                vol.Required(
+                    f"lost_{device_id}",
+                    default="keep",
+                    description={"label": field_label},
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        {"value": "keep", "label": "Keep (dismiss flag)"},
+                        {"value": "remove", "label": "Remove device"},
+                    ],
+                )
+            )
+
+        for entry in orphaned_only:
+            d = entry.device
+            device_id = d.device_id
+            last_seen = getattr(d, "last_seen", "—")
+            field_label = (
+                f"{device_id} | {d.likely_type or '?'} | "
+                f"last seen: {last_seen} | orphaned"
+            )
+            form_fields[
+                vol.Required(
+                    f"orphaned_{device_id}",
+                    default="keep",
+                    description={"label": field_label},
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        {"value": "keep", "label": "Keep (dismiss flag)"},
+                        {"value": "remove", "label": "Remove device"},
+                    ],
+                )
+            )
+
+        return self.async_show_form(
+            step_id="review_device_health",
             data_schema=vol.Schema(form_fields),
             description_placeholders={"message": summary},
             last_step=True,

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -502,6 +502,39 @@ class DiscoveryManager:
                 result.append(entry)
         return result
 
+    def get_orphaned_devices(self) -> list[DiscoveredDeviceEntry]:
+        """Get devices that have an orphaned flag set.
+
+        These are schema devices that haven't been seen by the scan
+        engine for longer than the orphan threshold (default 7 days).
+        The ``review_device_health`` config flow step shows them so the
+        user can remove them if truly gone, or dismiss the flag if the
+        device is just quiet.
+
+        :return: List of device entries with orphaned set.
+        """
+        result: list[DiscoveredDeviceEntry] = []
+        for entry in self.get_devices():
+            if entry.metadata.orphaned:
+                result.append(entry)
+        return result
+
+    def get_lost_devices(self) -> list[DiscoveredDeviceEntry]:
+        """Get devices that have LOST status.
+
+        These are ACCEPTED devices that haven't been seen for the
+        configured threshold (default 7 days).  The
+        ``review_device_health`` config flow step shows them so the user
+        can remove them if truly gone.
+
+        :return: List of device entries with LOST status.
+        """
+        result: list[DiscoveredDeviceEntry] = []
+        for entry in self.get_devices():
+            if entry.metadata.status == DiscoveryStatus.LOST:
+                result.append(entry)
+        return result
+
     def check_bound_mismatches(self, schema: dict[str, Any]) -> int:
         """Check for _bound mismatches between scan engine and schema.
 

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -147,6 +147,7 @@
                     "advanced_features": "Advanced features",
                     "packet_log": "Packet log",
                     "review_discovered": "Review discovered devices",
+                    "review_device_health": "Review device health",
                     "clear_cache": "Clear cache"
                 }
             },
@@ -246,6 +247,11 @@
             },
             "review_discovered": {
                 "title": "Review discovered devices",
+                "description": "{message}",
+                "data": {}
+            },
+            "review_device_health": {
+                "title": "Review device health",
                 "description": "{message}",
                 "data": {}
             }

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -147,6 +147,7 @@
                     "advanced_features": "Geavanceerde opties",
                     "packet_log": "Packet-log",
                     "review_discovered": "Bekijk ontdekte apparaten",
+                    "review_device_health": "Bekijk device-status",
                     "clear_cache": "Cache beheren"
                 }
             },
@@ -246,6 +247,11 @@
             },
             "review_discovered": {
                 "title": "Bekijk ontdekte apparaten",
+                "description": "{message}",
+                "data": {}
+            },
+            "review_device_health": {
+                "title": "Bekijk device-status",
                 "description": "{message}",
                 "data": {}
             }

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -2840,3 +2840,287 @@ async def test_options_flow_schema_strips_commands_for_validation(
     data = result.get("data")
     assert data is not None
     assert SZ_TR_COMMANDS in data[CONF_SCHEMA].get("37:153001", {})
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Options flow: review_device_health step (orphaned/lost devices)
+# ───────────────────────────────────────────────────────────────────────
+
+
+async def test_review_device_health_no_coordinator(hass: HomeAssistant) -> None:
+    """Test review_device_health step when no coordinator with discovery_manager."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "review_device_health"
+    placeholders = result.get("description_placeholders", {})
+    assert "not enabled" in placeholders.get("message", "")
+
+
+async def test_review_device_health_no_manager(hass: HomeAssistant) -> None:
+    """Test review_device_health step when coordinator has no discovery_manager."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = None
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    placeholders = result.get("description_placeholders", {})
+    assert "not enabled" in placeholders.get("message", "")
+
+
+async def test_review_device_health_no_devices(hass: HomeAssistant) -> None:
+    """Test review_device_health step when there are no orphaned/lost devices."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_orphaned_devices.return_value = []
+    mock_coord.discovery_manager.get_lost_devices.return_value = []
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    placeholders = result.get("description_placeholders", {})
+    assert "No orphaned or lost" in placeholders.get("message", "")
+
+
+async def test_review_device_health_shows_form_with_lost(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_device_health step shows form with lost device selector."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "04:056053"
+    mock_entry.device.likely_type = "TRV"
+    mock_entry.device.last_seen = "2026-07-01T10:00:00"
+    mock_entry.metadata.status = MagicMock()
+    mock_entry.metadata.orphaned = "last seen 2026-07-01 (>7 days)"
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_lost_devices.return_value = [mock_entry]
+    mock_coord.discovery_manager.get_orphaned_devices.return_value = []
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "review_device_health"
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    schema_dict = data_schema.schema
+    field_names = {
+        str(k) if hasattr(k, "schema") else k for k, _ in schema_dict.items()
+    }
+    assert "lost_04:056053" in field_names
+    placeholders = result.get("description_placeholders", {})
+    assert "04:056053" in placeholders.get("message", "")
+    assert "LOST" in placeholders.get("message", "")
+
+
+async def test_review_device_health_shows_form_with_orphaned(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_device_health step shows form with orphaned device selector."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "01:123456"
+    mock_entry.device.likely_type = "CTL"
+    mock_entry.device.last_seen = "2026-07-10T12:00:00"
+    mock_entry.metadata.orphaned = "last seen 2026-07-10 (>7 days)"
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_lost_devices.return_value = []
+    mock_coord.discovery_manager.get_orphaned_devices.return_value = [mock_entry]
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+    schema_dict = data_schema.schema
+    field_names = {
+        str(k) if hasattr(k, "schema") else k for k, _ in schema_dict.items()
+    }
+    assert "orphaned_01:123456" in field_names
+    placeholders = result.get("description_placeholders", {})
+    assert "01:123456" in placeholders.get("message", "")
+    assert "orphaned" in placeholders.get("message", "")
+
+
+async def test_review_device_health_keep_clears_flag(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_device_health 'keep' action clears the orphaned flag."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_meta = MagicMock()
+    mock_meta.orphaned = "last seen 2026-07-01 (>7 days)"
+    mock_meta.status = MagicMock()
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "04:056053"
+    mock_entry.device.likely_type = "TRV"
+    mock_entry.device.last_seen = "2026-07-01T10:00:00"
+    mock_entry.metadata = mock_meta
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_lost_devices.return_value = []
+    mock_coord.discovery_manager.get_orphaned_devices.return_value = [mock_entry]
+    mock_coord.discovery_manager._metadata = {"04:056053": mock_meta}
+    mock_coord.async_save_client_state = AsyncMock()
+    mock_coord.options = {SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}}
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    # Navigate to review_device_health
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+
+    # Submit with "keep" action
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"orphaned_04:056053": "keep"},
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Verify the orphaned flag was cleared
+    assert mock_meta.orphaned is None
+    # Verify save was called
+    mock_coord.async_save_client_state.assert_awaited_once()
+
+
+async def test_review_device_health_remove_calls_service(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_device_health 'remove' action calls the remove_device service."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_meta = MagicMock()
+    mock_meta.orphaned = "last seen 2026-07-01 (>7 days)"
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "04:056053"
+    mock_entry.device.likely_type = "TRV"
+    mock_entry.device.last_seen = "2026-07-01T10:00:00"
+    mock_entry.metadata = mock_meta
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_lost_devices.return_value = []
+    mock_coord.discovery_manager.get_orphaned_devices.return_value = [mock_entry]
+    mock_coord.discovery_manager._metadata = {"04:056053": mock_meta}
+    mock_coord.async_save_client_state = AsyncMock()
+    mock_coord.options = {SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}}
+    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+
+    # Register a mock remove_device service so async_call works
+    remove_calls: list[dict[str, Any]] = []
+
+    async def _mock_remove_device(call: Any) -> None:
+        remove_calls.append(dict(call.data))
+
+    hass.services.async_register(DOMAIN, "remove_device", _mock_remove_device)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    # Navigate to review_device_health
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+
+    # Submit with "remove" action
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"orphaned_04:056053": "remove"},
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Verify the remove_device service was called with the right device_id
+    assert len(remove_calls) == 1
+    assert remove_calls[0] == {"device_id": "04:056053"}

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1999,3 +1999,86 @@ class TestSyncWithSchema:
         # or if it is, its status should not be REMOVED
         if "18:130236" in manager._metadata:
             assert manager._metadata["18:130236"].status != DiscoveryStatus.REMOVED
+
+
+class TestGetOrphanedDevices:
+    """Tests for DiscoveryManager.get_orphaned_devices."""
+
+    def test_returns_only_orphaned(self) -> None:
+        """Only devices with orphaned flag set are returned."""
+        dev1 = make_discovered_device("04:056053", "TRV")
+        dev2 = make_discovered_device("01:145038", "CTL")
+        scan = make_mock_scan([dev1, dev2])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager._metadata["04:056053"] = DeviceMetadata(
+            orphaned="last seen 2026-07-01 (>7 days)"
+        )
+        manager._metadata["01:145038"] = DeviceMetadata()
+
+        result = manager.get_orphaned_devices()
+        assert len(result) == 1
+        assert result[0].device.device_id == "04:056053"
+
+    def test_empty_when_no_orphaned(self) -> None:
+        """No orphaned flags → empty list."""
+        dev = make_discovered_device("04:056053", "TRV")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        result = manager.get_orphaned_devices()
+        assert result == []
+
+    def test_cleared_orphaned_not_returned(self) -> None:
+        """An orphaned flag that was cleared (set to None) is not returned."""
+        dev = make_discovered_device("04:056053", "TRV")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager._metadata["04:056053"] = DeviceMetadata(
+            orphaned="last seen 2026-07-01 (>7 days)"
+        )
+        manager._metadata["04:056053"].orphaned = None
+
+        result = manager.get_orphaned_devices()
+        assert result == []
+
+
+class TestGetLostDevices:
+    """Tests for DiscoveryManager.get_lost_devices."""
+
+    def test_returns_only_lost(self) -> None:
+        """Only devices with LOST status are returned."""
+        dev1 = make_discovered_device("04:056053", "TRV")
+        dev2 = make_discovered_device("01:145038", "CTL")
+        scan = make_mock_scan([dev1, dev2])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager._metadata["04:056053"] = DeviceMetadata(status=DiscoveryStatus.LOST)
+        manager._metadata["01:145038"] = DeviceMetadata(status=DiscoveryStatus.ACCEPTED)
+
+        result = manager.get_lost_devices()
+        assert len(result) == 1
+        assert result[0].device.device_id == "04:056053"
+
+    def test_empty_when_no_lost(self) -> None:
+        """No LOST devices → empty list."""
+        dev = make_discovered_device("04:056053", "TRV")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager._metadata["04:056053"] = DeviceMetadata(status=DiscoveryStatus.ACCEPTED)
+
+        result = manager.get_lost_devices()
+        assert result == []
+
+    def test_accepted_not_returned(self) -> None:
+        """ACCEPTED devices are not returned by get_lost_devices."""
+        dev = make_discovered_device("04:056053", "TRV")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager._metadata["04:056053"] = DeviceMetadata(status=DiscoveryStatus.ACCEPTED)
+
+        result = manager.get_lost_devices()
+        assert result == []


### PR DESCRIPTION
Add a new `review_device_health` config flow step that shows devices flagged as orphaned (in schema but not seen for >7 days) or lost (ACCEPTED but not seen for >7 days), with per-device Keep/Remove selectors.

- DiscoveryManager.get_orphaned_devices() returns devices with the orphaned flag set
- DiscoveryManager.get_lost_devices() returns devices with LOST status
- async_step_review_device_health displays both categories in a summary table and generates per-device selectors
- "Keep" clears the orphaned flag / resets status to ACCEPTED
- "Remove" calls the existing remove_device service for full cleanup
- Translations added for en.json and nl.json
- 13 new unit tests (7 config flow, 6 discovery manager)

Implements item 7 of issue #767.

