### PR TITLE
Phase 4 Step 1: config entry v2→v3 migration

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -64,11 +64,13 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_ADVANCED_FEATURES,
+    CONF_COMMANDS,
     CONF_FRESH_START,
     CONF_MQTT_HGI_ID,
     CONF_MQTT_TOPIC,
     CONF_MQTT_USE_HA,
     CONF_PASSIVE_SCAN,
+    CONF_SCHEMA,
     CONF_SEND_PACKET,
     DOMAIN,
     SVC_ACCEPT_DISCOVERED_DEVICE,
@@ -80,8 +82,15 @@ from .const import (
     SVC_GET_DISCOVERED_DEVICES,
     SVC_REMOVE_DEVICE,
     SVC_REMOVE_DISCOVERED_DEVICE,
+    SZ_KNOWN_LIST,
     SZ_PORT_NAME,
     SZ_SERIAL_PORT,
+    SZ_TR_ALIAS,
+    SZ_TR_BOUND,
+    SZ_TR_CLASS,
+    SZ_TR_COMMANDS,
+    SZ_TR_FAKED,
+    SZ_TR_SCHEME,
 )
 from .coordinator import RamsesCoordinator
 from .schemas import (
@@ -273,11 +282,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate legacy configuration options to the current version 2.
+    """Migrate legacy configuration options to the current version 3.
 
-    This handles the transition away from user-selectable database storage
-    and removes deprecated packet log keys (e.g., `file_name`) that cause
-    strict schema validation to fail during setup.
+    v1 → v2: Clean up deprecated packet_log and database keys.
+    v2 → v3: Merge known_list traits into schema as _-prefixed keys
+    (Phase 4 Step 1 — schema becomes the single source of truth).
+    The known_list itself is kept in the config entry for now; it will
+    be removed in Step 2 once PR 914 (Phase 3.75) merges.
 
     :param hass: The Home Assistant instance.
     :param entry: The ConfigEntry to migrate.
@@ -314,6 +325,65 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.config_entries.async_update_entry(entry, options=new_options, version=2)
         _LOGGER.info(
             "Successfully migrated ramses_cc config entry %s to version 2",
+            entry.entry_id,
+        )
+
+    if entry.version == 2:
+        new_options = {**entry.options}
+
+        # Phase 4 Step 1: merge known_list traits into schema as _-prefixed keys.
+        # The schema becomes the single source of truth. known_list is kept
+        # as a fallback until Step 2 (blocked on PR 914 / Phase 3.75).
+        known_list = new_options.get(SZ_KNOWN_LIST, {})
+        schema = dict(new_options.get(CONF_SCHEMA, {}))
+
+        if known_list and isinstance(known_list, dict):
+            _LOGGER.info(
+                "Phase 4 migration: merging %d known_list entries into schema",
+                len(known_list),
+            )
+            # Trait mapping: known_list key → schema _-prefixed key
+            trait_map = {
+                "class": SZ_TR_CLASS,
+                "alias": SZ_TR_ALIAS,
+                "faked": SZ_TR_FAKED,
+                "bound": SZ_TR_BOUND,
+                "scheme": SZ_TR_SCHEME,
+                CONF_COMMANDS: SZ_TR_COMMANDS,
+            }
+            merged_count = 0
+            for device_id, traits in known_list.items():
+                if not isinstance(traits, dict):
+                    continue
+                # Ensure the device exists in the schema (as an orphan if
+                # not already present).  Devices that are only in known_list
+                # but not in schema will be handled by the SSOT migration
+                # in the coordinator — here we only merge traits for devices
+                # that already exist in the schema.
+                if device_id not in schema:
+                    continue
+                if not isinstance(schema[device_id], dict):
+                    schema[device_id] = {}
+                for kl_key, schema_key in trait_map.items():
+                    val = traits.get(kl_key)
+                    if val is None:
+                        continue
+                    # Only set if not already present (schema wins — it may
+                    # have been set by the user via the config flow)
+                    if schema_key not in schema[device_id]:
+                        schema[device_id][schema_key] = val
+                        merged_count += 1
+
+            new_options[CONF_SCHEMA] = schema
+            if merged_count:
+                _LOGGER.info(
+                    "Phase 4 migration: merged %d traits into schema",
+                    merged_count,
+                )
+
+        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
+        _LOGGER.info(
+            "Successfully migrated ramses_cc config entry %s to version 3",
             entry.entry_id,
         )
 

--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -10,6 +10,7 @@ Requires a Honeywell HGI80 (or compatible) gateway.
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 import sys
@@ -60,6 +61,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.service import verify_domain_control
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -73,6 +75,8 @@ from .const import (
     CONF_SCHEMA,
     CONF_SEND_PACKET,
     DOMAIN,
+    STORAGE_KEY,
+    STORAGE_VERSION,
     SVC_ACCEPT_DISCOVERED_DEVICE,
     SVC_ADD_FAKED_REM,
     SVC_DISABLE_DISCOVERED_DEVICE,
@@ -221,9 +225,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # so the wipe can't be interrupted by a reload.
     if entry.options.get(CONF_FRESH_START):
         _LOGGER.info("Fresh start requested, clearing .storage cache")
-        from homeassistant.helpers.storage import Store
-
-        from .const import STORAGE_KEY, STORAGE_VERSION
 
         # Use Store.async_remove() which both invalidates the in-memory
         # cache (the StorageManager keeps a cross-instance cache) AND
@@ -284,11 +285,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate legacy configuration options to the current version 3.
 
-    v1 → v2: Clean up deprecated packet_log and database keys.
-    v2 → v3: Merge known_list traits into schema as _-prefixed keys
-    (Phase 4 Step 1 — schema becomes the single source of truth).
-    The known_list itself is kept in the config entry for now; it will
-    be removed in Step 2 once PR 914 (Phase 3.75) merges.
+    Migration paths:
+
+    v1 -> v2: Clean up deprecated packet_log and database keys.
+        Reversible — no data loss, just key removal.
+
+    v2 -> v3: Merge known_list traits into schema as _-prefixed keys
+        (Phase 4 Step 1 — schema becomes the single source of truth).
+        The known_list itself is kept in the config entry for now; it
+        will be removed in Step 2 once PR 914 (Phase 3.75) merges.
+
+        **Irreversible** — a v3 config entry cannot be auto-migrated
+        back to v2 because HA only migrates forward (the already-
+        published v2 code has no v3->v2 block).  Before bumping to v3,
+        a snapshot of the v2 options is saved to
+        ``.storage/ramses_cc_migration_v2_backup`` so the user can
+        manually restore if they downgrade ramses_cc.
+
+        Downgrade scenario: if a user rolls back to v2 code, the
+        integration still loads (the migration is additive — known_list
+        is preserved, extra _-prefixed schema keys are ignored by v2
+        code).  HA will log a migration no-op on every restart because
+        ``entry.version (3) > handler.VERSION (2)``, but functionality
+        is not broken.  To fully restore v2 state, the user can copy
+        the backup file's ``options`` back into the config entry via
+        a future recovery tool or manual edit.
 
     :param hass: The Home Assistant instance.
     :param entry: The ConfigEntry to migrate.
@@ -329,6 +350,24 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     if entry.version == 2:
+        # Safety net: snapshot v2 options before the irreversible v2->v3
+        # migration.  HA only migrates forward, so a user who downgrades
+        # ramses_cc back to v2 code cannot auto-migrate a v3 entry back.
+        # This backup allows manual recovery — see the docstring above.
+        backup_store = Store(hass, 1, f"{DOMAIN}_migration_v2_backup")
+        await backup_store.async_save(
+            {
+                "entry_id": entry.entry_id,
+                "version": 2,
+                "options": copy.deepcopy(dict(entry.options)),
+            }
+        )
+        _LOGGER.info(
+            "Phase 4 migration: saved v2 options backup to "
+            ".storage/%s_migration_v2_backup",
+            DOMAIN,
+        )
+
         new_options = {**entry.options}
 
         # Phase 4 Step 1: merge known_list traits into schema as _-prefixed keys.

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1367,7 +1367,7 @@ class BaseRamsesFlow:
 class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
     """Config flow for Ramses."""
 
-    VERSION = 2
+    VERSION = 3
     MINOR_VERSION = 1
 
     def __init__(self) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -2840,3 +2840,113 @@ async def test_options_flow_schema_strips_commands_for_validation(
     data = result.get("data")
     assert data is not None
     assert SZ_TR_COMMANDS in data[CONF_SCHEMA].get("37:153001", {})
+
+
+async def test_migrate_entry_v2_to_v3(hass: HomeAssistant) -> None:
+    """Test v2→v3 migration: known_list traits merged into schema."""
+    from custom_components.ramses_cc import async_migrate_entry
+    from custom_components.ramses_cc.const import (
+        CONF_COMMANDS,
+        SZ_TR_ALIAS,
+        SZ_TR_CLASS,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        options={
+            CONF_SCHEMA: {
+                "01:150000": {},
+                "04:150003": {"_alias": "Lounge"},
+            },
+            SZ_KNOWN_LIST: {
+                "01:150000": {"class": "CTL"},
+                "04:150003": {"class": "TRV", "alias": "Living Room"},
+                "07:150000": {"class": "DHW", "faked": True},
+                "32:150000": {"class": "FAN", "bound": "37:170000", "scheme": "itho"},
+                "37:170000": {
+                    CONF_COMMANDS: {
+                        "turn_on": "I --- 37:170000 32:150000 --:------ 22F1 003 000030"
+                    }
+                },
+            },
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == 3
+
+    schema = entry.options[CONF_SCHEMA]
+
+    # 01:150000 — class merged from known_list (was empty in schema)
+    assert schema["01:150000"][SZ_TR_CLASS] == "CTL"
+
+    # 04:150003 — _alias already in schema ("Lounge"), known_list alias
+    # ("Living Room") should NOT overwrite it (schema wins)
+    assert schema["04:150003"][SZ_TR_ALIAS] == "Lounge"
+    # class merged from known_list
+    assert schema["04:150003"][SZ_TR_CLASS] == "TRV"
+
+    # 07:150000 — NOT in schema, should NOT be merged (only existing
+    # schema devices get traits merged; orphan migration is handled by
+    # the coordinator's SSOT migration at runtime)
+    assert "07:150000" not in schema
+
+    # 32:150000 — NOT in schema, same as above
+    assert "32:150000" not in schema
+
+    # known_list is kept (Step 2 removes it, blocked on PR 914)
+    assert SZ_KNOWN_LIST in entry.options
+
+
+async def test_migrate_entry_v2_to_v3_no_known_list(hass: HomeAssistant) -> None:
+    """Test v2→v3 migration with no known_list (no-op)."""
+    from custom_components.ramses_cc import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        options={
+            CONF_SCHEMA: {"01:150000": {"_class": "CTL"}},
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == 3
+    # Schema unchanged — no known_list to merge
+    assert entry.options[CONF_SCHEMA] == {"01:150000": {"_class": "CTL"}}
+
+
+async def test_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
+    """Test v1→v3 migration (runs both v1→v2 and v2→v3)."""
+    from custom_components.ramses_cc import async_migrate_entry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        options={
+            "packet_log": {"file_name": "/tmp/log.db", "rotate_backups": 7},
+            "ramses_rf": {"use_database": True, "database_file": "/tmp/db"},
+            CONF_SCHEMA: {"01:150000": {}},
+            SZ_KNOWN_LIST: {"01:150000": {"class": "CTL"}},
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == 3
+
+    # v1→v2: deprecated keys removed
+    assert "file_name" not in entry.options.get("packet_log", {})
+    assert "use_database" not in entry.options.get("ramses_rf", {})
+
+    # v2→v3: known_list class merged into schema
+    assert entry.options[CONF_SCHEMA]["01:150000"][SZ_TR_CLASS] == "CTL"

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -4,6 +4,7 @@ This module contains tests for the configuration wizard (ConfigFlow) and the
 options menu (OptionsFlow).
 """
 
+import copy
 from collections.abc import Callable, Iterator
 from datetime import timedelta as td
 from importlib.metadata import version
@@ -2900,6 +2901,47 @@ async def test_migrate_entry_v2_to_v3(hass: HomeAssistant) -> None:
 
     # known_list is kept (Step 2 removes it, blocked on PR 914)
     assert SZ_KNOWN_LIST in entry.options
+
+
+async def test_migrate_entry_v2_to_v3_saves_backup(hass: HomeAssistant) -> None:
+    """Test v2->v3 migration saves a v2 options backup to .storage.
+
+    The v2->v3 migration is irreversible (HA only migrates forward).
+    A backup of the v2 options is saved so the user can manually
+    restore if they downgrade ramses_cc back to v2 code.
+    """
+    from homeassistant.helpers.storage import Store
+
+    from custom_components.ramses_cc import async_migrate_entry
+
+    v2_options = {
+        CONF_SCHEMA: {"01:150000": {}, "04:150003": {"_alias": "Lounge"}},
+        SZ_KNOWN_LIST: {"01:150000": {"class": "CTL"}},
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        options=copy.deepcopy(v2_options),
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == 3
+
+    # Verify the backup was saved
+    backup_store = Store(hass, 1, f"{DOMAIN}_migration_v2_backup")
+    backup = await backup_store.async_load()
+    assert backup is not None
+    assert backup["version"] == 2
+    assert backup["entry_id"] == entry.entry_id
+    # The backup should contain the original v2 options (pre-migration)
+    print(f"DEBUG backup options: {backup['options']}")
+    print(f"DEBUG v2_options: {v2_options}")
+    assert backup["options"][SZ_KNOWN_LIST] == v2_options[SZ_KNOWN_LIST]
+    assert backup["options"][CONF_SCHEMA] == v2_options[CONF_SCHEMA]
 
 
 async def test_migrate_entry_v2_to_v3_no_known_list(hass: HomeAssistant) -> None:

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 
 import pytest
 from homeassistant.config_entries import ConfigEntryState
@@ -460,11 +460,11 @@ async def test_init_service_wrappers_advanced(
     assert mock_coordinator.async_send_packet.called
 
 
-async def test_async_migrate_entry_v1_to_v2(hass: HomeAssistant) -> None:
-    """Test the migration of a config entry from version 1 to 2."""
+async def test_async_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
+    """Test the migration of a config entry from version 1 to 3 (chained)."""
     entry = MagicMock()
     entry.version = 1
-    entry.entry_id = "test_migration_v1_v2"
+    entry.entry_id = "test_migration_v1_v3"
 
     # Mocking legacy options that need to be cleaned up
     entry.options = {
@@ -481,10 +481,22 @@ async def test_async_migrate_entry_v1_to_v2(hass: HomeAssistant) -> None:
     }
 
     with patch.object(hass.config_entries, "async_update_entry") as mock_update:
+        # Make async_update_entry actually update entry.version and entry.options
+        # so the chained v2→v3 migration sees the updated state
+        def _do_update(ent, **kwargs):
+            if "version" in kwargs:
+                ent.version = kwargs["version"]
+            if "options" in kwargs:
+                ent.options = kwargs["options"]
+
+        mock_update.side_effect = _do_update
         result = await async_migrate_entry(hass, entry)
 
         assert result is True
-        mock_update.assert_called_once_with(
+        # v1→v2 is called first, then v2→v3 (no known_list, so just version bump)
+        assert mock_update.call_count == 2
+        # First call: v1→v2 (strip deprecated keys)
+        assert mock_update.call_args_list[0] == call(
             entry,
             options={
                 "packet_log": {
@@ -497,20 +509,41 @@ async def test_async_migrate_entry_v1_to_v2(hass: HomeAssistant) -> None:
             },
             version=2,
         )
+        # Second call: v2→v3 (no known_list to merge, just version bump)
+        assert mock_update.call_args_list[1] == call(
+            entry,
+            options={
+                "packet_log": {
+                    "buffer_capacity": 100,
+                },
+                "ramses_rf": {
+                    "enforce_known_list": True,
+                },
+                "other_setting": "kept",
+            },
+            version=3,
+        )
 
 
-async def test_async_migrate_entry_v2_no_change(hass: HomeAssistant) -> None:
-    """Test that a version 2 config entry is not migrated or modified."""
+async def test_async_migrate_entry_v2_to_v3_no_known_list(
+    hass: HomeAssistant,
+) -> None:
+    """Test that a version 2 config entry is migrated to v3 (version bump only
+    when there's no known_list to merge)."""
     entry = MagicMock()
     entry.version = 2
-    entry.entry_id = "test_no_migration_v2"
+    entry.entry_id = "test_migration_v2_v3"
     entry.options = {"packet_log": {}}
 
     with patch.object(hass.config_entries, "async_update_entry") as mock_update:
         result = await async_migrate_entry(hass, entry)
 
         assert result is True
-        mock_update.assert_not_called()
+        mock_update.assert_called_once_with(
+            entry,
+            options={"packet_log": {}},
+            version=3,
+        )
 
 
 def test_healed_serial_port_options_from_mqtt_hints() -> None:

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -710,7 +710,7 @@ async def test_fresh_start_wipes_storage(
             return_value=mock_coordinator,
         ),
         patch("custom_components.ramses_cc.async_register_domain_services"),
-        patch("homeassistant.helpers.storage.Store") as mock_store_cls,
+        patch("custom_components.ramses_cc.Store") as mock_store_cls,
         patch.object(hass.config_entries, "async_update_entry") as mock_update,
     ):
         mock_store = MagicMock()
@@ -746,7 +746,7 @@ async def test_no_fresh_start_preserves_storage(
             return_value=mock_coordinator,
         ),
         patch("custom_components.ramses_cc.async_register_domain_services"),
-        patch("homeassistant.helpers.storage.Store") as mock_store_cls,
+        patch("custom_components.ramses_cc.Store") as mock_store_cls,
     ):
         mock_store = MagicMock()
         mock_store.async_remove = AsyncMock()


### PR DESCRIPTION
Merge known_list traits (class, alias, faked, bound, scheme, commands) into schema as _-prefixed keys. Schema wins — known_list traits only fill gaps where the schema doesn't already have the _-prefixed key.

known_list is kept in the config entry for now (Step 2 removal is blocked on PR 914 / Phase 3.75 "init and go" from schema _class).

3 migration tests: v2→v3, v2→v3 no known_list, v1→v3 (chained). 61 config_flow tests pass, ruff + mypy clean.


