### PR TITLE
fix(mqtt): enable autostart and bind transport pause/resume to MQTT connection events

### DIFF
--- a/custom_components/ramses_cc/mqtt_bridge.py
+++ b/custom_components/ramses_cc/mqtt_bridge.py
@@ -98,7 +98,10 @@ class RamsesMqttBridge:
         if config is None:
             config = TransportConfig(
                 disable_sending=disable_sending,
+                autostart=True,
             )
+        else:
+            config.autostart = True
 
         # Remove old kwargs that CallbackTransport.__init__ no longer accepts
         kwargs.pop("autostart", None)
@@ -303,10 +306,14 @@ class RamsesMqttBridge:
         _LOGGER.debug("MqttBridge: Connection status changed to %s", status_str)
         if connected:
             _LOGGER.info("MQTT Broker connected. Resuming ramses_rf.")
+            if self._transport is not None:
+                self._transport.resume_reading()
             # Send handshake immediately when MQTT comes online
             self.publish_command("!V")
         else:
             _LOGGER.warning("MQTT Broker disconnected. Pausing ramses_rf.")
+            if self._transport is not None:
+                self._transport.pause_reading()
 
     def close(self) -> None:
         """Cleanup subscriptions."""

--- a/tests/tests_new/test_mqtt_bridge.py
+++ b/tests/tests_new/test_mqtt_bridge.py
@@ -446,3 +446,29 @@ async def test_bridge_handle_cmd_result_int(
     # 0 -> "0" -> "# 0" -> "# 0"
     expected_response_2 = "# 0"
     bridge._transport.receive_frame.assert_called_with(expected_response_2)
+
+
+async def test_bridge_connection_status_toggles_transport_reading(
+    hass: HomeAssistant, mock_mqtt: dict[str, Any], mock_protocol: MagicMock
+) -> None:
+    """Test transport autostart and connection status pause/resume transitions (Issue #883)."""
+    # Arrange
+    bridge = RamsesMqttBridge(hass, "RAMSES/GATEWAY", TEST_DEVICE_ID)
+
+    # Act
+    transport = await bridge.async_transport_factory(mock_protocol)
+
+    # Assert
+    assert transport._reading is True
+
+    # Act
+    bridge._handle_connection_status(False)
+
+    # Assert
+    assert transport._reading is False
+
+    # Act
+    bridge._handle_connection_status(True)
+
+    # Assert
+    assert transport._reading is True


### PR DESCRIPTION
### The Problem:
`RamsesMqttBridge` initialised `CallbackTransport` without `autostart=True` on `TransportConfig`, leaving `self._reading = False` (transport paused). Consequently, all incoming MQTT frames were dropped with `Dropping received frame (transport paused)`, preventing entity state updates and packet log frame output. Additionally, connection status changes logged pause/resume events without toggling transport reading state.

### The Fix:
- Set `autostart=True` on `TransportConfig` within `RamsesMqttBridge.async_transport_factory()`.
- Connect `RamsesMqttBridge._handle_connection_status()` to invoke `self._transport.resume_reading()` when MQTT connects, and `self._transport.pause_reading()` when MQTT disconnects.
- Added regression test `test_bridge_connection_status_toggles_transport_reading` in `test_mqtt_bridge.py`.

### Testing Performed:
- Added regression test verifying autostart and connection status pause/resume toggles.
- Ran full test suite in `tests_new/` (1129 passed).
- Verified pre-commit checks and ruff formatting.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.