### PR TITLE
fix(services): migrate _adjust_sentinel_packet to CommandDTO position…

### DIFF
--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import copy
+import dataclasses
 import logging
 import re
 from typing import TYPE_CHECKING, Any, Final, cast
@@ -369,7 +370,7 @@ class RamsesServiceHandler:
 
         cmd = self._coordinator.client.create_cmd(**kwargs)
 
-        self._adjust_sentinel_packet(cmd)
+        cmd = self._adjust_sentinel_packet(cmd)
 
         try:
             await self._coordinator.client.async_send_cmd(cmd)
@@ -383,7 +384,7 @@ class RamsesServiceHandler:
 
         self._schedule_refresh_later()
 
-    def _adjust_sentinel_packet(self, cmd: CommandDTO) -> None:
+    def _adjust_sentinel_packet(self, cmd: CommandDTO) -> CommandDTO:
         """Fix address positioning for specific sentinel packets (18:000730)."""
         # HACK: to fix the device_id when GWY announcing.
         if not self._coordinator.client:
@@ -392,28 +393,25 @@ class RamsesServiceHandler:
             )
         hgi = self._coordinator.client.hgi
         if not hgi or not hgi.id:
-            return
+            return cmd
 
-        if cmd.src.id != "18:000730" or cmd.dst.id != hgi.id:
-            return
+        # CommandDTO uses positional addressing (addr1/addr2/addr3).
+        # addr1 is the source (from_id), addr2 is the destination.
+        if cmd.addr1 != "18:000730" or cmd.addr2 != hgi.id:
+            return cmd
 
         try:
-            # Validate if the current address structure is acceptable without slicing
-            addr1 = cmd._addrs[1].id if len(cmd._addrs) > 1 else "--:------"
-            addr2 = cmd._addrs[2].id if len(cmd._addrs) > 2 else "--:------"
-
-            pkt_addrs(f"{hgi.id} {addr1} {addr2}")
+            # Validate if the current address structure is acceptable
+            pkt_addrs(f"{hgi.id} {cmd.addr2} {cmd.addr3}")
         except PacketAddrSetInvalid:
-            # If invalid, swap addr1 and addr2 to correct the structure safely
-            if isinstance(cmd._addrs, list):
-                cmd._addrs[1], cmd._addrs[2] = cmd._addrs[2], cmd._addrs[1]
-            else:
-                cmd._addrs = (cmd._addrs[0], cmd._addrs[2], cmd._addrs[1])
-
-            cast(Any, cmd)._repr = None  # Invalidate cached representation
+            # If invalid, swap addr2 and addr3 to correct the structure.
+            # CommandDTO is frozen, so use dataclasses.replace.
+            cmd = dataclasses.replace(cmd, addr2=cmd.addr3, addr3=cmd.addr2)
             _LOGGER.debug(
                 "Swapped addresses for sentinel packet 18:000730 to maintain protocol validity"
             )
