### PR TITLE
Bump version, dep to 0.59.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Notice: our Wiki [Config System Schema](https://github.com/ramses-rf/ramses_cc/wiki/2.1-Configuration-step-3:-Schemas) explains the new Config Schema Discovery tool.
 
-Requires HA Core 2026.5.0 or later. Uses config format V2 since 0.56.3.
+Requires HA Core 2026.5.0 or later. Uses config format V2 since 0.56.3 up to 0.59.1.
 
 ## Overview
 **ramses_cc** is a Home Assistant custom integration that works with RAMSES II-based RF 868 Mhz systems for (heating) **CH/DHW** (e.g. Honeywell Evohome) and (ventilation) **HVAC** (e.g. Itho Spider, Orcon).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 ![pytest](https://github.com/ramses-rf/ramses_cc/actions/workflows/check-test.yml/badge.svg?master)
 [![Coverage](https://github.com/ramses-rf/ramses_cc/actions/workflows/check-cov.yml/badge.svg?event=push)](https://github.com/ramses-rf/ramses_cc/actions/workflows/check-cov.yml)
 
+This is a pre-release with many changes in the ramses_rf library and a new v3 format for the Config schema.
+So backup before updating!
+
 Notice: our Wiki [Config System Schema](https://github.com/ramses-rf/ramses_cc/wiki/2.1-Configuration-step-3:-Schemas) explains the new Config Schema Discovery tool.
 
 Requires HA Core 2026.5.0 or later. Uses config format V2 since 0.56.3 up to 0.59.1.

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -14,9 +14,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.59.0",
+      "ramses-rf==0.59.1",
       "serialx>=1.6.0"
     ],
     "single_config_entry": true,
-    "version": "0.59.0"
+    "version": "0.59.1"
   }

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
   aioesphomeapi         >= 45.6.2                # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.59.0                # as per: manifest.json latest:
+  ramses-rf             == 0.59.1                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.8.2                 # required by config_flow > homeassistant.components.usb, see issue #623


### PR DESCRIPTION
On hold for two fixes (in ramses_rf):
- Evohome DHW Conversation timeout, reported in #873
- ConversationManager crossmatchrisk reported in https://github.com/ramses-rf/ramses_rf/issues/934

Assigned to @PWhite-Eng, no due date