### PR TITLE
refactor(services): support service response data and dict payloads for schedule services (PR 1)

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -18,13 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from ramses_rf.const import SZ_SUMMER_MODE
-from ramses_rf.devices import BdrSwitch, HgiGateway, OtbGateway, TrvActuator
-from ramses_rf.entity import Entity as RamsesRFEntity
-from ramses_rf.gateway import Gateway
-from ramses_rf.schemas import SZ_CONFIG, SZ_SCHEMA
-from ramses_rf.systems.tcs import Logbook, System
-from ramses_tx.const import (
+from ramses_rf.const import (
     SZ_BATTERY_LEVEL,
     SZ_BATTERY_LOW,
     SZ_BATTERY_STATE,
@@ -38,9 +32,15 @@ from ramses_tx.const import (
     SZ_DHW_ENABLED,
     SZ_FAULT_PRESENT,
     SZ_FLAME_ACTIVE,
-    SZ_IS_EVOFW3,
     SZ_OTC_ACTIVE,
+    SZ_SUMMER_MODE,
 )
+from ramses_rf.devices import BdrSwitch, HgiGateway, OtbGateway, TrvActuator
+from ramses_rf.entity import Entity as RamsesRFEntity
+from ramses_rf.gateway import Gateway
+from ramses_rf.schemas import SZ_CONFIG, SZ_SCHEMA
+from ramses_rf.systems.tcs import Logbook, System
+from ramses_tx.const import SZ_IS_EVOFW3
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.schemas import SZ_KNOWN_LIST
 

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from ramses_rf.const import SZ_SUMMER_MODE
 from ramses_rf.devices import BdrSwitch, HgiGateway, OtbGateway, TrvActuator
 from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.gateway import Gateway
@@ -39,7 +40,6 @@ from ramses_tx.const import (
     SZ_FLAME_ACTIVE,
     SZ_IS_EVOFW3,
     SZ_OTC_ACTIVE,
-    SZ_SUMMER_MODE,
 )
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.schemas import SZ_KNOWN_LIST

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -915,14 +915,23 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to set zone mode: {err}") from err
 
-    async def async_get_zone_schedule(self) -> None:
+    async def async_get_zone_schedule(self) -> dict[str, Any]:
         """Get the latest weekly schedule of the Zone.
 
-        :raises HomeAssistantError: If the command fails.
+        :returns: Dictionary containing the schedule.
+        :rtype: dict[str, Any]
+        :raises ServiceValidationError: If backend call fails or times out.
+        :raises HomeAssistantError: If an error occurs.
         """
         # {{ state_attr('climate.ramses_cc_01_145038_04', 'schedule') }}
         try:
-            await self._device.get_schedule()
+            res = await self._device.get_schedule()
+        except (TypeError, ValueError) as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="error_get_schedule",
+                translation_placeholders={"error": str(err)},
+            ) from err
         except (
             RamsesException,
             ProtocolSendFailed,
@@ -932,16 +941,31 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to get zone schedule: {err}") from err
         self.async_write_ha_state()
+        return {
+            "schedule": res
+            if res is not None
+            else getattr(self._device, "schedule", None)
+        }
 
-    async def async_set_zone_schedule(self, schedule: str) -> None:
+    async def async_set_zone_schedule(
+        self, schedule: str | dict[str, Any] | list[Any]
+    ) -> None:
         """Set the weekly schedule of the Zone.
 
-        :param schedule: The schedule json string.
+        :param schedule: The schedule payload (JSON string or dict/list object).
+        :raises ServiceValidationError: If JSON is invalid.
         :raises HomeAssistantError: If the command fails.
         """
         try:
-            await self._device.set_schedule(json.loads(schedule))
+            payload = json.loads(schedule) if isinstance(schedule, str) else schedule
+            await self._device.set_schedule(payload)
             self.async_write_ha_state()
+        except (TypeError, ValueError, json.JSONDecodeError) as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="error_set_schedule",
+                translation_placeholders={"error": str(err)},
+            ) from err
         except (
             RamsesException,
             ProtocolSendFailed,

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -35,10 +35,11 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.util import dt as dt_util
 
 from custom_components.ramses_cc.helpers import parse_packet_string
+from ramses_rf.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_rf.devices import HvacVentilator
 from ramses_rf.systems.tcs import Evohome
 from ramses_rf.systems.zones import Zone
-from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE, Priority
+from ramses_tx.const import Priority
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     ProtocolSendFailed,

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -10,9 +10,9 @@ from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
+from ramses_rf.const import DevType
 from ramses_rf.devices import Device, HvacRemoteBase, HvacVentilator
 from ramses_rf.entity import Entity as RamsesRFEntity
-from ramses_tx.const import DevType
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.typing import DeviceIdT
 

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -14,9 +14,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.59.2",
+      "ramses-rf==0.59.3",
       "serialx>=1.6.0"
     ],
     "single_config_entry": true,
-    "version": "0.59.2"
+    "version": "0.59.3"
   }

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -21,6 +21,7 @@ from ramses_rf.schemas import (
     SCH_GATEWAY_CONFIG,
     SCH_GLOBAL_SCHEMAS_DICT,
     SCH_RESTORE_CACHE_DICT,
+    SZ_ACTUATORS,
     SZ_APPLIANCE_CONTROL,
     SZ_BOUND_TO,
     SZ_CLASS,
@@ -36,6 +37,7 @@ from ramses_rf.schemas import (
     SZ_SENSORS,
     SZ_SYSTEM,
     SZ_UFH_SYSTEM,
+    SZ_ZONES,
 )
 from ramses_tx.const import (
     COMMAND_REGEX,
@@ -45,8 +47,6 @@ from ramses_tx.const import (
     MAX_NUM_REPEATS,
     MIN_GAP_DURATION,  # renamed from local MIN_DELAY_SECS
     MIN_NUM_REPEATS,
-    SZ_ACTUATORS,
-    SZ_ZONES,
 )
 from ramses_tx.schemas import (
     SCH_ENGINE_DICT,

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2610,7 +2610,7 @@ SCH_SET_ZONE_MODE_EXTRA = (
 SVC_SET_ZONE_SCHEDULE: Final = "set_zone_schedule"
 SCH_SET_ZONE_SCHEDULE = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_SCHEDULE): cv.string,
+        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
 )
 
@@ -2836,7 +2836,7 @@ SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
 SVC_SET_DHW_SCHEDULE: Final = "set_dhw_schedule"
 SCH_SET_DHW_SCHEDULE = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_SCHEDULE): cv.string,
+        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
 )
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -57,6 +57,7 @@ from ramses_rf.const import (
     SZ_INDOOR_HUMIDITY,
     SZ_INDOOR_TEMP,
     SZ_MAX_REL_MODULATION,
+    SZ_OEM_CODE,
     SZ_OUTDOOR_HUMIDITY,
     SZ_OUTDOOR_TEMP,
     SZ_OUTSIDE_TEMP,
@@ -87,7 +88,7 @@ from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.schemas import SZ_SCHEMA
 from ramses_rf.systems.tcs import System
 from ramses_rf.systems.zones import ZoneBase
-from ramses_tx.const import SZ_OEM_CODE, Code
+from ramses_tx.const import Code
 from ramses_tx.dtos import CommandDTO
 
 from .const import ATTR_SETPOINT, ATTR_WORKING_SCHEMA, DOMAIN, UnitOfVolumeFlowRate

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -33,9 +33,18 @@ from homeassistant.helpers.entity_platform import (
 from ramses_rf.const import (
     SZ_AIR_QUALITY,
     SZ_AIR_QUALITY_BASIS,
+    SZ_BOILER_OUTPUT_TEMP,
+    SZ_BOILER_RETURN_TEMP,
+    SZ_BOILER_SETPOINT,
     SZ_BYPASS_MODE,
+    SZ_CH_MAX_SETPOINT,
+    SZ_CH_SETPOINT,
+    SZ_CH_WATER_PRESSURE,
     SZ_CO2_LEVEL,
     SZ_DEWPOINT_TEMP,
+    SZ_DHW_FLOW_RATE,
+    SZ_DHW_SETPOINT,
+    SZ_DHW_TEMP,
     SZ_EXHAUST_FAN_SPEED,
     SZ_EXHAUST_FLOW,
     SZ_EXHAUST_TEMP,
@@ -47,10 +56,13 @@ from ramses_rf.const import (
     SZ_HEAT_DEMAND,
     SZ_INDOOR_HUMIDITY,
     SZ_INDOOR_TEMP,
+    SZ_MAX_REL_MODULATION,
     SZ_OUTDOOR_HUMIDITY,
     SZ_OUTDOOR_TEMP,
+    SZ_OUTSIDE_TEMP,
     SZ_POST_HEAT,
     SZ_PRE_HEAT,
+    SZ_REL_MODULATION_LEVEL,
     SZ_RELAY_DEMAND,
     SZ_REMAINING_MINS,
     SZ_SETPOINT,
@@ -75,22 +87,7 @@ from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.schemas import SZ_SCHEMA
 from ramses_rf.systems.tcs import System
 from ramses_rf.systems.zones import ZoneBase
-from ramses_tx.const import (
-    SZ_BOILER_OUTPUT_TEMP,
-    SZ_BOILER_RETURN_TEMP,
-    SZ_BOILER_SETPOINT,
-    SZ_CH_MAX_SETPOINT,
-    SZ_CH_SETPOINT,
-    SZ_CH_WATER_PRESSURE,
-    SZ_DHW_FLOW_RATE,
-    SZ_DHW_SETPOINT,
-    SZ_DHW_TEMP,
-    SZ_MAX_REL_MODULATION,
-    SZ_OEM_CODE,
-    SZ_OUTSIDE_TEMP,
-    SZ_REL_MODULATION_LEVEL,
-    Code,
-)
+from ramses_tx.const import SZ_OEM_CODE, Code
 from ramses_tx.dtos import CommandDTO
 
 from .const import ATTR_SETPOINT, ATTR_WORKING_SCHEMA, DOMAIN, UnitOfVolumeFlowRate

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -417,8 +417,7 @@ set_zone_schedule:
     schedule:
       required: true
       selector:
-        text:
-          multiline: true
+        object:
 
 
 #
@@ -554,8 +553,7 @@ set_dhw_schedule:
     schedule:
       required: true
       selector:
-        text:
-          multiline: true
+        object:
 
 
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -24,10 +24,10 @@ from homeassistant.helpers.entity_platform import (
 )
 from homeassistant.util import dt as dt_util
 
+from ramses_rf.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE
 from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.systems.tcs import StoredHw
 from ramses_rf.systems.zones import DhwZone
-from ramses_tx.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE
 from ramses_tx.exceptions import (
     ProtocolSendFailed,
     ProtocolTimeoutError,

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -408,14 +408,16 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to set DHW params: {err}") from err
 
-    async def async_get_dhw_schedule(self) -> None:
+    async def async_get_dhw_schedule(self) -> dict[str, Any]:
         """Get the latest weekly schedule of the DHW.
 
+        :returns: Dictionary containing the schedule.
+        :rtype: dict[str, Any]
         :raises ServiceValidationError: If the backend call fails or times out.
         """
         # {{ state_attr('water_heater.stored_hw', 'schedule') }}
         try:
-            await self._device.get_schedule()
+            res = await self._device.get_schedule()
         except (TypeError, ValueError) as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -430,15 +432,23 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to get DHW schedule: {err}") from err
         self.async_write_ha_state()
+        return {
+            "schedule": res
+            if res is not None
+            else getattr(self._device, "schedule", None)
+        }
 
-    async def async_set_dhw_schedule(self, schedule: str) -> None:
+    async def async_set_dhw_schedule(
+        self, schedule: str | dict[str, Any] | list[Any]
+    ) -> None:
         """Set the weekly schedule of the DHW.
 
-        :param schedule: The schedule as a JSON string.
+        :param schedule: The schedule payload (JSON string or dict/list object).
         :raises ServiceValidationError: If the backend call fails or JSON is invalid.
         """
         try:
-            await self._device.set_schedule(json.loads(schedule))
+            payload = json.loads(schedule) if isinstance(schedule, str) else schedule
+            await self._device.set_schedule(payload)
             self.async_write_ha_state()
         except (TypeError, ValueError, json.JSONDecodeError) as err:
             raise ServiceValidationError(

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
   aioesphomeapi         >= 45.7.0                # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.59.2                # as per: manifest.json latest:
+  ramses-rf             == 0.59.3                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.8.2                 # required by config_flow > homeassistant.components.usb, see issue #623

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -31,11 +31,11 @@ from custom_components.ramses_cc.const import (
     PRESET_TEMPORARY,
     SZ_KNOWN_LIST,
 )
+from ramses_rf.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_rf.devices import HvacVentilator
 from ramses_rf.models import TemperatureState
 from ramses_rf.systems.tcs import Evohome
 from ramses_rf.systems.zones import Zone
-from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_tx.exceptions import ProtocolSendFailed, TransportError
 
 # Constants

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -671,11 +671,16 @@ async def test_zone_methods_and_services(
     await zone.async_set_zone_config(min_temp=10)
     mock_device.set_config.assert_awaited_with(min_temp=10)
 
-    await zone.async_get_zone_schedule()
+    res = await zone.async_get_zone_schedule()
     mock_device.get_schedule.assert_awaited_once()
+    assert isinstance(res, dict)
+    assert "schedule" in res
 
     await zone.async_set_zone_schedule('{"day": 1}')
-    mock_device.set_schedule.assert_awaited_once()
+    mock_device.set_schedule.assert_awaited_with({"day": 1})
+
+    await zone.async_set_zone_schedule({"day": 2})
+    mock_device.set_schedule.assert_awaited_with({"day": 2})
 
 
 async def test_hvac_properties_and_modes(

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 
 from custom_components.ramses_cc.const import CONF_SCHEMA, DOMAIN, SZ_TR_BOUND
 from custom_components.ramses_cc.coordinator import RamsesCoordinator
-from ramses_tx.const import DevType
+from ramses_rf.const import DevType
 
 # Constants
 FAN_ID = "30:123456"

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -39,8 +39,8 @@ from ramses_rf.schemas import (
     SZ_SENSOR,
     SZ_SENSORS,
     SZ_SYSTEM,
+    SZ_ZONES,
 )
-from ramses_tx.const import SZ_ZONES
 from ramses_tx.schemas import SZ_PORT_NAME, SZ_SERIAL_PORT
 
 

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -33,6 +33,7 @@ from custom_components.ramses_cc.helpers import (
     ramses_device_id_to_ha_device_id,
 )
 from custom_components.ramses_cc.services import RamsesServiceHandler
+from ramses_rf.const import DevType
 from ramses_rf.devices import Device, HvacRemoteBase, HvacVentilator
 from ramses_rf.exceptions import BindingFlowFailed
 from ramses_rf.schemas import (
@@ -54,7 +55,6 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.systems import System, Zone
 from ramses_rf.topology import Child
-from ramses_tx.const import DevType
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     PacketAddrSetInvalid,

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -357,15 +357,20 @@ async def test_integration_services(
 async def test_schedule_management(
     water_heater: RamsesWaterHeater, mock_device: MagicMock
 ) -> None:
-    """Test get and set schedule methods."""
     # Test Get
-    await water_heater.async_get_dhw_schedule()
+    res = await water_heater.async_get_dhw_schedule()
     mock_device.get_schedule.assert_awaited_once()
+    assert isinstance(res, dict)
+    assert "schedule" in res
 
-    # Test Set (Valid JSON)
+    # Test Set (Valid JSON string)
     valid_json = '{"mon": []}'
     await water_heater.async_set_dhw_schedule(valid_json)
-    mock_device.set_schedule.assert_awaited_once()
+    mock_device.set_schedule.assert_awaited_with({"mon": []})
+
+    # Test Set (Valid Dict object)
+    await water_heater.async_set_dhw_schedule({"tue": []})
+    mock_device.set_schedule.assert_awaited_with({"tue": []})
 
     # Test Set (Invalid JSON)
     with pytest.raises(ServiceValidationError) as excinfo:

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -18,9 +18,9 @@ from custom_components.ramses_cc.water_heater import (
     RamsesWaterHeater,
     async_setup_entry,
 )
+from ramses_rf.const import SZ_SYSTEM_MODE
 from ramses_rf.models import TemperatureState
 from ramses_rf.systems.zones import DhwZone
-from ramses_tx.const import SZ_SYSTEM_MODE
 from ramses_tx.exceptions import ProtocolSendFailed
 
 # Constants for testing


### PR DESCRIPTION
### The Problem
Previously, calling `get_zone_schedule` or `get_dhw_schedule` in `ramses_cc` fetched the schedule asynchronously from hardware and recorded it as an entity state attribute, but did not return the payload directly in the Home Assistant service response. Furthermore, `set_zone_schedule` and `set_dhw_schedule` only accepted multiline JSON strings, causing errors if structured dictionary or list objects were passed directly from Home Assistant automations or UI dashboards.

### The Fix
- Updated `async_get_zone_schedule` and `async_get_dhw_schedule` in `climate.py` and `water_heater.py` to return `{"schedule": schedule_dict}` as ServiceResponse data.
- Updated `async_set_zone_schedule` and `async_set_dhw_schedule` to accept both JSON strings and native dictionary/list objects.
- Updated `SCH_SET_ZONE_SCHEDULE` and `SCH_SET_DHW_SCHEDULE` in `schemas.py` using `vol.Any(cv.string, dict, list)`.
- Updated service field selectors in `services.yaml` to `object`.
- Updated `ramses_rf` import paths across `binary_sensor.py`, `sensor.py`, `fan_handler.py`, and test files for compatibility with `ramses_rf` Phase 5 constants layering (`ramses-rf/ramses_rf#994`).
- Updated unit tests in `test_climate.py` and `test_water_heater.py` to verify service response data and structured schedule object inputs.

### Testing Performed
- Verified local `ramses_cc` virtual environment imports `ramses_rf` from local development branch (`refactor/event-bus-and-handshake`, ramses-rf/ramses_rf#997).
- Ran `.venv/bin/pytest tests/tests_new` (`1,134` tests passed cleanly).
- Ran `.venv/bin/mypy custom_components/ramses_cc` (`100%` type safety across 21 source files).
- Ran `.venv/bin/prek run -a` (all 17 pre-commit checks passed).

### AI Assistance Disclosure
This contribution was developed with the assistance of Google Gemini for code generation, type safety checking, and unit test verification. All logic and implementations were reviewed and verified by the author.

---
Coordinated via ramses-rf/ramses_cc#884 (ref: ramses-rf/ramses_rf#997).
