### PR TITLE
refactor: Add TypedDict schemas and type HA event/message handlers (#896)

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -6,7 +6,7 @@ import json
 import logging
 from dataclasses import dataclass, replace as dc_replace
 from datetime import datetime as dt, timedelta as td
-from typing import Any, Final, cast
+from typing import Any, Final
 
 import voluptuous as vol
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
@@ -130,7 +130,7 @@ async def async_setup_entry(
     @callback
     def add_devices(devices: Any) -> None:
         entities = [
-            cast(Any, description.ramses_cc_class)(coordinator, device, description)
+            description.ramses_cc_class(coordinator, device, description)
             for device in devices
             for description in CLIMATE_DESCRIPTIONS
             if isinstance(device, description.ramses_rf_class)
@@ -788,15 +788,16 @@ class RamsesZone(RamsesEntity, ClimateEntity):
                 f"Zone {self.entity_id} has no sensor to fake temp on."
             )
 
-        sensor = cast(Any, self._device.sensor)
+        sensor = self._device.sensor
         await sensor.set_temperature(temperature)
 
         # Also update the zone's temp_state so that current_temperature
         # reflects the faked value immediately (the zone's temp_state is
         # separate from the sensor's temp_state in ramses_rf's CQRS model)
-        zone = cast(Any, self._device)
-        if hasattr(zone, "temp_state"):
-            zone.temp_state = dc_replace(zone.temp_state, temperature=temperature)
+        if hasattr(self._device, "temp_state"):
+            self._device.temp_state = dc_replace(
+                self._device.temp_state, temperature=temperature
+            )
         self.async_write_ha_state()
 
     async def async_reset_zone_config(self) -> None:
@@ -885,7 +886,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             ) from err
 
         # Cast to dict to satisfy strict type checking
-        checked_dict = cast(dict[str, Any], checked_entry)
+        checked_dict: dict[str, Any] = checked_entry
 
         # default `duration` of 1 hour is updated by SCH_ default, so can't
         # use original
@@ -1250,8 +1251,10 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
         try:
             # Delegate to the underlying ramses_rf device.
             # This method will be implemented in ramses_rf in the future.
-            device_any = cast(Any, self._device)
-            await device_any.set_preset_mode(preset_mode)
+            set_preset_mode = getattr(self._device, "set_preset_mode", None)
+            if set_preset_mode is None:
+                raise AttributeError("Device does not support set_preset_mode")
+            await set_preset_mode(preset_mode)
             self.async_write_ha_state()
 
         except AttributeError as err:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -20,7 +20,7 @@ import serial  # type: ignore[import-untyped]
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -1688,7 +1688,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         except Exception as err:
             _LOGGER.warning("Unexpected error while stopping RAMSES client: %s", err)
 
-    async def _async_on_ha_stop(self, _event: Any) -> None:
+    async def _async_on_ha_stop(self, _event: Event) -> None:
         """Cancel non-critical tasks when HA stops (issue 802).
 
         This runs on EVENT_HOMEASSISTANT_STOP, before the 'final writes'

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from datetime import datetime as dt, timedelta as td
 from functools import lru_cache
 from threading import Semaphore
-from typing import TYPE_CHECKING, Any, Final, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Final, TypeVar
 
 import serial  # type: ignore[import-untyped]
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
@@ -1758,8 +1758,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return
 
         # Support both async (new) and sync (old) client.get_state()
-        # Cast to Any prevents Pylance from inferring Never on the else block
-        result = cast(Any, self.client.get_state())
+        result: Any = self.client.get_state()
 
         if inspect.isawaitable(result):
             schema, packets = await result
@@ -2023,7 +2022,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if dev := next((d for d in self._devices if d.id == device_id), None):
             return dev
         if self.client and hasattr(self.client, "device_registry"):
-            return self.client.device_registry.device_by_id.get(cast(Any, device_id))
+            return self.client.device_registry.device_by_id.get(device_id)
         return None
 
     def async_register_platform(
@@ -2216,7 +2215,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             and active_hgi_id not in gwy.device_registry.device_by_id
         ):
             with suppress(Exception):
-                gwy.device_registry.get_device(cast(Any, active_hgi_id))
+                gwy.device_registry.get_device(active_hgi_id)
 
         # Snapshot the lists to avoid RuntimeError if ramses_rf updates them continuously
         # This fixes the silent failure where list changes size during iteration
@@ -2266,11 +2265,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ]
         self._zones, new_zones = find_new_entities(self._zones, current_zones)
 
-        # Cast element directly in comprehension to securely enforce list[Zone]
         current_dhws: list[Zone] = [
-            cast(Zone, s.dhw)
-            for s in current_systems
-            if isinstance(s, Evohome) and s.dhw
+            s.dhw for s in current_systems if isinstance(s, Evohome) and s.dhw
         ]
         self._dhws, new_dhws = find_new_entities(self._dhws, current_dhws)
 
@@ -2279,7 +2275,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Process new devices for fan logic
         # Systems/DHWs must be processed before Devices to ensure via_device parents exist
         for device in new_systems + new_dhws + new_zones + new_devices:
-            await self.fan_handler.async_setup_fan_device(cast(Device, device))
+            await self.fan_handler.async_setup_fan_device(device)
             # Register device in registry once upon discovery
             await self._async_update_device(device)
 

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
@@ -251,12 +251,13 @@ class RamsesFanHandler:
                             exc_info=True,
                         )
 
-                cast(Any, device).set_initialized_callback(
-                    lambda: self.hass.async_create_task(on_fan_first_message())
-                )
+            set_init_cb = getattr(device, "set_initialized_callback", None)
+            if callable(set_init_cb):
+                set_init_cb(lambda: self.hass.async_create_task(on_fan_first_message()))
 
             # Set up parameter update callback
-            if hasattr(device, "set_param_update_callback"):
+            set_param_cb = getattr(device, "set_param_update_callback", None)
+            if callable(set_param_cb):
                 # Create a closure to capture the current device_id
                 def create_param_callback(dev_id: str) -> Callable[[str, Any], None]:
                     def param_callback(param_id: str, value: Any) -> None:
@@ -274,9 +275,7 @@ class RamsesFanHandler:
 
                     return param_callback
 
-                cast(Any, device).set_param_update_callback(
-                    create_param_callback(device.id)
-                )
+                set_param_cb(create_param_callback(device.id))
                 _LOGGER.debug(
                     "Set up parameter update callback for device %s", device.id
                 )

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -9,7 +9,7 @@ import time
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime as dt
-from typing import Any, Final, cast
+from typing import Any, Final
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -83,7 +83,7 @@ def ramses_device_id_to_ha_device_id(
     if not device_entry:
         return None
 
-    return cast(str, device_entry.id)
+    return device_entry.id
 
 
 def fields_to_aware(dt_or_none: dt | str | None) -> dt | None:
@@ -113,7 +113,7 @@ def fields_to_aware(dt_or_none: dt | str | None) -> dt | None:
         return final_dt
 
     # If it is naive, assume it is Local Time (Wall Clock) and make it aware
-    return cast(dt, dt_util.as_local(final_dt))
+    return dt_util.as_local(final_dt)
 
 
 def as_iso(val: Any) -> str:
@@ -148,8 +148,9 @@ def resolve_async_attr(
     if is_async:
         # Prevent "RuntimeWarning: coroutine was never awaited" if we cannot resolve it
         if not hasattr(entity, "hass") or entity.hass is None:
-            if hasattr(val, "close"):
-                cast(Any, val).close()
+            close_fn = getattr(val, "close", None)
+            if callable(close_fn):
+                close_fn()
             return default
 
         state_map: dict[tuple[int, str], _AsyncAttrState]
@@ -211,8 +212,9 @@ def resolve_async_attr(
             state.resolving_task = entity.hass.async_create_task(_resolve())
 
         # Cleanup the initial coroutine we created synchronously
-        if hasattr(val, "close"):
-            cast(Any, val).close()
+        close_fn = getattr(val, "close", None)
+        if callable(close_fn):
+            close_fn()
 
         cached = state.cached if state.cached is not _UNSET else default
 

--- a/custom_components/ramses_cc/mqtt_bridge.py
+++ b/custom_components/ramses_cc/mqtt_bridge.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import mqtt
+from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.core import HomeAssistant, callback
 
 from ramses_tx.transport import CallbackTransport, TransportConfig
@@ -156,7 +157,7 @@ class RamsesMqttBridge:
             )
 
     @callback
-    def _handle_rx_message(self, msg: Any) -> None:
+    def _handle_rx_message(self, msg: ReceiveMessage) -> None:
         """Process incoming radio packets."""
         if self._transport is None:
             _LOGGER.warning("MqttBridge RX: Transport is None, dropping message")
@@ -205,7 +206,7 @@ class RamsesMqttBridge:
             )
 
     @callback
-    def _handle_cmd_message(self, msg: Any) -> None:
+    def _handle_cmd_message(self, msg: ReceiveMessage) -> None:
         """Process incoming MQTT messages and inject into ramses_rf."""
         if self._transport is None:
             _LOGGER.warning("MqttBridge CMD: Transport is None, dropping message")
@@ -273,7 +274,7 @@ class RamsesMqttBridge:
                 exc_info=True,
             )
 
-    def _extract_payload(self, msg: Any) -> str:
+    def _extract_payload(self, msg: ReceiveMessage) -> str:
         """Helper to decode bytes to string."""
         if isinstance(msg.payload, bytes):
             return msg.payload.decode("utf-8", errors="ignore")

--- a/custom_components/ramses_cc/mqtt_bridge.py
+++ b/custom_components/ramses_cc/mqtt_bridge.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import mqtt
 from homeassistant.core import HomeAssistant, callback
@@ -44,7 +44,7 @@ class RamsesMqttBridge:
 
     async def async_transport_factory(
         self,
-        protocol: asyncio.Protocol,
+        protocol: Any,
         disable_sending: bool = False,
         extra: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -107,7 +107,7 @@ class RamsesMqttBridge:
         kwargs.pop("autostart", None)
 
         self._transport = CallbackTransport(
-            cast(Any, protocol),
+            protocol,
             mqtt_packet_sender,  # <-- Passed as POSITIONAL argument
             config=config,  # <-- Passed via the new config object
             extra=extra,

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -48,7 +48,7 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from types import UnionType
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -174,7 +174,9 @@ async def async_setup_entry(
             _LOGGER.debug("Adding %d entities directly", len(device_list))
             # Filter out entities that are already loaded in the platform
             entities_to_add = []
-            for entity in cast(Sequence[RamsesNumberBase], device_list):
+            for entity in device_list:
+                if not isinstance(entity, RamsesNumberBase):
+                    continue
                 entity_id = entity.entity_id
                 unique_id = entity.unique_id
 
@@ -610,8 +612,9 @@ class RamsesNumberParam(RamsesNumberBase):
         self._param_native_value[self._param_id] = None
 
         # Clear any existing value from the store if needed
-        if hasattr(self._device, "clear_fan_param"):
-            cast(Any, self._device).clear_fan_param(self._param_id)
+        clear_fan_param = getattr(self._device, "clear_fan_param", None)
+        if callable(clear_fan_param):
+            clear_fan_param(self._param_id)
 
         # Assign unique ID using standard device ID and parameter key format
         self._attr_unique_id = f"{device.id}-{entity_description.key}"
@@ -822,14 +825,15 @@ class RamsesNumberParam(RamsesNumberBase):
             return
 
         # This just checks the store, doesn't send RQ
-        if not hasattr(self._device, "get_fan_param"):
+        get_fan_param = getattr(self._device, "get_fan_param", None)
+        if not callable(get_fan_param):
             _LOGGER.debug(
                 "Device %s (%s) has no get_fan_param, skipping",
                 self._device.id,
                 type(self._device).__name__,
             )
             return
-        value = cast(Any, self._device).get_fan_param(param_id)
+        value = get_fan_param(param_id)
 
         _LOGGER.debug(
             "Got value %s for parameter %s from device %s store",
@@ -856,8 +860,8 @@ class RamsesNumberParam(RamsesNumberBase):
 
         self.set_pending()
 
-        if hasattr(self._device, "get_fan_param"):
-            cast(Any, self._device).get_fan_param(param_id)
+        if callable(get_fan_param):
+            get_fan_param(param_id)
 
         # Cancel any previous pending timer before starting a new one
         if self._pending_timer is not None and not self._pending_timer.done():
@@ -1193,7 +1197,8 @@ def create_parameter_entities(
 
             entity = description.ramses_cc_class(coordinator, device, description)
             entities.append(entity)
-            created_param_entities[new_unique_id] = cast(Any, entity)
+            if isinstance(entity, RamsesNumberParam):
+                created_param_entities[new_unique_id] = entity
             _LOGGER.debug(
                 "Prepared parameter entity (unique_id=%s) for %s (param_id=%s)",
                 new_unique_id,

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -14,7 +14,7 @@ from homeassistant.components.remote import (
     RemoteEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
@@ -432,7 +432,7 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         learning_session = asyncio.Event()
 
         @callback
-        async def _async_on_change(event: Any) -> None:
+        async def _async_on_change(event: Event) -> None:
             """Save the new command to storage.
 
             For REM entities: listens to ``src == self._device.id``,

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta as td
 from types import UnionType
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -214,12 +214,13 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         assert self.device_class == SensorDeviceClass.CO2
         assert self.native_unit_of_measurement == CONCENTRATION_PARTS_PER_MILLION
 
-        if not isinstance(self._device, HvacCarbonDioxideSensor):
-            raise TypeError(f"Cannot set CO2 level on {self._device}")
+        device = self._device
+        if not isinstance(device, HvacCarbonDioxideSensor):
+            raise TypeError(f"Cannot set CO2 level on {device}")
         # TODO: Until here
 
         # setter will raise an exception if device is not faked
-        cast(Any, self._device).co2_level = co2_level  # would accept None
+        device.co2_level = co2_level  # would accept None
 
     async def async_put_dhw_temp(self, temperature: float) -> None:
         """Cast the DHW cylinder temperature (if faked).
@@ -232,12 +233,13 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         assert self.device_class == SensorDeviceClass.TEMPERATURE
         assert self.native_unit_of_measurement == UnitOfTemperature.CELSIUS
 
-        if not isinstance(self._device, DhwSensor):
-            raise TypeError(f"Cannot set DHW temperature on {self._device}")
+        device = self._device
+        if not isinstance(device, DhwSensor):
+            raise TypeError(f"Cannot set DHW temperature on {device}")
         # TODO: Until here
 
         # set_temperature will raise DeviceNotFaked if device is not faked
-        await cast(Any, self._device).set_temperature(temperature)
+        await device.set_temperature(temperature)
         self.async_write_ha_state()
 
     @callback
@@ -252,14 +254,13 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         assert self.device_class == SensorDeviceClass.HUMIDITY
         assert self.native_unit_of_measurement == PERCENTAGE
 
-        if not isinstance(self._device, HvacHumiditySensor):
-            raise TypeError(f"Cannot set indoor humidity level on {self._device}")
+        device = self._device
+        if not isinstance(device, HvacHumiditySensor):
+            raise TypeError(f"Cannot set indoor humidity level on {device}")
         # TODO: Until here
 
         # setter will raise an exception if device is not faked
-        cast(Any, self._device).indoor_humidity = (
-            indoor_humidity / 100
-        )  # would accept None
+        device.indoor_humidity = indoor_humidity / 100  # would accept None
 
     async def async_put_room_temp(self, temperature: float) -> None:
         """Cast the room temperature (if faked).
@@ -272,12 +273,13 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         assert self.device_class == SensorDeviceClass.TEMPERATURE
         assert self.native_unit_of_measurement == UnitOfTemperature.CELSIUS
 
-        if not isinstance(self._device, Thermostat):
-            raise TypeError(f"Cannot set room temperature on {self._device}")
+        device = self._device
+        if not isinstance(device, Thermostat):
+            raise TypeError(f"Cannot set room temperature on {device}")
         # TODO: Until here
 
         # set_temperature will raise DeviceNotFaked if device is not faked
-        await cast(Any, self._device).set_temperature(temperature)
+        await device.set_temperature(temperature)
         self.async_write_ha_state()
 
 

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -8,7 +8,7 @@ import copy
 import dataclasses
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final
 
 from homeassistant.core import ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -244,16 +244,16 @@ class RamsesServiceHandler:
         :param entity: The entity to clear pending state on.
         :param timeout: Timeout in seconds.
         """
-        if not entity or not hasattr(entity, "_clear_pending_after_timeout"):
+        clear_fn = getattr(entity, "_clear_pending_after_timeout", None)
+        if not callable(clear_fn):
             return
         # Cancel any previous pending timer on the entity
         prev = getattr(entity, "_pending_timer", None)
         if prev and not prev.done():
             prev.cancel()
-        task = self.hass.async_create_task(
-            cast(Any, entity)._clear_pending_after_timeout(timeout)
-        )
-        entity._pending_timer = task
+        task = self.hass.async_create_task(clear_fn(timeout))
+        if hasattr(entity, "_pending_timer") or entity is not None:
+            entity._pending_timer = task
         self._pending_timers.append(task)
 
     def register_pending_timer(self, task: asyncio.Task[Any]) -> None:
@@ -477,8 +477,9 @@ class RamsesServiceHandler:
             entity = self._coordinator.fan_handler.find_param_entity(
                 normalized_device_id, param_id
             )
-            if entity and hasattr(entity, "set_pending"):
-                cast(Any, entity).set_pending()
+            set_pending = getattr(entity, "set_pending", None)
+            if callable(set_pending):
+                set_pending()
 
             intent = Intent(
                 src=Address(from_id),
@@ -673,8 +674,9 @@ class RamsesServiceHandler:
             entity = self._coordinator.fan_handler.find_param_entity(
                 normalized_device_id, param_id
             )
-            if entity and hasattr(entity, "set_pending"):
-                cast(Any, entity).set_pending()
+            set_pending = getattr(entity, "set_pending", None)
+            if callable(set_pending):
+                set_pending()
 
             intent = Intent(
                 src=Address(from_id),

--- a/custom_components/ramses_cc/typing.py
+++ b/custom_components/ramses_cc/typing.py
@@ -124,11 +124,22 @@ class FanParamEventData(TypedDict):
     value: Any
 
 
-class StoreStateDict(TypedDict):
+class StoreStateDict(TypedDict, total=False):
     """Schema for persistent client state storage."""
 
     schema: dict[str, Any]
     packets: list[str]
+    remotes: dict[str, Any]
+    discovery_state: dict[str, Any]
+    hvac_schema: dict[str, Any]
+
+
+class RamsesConfigData(TypedDict, total=False):
+    """Schema for Ramses config entry data and options."""
+
+    schema: dict[str, Any]
+    advanced_features: dict[str, Any]
+    ramses_rf: dict[str, Any]
 
 
 def is_fan_param_device(obj: Any) -> TypeGuard[FanParamDevice]:

--- a/custom_components/ramses_cc/typing.py
+++ b/custom_components/ramses_cc/typing.py
@@ -1,0 +1,164 @@
+"""Type definitions, protocols, and type guards for ramses_cc.
+
+This module provides structural typing protocols, type guard functions, and
+TypedDict schemas to enforce strict type safety across the integration.
+"""
+
+from collections.abc import Callable
+from typing import Any, Protocol, TypedDict, TypeGuard, runtime_checkable
+
+from homeassistant.config_entries import ConfigEntry
+
+type RamsesConfigEntry = ConfigEntry[Any]
+
+
+@runtime_checkable
+class FanParamDevice(Protocol):
+    """Protocol for RAMSES devices that support fan parameters."""
+
+    id: str
+
+    def get_fan_param(self, param_id: str) -> Any:
+        """Get the value of a fan parameter.
+
+        :param param_id: The identifier of the parameter.
+        :type param_id: str
+        :returns: The parameter value or None.
+        :rtype: Any
+        """
+        ...
+
+    def clear_fan_param(self, param_id: str) -> None:
+        """Clear a stored fan parameter.
+
+        :param param_id: The identifier of the parameter.
+        :type param_id: str
+        :returns: None
+        :rtype: None
+        """
+        ...
+
+    def set_initialized_callback(self, cb: Callable[[], Any]) -> None:
+        """Register a callback for when the device finishes initialization.
+
+        :param cb: The callback function to invoke.
+        :type cb: Callable[[], Any]
+        :returns: None
+        :rtype: None
+        """
+        ...
+
+    def set_param_update_callback(self, cb: Callable[[str, Any], None]) -> None:
+        """Register a callback for parameter updates.
+
+        :param cb: The callback function to invoke on parameter update.
+        :type cb: Callable[[str, Any], None]
+        :returns: None
+        :rtype: None
+        """
+        ...
+
+
+@runtime_checkable
+class PendingEntity(Protocol):
+    """Protocol for entities supporting pending state management."""
+
+    _pending_timer: Any
+
+    def set_pending(self) -> None:
+        """Mark the entity as having a pending state update.
+
+        :returns: None
+        :rtype: None
+        """
+        ...
+
+    def _clear_pending_after_timeout(self, timeout: int) -> Any:
+        """Clear pending state after a timeout period.
+
+        :param timeout: The timeout duration in seconds.
+        :type timeout: int
+        :returns: Coroutine or None.
+        :rtype: Any
+        """
+        ...
+
+
+@runtime_checkable
+class FakedSensorDevice(Protocol):
+    """Protocol for devices supporting faked temperature or sensor values."""
+
+    co2_level: float | None
+    indoor_humidity: float | None
+
+    async def set_temperature(self, temperature: float) -> None:
+        """Set a faked temperature value on the device.
+
+        :param temperature: The target temperature in Celsius.
+        :type temperature: float
+        :returns: None
+        :rtype: None
+        """
+        ...
+
+
+@runtime_checkable
+class HasSensorProperty(Protocol):
+    """Protocol for objects exposing a sensor child property."""
+
+    @property
+    def sensor(self) -> Any:
+        """The child sensor property.
+
+        :returns: The sensor instance or None.
+        :rtype: Any
+        """
+        ...
+
+
+class FanParamEventData(TypedDict):
+    """Event data payload for fan parameter update events."""
+
+    device_id: str
+    param_id: str
+    value: Any
+
+
+class StoreStateDict(TypedDict):
+    """Schema for persistent client state storage."""
+
+    schema: dict[str, Any]
+    packets: list[str]
+
+
+def is_fan_param_device(obj: Any) -> TypeGuard[FanParamDevice]:
+    """Type guard to check if an object satisfies the FanParamDevice protocol.
+
+    :param obj: The object instance to check.
+    :type obj: Any
+    :returns: True if the object implements FanParamDevice.
+    :rtype: bool
+    """
+    return isinstance(obj, FanParamDevice)
+
+
+def is_pending_entity(obj: Any) -> TypeGuard[PendingEntity]:
+    """Type guard to check if an object satisfies the PendingEntity protocol.
+
+    :param obj: The object instance to check.
+    :type obj: Any
+    :returns: True if the object implements PendingEntity.
+    :rtype: bool
+    """
+    return isinstance(obj, PendingEntity)
+
+
+def is_faked_sensor_device(obj: Any) -> TypeGuard[FakedSensorDevice]:
+    """Type guard to check if an object satisfies FakedSensorDevice.
+
+    :param obj: The object instance to check.
+    :type obj: Any
+    :returns: True if the object implements FakedSensorDevice.
+    :rtype: bool
+    """
+    return isinstance(obj, FakedSensorDevice)

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, replace as dc_replace
 from datetime import datetime as dt, timedelta as td
-from typing import Any, Final, cast
+from typing import Any, Final
 
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
@@ -232,7 +232,7 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
     async def async_fake_dhw_temp(self, temperature: float) -> None:
         """Cast the temperature of this water heater (if faked)."""
-        sensor = cast(Any, self._device).sensor
+        sensor = getattr(self._device, "sensor", None)
         if sensor is None:
             raise HomeAssistantError(
                 f"Water heater {self.entity_id} has no sensor to fake temp on."
@@ -241,9 +241,10 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
         # Also update the DHW zone's temp_state so that current_temperature
         # reflects the faked value immediately
-        dhw = cast(Any, self._device)
-        if hasattr(dhw, "temp_state"):
-            dhw.temp_state = dc_replace(dhw.temp_state, temperature=temperature)
+        if hasattr(self._device, "temp_state"):
+            self._device.temp_state = dc_replace(
+                self._device.temp_state, temperature=temperature
+            )
         self.async_write_ha_state()
 
     async def async_reset_dhw_mode(self) -> None:
@@ -337,7 +338,7 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
         try:
             # strict, non-entity schema check
-            checked_entry = cast(dict[str, Any], SCH_SET_DHW_MODE_EXTRA(entry))
+            checked_entry: dict[str, Any] = SCH_SET_DHW_MODE_EXTRA(entry)
         except (ValueError, TypeError) as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #897 < was merged

### The Problem:
Event listeners (`coordinator.py`, `remote.py`), MQTT packet handlers (`mqtt_bridge.py`), and client storage states used unannotated parameters (`msg: Any`, `event: Any`) or untyped dictionary payloads (`dict[str, Any]`).

### The Fix:
- Added `StoreStateDict` and `RamsesConfigData` `TypedDict` schemas in `custom_components/ramses_cc/typing.py`.
- Typed MQTT message handler methods (`_handle_rx_message`, `_handle_cmd_message`, `_extract_payload`) using Home Assistant's `ReceiveMessage`.
- Typed Home Assistant bus event listener callbacks using Home Assistant's `Event`.

### Testing Performed:
- `mypy`: `.venv/bin/mypy custom_components/ramses_cc` passed cleanly (`Success: no issues found in 20 source files`).
- `ruff`: Code formatting and docstring checks passed cleanly.
- `pytest`: Full test suite passed (`1235 passed, 10 skipped`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.

Ref #896