### PR TITLE
fix(number): guard against null hass in request_parameter_value

### DIFF
--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -132,7 +132,6 @@ async def async_setup_entry(
     :return: None
     :rtype: None
     """
-
     coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
     coordinator._parameter_entities_pending.clear()
     coordinator._parameter_entities_loaded.clear()
@@ -725,6 +724,8 @@ class RamsesNumberParam(RamsesNumberBase):
             )
         )
 
+        await self._request_parameter_value()
+
     @callback
     def _async_param_updated(self, event: Event | dict[str, Any] | object) -> None:
         """Handle parameter updates from the device.
@@ -780,7 +781,6 @@ class RamsesNumberParam(RamsesNumberBase):
         :return: True if the entity has a valid value, False otherwise
         :rtype: bool
         """
-
         if not super().available:
             return False
 
@@ -802,10 +802,13 @@ class RamsesNumberParam(RamsesNumberBase):
         """
         if (
             not hasattr(self, "hass")
+            or self.hass is None
             or not hasattr(self, "_device")
             or not hasattr(self.entity_description, "ramses_rf_attr")
         ):
-            _LOGGER.debug("_request_parameter_value: missing required attributes")
+            _LOGGER.debug(
+                "_request_parameter_value: missing required attributes or hass is None"
+            )
             return
 
         if not self._device:

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -997,3 +997,41 @@ async def test_number_param_state_isolation(
     # 5. Assert entity 2 was completely unaffected
     assert entity1._param_native_value.get("75") == 21.0
     assert entity2._param_native_value.get("75") is None
+
+
+@pytest.mark.asyncio
+async def test_number_param_request_parameter_value_when_hass_is_none(
+    mock_coordinator: MagicMock, mock_fan_device: MagicMock
+) -> None:
+    # Arrange
+    desc = RamsesNumberEntityDescription(
+        key="param_4c",
+        ramses_rf_attr="4C",
+    )
+    entity = RamsesNumberParam(mock_coordinator, mock_fan_device, desc)
+    entity.hass = None
+
+    # Act & Assert
+    await entity._request_parameter_value()
+
+
+@pytest.mark.asyncio
+async def test_number_param_async_added_to_hass(
+    mock_coordinator: MagicMock, mock_fan_device: MagicMock
+) -> None:
+    # Arrange
+    desc = RamsesNumberEntityDescription(
+        key="param_4c",
+        ramses_rf_attr="4C",
+    )
+    entity = RamsesNumberParam(mock_coordinator, mock_fan_device, desc)
+    entity.hass = mock_coordinator.hass
+    entity.async_on_remove = MagicMock()
+    entity._request_parameter_value = AsyncMock()
+
+    # Act
+    await entity.async_added_to_hass()
+
+    # Assert
+    assert entity.async_on_remove.called
+    assert entity._request_parameter_value.called


### PR DESCRIPTION
### The Problem:
`RamsesNumberParam._request_parameter_value()` invokes `self.async_write_ha_state()` when scheduled asynchronously during platform setup. If `self.hass` has not yet been attached to the entity, Home Assistant raises `RuntimeError: Attribute hass is None for <entity unknown.unknown=unknown>`, causing startup background task failures reported in ramses-rf/ramses_cc#864.

### The Fix:
- Added explicit `self.hass is None` check in `_request_parameter_value()` to exit cleanly if `hass` is not attached.
- Updated `async_added_to_hass()` in `RamsesNumberParam` to trigger `_request_parameter_value()` safely once the entity is registered with Home Assistant.
- Added unit tests in `test_number.py` covering null `hass` handling and `async_added_to_hass()` parameter requests.

### Testing Performed:
- `pytest tests/tests_new/test_number.py` passed (39/39).
- `pytest tests/tests_new/` passed (1128/1128).
- `ruff check --select D custom_components/ramses_cc/number.py` passed.
- `ruff format --check .` passed.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.