### PR TITLE
fix: preserve user-configured TRV zone sensors in sync_learned_topology

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1439,6 +1439,19 @@ def sync_learned_topology(
             if isinstance(orig_config_zones, dict):
                 orig_config_zone_keys = set(orig_config_zones.keys())
 
+            # Track original user-authored sensors per zone.  The
+            # issue-813 TRV-demotion logic below must NOT null a sensor
+            # the user explicitly set in the config flow (e.g. a TRV's
+            # built-in sensor that is also listed in actuators).  See
+            # ramses-rf/ramses_cc#887.
+            orig_config_sensors: dict[str, str] = {}
+            if isinstance(orig_config_zones, dict):
+                for z_idx, z_val in orig_config_zones.items():
+                    if isinstance(z_val, dict) and isinstance(
+                        z_val.get(SZ_SENSOR), str
+                    ):
+                        orig_config_sensors[z_idx] = z_val[SZ_SENSOR]
+
             # 1a. Sync appliance_control
             learned_sys = learned_entry.get(SZ_SYSTEM, {})
             if isinstance(learned_sys, dict):
@@ -1515,7 +1528,7 @@ def sync_learned_topology(
             # the thermostat to sensor (see issue 813).
             config_zones = config_entry.get(SZ_ZONES)
             if isinstance(config_zones, dict):
-                for zone in config_zones.values():
+                for zone_idx, zone in config_zones.items():
                     if not isinstance(zone, dict):
                         continue
                     # If a TRV (04:) is the sensor, it should be in actuators
@@ -1555,8 +1568,10 @@ def sync_learned_topology(
                                 sensor,
                                 thermostat,
                             )
-                        else:
-                            # No thermostat to swap — just move TRV to actuators
+                        elif zone_idx not in orig_config_sensors:
+                            # No thermostat to swap — just move TRV to
+                            # actuators.  Skipped when the user explicitly
+                            # set the sensor (ramses-rf/ramses_cc#887).
                             if sensor not in actuators:
                                 actuators.append(sensor)
                                 actuators.sort()
@@ -1582,7 +1597,9 @@ def sync_learned_topology(
                             "sensor to new actuators list",
                             sensor,
                         )
-                    # Clear 04: (TRV) from sensor if also in actuators (dup)
+                    # Clear 04: (TRV) from sensor if also in actuators
+                    # (dup).  Skipped when the user explicitly set the
+                    # sensor (ramses-rf/ramses_cc#887).
                     sensor = zone.get(SZ_SENSOR)
                     actuators = zone.get("actuators")
                     if (
@@ -1590,6 +1607,7 @@ def sync_learned_topology(
                         and sensor.startswith("04:")
                         and isinstance(actuators, list)
                         and sensor in actuators
+                        and zone_idx not in orig_config_sensors
                     ):
                         zone[SZ_SENSOR] = None
                         changed = True

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -3014,6 +3014,65 @@ def test_sync_learned_topology_single_trv_as_sensor_moved_to_actuators() -> None
     assert "04:056675" in zone["actuators"]
 
 
+def test_sync_learned_topology_preserves_user_trv_sensor_in_actuators() -> None:
+    """A TRV the user set as zone sensor must not be nulled when it
+    is also in the actuators list (ramses-rf/ramses_cc#887).
+
+    TRVs with built-in temperature sensors are valid zone sensors.
+    The issue-813 TRV-demotion heuristic must not override user
+    intent when the sensor is also listed as an actuator.
+    """
+    # Arrange — user explicitly set 04: TRV as sensor AND actuator
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:161591",
+        "01:161591": {
+            SZ_ZONES: {
+                "00": {
+                    SZ_SENSOR: "04:147093",
+                    "actuators": ["04:147093", "04:107745"],
+                    SZ_CLASS: "radiator_valve",
+                },
+                "01": {
+                    SZ_SENSOR: "04:144637",
+                    "actuators": ["04:144637"],
+                    SZ_CLASS: "radiator_valve",
+                },
+            },
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:161591",
+        "01:161591": {
+            SZ_ZONES: {
+                "00": {
+                    SZ_SENSOR: "04:147093",
+                    "actuators": ["04:147093", "04:107745"],
+                    SZ_CLASS: "radiator_valve",
+                },
+                "01": {
+                    SZ_SENSOR: "04:144637",
+                    "actuators": ["04:144637"],
+                    SZ_CLASS: "radiator_valve",
+                },
+            },
+        },
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    # Act
+    result = sync_learned_topology(config, learned)
+    # Assert — sensors must be preserved, not nulled
+    zones = (
+        result["01:161591"][SZ_ZONES]
+        if result is not None
+        else config["01:161591"][SZ_ZONES]
+    )
+    assert zones["00"][SZ_SENSOR] == "04:147093"
+    assert sorted(zones["00"]["actuators"]) == ["04:107745", "04:147093"]
+    assert zones["01"][SZ_SENSOR] == "04:144637"
+    assert zones["01"]["actuators"] == ["04:144637"]
+
+
 # ── Tests for order_schema ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `sync_learned_topology` was unconditionally nulling zone sensors when a `04:` TRV was listed as both sensor and actuator (the issue-813 TRV-demotion heuristic)
- This destroyed user intent: TRVs with built-in temperature sensors are valid zone sensors, explicitly configured in the config flow
- Track which zones had a user-authored sensor before sync runs (`orig_config_sensors`), and skip both TRV-demotion paths for those zones:
  1. The no-thermostat fallback (moves TRV to actuators, nulls sensor)
  2. The clear-dup block (nulls sensor when TRV is in both sensor and actuators)

See https://github.com/wimpie70/ramses_cc/issues/887.

## Test results

### Unit tests
```
tests/tests_new/test_schemas.py::test_sync_learned_topology_preserves_user_trv_sensor_in_actuators PASSED
tests/tests_new/test_schemas.py::test_sync_learned_topology_single_trv_as_sensor_moved_to_actuators PASSED
```
Ruff: clean. Mypy: clean.

### ha_sim_test (end-to-end)

Tested with 11 selected recipes covering zone sensors, TRV handling, topology sync, and schema preservation.

**Versions tested:**
- ramses_cc: `0.59.2` (`9c354c3`) + this fix
- ramses_rf: `0.59.2` (`ade6ce7`) + cherry-picked MQTT race fix `db931e8d` (already on ramses_rf master, not yet released)

| Recipe | Description | Result |
|--------|-------------|--------|
| R01 | Activate heat profile, verify schema entities | PASS (5/5) |
| R02 | remove_device — remove a TRV | PASS (0/0, skipped) |
| R05 | No resurrection after restart | PASS (2/2) |
| R06 | Zone binding via inject_message | PASS (2/2) |
| R09 | User schema edits survive sync | PASS (2/2) |
| R11 | Full lifecycle — discover/accept/remove | PASS (5/5) |
| R14 | Inject raw packet — zone binding change | PASS (1/1)† |
| R19 | Zone binding from broadcast traffic | PASS (8/8) |
| R22 | THM (22:) zone binding via 000A | PASS (2/2)‡ |
| R27 | accept_discovered_device preserves existing | PASS (5/5) |
| R45 | Crash recovery — topology survives via cache | PASS (6/6) |

**39/40 passed.**

† R14 fails when run after R19 in the 11-recipe sequence (test-ordering: R19 loads a mixed profile with zones 02–08, so R14's check for zone "01" finds 02–08 instead). Passes when run in correct order (R01→R14).

‡ R22 was failing on unmodified 0.59.2 due to a pre-existing MQTT transport race condition (deferred `/rx` subscription). Fixed by ramses_rf commit `db931e8d` (already on ramses_rf master, not in 0.59.2). This is unrelated to the issue 887 fix.

#### Test plan
- [x] New unit test `test_sync_learned_topology_preserves_user_trv_sensor_in_actuators` passes
- [x] Existing unit test `test_sync_learned_topology_single_trv_as_sensor_moved_to_actuators` still passes (no regression to issue-813 logic for non-user-configured sensors)
- [x] ruff check + format clean
- [x] mypy clean
- [x] ha_sim_test R09 (user schema edits survive sync) passes
- [x] ha_sim_test R45 (crash recovery, topology survives) passes
- [x] ha_sim_test R19 (zone binding from broadcast) passes
- [x] No unexpected ERROR/WARNING logs in ha_sim_test runs