### PR TITLE
perf: Refactor `resolve_async_attr` to use structured state container

### DIFF
--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -7,8 +7,9 @@ import inspect
 import logging
 import time
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime as dt
-from typing import Any, cast
+from typing import Any, Final, cast
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -21,6 +22,17 @@ from ramses_tx.packet import Packet
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+_UNSET: Final[Any] = object()
+
+
+@dataclass(slots=True)
+class _AsyncAttrState:
+    """State container for lazy async property resolution."""
+
+    cached: Any = _UNSET
+    resolving: bool = False
+    resolving_task: asyncio.Task[None] | None = None
+    last_dispatch: float = 0.0
 
 
 def ha_device_id_to_ramses_device_id(
@@ -140,10 +152,16 @@ def resolve_async_attr(
                 cast(Any, val).close()
             return default
 
-        cache_key = f"_cached_{id(obj)}_{attr_name}"
-        resolving_key = f"_resolving_{id(obj)}_{attr_name}"
-        resolving_task_key = f"_resolving_task_{id(obj)}_{attr_name}"
-        cooldown_key = f"_cooldown_{id(obj)}_{attr_name}"
+        state_map: dict[tuple[int, str], _AsyncAttrState]
+        if not hasattr(entity, "_async_attr_state"):
+            entity._async_attr_state = {}
+        state_map = entity._async_attr_state
+
+        state_key = (id(obj), attr_name)
+        state = state_map.get(state_key)
+        if state is None:
+            state = _AsyncAttrState()
+            state_map[state_key] = state
 
         # Cooldown: don't re-dispatch the async getter within 30 seconds of
         # the last dispatch.  This prevents command floods when the getter
@@ -153,17 +171,16 @@ def resolve_async_attr(
         # cooldown so that the first real data (e.g. a 30C9 temperature
         # broadcast) is picked up immediately rather than waiting 30s.
         COOLDOWN_SECS = 30
-        last_dispatch = getattr(entity, cooldown_key, 0)
         now = time.monotonic()
-        cached_val = getattr(entity, cache_key, default)
+        cached_val = state.cached if state.cached is not _UNSET else default
         within_cooldown = (
-            cached_val is not None and (now - last_dispatch) < COOLDOWN_SECS
+            cached_val is not None and (now - state.last_dispatch) < COOLDOWN_SECS
         )
 
         # Dispatch the background task to resolve the coroutine
-        if not getattr(entity, resolving_key, False) and not within_cooldown:
-            setattr(entity, resolving_key, True)
-            setattr(entity, cooldown_key, now)
+        if not state.resolving and not within_cooldown:
+            state.resolving = True
+            state.last_dispatch = now
 
             async def _resolve() -> None:
                 try:
@@ -180,8 +197,8 @@ def resolve_async_attr(
                         res = fresh_val
 
                     # Update cache and trigger a state write if the value changed
-                    if getattr(entity, cache_key, object()) != res:
-                        setattr(entity, cache_key, res)
+                    if state.cached != res:
+                        state.cached = res
                         if getattr(entity, "entity_id", None):
                             entity.async_write_ha_state()
                 except asyncio.CancelledError:
@@ -189,16 +206,15 @@ def resolve_async_attr(
                 except Exception as err:
                     _LOGGER.debug("Error resolving async state %s: %s", attr_name, err)
                 finally:
-                    setattr(entity, resolving_key, False)
+                    state.resolving = False
 
-            task = entity.hass.async_create_task(_resolve())
-            setattr(entity, resolving_task_key, task)
+            state.resolving_task = entity.hass.async_create_task(_resolve())
 
         # Cleanup the initial coroutine we created synchronously
         if hasattr(val, "close"):
             cast(Any, val).close()
 
-        cached = getattr(entity, cache_key, default)
+        cached = state.cached if state.cached is not _UNSET else default
 
         # Absolute safeguard: never return a coroutine to Home Assistant properties
         if inspect.isawaitable(cached) or isinstance(cached, asyncio.Future):
@@ -226,23 +242,20 @@ def clear_async_attr_cache(entity: Any) -> None:
     compounds badly when force_update is invoked frequently (e.g. across
     many test recipes), overloading the transport.
     """
+    state_map: dict[tuple[int, str], _AsyncAttrState] | None = getattr(
+        entity, "_async_attr_state", None
+    )
+    if not state_map:
+        return
+
     # First cancel any in-flight resolution tasks.
-    for attr in list(entity.__dict__):
-        if attr.startswith("_resolving_task_"):
-            task = getattr(entity, attr, None)
-            if task is not None and not task.done():
-                task.cancel()
-            delattr(entity, attr)
+    for state in state_map.values():
+        if state.resolving_task is not None and not state.resolving_task.done():
+            state.resolving_task.cancel()
 
     # Then clear cooldown/cache/resolving-flag state so the next property
     # access re-dispatches a fresh getter.
-    for attr in list(entity.__dict__):
-        if (
-            attr.startswith("_cooldown_")
-            or attr.startswith("_cached_")
-            or attr.startswith("_resolving_")
-        ):
-            delattr(entity, attr)
+    state_map.clear()
 
 
 def parse_packet_string(packet_str: str) -> CommandDTO | None:

--- a/tests/tests_new/test_helpers.py
+++ b/tests/tests_new/test_helpers.py
@@ -5,8 +5,11 @@ mappings between Home Assistant and RAMSES RF hardware IDs, as well as
 datetime utility functions.
 """
 
+import asyncio
 from datetime import datetime as dt
+from types import SimpleNamespace
 
+import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt as dt_util
@@ -17,9 +20,11 @@ from pytest_homeassistant_custom_component.common import (  # type: ignore[impor
 from custom_components.ramses_cc.const import DOMAIN
 from custom_components.ramses_cc.helpers import (
     as_iso,
+    clear_async_attr_cache,
     fields_to_aware,
     ha_device_id_to_ramses_device_id,
     ramses_device_id_to_ha_device_id,
+    resolve_async_attr,
 )
 
 # Constants
@@ -131,3 +136,55 @@ def test_as_iso_conversion() -> None:
 
     # Test None - implementation converts None to "None"
     assert as_iso(None) == "None"
+
+
+@pytest.mark.asyncio
+async def test_resolve_async_attr_sync_and_async(hass: HomeAssistant) -> None:
+    """Test resolve_async_attr helper with sync and async targets."""
+    # 1. Sync value test
+    entity = SimpleNamespace(hass=hass)
+    obj = SimpleNamespace(sync_prop="sync_val")
+
+    val = resolve_async_attr(entity, obj, "sync_prop")
+    assert val == "sync_val"
+    assert not hasattr(entity, "_async_attr_state")
+
+    # 2. Async target resolution test
+    async def _async_getter() -> str:
+        await asyncio.sleep(0.01)
+        return "async_resolved"
+
+    obj.async_prop = _async_getter
+    res = resolve_async_attr(entity, obj, "async_prop", default="default_val")
+    assert res == "default_val"
+    assert hasattr(entity, "_async_attr_state")
+
+    # Wait for background task to resolve
+    state_map = entity._async_attr_state
+    state = list(state_map.values())[0]
+    if state.resolving_task:
+        await state.resolving_task
+
+    # Next call returns cached value
+    res_cached = resolve_async_attr(entity, obj, "async_prop")
+    assert res_cached == "async_resolved"
+
+
+@pytest.mark.asyncio
+async def test_clear_async_attr_cache(hass: HomeAssistant) -> None:
+    """Test clearing async attribute resolution cache and cancelling tasks."""
+    entity = SimpleNamespace(hass=hass)
+    obj = SimpleNamespace()
+
+    async def _slow_getter() -> str:
+        await asyncio.sleep(10)
+        return "slow"
+
+    obj.slow_prop = _slow_getter
+    resolve_async_attr(entity, obj, "slow_prop", default="default")
+
+    state_map = getattr(entity, "_async_attr_state", {})
+    assert len(state_map) == 1
+
+    clear_async_attr_cache(entity)
+    assert len(state_map) == 0


### PR DESCRIPTION
Ref ramses-rf/ramses_cc#893

### The Problem:
`resolve_async_attr` in `helpers.py` dynamically formats 4 string keys (`_cached_{id(obj)}_{attr_name}`, `_resolving_...`, etc.) on every Home Assistant entity property access, causing repeated string allocations and dynamic instance `__dict__` mutations. `clear_async_attr_cache` scans `entity.__dict__` looking for matching key prefixes.

### The Fix:
- Refactored `resolve_async_attr` in `helpers.py` to use a single `_AsyncAttrState` slotted container map (`entity._async_attr_state`) keyed by `(id(obj), attr_name)`.
- Replaced dynamic string key formatting and dynamic attribute mutation with direct property reads on `_AsyncAttrState`.
- Simplified `clear_async_attr_cache` to iterate over `_AsyncAttrState` instances directly and call `state_map.clear()`, eliminating `entity.__dict__` string scanning.
- Added comprehensive unit tests in `tests/tests_new/test_helpers.py` targeting `_AsyncAttrState`, `resolve_async_attr`, and `clear_async_attr_cache`.

### Testing Performed:
- Full `pytest` test suite: 1,235 passed, 10 skipped (including new tests in `test_helpers.py`).
- `ruff format --check .` and `prek run -a` passed cleanly.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.