### PR TITLE
fix: Refactor setup error semantics and async task cancellation handling (#900)

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -58,7 +58,7 @@ from homeassistant.components.water_heater.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.service import verify_domain_control
 from homeassistant.helpers.storage import Store
@@ -128,7 +128,6 @@ _RAMSES_TX_EXC: ModuleType | None = None
 
 def _get_ramses_tx_exceptions() -> ModuleType:
     """Import ramses_tx.exceptions lazily to avoid circular import issues."""
-
     global _RAMSES_TX_EXC
     if _RAMSES_TX_EXC is None:
         from ramses_tx import exceptions as exc_module
@@ -147,7 +146,6 @@ PLATFORMS = [Platform.EVENT]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Ramses integration."""
-
     hass.data[DOMAIN] = {}
 
     # If required, do a one-off import of entry from config yaml
@@ -190,7 +188,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: RamsesConfigEntry) -> bool:
     """Create a ramses_rf (RAMSES_II)-based system."""
-
     _LOGGER.debug("Setting up entry %s...", entry.entry_id)
 
     tx_exc = _get_ramses_tx_exceptions()
@@ -247,23 +244,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: RamsesConfigEntry) -> bo
     except tx_exc.TransportSourceInvalid as err:  # not TransportSerialError
         _LOGGER.error("Unrecoverable problem with the serial port: %s", err)
         hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
-        return False
-    except tx_exc.TransportError as err:
-        msg = f"There is a problem with the serial port: {err} (check config)"
+        raise ConfigEntryError(f"Unrecoverable serial port error: {err}") from err
+    except (tx_exc.TransportError, TimeoutError, ConfigEntryNotReady) as err:
         _LOGGER.warning(
-            "Failed to set up entry %s (will retry): %s", entry.entry_id, msg
+            "Failed to set up entry %s (will retry): %s", entry.entry_id, err
         )
         hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
-        raise ConfigEntryNotReady(msg) from err
-    except Exception as err:
-        _LOGGER.error(
-            "Unexpected error during setup of entry %s: %s",
-            entry.entry_id,
-            err,
-            exc_info=True,
-        )
+        raise ConfigEntryNotReady(
+            f"There is a problem with the serial port: {err}"
+        ) from err
+    except Exception:
         hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
-        raise ConfigEntryNotReady(f"Setup failed: {err}") from err
+        raise
 
     # Start the coordinator after successful setup
     await coordinator.async_start()
@@ -431,7 +423,6 @@ def _healed_serial_port_options(
     options: dict[str, Any], *, mqtt_entries_present: bool
 ) -> dict[str, Any] | None:
     """Return healed options if serial_port is missing and MQTT is implied."""
-
     serial_port = options.get(SZ_SERIAL_PORT)
     serial_port_missing = not isinstance(serial_port, dict) or not serial_port.get(
         SZ_PORT_NAME

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -408,7 +408,7 @@ class RamsesNumberBase(RamsesEntity, NumberEntity):
                 )
                 self.clear_pending()
         except asyncio.CancelledError:
-            pass
+            raise
         except Exception as err:
             _LOGGER.debug("Error in pending clear task: %s", err, exc_info=True)
 

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, call, patch
 import pytest
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
 from syrupy.assertion import SnapshotAssertion
 
@@ -234,7 +234,7 @@ async def test_setup_entry_transport_error(
 async def test_setup_entry_source_invalid(
     hass: HomeAssistant, mock_coordinator: MagicMock
 ) -> None:
-    """Test setup returns False on TransportSourceInvalid."""
+    """Test setup raises ConfigEntryError on TransportSourceInvalid."""
     entry = MagicMock()
     entry.entry_id = "test_source_invalid"
     entry.options = {}
@@ -256,9 +256,9 @@ async def test_setup_entry_source_invalid(
 
         hass.data[DOMAIN] = {}
 
-        # Expect return False
-        result = await async_setup_entry(hass, entry)
-        assert result is False
+        # Expect ConfigEntryError
+        with pytest.raises(ConfigEntryError):
+            await async_setup_entry(hass, entry)
 
         # Verify cleanup
         assert entry.entry_id not in hass.data[DOMAIN]


### PR DESCRIPTION
### The Problem:
1. Unrecoverable transport source errors during integration setup returned `False` instead of raising `ConfigEntryError`.
2. Broad `except Exception` during setup caught all unexpected programming errors (`AttributeError`, `TypeError`, `KeyError`) and wrapped them into `ConfigEntryNotReady`, causing Home Assistant to retry setting up broken code endlessly.
3. `custom_components/ramses_cc/number.py` swallowed `asyncio.CancelledError` with `pass` in `_async_schedule_pending_clear`, breaking task cancellation state propagation.

### The Fix:
- Refactored setup error handling in `custom_components/ramses_cc/__init__.py`:
  - `TransportSourceInvalid` raises `ConfigEntryError` to fail setup cleanly and alert users.
  - Transient transport issues raise `ConfigEntryNotReady`.
  - Unexpected generic `Exception` instances clean up entry data and re-raise to fail fast.
- Re-raised `asyncio.CancelledError` in `custom_components/ramses_cc/number.py`.
- Updated corresponding lifecycle tests in `tests/tests_new/test_init.py`.

### Testing Performed:
- Verified all pre-commit hooks (`.venv/bin/prek run -a`) pass.
- Verified ruff formatting (`.venv/bin/ruff format --check .`) and docstrings (`.venv/bin/ruff check --select D`).
- Executed full test suite (`.venv/bin/pytest tests/`), 1235 passed cleanly.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.6 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.