### PR TITLE
refactor: Adopt RamsesConfigEntry and PEP 695 generics (#896)

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -119,6 +119,7 @@ from .schemas import (
     SVCS_RAMSES_WATER_HEATER,
     migrate_known_list_traits,
 )
+from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -187,7 +188,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: RamsesConfigEntry) -> bool:
     """Create a ramses_rf (RAMSES_II)-based system."""
 
     _LOGGER.debug("Setting up entry %s...", entry.entry_id)

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
@@ -55,6 +54,7 @@ from .const import (
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import resolve_async_attr
+from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ def _shrink_hints(device_hints: dict[str, Any]) -> dict[str, Any]:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RamsesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the binary sensor platform.

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -24,7 +24,6 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PRECISION_HALVES, PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -62,6 +61,7 @@ from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import fields_to_aware, resolve_async_attr
 from .remote import _build_packet_from_template, _is_command_dict, _split_commands
 from .schemas import SCH_SET_SYSTEM_MODE_EXTRA, SCH_SET_ZONE_MODE_EXTRA
+from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -115,7 +115,7 @@ PRESET_HA_TO_ZONE: Final[dict[str, str]] = {v: k for k, v in PRESET_ZONE_TO_HA.i
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RamsesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the climate platform.

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -20,7 +20,7 @@ import serial  # type: ignore[import-untyped]
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -1688,7 +1688,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         except Exception as err:
             _LOGGER.warning("Unexpected error while stopping RAMSES client: %s", err)
 
-    async def _async_on_ha_stop(self, _event: Any) -> None:
+    async def _async_on_ha_stop(self, _event: Event) -> None:
         """Cancel non-critical tasks when HA stops (issue 802).
 
         This runs on EVENT_HOMEASSISTANT_STOP, before the 'final writes'

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -11,7 +11,6 @@ from re import Pattern
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.event import EventEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -21,6 +20,7 @@ from ramses_tx.dtos import PacketDTO
 from ramses_tx.exceptions import PacketInvalid
 
 from .const import CONF_ADVANCED_FEATURES, CONF_MESSAGE_EVENTS, DOMAIN
+from .typing import RamsesConfigEntry
 
 if TYPE_CHECKING:
     from .coordinator import RamsesCoordinator
@@ -52,7 +52,7 @@ class RamsesEventType(StrEnum):
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: RamsesConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Event setup for RAMSES RF entry system-wide events."""

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -123,9 +123,9 @@ def as_iso(val: Any) -> str:
     return str(val)
 
 
-def resolve_async_attr(
-    entity: Any, obj: Any, attr_name: str, default: Any = None
-) -> Any:
+def resolve_async_attr[T](
+    entity: Any, obj: Any, attr_name: str, default: T | None = None
+) -> T | Any:
     """Safely get an attribute, resolving coroutines lazily.
 
     Bridges the gap between HA's synchronous properties and ramses_rf's async DTOs.

--- a/custom_components/ramses_cc/mqtt_bridge.py
+++ b/custom_components/ramses_cc/mqtt_bridge.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import mqtt
+from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.core import HomeAssistant, callback
 
 from ramses_tx.transport import CallbackTransport, TransportConfig
@@ -156,7 +157,7 @@ class RamsesMqttBridge:
             )
 
     @callback
-    def _handle_rx_message(self, msg: Any) -> None:
+    def _handle_rx_message(self, msg: ReceiveMessage) -> None:
         """Process incoming radio packets."""
         if self._transport is None:
             _LOGGER.warning("MqttBridge RX: Transport is None, dropping message")
@@ -205,7 +206,7 @@ class RamsesMqttBridge:
             )
 
     @callback
-    def _handle_cmd_message(self, msg: Any) -> None:
+    def _handle_cmd_message(self, msg: ReceiveMessage) -> None:
         """Process incoming MQTT messages and inject into ramses_rf."""
         if self._transport is None:
             _LOGGER.warning("MqttBridge CMD: Transport is None, dropping message")
@@ -273,7 +274,7 @@ class RamsesMqttBridge:
                 exc_info=True,
             )
 
-    def _extract_payload(self, msg: Any) -> str:
+    def _extract_payload(self, msg: ReceiveMessage) -> str:
         """Helper to decode bytes to string."""
         if isinstance(msg.payload, bytes):
             return msg.payload.decode("utf-8", errors="ignore")

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -51,7 +51,6 @@ from types import UnionType
 from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
@@ -75,6 +74,7 @@ from ramses_rf.protocol.ramses import _2411_PARAMS_SCHEMA as _2411_PARAMS_SCHEMA
 from .const import DOMAIN
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
+from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,7 +114,7 @@ def _has_existing_param_entities(entity_registry: Any, device_id: str) -> bool:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: RamsesConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the RAMSES number platform from a config entry.

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -13,7 +13,6 @@ from homeassistant.components.remote import (
     RemoteEntityDescription,
     RemoteEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import (
@@ -33,6 +32,7 @@ from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import parse_packet_string
 from .schemas import DEFAULT_NUM_REPEATS, DEFAULT_TIMEOUT
+from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -204,7 +204,9 @@ def _is_command_dict(value: Any) -> bool:
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: RamsesConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the remote platform.
 

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -14,7 +14,7 @@ from homeassistant.components.remote import (
     RemoteEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
@@ -432,7 +432,7 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         learning_session = asyncio.Event()
 
         @callback
-        async def _async_on_change(event: Any) -> None:
+        async def _async_on_change(event: Event) -> None:
             """Save the new command to storage.
 
             For REM entities: listens to ``src == self._device.id``,

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -15,7 +15,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
@@ -98,13 +97,16 @@ from .const import ATTR_SETPOINT, ATTR_WORKING_SCHEMA, DOMAIN, UnitOfVolumeFlowR
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import resolve_async_attr
+from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = td(minutes=20)  # only used for polling 10D0 filter_remaining
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: RamsesConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
 

--- a/custom_components/ramses_cc/typing.py
+++ b/custom_components/ramses_cc/typing.py
@@ -124,11 +124,22 @@ class FanParamEventData(TypedDict):
     value: Any
 
 
-class StoreStateDict(TypedDict):
+class StoreStateDict(TypedDict, total=False):
     """Schema for persistent client state storage."""
 
     schema: dict[str, Any]
     packets: list[str]
+    remotes: dict[str, Any]
+    discovery_state: dict[str, Any]
+    hvac_schema: dict[str, Any]
+
+
+class RamsesConfigData(TypedDict, total=False):
+    """Schema for Ramses config entry data and options."""
+
+    schema: dict[str, Any]
+    advanced_features: dict[str, Any]
+    ramses_rf: dict[str, Any]
 
 
 def is_fan_param_device(obj: Any) -> TypeGuard[FanParamDevice]:

--- a/custom_components/ramses_cc/typing.py
+++ b/custom_components/ramses_cc/typing.py
@@ -5,11 +5,14 @@ TypedDict schemas to enforce strict type safety across the integration.
 """
 
 from collections.abc import Callable
-from typing import Any, Protocol, TypedDict, TypeGuard, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeGuard, runtime_checkable
 
 from homeassistant.config_entries import ConfigEntry
 
-type RamsesConfigEntry = ConfigEntry[Any]
+if TYPE_CHECKING:
+    from .coordinator import RamsesCoordinator
+
+type RamsesConfigEntry = ConfigEntry[RamsesCoordinator]
 
 
 @runtime_checkable

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -14,7 +14,6 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntityDescription,
     WaterHeaterEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -40,6 +39,7 @@ from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import fields_to_aware, resolve_async_attr
 from .schemas import SCH_SET_DHW_MODE_EXTRA
+from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +56,9 @@ MODE_HA_TO_RAMSES: Final[dict[str, str]] = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: RamsesConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the water heater platform."""
     coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #898 < was merged

### The Problem:
`ConfigEntry` was un-typed across component setup modules (`async_setup_entry`), and `resolve_async_attr` in `helpers.py` lacked type parameters for default fallbacks.

### The Fix:
- Defined `type RamsesConfigEntry = ConfigEntry[RamsesCoordinator]` in `custom_components/ramses_cc/typing.py`.
- Updated `async_setup_entry` across all component setup modules (`__init__.py`, `binary_sensor.py`, `climate.py`, `event.py`, `number.py`, `remote.py`, `sensor.py`, `water_heater.py`) to type `entry: RamsesConfigEntry`.
- Refined `resolve_async_attr` in `helpers.py` using Python 3.12+ PEP 695 generic function syntax (`def resolve_async_attr[T](..., default: T | None = None) -> T | Any:`).

### Testing Performed:
- `mypy`: `.venv/bin/mypy custom_components/ramses_cc` passed cleanly (`Success: no issues found in 20 source files`).
- `ruff`: Code formatting and docstring checks passed cleanly.
- `pytest`: Full test suite passed (`1235 passed, 10 skipped`).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.

Closes #896