### PR TITLE
perf: Add slots=True to discovery dataclasses, LRU cache, and lazy log formatting

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -267,7 +267,7 @@ class BaseRamsesFlow:
                 parts = msg.topic.split("/")
                 for part in parts:
                     if part.startswith("18:"):
-                        _LOGGER.debug(f"Discovery found device: {part}")
+                        _LOGGER.debug("Discovery found device: %s", part)
                         found_device.set_result(part)
                         return
             except Exception:
@@ -276,7 +276,7 @@ class BaseRamsesFlow:
         # Determine topic to scan. Use default if not set.
         # We use a wildcard # to catch ANY topic (rx, status, etc) that might be retained
         scan_topic = f"{DEFAULT_MQTT_TOPIC}/#"
-        _LOGGER.debug(f"Starting discovery on topic: {scan_topic}")
+        _LOGGER.debug("Starting discovery on topic: %s", scan_topic)
 
         try:
             # We must be careful if MQTT is not fully loaded, though check is done before calling this
@@ -667,10 +667,11 @@ class BaseRamsesFlow:
                 else:
                     # Debug: Check what we have in options
                     _LOGGER.debug(
-                        f"DEBUG: self.options[SZ_SERIAL_PORT] = {self.options[SZ_SERIAL_PORT]}"
+                        "DEBUG: self.options[SZ_SERIAL_PORT] = %s",
+                        self.options[SZ_SERIAL_PORT],
                     )
                     port_name = self.options[SZ_SERIAL_PORT][SZ_PORT_NAME]
-                    _LOGGER.debug(f"DEBUG: Retrieved port_name = {port_name}")
+                    _LOGGER.debug("DEBUG: Retrieved port_name = %s", port_name)
                     if port_name is None:
                         _LOGGER.error("ERROR: port_name is None!")
                         errors[SZ_PORT_NAME] = "port_name_required"
@@ -678,7 +679,7 @@ class BaseRamsesFlow:
                         config[SZ_PORT_NAME] = port_name
 
                 if not errors:
-                    _LOGGER.debug(f"DEBUG: Final config = {config}")
+                    _LOGGER.debug("DEBUG: Final config = %s", config)
                     self.options[SZ_SERIAL_PORT] = config
                     # Ensure internal flag is cleared if we set a manual port
                     self.options.pop(CONF_MQTT_USE_HA, None)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Coroutine, Sequence
 from contextlib import suppress
 from copy import deepcopy
 from datetime import datetime as dt, timedelta as td
+from functools import lru_cache
 from threading import Semaphore
 from typing import TYPE_CHECKING, Any, Final, TypeVar, cast
 
@@ -140,6 +141,7 @@ _EXTRACT_DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(
 )
 
 
+@lru_cache(maxsize=128)
 def _normalize_class_slug(value: str) -> str:
     """Normalize a class value to a short DevType slug.
 
@@ -2135,12 +2137,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         via_device: tuple[str, str] | None = None
         if isinstance(device, Zone) and device.tcs:
-            _LOGGER.info(f"ZONE {model} via_device SET to {device.tcs.id}")
+            _LOGGER.info("ZONE %s via_device SET to %s", model, device.tcs.id)
             via_device = (DOMAIN, str(device.tcs.id))
         elif isinstance(device, Child) and getattr(device, "_parent", None):
             parent = getattr(device, "_parent", None)
             parent_id = getattr(parent, "id", None) if parent else None
-            _LOGGER.info(f"CHILD {model} via_device SET to {parent_id}")
+            _LOGGER.info("CHILD %s via_device SET to %s", model, parent_id)
             if parent_id:
                 via_device = (DOMAIN, str(parent_id))
         else:

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -61,7 +61,7 @@ class DiscoveryStatus(StrEnum):
     LOST = "lost"
 
 
-@dataclass
+@dataclass(slots=True)
 class DeviceMetadata:
     """ramses_cc-specific metadata for a discovered device.
 
@@ -138,7 +138,7 @@ class DeviceMetadata:
         )
 
 
