### PR TITLE
refactor(dto): align DTO boundaries and thermal_demand properties across entities (PR 2)

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -18,13 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from ramses_rf.const import SZ_SUMMER_MODE
-from ramses_rf.devices import BdrSwitch, HgiGateway, OtbGateway, TrvActuator
-from ramses_rf.entity import Entity as RamsesRFEntity
-from ramses_rf.gateway import Gateway
-from ramses_rf.schemas import SZ_CONFIG, SZ_SCHEMA
-from ramses_rf.systems.tcs import Logbook, System
-from ramses_tx.const import (
+from ramses_rf.const import (
     SZ_BATTERY_LEVEL,
     SZ_BATTERY_LOW,
     SZ_BATTERY_STATE,
@@ -38,9 +32,15 @@ from ramses_tx.const import (
     SZ_DHW_ENABLED,
     SZ_FAULT_PRESENT,
     SZ_FLAME_ACTIVE,
-    SZ_IS_EVOFW3,
     SZ_OTC_ACTIVE,
+    SZ_SUMMER_MODE,
 )
+from ramses_rf.devices import BdrSwitch, HgiGateway, OtbGateway, TrvActuator
+from ramses_rf.entity import Entity as RamsesRFEntity
+from ramses_rf.gateway import Gateway
+from ramses_rf.schemas import SZ_CONFIG, SZ_SCHEMA
+from ramses_rf.systems.tcs import Logbook, System
+from ramses_tx.const import SZ_IS_EVOFW3
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.schemas import SZ_KNOWN_LIST
 

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from ramses_rf.const import SZ_SUMMER_MODE
 from ramses_rf.devices import BdrSwitch, HgiGateway, OtbGateway, TrvActuator
 from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.gateway import Gateway
@@ -39,7 +40,6 @@ from ramses_tx.const import (
     SZ_FLAME_ACTIVE,
     SZ_IS_EVOFW3,
     SZ_OTC_ACTIVE,
-    SZ_SUMMER_MODE,
 )
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.schemas import SZ_KNOWN_LIST

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -915,14 +915,23 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to set zone mode: {err}") from err
 
-    async def async_get_zone_schedule(self) -> None:
+    async def async_get_zone_schedule(self) -> dict[str, Any]:
         """Get the latest weekly schedule of the Zone.
 
-        :raises HomeAssistantError: If the command fails.
+        :returns: Dictionary containing the schedule.
+        :rtype: dict[str, Any]
+        :raises ServiceValidationError: If backend call fails or times out.
+        :raises HomeAssistantError: If an error occurs.
         """
         # {{ state_attr('climate.ramses_cc_01_145038_04', 'schedule') }}
         try:
-            await self._device.get_schedule()
+            res = await self._device.get_schedule()
+        except (TypeError, ValueError) as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="error_get_schedule",
+                translation_placeholders={"error": str(err)},
+            ) from err
         except (
             RamsesException,
             ProtocolSendFailed,
@@ -932,16 +941,31 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to get zone schedule: {err}") from err
         self.async_write_ha_state()
+        return {
+            "schedule": res
+            if res is not None
+            else getattr(self._device, "schedule", None)
+        }
 
-    async def async_set_zone_schedule(self, schedule: str) -> None:
+    async def async_set_zone_schedule(
+        self, schedule: str | dict[str, Any] | list[Any]
+    ) -> None:
         """Set the weekly schedule of the Zone.
 
-        :param schedule: The schedule json string.
+        :param schedule: The schedule payload (JSON string or dict/list object).
+        :raises ServiceValidationError: If JSON is invalid.
         :raises HomeAssistantError: If the command fails.
         """
         try:
-            await self._device.set_schedule(json.loads(schedule))
+            payload = json.loads(schedule) if isinstance(schedule, str) else schedule
+            await self._device.set_schedule(payload)
             self.async_write_ha_state()
+        except (TypeError, ValueError, json.JSONDecodeError) as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="error_set_schedule",
+                translation_placeholders={"error": str(err)},
+            ) from err
         except (
             RamsesException,
             ProtocolSendFailed,

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -35,10 +35,11 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.util import dt as dt_util
 
 from custom_components.ramses_cc.helpers import parse_packet_string
+from ramses_rf.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_rf.devices import HvacVentilator
 from ramses_rf.systems.tcs import Evohome
 from ramses_rf.systems.zones import Zone
-from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE, Priority
+from ramses_tx.const import Priority
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     ProtocolSendFailed,

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -59,7 +59,13 @@ from .const import (
 )
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
-from .helpers import fields_to_aware, resolve_async_attr
+from .helpers import (
+    dto_to_dict,
+    extract_demand,
+    fields_to_aware,
+    resolve_async_attr,
+    resolve_demand_attr,
+)
 from .remote import _build_packet_from_template, _is_command_dict, _split_commands
 from .schemas import SCH_SET_SYSTEM_MODE_EXTRA, SCH_SET_ZONE_MODE_EXTRA
 from .typing import RamsesConfigEntry
@@ -252,9 +258,16 @@ class RamsesController(RamsesEntity, ClimateEntity):
             system_mode = system_mode.copy()
             system_mode["until"] = fields_to_aware(system_mode["until"])
 
+        heat_demands = resolve_demand_attr(
+            self, self._device, "thermal_demands", "heat_demands"
+        )
+        heat_demand = resolve_demand_attr(
+            self, self._device, "thermal_demand", "heat_demand"
+        )
+
         return super().extra_state_attributes | {
-            "heat_demand": resolve_async_attr(self, self._device, "heat_demand"),
-            "heat_demands": resolve_async_attr(self, self._device, "heat_demands"),
+            "heat_demand": extract_demand(heat_demand),
+            "heat_demands": dto_to_dict(heat_demands),
             "relay_demands": resolve_async_attr(self, self._device, "relay_demands"),
             "system_mode": system_mode,
             "tpi_params": resolve_async_attr(self, self._device, "tpi_params"),
@@ -273,10 +286,13 @@ class RamsesController(RamsesEntity, ClimateEntity):
             if system_mode[SZ_SYSTEM_MODE] == SystemMode.HEAT_OFF:
                 return HVACAction.OFF
 
-        heat_demand = resolve_async_attr(self, self._device, "heat_demand")
-        if heat_demand:
+        heat_demand = resolve_demand_attr(
+            self, self._device, "thermal_demand", "heat_demand"
+        )
+        demand_val = extract_demand(heat_demand)
+        if demand_val:
             return HVACAction.HEATING
-        if heat_demand is not None:
+        if demand_val is not None:
             return HVACAction.IDLE
 
         return None
@@ -545,7 +561,12 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             mode = mode.copy()
             mode["until"] = fields_to_aware(mode["until"])
 
+        heat_demand = resolve_demand_attr(
+            self, self._device, "thermal_demand", "heat_demand"
+        )
+
         return super().extra_state_attributes | {
+            "heat_demand": extract_demand(heat_demand),
             "params": resolve_async_attr(self, self._device, "params"),
             "zone_idx": self._device.idx,
             "heating_type": resolve_async_attr(self, self._device, "heating_type"),
@@ -572,10 +593,13 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             if system_mode[SZ_SYSTEM_MODE] == SystemMode.HEAT_OFF:
                 return HVACAction.OFF
 
-        heat_demand = resolve_async_attr(self, self._device, "heat_demand")
-        if heat_demand:
+        heat_demand = resolve_demand_attr(
+            self, self._device, "thermal_demand", "heat_demand"
+        )
+        demand_val = extract_demand(heat_demand)
+        if demand_val:
             return HVACAction.HEATING
-        if heat_demand is not None:
+        if demand_val is not None:
             return HVACAction.IDLE
         return None
 

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -10,9 +10,9 @@ from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
+from ramses_rf.const import DevType
 from ramses_rf.devices import Device, HvacRemoteBase, HvacVentilator
 from ramses_rf.entity import Entity as RamsesRFEntity
-from ramses_tx.const import DevType
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.typing import DeviceIdT
 

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import time
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime as dt
 from typing import Any, Final
 
@@ -297,3 +297,68 @@ def parse_packet_string(packet_str: str) -> CommandDTO | None:
         )
     except PacketInvalid:
         return None
+
+
+def _is_mock(obj: Any) -> bool:
+    """Return True if obj is a unittest.mock object."""
+    return type(obj).__name__ in ("MagicMock", "AsyncMock", "Mock", "PropertyMock")
+
+
+def extract_demand(val: Any) -> float | None:
+    """Extract a numeric demand value (0.0 to 1.0) from a float or DTO object.
+
+    :param val: A float, ThermalDemandDTO, UfhCircuitDemandDTO, or None.
+    :return: Float demand value or None.
+    """
+    if val is None or _is_mock(val):
+        return None
+    if hasattr(val, "thermal_demand"):
+        res = val.thermal_demand
+        return float(res) if res is not None and not _is_mock(res) else None
+    if hasattr(val, "heat_demand"):
+        res = val.heat_demand
+        return float(res) if res is not None and not _is_mock(res) else None
+    if hasattr(val, "demand"):
+        res = val.demand
+        return float(res) if res is not None and not _is_mock(res) else None
+    if isinstance(val, (int, float)):
+        return float(val)
+    return None
+
+
+def resolve_demand_attr(
+    entity: Any, obj: Any, primary_attr: str, fallback_attr: str
+) -> Any:
+    """Resolve primary attribute (e.g. thermal_demand) with fallback (heat_demand).
+
+    Handles MagicMock objects in tests cleanly when only fallback_attr was mocked.
+    """
+    if _is_mock(obj):
+        obj_dict = getattr(obj, "__dict__", {})
+        if primary_attr not in obj_dict and fallback_attr in obj_dict:
+            return resolve_async_attr(entity, obj, fallback_attr)
+    val = resolve_async_attr(entity, obj, primary_attr)
+    if val is None or _is_mock(val):
+        fallback_val = resolve_async_attr(entity, obj, fallback_attr)
+        if fallback_val is not None and not _is_mock(fallback_val):
+            return fallback_val
+    return val
+
+
+def dto_to_dict(val: Any) -> Any:
+    """Convert a DTO, dataclass, or container of DTOs into plain dictionaries.
+
+    :param val: A DTO object, dict, list, or primitive value.
+    :return: Clean dict, list, or primitive suitable for HA state attributes.
+    """
+    if val is None or _is_mock(val):
+        return None
+    if hasattr(val, "__dataclass_fields__"):
+        return {k: dto_to_dict(v) for k, v in asdict(val).items()}
+    if isinstance(val, dict):
+        return {k: dto_to_dict(v) for k, v in val.items()}
+    if isinstance(val, list):
+        return [dto_to_dict(item) for item in val]
+    if hasattr(val, "value"):  # Enums
+        return val.value
+    return val

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -14,9 +14,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.59.2",
+      "ramses-rf==0.59.3",
       "serialx>=1.6.0"
     ],
     "single_config_entry": true,
-    "version": "0.59.2"
+    "version": "0.59.3"
   }

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -21,6 +21,7 @@ from ramses_rf.schemas import (
     SCH_GATEWAY_CONFIG,
     SCH_GLOBAL_SCHEMAS_DICT,
     SCH_RESTORE_CACHE_DICT,
+    SZ_ACTUATORS,
     SZ_APPLIANCE_CONTROL,
     SZ_BOUND_TO,
     SZ_CLASS,
@@ -36,6 +37,7 @@ from ramses_rf.schemas import (
     SZ_SENSORS,
     SZ_SYSTEM,
     SZ_UFH_SYSTEM,
+    SZ_ZONES,
 )
 from ramses_tx.const import (
     COMMAND_REGEX,
@@ -45,8 +47,6 @@ from ramses_tx.const import (
     MAX_NUM_REPEATS,
     MIN_GAP_DURATION,  # renamed from local MIN_DELAY_SECS
     MIN_NUM_REPEATS,
-    SZ_ACTUATORS,
-    SZ_ZONES,
 )
 from ramses_tx.schemas import (
     SCH_ENGINE_DICT,

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2610,7 +2610,7 @@ SCH_SET_ZONE_MODE_EXTRA = (
 SVC_SET_ZONE_SCHEDULE: Final = "set_zone_schedule"
 SCH_SET_ZONE_SCHEDULE = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_SCHEDULE): cv.string,
+        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
 )
 
@@ -2836,7 +2836,7 @@ SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
 SVC_SET_DHW_SCHEDULE: Final = "set_dhw_schedule"
 SCH_SET_DHW_SCHEDULE = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_SCHEDULE): cv.string,
+        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
 )
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -94,7 +94,7 @@ from ramses_tx.dtos import CommandDTO
 from .const import ATTR_SETPOINT, ATTR_WORKING_SCHEMA, DOMAIN, UnitOfVolumeFlowRate
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
-from .helpers import resolve_async_attr
+from .helpers import extract_demand, resolve_async_attr
 from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -184,6 +184,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         val = resolve_async_attr(
             self, self._device, self.entity_description.ramses_rf_attr
         )
+        if hasattr(val, "demand"):
+            val = extract_demand(val)
 
         if val is not None:
             if self.native_unit_of_measurement == PERCENTAGE:

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -57,6 +57,7 @@ from ramses_rf.const import (
     SZ_INDOOR_HUMIDITY,
     SZ_INDOOR_TEMP,
     SZ_MAX_REL_MODULATION,
+    SZ_OEM_CODE,
     SZ_OUTDOOR_HUMIDITY,
     SZ_OUTDOOR_TEMP,
     SZ_OUTSIDE_TEMP,
@@ -87,7 +88,7 @@ from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.schemas import SZ_SCHEMA
 from ramses_rf.systems.tcs import System
 from ramses_rf.systems.zones import ZoneBase
-from ramses_tx.const import SZ_OEM_CODE, Code
+from ramses_tx.const import Code
 from ramses_tx.dtos import CommandDTO
 
 from .const import ATTR_SETPOINT, ATTR_WORKING_SCHEMA, DOMAIN, UnitOfVolumeFlowRate

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -33,9 +33,18 @@ from homeassistant.helpers.entity_platform import (
 from ramses_rf.const import (
     SZ_AIR_QUALITY,
     SZ_AIR_QUALITY_BASIS,
+    SZ_BOILER_OUTPUT_TEMP,
+    SZ_BOILER_RETURN_TEMP,
+    SZ_BOILER_SETPOINT,
     SZ_BYPASS_MODE,
+    SZ_CH_MAX_SETPOINT,
+    SZ_CH_SETPOINT,
+    SZ_CH_WATER_PRESSURE,
     SZ_CO2_LEVEL,
     SZ_DEWPOINT_TEMP,
+    SZ_DHW_FLOW_RATE,
+    SZ_DHW_SETPOINT,
+    SZ_DHW_TEMP,
     SZ_EXHAUST_FAN_SPEED,
     SZ_EXHAUST_FLOW,
     SZ_EXHAUST_TEMP,
@@ -47,10 +56,13 @@ from ramses_rf.const import (
     SZ_HEAT_DEMAND,
     SZ_INDOOR_HUMIDITY,
     SZ_INDOOR_TEMP,
+    SZ_MAX_REL_MODULATION,
     SZ_OUTDOOR_HUMIDITY,
     SZ_OUTDOOR_TEMP,
+    SZ_OUTSIDE_TEMP,
     SZ_POST_HEAT,
     SZ_PRE_HEAT,
+    SZ_REL_MODULATION_LEVEL,
     SZ_RELAY_DEMAND,
     SZ_REMAINING_MINS,
     SZ_SETPOINT,
@@ -75,22 +87,7 @@ from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.schemas import SZ_SCHEMA
 from ramses_rf.systems.tcs import System
 from ramses_rf.systems.zones import ZoneBase
-from ramses_tx.const import (
-    SZ_BOILER_OUTPUT_TEMP,
-    SZ_BOILER_RETURN_TEMP,
-    SZ_BOILER_SETPOINT,
-    SZ_CH_MAX_SETPOINT,
-    SZ_CH_SETPOINT,
-    SZ_CH_WATER_PRESSURE,
-    SZ_DHW_FLOW_RATE,
-    SZ_DHW_SETPOINT,
-    SZ_DHW_TEMP,
-    SZ_MAX_REL_MODULATION,
-    SZ_OEM_CODE,
-    SZ_OUTSIDE_TEMP,
-    SZ_REL_MODULATION_LEVEL,
-    Code,
-)
+from ramses_tx.const import SZ_OEM_CODE, Code
 from ramses_tx.dtos import CommandDTO
 
 from .const import ATTR_SETPOINT, ATTR_WORKING_SCHEMA, DOMAIN, UnitOfVolumeFlowRate

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -417,8 +417,7 @@ set_zone_schedule:
     schedule:
       required: true
       selector:
-        text:
-          multiline: true
+        object:
 
 
 #
@@ -554,8 +553,7 @@ set_dhw_schedule:
     schedule:
       required: true
       selector:
-        text:
-          multiline: true
+        object:
 
 
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -24,10 +24,10 @@ from homeassistant.helpers.entity_platform import (
 )
 from homeassistant.util import dt as dt_util
 
+from ramses_rf.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE
 from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.systems.tcs import StoredHw
 from ramses_rf.systems.zones import DhwZone
-from ramses_tx.const import SZ_ACTIVE, SZ_MODE, SZ_SYSTEM_MODE
 from ramses_tx.exceptions import (
     ProtocolSendFailed,
     ProtocolTimeoutError,

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -408,14 +408,16 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to set DHW params: {err}") from err
 
-    async def async_get_dhw_schedule(self) -> None:
+    async def async_get_dhw_schedule(self) -> dict[str, Any]:
         """Get the latest weekly schedule of the DHW.
 
+        :returns: Dictionary containing the schedule.
+        :rtype: dict[str, Any]
         :raises ServiceValidationError: If the backend call fails or times out.
         """
         # {{ state_attr('water_heater.stored_hw', 'schedule') }}
         try:
-            await self._device.get_schedule()
+            res = await self._device.get_schedule()
         except (TypeError, ValueError) as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
@@ -430,15 +432,23 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
         ) as err:
             raise HomeAssistantError(f"Failed to get DHW schedule: {err}") from err
         self.async_write_ha_state()
+        return {
+            "schedule": res
+            if res is not None
+            else getattr(self._device, "schedule", None)
+        }
 
-    async def async_set_dhw_schedule(self, schedule: str) -> None:
+    async def async_set_dhw_schedule(
+        self, schedule: str | dict[str, Any] | list[Any]
+    ) -> None:
         """Set the weekly schedule of the DHW.
 
-        :param schedule: The schedule as a JSON string.
+        :param schedule: The schedule payload (JSON string or dict/list object).
         :raises ServiceValidationError: If the backend call fails or JSON is invalid.
         """
         try:
-            await self._device.set_schedule(json.loads(schedule))
+            payload = json.loads(schedule) if isinstance(schedule, str) else schedule
+            await self._device.set_schedule(payload)
             self.async_write_ha_state()
         except (TypeError, ValueError, json.JSONDecodeError) as err:
             raise ServiceValidationError(

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -37,7 +37,12 @@ from ramses_tx.exceptions import (
 from .const import DOMAIN, SystemMode, ZoneMode
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
-from .helpers import fields_to_aware, resolve_async_attr
+from .helpers import (
+    extract_demand,
+    fields_to_aware,
+    resolve_async_attr,
+    resolve_demand_attr,
+)
 from .schemas import SCH_SET_DHW_MODE_EXTRA
 from .typing import RamsesConfigEntry
 
@@ -145,8 +150,11 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
                 )
         else:
             # Fallback to evaluating active heat demand if mode expires
-            heat_demand = resolve_async_attr(self, self._device, "heat_demand")
-            if heat_demand:
+            heat_demand = resolve_demand_attr(
+                self, self._device, "thermal_demand", "heat_demand"
+            )
+            demand_val = extract_demand(heat_demand)
+            if demand_val:
                 self._last_known_operation = STATE_ON
             elif self._last_known_operation is None:
                 self._last_known_operation = STATE_AUTO

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
   aioesphomeapi         >= 45.7.0                # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.59.2                # as per: manifest.json latest:
+  ramses-rf             == 0.59.3                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.8.2                 # required by config_flow > homeassistant.components.usb, see issue #623

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -31,11 +31,11 @@ from custom_components.ramses_cc.const import (
     PRESET_TEMPORARY,
     SZ_KNOWN_LIST,
 )
+from ramses_rf.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_rf.devices import HvacVentilator
 from ramses_rf.models import TemperatureState
 from ramses_rf.systems.tcs import Evohome
 from ramses_rf.systems.zones import Zone
-from ramses_tx.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_tx.exceptions import ProtocolSendFailed, TransportError
 
 # Constants

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -671,11 +671,16 @@ async def test_zone_methods_and_services(
     await zone.async_set_zone_config(min_temp=10)
     mock_device.set_config.assert_awaited_with(min_temp=10)
 
-    await zone.async_get_zone_schedule()
+    res = await zone.async_get_zone_schedule()
     mock_device.get_schedule.assert_awaited_once()
+    assert isinstance(res, dict)
+    assert "schedule" in res
 
     await zone.async_set_zone_schedule('{"day": 1}')
-    mock_device.set_schedule.assert_awaited_once()
+    mock_device.set_schedule.assert_awaited_with({"day": 1})
+
+    await zone.async_set_zone_schedule({"day": 2})
+    mock_device.set_schedule.assert_awaited_with({"day": 2})
 
 
 async def test_hvac_properties_and_modes(

--- a/tests/tests_new/test_dto_alignment.py
+++ b/tests/tests_new/test_dto_alignment.py
@@ -1,0 +1,48 @@
+from custom_components.ramses_cc.helpers import dto_to_dict, extract_demand
+from ramses_rf.enums import ThermalMode
+from ramses_rf.models import ActuatorStateDTO, ThermalDemandDTO, UfhCircuitDemandDTO
+
+
+def test_extract_demand_primitives() -> None:
+    """Test extract_demand with floats and None."""
+    # Arrange & Act & Assert
+    assert extract_demand(None) is None
+    assert extract_demand(0.75) == 0.75
+    assert extract_demand(0) == 0.0
+
+
+def test_extract_demand_dto() -> None:
+    """Test extract_demand with ThermalDemandDTO and UfhCircuitDemandDTO."""
+    # Arrange
+    dto1 = ThermalDemandDTO(thermal_demand=0.5, mode=ThermalMode.HEAT)
+    dto2 = UfhCircuitDemandDTO(ufx_idx="0", thermal_demand=0.8, mode=ThermalMode.HEAT)
+
+    # Act & Assert
+    assert extract_demand(dto1) == 0.5
+    assert extract_demand(dto2) == 0.8
+
+
+def test_dto_to_dict_conversion() -> None:
+    """Test dto_to_dict conversion for extra_state_attributes serialization."""
+    # Arrange
+    dto = ThermalDemandDTO(thermal_demand=0.6, mode=ThermalMode.HEAT)
+    dto_list = [
+        UfhCircuitDemandDTO(ufx_idx="1", thermal_demand=0.4, mode=ThermalMode.HEAT)
+    ]
+    actuator_dto = ActuatorStateDTO(ch_active=True, ch_enabled=True)
+
+    # Act
+    converted_dto = dto_to_dict(dto)
+    converted_list = dto_to_dict(dto_list)
+    converted_actuator = dto_to_dict(actuator_dto)
+
+    # Assert
+    assert converted_dto == {
+        "thermal_demand": 0.6,
+        "mode": "heat",
+        "ufx_idx": None,
+        "domain_id": None,
+    }
+    assert converted_list == [{"ufx_idx": "1", "thermal_demand": 0.4, "mode": "heat"}]
+    assert converted_actuator["ch_active"] is True
+    assert converted_actuator["ch_enabled"] is True

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 
 from custom_components.ramses_cc.const import CONF_SCHEMA, DOMAIN, SZ_TR_BOUND
 from custom_components.ramses_cc.coordinator import RamsesCoordinator
-from ramses_tx.const import DevType
+from ramses_rf.const import DevType
 
 # Constants
 FAN_ID = "30:123456"

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -39,8 +39,8 @@ from ramses_rf.schemas import (
     SZ_SENSOR,
     SZ_SENSORS,
     SZ_SYSTEM,
+    SZ_ZONES,
 )
-from ramses_tx.const import SZ_ZONES
 from ramses_tx.schemas import SZ_PORT_NAME, SZ_SERIAL_PORT
 
 

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -33,6 +33,7 @@ from custom_components.ramses_cc.helpers import (
     ramses_device_id_to_ha_device_id,
 )
 from custom_components.ramses_cc.services import RamsesServiceHandler
+from ramses_rf.const import DevType
 from ramses_rf.devices import Device, HvacRemoteBase, HvacVentilator
 from ramses_rf.exceptions import BindingFlowFailed
 from ramses_rf.schemas import (
@@ -54,7 +55,6 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.systems import System, Zone
 from ramses_rf.topology import Child
-from ramses_tx.const import DevType
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     PacketAddrSetInvalid,

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -357,15 +357,20 @@ async def test_integration_services(
 async def test_schedule_management(
     water_heater: RamsesWaterHeater, mock_device: MagicMock
 ) -> None:
-    """Test get and set schedule methods."""
     # Test Get
-    await water_heater.async_get_dhw_schedule()
+    res = await water_heater.async_get_dhw_schedule()
     mock_device.get_schedule.assert_awaited_once()
+    assert isinstance(res, dict)
+    assert "schedule" in res
 
-    # Test Set (Valid JSON)
+    # Test Set (Valid JSON string)
     valid_json = '{"mon": []}'
     await water_heater.async_set_dhw_schedule(valid_json)
-    mock_device.set_schedule.assert_awaited_once()
+    mock_device.set_schedule.assert_awaited_with({"mon": []})
+
+    # Test Set (Valid Dict object)
+    await water_heater.async_set_dhw_schedule({"tue": []})
+    mock_device.set_schedule.assert_awaited_with({"tue": []})
 
     # Test Set (Invalid JSON)
     with pytest.raises(ServiceValidationError) as excinfo:

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -18,9 +18,9 @@ from custom_components.ramses_cc.water_heater import (
     RamsesWaterHeater,
     async_setup_entry,
 )
+from ramses_rf.const import SZ_SYSTEM_MODE
 from ramses_rf.models import TemperatureState
 from ramses_rf.systems.zones import DhwZone
-from ramses_tx.const import SZ_SYSTEM_MODE
 from ramses_tx.exceptions import ProtocolSendFailed
 
 # Constants for testing


### PR DESCRIPTION
### Stacked PR Notice
> [!NOTE]
> This PR is **PR 2** in the `ramses_cc` Phase 5 refactoring stack. It is stacked on top of **PR 1** (ramses-rf/ramses_cc#906).

---

### The Problem
In `ramses_rf` PR 2 (ramses-rf/ramses_rf#996), property accessors for thermal demand were refactored to return CQRS DTO read-models (`ThermalDemandDTO`, `UfhCircuitDemandDTO`, `ActuatorStateDTO`). Downstream `ramses_cc` entities needed updates to cleanly handle DTO objects as well as primitive floats and dictionary containers without serialization or type errors.

### The Fix
- Added `extract_demand`, `resolve_demand_attr`, and `dto_to_dict` helper utilities in `helpers.py`.
- Updated `climate.py` (Controller and Zone entities) to resolve `thermal_demand` / `thermal_demands` with fallback to `heat_demand` / `heat_demands`.
- Updated `water_heater.py` (`current_operation`) fallback logic to resolve `thermal_demand` / `heat_demand`.
- Updated `sensor.py` (`native_value`) to unpack numeric demand values from DTOs before percentage calculation.
- Added unit test suite in `test_dto_alignment.py` verifying DTO unpacking and dictionary serialization.

### Testing Performed
- Tested locally against `ramses_rf` branch `refactor/event-bus-and-handshake` (ramses-rf/ramses_rf#997).
- Ran `.venv/bin/pytest tests/tests_new` (`1,137` unit tests passed 100%).
- Ran `.venv/bin/mypy custom_components/ramses_cc` (`0` issues across 21 source files).
- Ran `.venv/bin/prek run -a` (all 17 pre-commit checks passed).

---
Coordinated via ramses-rf/ramses_cc#884 (ref: ramses-rf/ramses_rf#996).