+
+        return cmd
 
     async def async_get_fan_param(self, call: dict[str, Any] | ServiceCall) -> None:
         """Handle 'get_fan_param' service call.

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -57,6 +57,7 @@ from ramses_rf.schemas import (
 from ramses_rf.systems import System, Zone
 from ramses_rf.topology import Child
 from ramses_tx.const import DevType
+from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     PacketAddrSetInvalid,
     ProtocolSendFailed,
@@ -192,22 +193,21 @@ def test_adjust_sentinel_packet_swaps_on_invalid() -> None:
 
     handler = RamsesServiceHandler(coordinator)
 
-    cmd = MagicMock()
-    cmd.src.id = SENTINEL_ID
-    cmd.dst.id = HGI_ID
-    cmd._frame = "X" * 40
-
-    m0, m1, m2 = MagicMock(), MagicMock(), MagicMock()
-    m0.id, m1.id, m2.id = "addr0", "addr1", "addr2"
-    cmd._addrs = [m0, m1, m2]
+    cmd = CommandDTO(
+        verb=" I",
+        addr1=SENTINEL_ID,
+        addr2=HGI_ID,
+        addr3="--:------",
+        code="1F09",
+        payload="FF",
+    )
 
     with patch("custom_components.ramses_cc.services.pkt_addrs") as mock_validate:
         mock_validate.side_effect = PacketAddrSetInvalid("Invalid structure")
-        handler._adjust_sentinel_packet(cmd)
+        result = handler._adjust_sentinel_packet(cmd)
 
-        assert cmd._addrs[1].id == "addr2"
-        assert cmd._addrs[2].id == "addr1"
-        assert cmd._repr is None
+        assert result.addr2 == "--:------"
+        assert result.addr3 == HGI_ID
 
 
 def test_adjust_sentinel_packet_no_swap_on_valid() -> None:
@@ -218,18 +218,20 @@ def test_adjust_sentinel_packet_no_swap_on_valid() -> None:
 
     handler = RamsesServiceHandler(coordinator)
 
-    cmd = MagicMock()
-    cmd.src.id = SENTINEL_ID
-    cmd.dst.id = HGI_ID
-
-    m0, m1, m2 = MagicMock(), MagicMock(), MagicMock()
-    m0.id, m1.id, m2.id = "addr0", "addr1", "addr2"
-    cmd._addrs = [m0, m1, m2]
+    cmd = CommandDTO(
+        verb=" I",
+        addr1=SENTINEL_ID,
+        addr2=HGI_ID,
+        addr3="--:------",
+        code="1F09",
+        payload="FF",
+    )
 
     with patch("custom_components.ramses_cc.services.pkt_addrs") as mock_validate:
         mock_validate.return_value = True
-        handler._adjust_sentinel_packet(cmd)
-        assert cmd._addrs[1].id == "addr1"
+        result = handler._adjust_sentinel_packet(cmd)
+        assert result.addr2 == HGI_ID
+        assert result.addr3 == "--:------"
 
 
 def test_adjust_sentinel_packet_ignores_other_devices() -> None:
@@ -239,17 +241,19 @@ def test_adjust_sentinel_packet_ignores_other_devices() -> None:
     mock_client.hgi.id = HGI_ID
     handler = RamsesServiceHandler(coordinator)
 
-    cmd = MagicMock()
-    cmd.src.id = "01:123456"  # Not sentinel
+    cmd = CommandDTO(
+        verb=" I",
+        addr1="01:123456",  # Not sentinel
+        addr2=HGI_ID,
+        addr3="--:------",
+        code="30C9",
+        payload="000834",
+    )
 
-    m0, m1, m2 = MagicMock(), MagicMock(), MagicMock()
-    m0.id, m1.id, m2.id = "addr0", "addr1", "addr2"
-    cmd._addrs = [m0, m1, m2]
-
-    handler._adjust_sentinel_packet(cmd)
-    assert cmd._addrs[0].id == "addr0"
-    assert cmd._addrs[1].id == "addr1"
-    assert cmd._addrs[2].id == "addr2"
+    result = handler._adjust_sentinel_packet(cmd)
+    assert result.addr1 == "01:123456"
+    assert result.addr2 == HGI_ID
+    assert result.addr3 == "--:------"
 
 
 def test_get_param_id_validation(mock_coordinator: RamsesCoordinator) -> None:
@@ -956,18 +960,24 @@ async def test_update_device_via_device_logic(
 async def test_adjust_sentinel_packet_early_return(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Test _adjust_sentinel_packet returns early if src/dst don't match."""
+    """Test _adjust_sentinel_packet returns early if addr1/addr2 don't match."""
     handler = RamsesServiceHandler(mock_coordinator)
 
     mock_client = cast(Any, mock_coordinator.client)
     mock_client.hgi.id = "18:006402"
-    cmd = MagicMock()
-    cmd.src.id = "18:999999"  # Not sentinel
-    cmd.dst.id = "01:000000"  # Not HGI
+    cmd = CommandDTO(
+        verb=" I",
+        addr1="18:999999",  # Not sentinel
+        addr2="01:000000",  # Not HGI
+        addr3="--:------",
+        code="30C9",
+        payload="000834",
+    )
 
     with patch("custom_components.ramses_cc.services.pkt_addrs") as mock_pkt_addrs:
-        handler._adjust_sentinel_packet(cmd)
+        result = handler._adjust_sentinel_packet(cmd)
         mock_pkt_addrs.assert_not_called()
+        assert result is cmd  # unchanged
 
 
 async def test_find_param_entity_missing_in_platform(


### PR DESCRIPTION
…al addressing

The CommandDTO migration (PR 853) replaced src/dst (Address objects with .id) with addr1/addr2/addr3 (plain strings), and made the dataclass frozen.  _adjust_sentinel_packet still used cmd.src.id/cmd.dst.id and mutated cmd._addrs in place, causing AttributeError on every send_packet call.

Fix: use cmd.addr1/cmd.addr2 for the sentinel check, and dataclasses.replace() to create a new CommandDTO with swapped addr2/addr3 when validation fails.  _adjust_sentinel_packet now returns the (possibly modified) CommandDTO instead of mutating in place.

Tests updated to use real CommandDTO objects instead of MagicMock with the old src/dst/_addrs API.

see 
https://github.com/ramses-rf/ramses_cc/issues/864
AI used: GLM 5.2 high