-@dataclass
+@dataclass(slots=True)
 class DiscoveredDeviceEntry:
     """Full discovery entry: engine data + ramses_cc metadata."""
 

--- a/tests/virtual_rf/virtual_rf.py
+++ b/tests/virtual_rf/virtual_rf.py
@@ -162,7 +162,7 @@ class VirtualRfBase:
                 fp.flush()
                 fp.close()  # also closes corresponding master fd
             except (OSError, ValueError) as err:
-                _LOGGER.debug(f"Note: Master FP for {port_name} closure: {err}")
+                _LOGGER.debug("Note: Master FP for %s closure: %s", port_name, err)
 
         # 2. Close slave FDs
         for port_name, fd in self._port_to_slave_.items():
@@ -171,7 +171,9 @@ class VirtualRfBase:
             except OSError as err:
                 if err.errno != 9:  # EBADF — OS already reclaimed it
                     _LOGGER.warning(
-                        f"Unexpected OSError closing slave FD for {port_name}: {err}"
+                        "Unexpected OSError closing slave FD for %s: %s",
+                        port_name,
+                        err,
                     )
 
         # 3. Clear maps so _read_ready safely exits if called after cleanup
@@ -198,7 +200,7 @@ class VirtualRfBase:
         try:
             self._pull_data_from_src_port(self._master_to_port[fd])
         except (OSError, KeyError) as err:
-            _LOGGER.error(f"Error reading from port {fd}: {err}")
+            _LOGGER.error("Error reading from port %s: %s", fd, err)
 
     def _pull_data_from_src_port(self, src_port: _PN) -> None:
         """Pull the data from the sending port and process any frames."""
@@ -227,7 +229,7 @@ class VirtualRfBase:
     def _cast_frame_to_all_ports(self, src_port: _PN, frame: bytes) -> None:
         """Pull the frame from the source port and cast it to the RF."""
 
-        _LOGGER.info(f"{src_port:<11} cast:  {frame!r}")
+        _LOGGER.info("%-11s cast:  %r", src_port, frame)
         for dst_port in self._port_to_master:
             self._push_frame_to_dst_port(dst_port, frame)
 
@@ -235,7 +237,7 @@ class VirtualRfBase:
         if not (reply := self._find_reply_for_cmd(frame)):
             return
 
-        _LOGGER.info(f"{src_port:<11} rply:  {reply!r}")
+        _LOGGER.info("%-11s rply:  %r", src_port, reply)
         for dst_port in self._port_to_master:
             self._push_frame_to_dst_port(dst_port, reply)  # is not echo only
 
@@ -263,9 +265,9 @@ class VirtualRfBase:
             try:
                 self._port_to_object[dst_port].write(data)
             except BlockingIOError:
-                _LOGGER.warning(f"Buffer full writing to {dst_port}, dropping packet")
+                _LOGGER.warning("Buffer full writing to %s, dropping packet", dst_port)
             except OSError as err:
-                _LOGGER.error(f"Write error to {dst_port}: {err}")
+                _LOGGER.error("Write error to %s: %s", dst_port, err)
 
     def _proc_after_rx(self, rcv_port: _PN, frame: bytes) -> bytes | None:
         """Allow the device to modify the frame after receiving (e.g. adding RSSI)."""


### PR DESCRIPTION
Ref ramses-rf/ramses_cc#893

### The Problem:
`ramses_cc` contains data structure and string formatting overhead in discovery entries, device class slug resolution, and logging calls.

### The Fix:
- Added `slots=True` to `DeviceMetadata` and `DiscoveredDeviceEntry` dataclasses in `discovery.py` to eliminate `__dict__` overhead and improve attribute lookup performance.
- Added `@lru_cache(maxsize=128)` to `_normalize_class_slug` in `coordinator.py` to cache frequent class slug lookups.
- Converted all remaining f-strings in `_LOGGER` calls across `coordinator.py`, `config_flow.py`, and `virtual_rf.py` to lazy `%`-formatting.

### Testing Performed:
- Full `pytest` suite run: 1,233 passed, 10 skipped.
- `ruff format --check .` and `prek run -a` passed cleanly.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.