### PR TITLE
refactor(schema): address Phase 4 config migration follow-ups and tech debt

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -117,6 +117,7 @@ from .schemas import (
     SVCS_RAMSES_REMOTE,
     SVCS_RAMSES_SENSOR,
     SVCS_RAMSES_WATER_HEATER,
+    migrate_known_list_traits,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -359,43 +360,12 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if known_list and isinstance(known_list, dict):
             schema = new_options.get("schema", {})
             if isinstance(schema, dict):
-                schema = dict(schema)
-                trait_map = {
-                    "class": "_class",
-                    "faked": "_faked",
-                    "bound": "_bound",
-                    "scheme": "_scheme",
-                    "alias": "_alias",
-                }
-                migrated = 0
-                created = 0
-                for dev_id, kl_entry in known_list.items():
-                    if not isinstance(kl_entry, dict) or not kl_entry:
-                        # Empty trait dict — still need the device ID in
-                        # schema so enforce_known_list allows it through.
-                        if dev_id not in schema:
-                            schema[dev_id] = {}
-                            created += 1
-                        continue
-                    entry_obj = schema.get(dev_id)
-                    if not isinstance(entry_obj, dict):
-                        # Device not in schema — create entry with traits
-                        entry_obj = {}
-                        schema[dev_id] = entry_obj
-                        created += 1
-                    for kl_key, schema_key in trait_map.items():
-                        if kl_key in kl_entry and schema_key not in entry_obj:
-                            entry_obj[schema_key] = kl_entry[kl_key]
-                            migrated += 1
-                new_options["schema"] = schema
-                if migrated or created:
-                    _LOGGER.info(
-                        "Phase 4 migration: merged %d trait(s), created %d "
-                        "schema entr(y/ies) from known_list for config entry %s",
-                        migrated,
-                        created,
-                        entry.entry_id,
-                    )
+                new_options["schema"] = migrate_known_list_traits(schema, known_list)
+                _LOGGER.info(
+                    "Phase 4 migration: merged known_list traits into schema "
+                    "for config entry %s",
+                    entry.entry_id,
+                )
 
         # Remove enforce_known_list from ramses_rf sub-dict — it is now
         # always-on (hardcoded in coordinator._create_client).
@@ -438,31 +408,7 @@ def _cleanup_stale_known_list(hass: HomeAssistant, entry: ConfigEntry) -> None:
         if known_list and isinstance(known_list, dict):
             schema = new_options.get("schema", {})
             if isinstance(schema, dict):
-                schema = dict(schema)
-                trait_map = {
-                    "class": "_class",
-                    "alias": "_alias",
-                    "faked": "_faked",
-                    "bound": "_bound",
-                    "scheme": "_scheme",
-                }
-                for dev_id, kl_entry in known_list.items():
-                    if not isinstance(kl_entry, dict) or not kl_entry:
-                        # Empty/non-dict trait entry — still need the device
-                        # ID in schema so enforce_known_list allows it
-                        # through (aligned with async_migrate_entry).
-                        if dev_id not in schema:
-                            schema[dev_id] = {}
-                        continue
-                    existing = schema.get(dev_id, {})
-                    if not isinstance(existing, dict):
-                        existing = {}
-                    merged = dict(existing)
-                    for kl_key, schema_key in trait_map.items():
-                        if kl_key in kl_entry and schema_key not in merged:
-                            merged[schema_key] = kl_entry[kl_key]
-                    schema[dev_id] = merged
-                new_options["schema"] = schema
+                new_options["schema"] = migrate_known_list_traits(schema, known_list)
         changed = True
 
     ramses_rf = new_options.get("ramses_rf", {})

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1142,7 +1142,6 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
             # Priority (highest first):
             #   a. FAN's schema _commands (Phase 3b — dict templates)
             #   b. Bound REM's schema _commands (Phase 3a — packet strings)
-            #   c. known_list[bound_rem][commands] (legacy fallback)
             remotes = getattr(self.coordinator, "_remotes", {}) or {}
             if not isinstance(remotes, dict):
                 remotes = {}

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -76,7 +76,7 @@ from .const import (
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
 )
-from .schemas import order_schema
+from .schemas import migrate_known_list_traits, order_schema
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1389,27 +1389,9 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         if known_list and isinstance(known_list, dict):
             schema = self.options.get(CONF_SCHEMA, {})
             if isinstance(schema, dict):
-                schema = dict(schema)
-                trait_map = {
-                    "class": "_class",
-                    "faked": "_faked",
-                    "bound": "_bound",
-                    "scheme": "_scheme",
-                    "alias": "_alias",
-                }
-                for dev_id, kl_entry in known_list.items():
-                    if not isinstance(kl_entry, dict) or not kl_entry:
-                        if dev_id not in schema:
-                            schema[dev_id] = {}
-                        continue
-                    entry_obj = schema.get(dev_id)
-                    if not isinstance(entry_obj, dict):
-                        entry_obj = {}
-                        schema[dev_id] = entry_obj
-                    for kl_key, schema_key in trait_map.items():
-                        if kl_key in kl_entry and schema_key not in entry_obj:
-                            entry_obj[schema_key] = kl_entry[kl_key]
-                self.options[CONF_SCHEMA] = schema
+                self.options[CONF_SCHEMA] = migrate_known_list_traits(
+                    schema, known_list
+                )
 
         # Remove enforce_known_list from ramses_rf — always-on now.
         if isinstance(self.options.get(CONF_RAMSES_RF), dict):

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1038,6 +1038,47 @@ _VALID_ZONE_ACTUATOR_RE = re.compile(r"^[0-9]{2}:[0-9]{6}$")
 _VALID_ZONE_IDX_RE = re.compile(r"^0[0-9AB]$")
 
 
+def migrate_known_list_traits(
+    schema: dict[str, Any], known_list: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge legacy known_list traits into schema entries.
+
+    Iterates through the legacy known_list entries and transfers trait
+    attributes (_class, _faked, _bound, _scheme, _alias) into the
+    corresponding schema entry dictionaries.
+
+    :param schema: Target schema dictionary to update.
+    :type schema: dict[str, Any]
+    :param known_list: Source legacy known_list dictionary.
+    :type known_list: dict[str, Any]
+    :returns: Enriched schema dictionary containing merged traits.
+    :rtype: dict[str, Any]
+    """
+    new_schema = dict(schema) if isinstance(schema, dict) else {}
+
+    trait_map = {
+        "class": "_class",
+        "faked": "_faked",
+        "bound": "_bound",
+        "scheme": "_scheme",
+        "alias": "_alias",
+    }
+    for dev_id, kl_entry in known_list.items():
+        if not isinstance(kl_entry, dict) or not kl_entry:
+            if dev_id not in new_schema:
+                new_schema[dev_id] = {}
+            continue
+        entry_obj = new_schema.get(dev_id)
+        if not isinstance(entry_obj, dict):
+            entry_obj = {}
+            new_schema[dev_id] = entry_obj
+        for kl_key, schema_key in trait_map.items():
+            if kl_key in kl_entry and schema_key not in entry_obj:
+                entry_obj[schema_key] = kl_entry[kl_key]
+
+    return new_schema
+
+
 def sync_learned_topology(
     config_schema: _SchemaT,
     learned_schema: _SchemaT,
@@ -1842,6 +1883,8 @@ def sync_learned_topology(
         for device_id, comment in device_comments.items():
             if not isinstance(comment, str) or not device_id.startswith("37:"):
                 continue
+            if device_id in _removed:
+                continue
             fan_id = _parse_bound_tcs_from_comment(comment)
             if not fan_id or not fan_id.startswith("32:"):
                 continue
@@ -1874,6 +1917,8 @@ def sync_learned_topology(
         bound_rem = fan_entry.get("_bound")
         if not isinstance(bound_rem, str) or not bound_rem.startswith("37:"):
             continue  # _bound should be a REM device ID
+        if bound_rem in _removed:
+            continue
         # Add REM to FAN's remotes[] list if not already present
         remotes = fan_entry.get(SZ_REMOTES)
         if not isinstance(remotes, list):
@@ -1948,6 +1993,7 @@ def sync_learned_topology(
         all_learned_zone_devices.update(comment_device_zones.keys())
 
         to_remove = config_heat_orphans & all_learned_zone_devices
+        to_remove |= config_heat_orphans & _removed
         # Also remove HGI gateways (18:) — they are not heating devices
         to_remove |= {
             d for d in config_heat_orphans if isinstance(d, str) and d.startswith("18:")
@@ -2160,6 +2206,7 @@ def sync_learned_topology(
                 if list_key in val and isinstance(val[list_key], list):
                     all_hvac_entry_devices.update(val[list_key])
         to_remove = config_hvac_orphans & all_hvac_entry_devices
+        to_remove |= config_hvac_orphans & _removed
         # Also remove HGI gateways (18:) — they are not HVAC devices
         to_remove |= {
             d for d in config_hvac_orphans if isinstance(d, str) and d.startswith("18:")

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -3222,3 +3222,72 @@ async def test_review_device_health_remove_calls_service(
     # Verify the remove_device service was called with the right device_id
     assert len(remove_calls) == 1
     assert remove_calls[0] == {"device_id": "04:056053"}
+
+
+async def test_cleanup_stale_known_list_empty_or_non_dict_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test _cleanup_stale_known_list aligns empty entries with schema."""
+    # Arrange
+    from custom_components.ramses_cc import _cleanup_stale_known_list
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        options={
+            "known_list": {
+                "04:123456": {},
+                "04:654321": None,
+            },
+            "schema": {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    # Act
+    _cleanup_stale_known_list(hass, config_entry)
+
+    # Assert
+    schema = config_entry.options["schema"]
+    assert "04:123456" in schema
+    assert schema["04:123456"] == {}
+    assert "04:654321" in schema
+    assert schema["04:654321"] == {}
+
+
+async def test_chained_config_entry_migration_v1_to_v3(
+    hass: HomeAssistant,
+) -> None:
+    """Test chained config entry migration from v1 to v3."""
+    # Arrange
+    from custom_components.ramses_cc import async_migrate_entry
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        options={
+            "packet_log": {"file_name": "log.txt", "rotate_backups": 7},
+            "ramses_rf": {
+                "use_database": True,
+                "database_file": "db.json",
+                "enforce_known_list": True,
+            },
+            "known_list": {"04:123456": {"class": "TRV"}},
+            "schema": {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    # Act
+    result = await async_migrate_entry(hass, config_entry)
+
+    # Assert
+    assert result is True
+    assert config_entry.version == 3
+    assert "file_name" not in config_entry.options.get("packet_log", {})
+    assert (
+        config_entry.options.get("packet_log", {}).get("packet_log_retention_days") == 7
+    )
+    assert "use_database" not in config_entry.options.get("ramses_rf", {})
+    assert "known_list" not in config_entry.options
+    assert config_entry.options["schema"]["04:123456"] == {"_class": "TRV"}

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -3099,3 +3099,30 @@ def test_order_schema_hvac_devices_sorted_by_owner_then_id() -> None:
     keys = list(result.keys())
     # No-owner first, then "me" group, then "not-me" group
     assert keys == ["18:444444", "29:333333", "37:111111", "32:222222"]
+
+
+def test_migrate_known_list_traits_empty_and_populated() -> None:
+    """Test migrate_known_list_traits with empty and populated schema entries."""
+    from custom_components.ramses_cc.schemas import migrate_known_list_traits
+
+    schema: dict[str, Any] = {
+        "04:111111": {"_class": "TRV"},
+    }
+    known_list: dict[str, Any] = {
+        "04:111111": {"alias": "Living Room", "class": "BAD_OVERWRITE"},
+        "04:222222": {"class": "TRV", "faked": True},
+        "04:333333": {},
+    }
+
+    result = migrate_known_list_traits(schema, known_list)
+
+    # Existing trait _class is NOT overwritten, but _alias is added
+    assert result["04:111111"]["_class"] == "TRV"
+    assert result["04:111111"]["_alias"] == "Living Room"
+
+    # New device created with traits
+    assert result["04:222222"]["_class"] == "TRV"
+    assert result["04:222222"]["_faked"] is True
+
+    # Empty known_list entry creates empty schema entry
+    assert result["04:333333"] == {}


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #882 (supersedes #870)

### The Problem:
Following the Phase 4 known-list removal refactor in PR ramses-rf/ramses_cc#882 (which supersedes #870), several minor technical debt items, edge-case filtering gaps, and duplicate logic blocks were identified (tracked in #880):
1. In-session device removals (`_removed_devices`) were not filtered in `orphans_heat` and `orphans_hvac` topology sync paths.
2. Trait migration logic for legacy `known_list` was duplicated across `__init__.py` and `config_flow.py`.
3. Stale docstring comment in `climate.py` referenced deleted `known_list` fallback.
4. Test gaps for `_cleanup_stale_known_list` edge cases and chained v1→v3 migrations.

### The Fix:
- Added `_removed` device filtering across orphan and HVAC remote syncing paths in `schemas.py`.
- Extracted `migrate_known_list_traits` helper function in `schemas.py` and replaced duplicated logic across `__init__.py` and `config_flow.py`.
- Removed stale comment from `climate.py`.
- Added unit tests for `_cleanup_stale_known_list`, chained v1→v3 config entry migrations, and `migrate_known_list_traits`.

Closes #880

### Testing Performed:
- Executed full unit test suite (`pytest`) - 1,227 tests passed.
- Ran full linter and typing suite (`prek run -a` and `mypy custom_components/ramses_cc`) - 100% clean.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
