### PR TITLE
docs: update CONTRIBUTING.md, add LLM_INSTRUCTIONS.md, and update project URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,7 @@
 
 #### **Did you find a bug?**
 
-* **Do not open up a GitHub issue if the bug is a security vulnerability
-  in ramses_cc** or the ramses_rf backend, and instead refer to our [security policy](SECURITY).
+* **Do not open up a GitHub issue if the bug is a security vulnerability in ramses_cc** or the `ramses_rf` backend, and instead refer to our [security policy](SECURITY).
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/ramses-rf/ramses_cc/issues).
 
@@ -18,11 +17,11 @@
 
 * Open a new GitHub pull request with the patch.
 
-* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+* Ensure the PR description clearly describes the problem and solution. Include relevant issue number(s), if applicable. (e.g. `ramses_cc#123` or cross-repo `ramses-rf/ramses_rf#456`).
 
 * Before submitting, please read the [Contributing to Ramses RF](https://github.com/ramses-rf/ramses_cc/wiki/7.-How-to-submit-a-PR) guide to know more about coding conventions and benchmarks.
 
-* Include a pytest to demonstrate you change works, and to keep it working in the future.
+* Include a pytest to demonstrate your change works and prevent regressions.
 
 #### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
 
@@ -41,6 +40,42 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 #### **Do you want to contribute to the Ramses RF documentation?**
 
 * Please read [The Ramses RF Dev Wiki](https://github.com/ramses-rf/ramses_rf/wiki).
+
+---
+
+## Coding & Development Standards
+
+All contributions (whether written by human contributors or generated via AI coding assistants) must strictly adhere to the following standards:
+
+### 1. Code Style & Conventions
+* **Line Constraints**: PEP 8 compliance (code ≤ 79 characters, docstrings/comments ≤ 72 characters).
+* **EXEMPTION (Raw Data)**: Raw RF packets, hex strings, routing dictionaries, and timestamped packet logs are strictly exempt from line limits to preserve readability and grep-ability.
+* **String Literals**: Prefer double quotes (`"`) for all string literals.
+
+### 2. Typing & Type Safety
+* **Strict Type Safety**: 100% compliance with `mypy`. Do not introduce untyped definitions (`Any`) without strong technical justification.
+* **Domain Types**: Prefer domain-specific types (`Address`, `DeviceIdT`, dataclasses, enums) over primitive `str` or `dict`.
+* **Python Syntax**: Use modern Python 3.13+ syntax:
+  * Use `|` for unions (e.g., `str | int`).
+  * Use native collection types (e.g., `list[int]`, `dict[str, Any]`).
+  * **Banned Imports**: Do not import `List`, `Dict`, `Set`, `Tuple`, `Optional`, or `Union` from `typing`.
+
+### 3. Code Quality & Modularity
+* **Immutability & State**: Treat data objects as immutable where possible. Avoid unnecessary state mutations and return new instances instead.
+* **Context Managers**: Avoid nested `with` statements. Use parenthetical multi-context syntax (`with (A(), B()):`).
+* **Imports**: Place imports at module level (top of file). Combine imports from the same module onto a single line (`combine-as-imports = true`).
+
+### 4. Documentation & Comments
+* **Public APIs**: Require full Sphinx-style docstrings (summary, detailed explanation, `:param:`, `:type:`, `:returns:`, `:rtype:`).
+* **Private Helpers**: Concise, single-line summaries are preferred for internal helpers (`_helper`).
+* **Preserve Inline Comments**: Treat existing comments, `#TODO`, `#FIXME`, and `#HACK` markers as locked anchors. Multi-line wrap comments rather than truncating text.
+
+### 5. Testing & Verification
+* **Test Structure**: Exempt from Sphinx docstrings. Use descriptive test names following the **Arrange, Act, Assert (AAA)** pattern with inline comments.
+* **Snapshot Policy**: Regression snapshots (`.ambr` files) are treated as source code. Never run `--snapshot-update` blindly. If output changes, document in the PR whether it is a bug fix or feature improvement.
+* **Tooling**: Verify changes locally using `.venv/bin/prek run -a`, `.venv/bin/ruff check .`, `.venv/bin/mypy`, and `.venv/bin/pytest`.
+
+---
 
 Ramses RF is a volunteer effort. We encourage you to pitch in and join us!
 

--- a/LLM_INSTRUCTIONS.md
+++ b/LLM_INSTRUCTIONS.md
@@ -1,0 +1,21 @@
+# AI Agent Instructions and Guidelines for ramses_cc
+
+This file contains behavioral rules and guardrails for any AI agent or LLM working on the `ramses_cc` codebase.
+
+For all general coding, typing, docstring, and architectural standards, you **must strictly adhere** to [CONTRIBUTING.md](https://github.com/ramses-rf/ramses_cc/blob/master/CONTRIBUTING.md).
+
+## 1. Identity, Tone & Behavior
+
+* **Professional Tone**: Keep feedback, PR titles, and PR descriptions professional, objective, and concise. Avoid marketing-style hype or aggressive terminology (e.g. avoid words like "lobotomy", "purge", "nuke", "eradicate").
+* **No Advertising**: Never add signatures like "co-authored by Devin" or promote AI tools in commits, comments, code, or PR descriptions.
+* **Wait for Approval**: Do not automatically commit or push code unless explicitly instructed by the user.
+* **Must Pass Tests**: Ensure all linter checks (`prek`, `ruff`, `mypy`) and test suites (`pytest`) pass cleanly before declaring success.
+* **PR Description Framing**: Keep PR titles and descriptions lean, factual, and scaled to the complexity of the change. Avoid AI-generated lengthy risk analyses or hypothetical scenarios.
+
+## 2. Code Modification Guardrails
+
+* **Surgical Precision**: Modify only lines strictly necessary to complete the task. Do not perform unrequested "general cleanup" on legacy code.
+* **Comment Preservation**: Treat existing inline comments, `#TODO`, `#FIXME`, and `#HACK` markers as sacred anchors. Git relies on line stability; preserving comments preserves history.
+* **Wrap, Don't Hack**: When wrapping long comments or docstrings, never truncate sentences or strip English determiners/words to force line limits. Use standard multi-line wrapping.
+* **Tooling Execution**: Use project virtual environment binaries (e.g., `.venv/bin/pytest`, `.venv/bin/prek run -a`). Do not invent custom runner scripts or bypass existing quality checks.
+* **Cross-Repository References**: Fully qualify cross-repository issue and PR references (e.g., `ramses-rf/ramses_cc#123`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,13 @@
     "Programming Language :: Python :: 3.14",
   ]
   requires-python = ">=3.14.2"        # HA core >=3.14.2
+
+#
+[project.urls]
+  "Homepage" = "https://github.com/ramses-rf/ramses_cc"
+  "Bug Tracker" = "https://github.com/ramses-rf/ramses_cc/issues"
+  "Wiki" = "https://github.com/ramses-rf/ramses_rf/wiki"
+  "Contributing" = "https://github.com/ramses-rf/ramses_cc/blob/master/CONTRIBUTING.md"
 #
 ### pytest ###########################################################################
 


### PR DESCRIPTION
### The Problem:
As discussed in ramses-rf/ramses_rf#887, coding standards and AI contributor guidelines were fragmented and needed clear separation between developer standards and AI agent guardrails.

### The Fix:
- Consolidated all developer coding standards (PEP 8, strict typing, Sphinx docstrings, AAA testing, snapshot policy) in `CONTRIBUTING.md`.
- Added `LLM_INSTRUCTIONS.md` containing behavioral guidelines, tone rules, and guardrails for AI coding assistants.
- Updated `[project.urls]` in `pyproject.toml` to include the `Contributing` document link.

### Testing Performed:
- Verified `pyproject.toml` syntax with `ruff check`.
- Verified pre-commit hooks passed cleanly (`prek run -a`).
- Verified test suite passes cleanly (`pytest`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.