### PR TITLE
fix: foreign/removed devices reappear in schema after sync

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -983,7 +983,30 @@ class BaseRamsesFlow:
                 # discovery metadata so they're re-discovered as NEW.
                 # Without this, the scan restores old ACCEPTED/DISCARDED
                 # statuses and get_devices(status=NEW) returns empty.
+                #
+                # Also clean up device_comments for removed devices (issue 905):
+                # the scan engine keeps tracking ALL RF traffic (including
+                # foreign/neighbour devices), so stale comments with zone
+                # bindings would cause sync_learned_topology to re-add the
+                # removed device to a zone on the next save cycle.
                 if removed_devices and self.config_entry is not None:
+                    # Clean up device_comments for removed devices
+                    schema_dict = self.options[CONF_SCHEMA]
+                    if isinstance(schema_dict, dict):
+                        comments = schema_dict.get(SZ_DEVICE_COMMENTS)
+                        if isinstance(comments, dict):
+                            cleaned_comments = {
+                                k: v
+                                for k, v in comments.items()
+                                if k not in removed_devices
+                            }
+                            if len(cleaned_comments) != len(comments):
+                                schema_dict[SZ_DEVICE_COMMENTS] = cleaned_comments
+                                _LOGGER.info(
+                                    "Removed %d device comment(s) for removed devices: %s",
+                                    len(comments) - len(cleaned_comments),
+                                    sorted(removed_devices & set(comments.keys())),
+                                )
                     store = Store(self.hass, STORAGE_VERSION, STORAGE_KEY)
                     _stored = await store.async_load() or {}
                     from .discovery import SZ_DISCOVERY, SZ_DISCOVERY_DEVICES
@@ -1036,6 +1059,17 @@ class BaseRamsesFlow:
                         _stored[SZ_DISCOVERY] = discovery
 
                     await store.async_save(_stored)
+
+                    # Add removed devices to the coordinator's _removed_devices
+                    # set so sync_learned_topology doesn't re-add them from
+                    # the learned schema on the next save cycle (issue 905).
+                    # ramses_rf has no remove_device API, so the learned schema
+                    # still references removed devices until restart.
+                    coordinators = self.hass.data.get(DOMAIN, {})
+                    for coord in coordinators.values():
+                        if hasattr(coord, "_removed_devices"):
+                            coord._removed_devices.update(removed_devices)  # noqa: SLF001
+                        break
 
                 if self._initial_setup:
                     return await self.async_step_advanced_features()

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1383,6 +1383,20 @@ def sync_learned_topology(
             # but creating a zone from it would add an empty phantom zone.
             if device_id.startswith("01:"):
                 continue
+            # Skip foreign devices (issue 905): a device with _owner that
+            # doesn't match the root _owner is a neighbour's device.  Don't
+            # re-add it to zones from device_comments — the scan engine
+            # tracks ALL RF traffic including foreign devices, but
+            # sync_learned_topology must only place devices the user owns.
+            # Devices with no root entry are NOT skipped here — that's the
+            # passive scan discovery case (a new device the scan engine
+            # found but the user hasn't accepted yet).  Removed devices are
+            # handled by the _removed set check in step 1g.
+            dev_entry = new_schema.get(device_id)
+            if isinstance(dev_entry, dict) and root_owner:
+                dev_owner = dev_entry.get(SZ_TR_OWNER)
+                if isinstance(dev_owner, str) and dev_owner != root_owner:
+                    continue  # foreign owner — neighbour's device
             # Build comment_device_zones for ALL devices with zone info in
             # comments, even if they're also in learned_device_zones.  This
             # allows comments (from the scan engine, which tracks zone bindings
@@ -1801,6 +1815,10 @@ def sync_learned_topology(
             # not in a heating zone.  The "zone 00" in their comment is the
             # DHW domain, not a heating zone index.
             if device_id.startswith("07:"):
+                continue
+            # Skip devices explicitly removed by the user via remove_device
+            # (issue 905: sync must not re-add removed devices from comments)
+            if device_id in _removed:
                 continue
             # Skip if TCS doesn't exist in config
             if tcs_id not in new_schema:

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -47,7 +47,13 @@ from ramses_tx.exceptions import (
     TransportError,
 )
 
-from .const import ATTR_POLLING_INTERVAL, CONF_SCHEMA, DOMAIN, SZ_TR_SKIPPED
+from .const import (
+    ATTR_POLLING_INTERVAL,
+    CONF_SCHEMA,
+    DOMAIN,
+    SZ_DEVICE_COMMENTS,
+    SZ_TR_SKIPPED,
+)
 from .exceptions import RamsesBindingError, RamsesProtocolError
 from .helpers import parse_packet_string
 
@@ -1690,6 +1696,18 @@ class RamsesServiceHandler:
         # Clear main_tcs if it points to this device
         if cleaned.get(SZ_MAIN_TCS) == device_id:
             cleaned.pop(SZ_MAIN_TCS, None)
+
+        # Clean up device_comments for the removed device (issue 905):
+        # the scan engine keeps tracking ALL RF traffic (including
+        # foreign/neighbour devices), so stale comments with zone
+        # bindings would cause sync_learned_topology to re-add the
+        # removed device to a zone on the next save cycle.
+        comments = cleaned.get(SZ_DEVICE_COMMENTS)
+        if isinstance(comments, dict) and device_id in comments:
+            cleaned[SZ_DEVICE_COMMENTS] = {
+                k: v for k, v in comments.items() if k != device_id
+            }
+            _LOGGER.info("Removed device comment for %s (remove_device)", device_id)
 
         options[CONF_SCHEMA] = cleaned
 

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -16,6 +16,7 @@ from custom_components.ramses_cc.const import (
     SZ_OWNER,
     SZ_TR_COMMANDS,
     SZ_TR_NAME,
+    SZ_TR_OWNER,
 )
 from custom_components.ramses_cc.schemas import (
     extract_hvac_schema,
@@ -3185,3 +3186,175 @@ def test_migrate_known_list_traits_empty_and_populated() -> None:
 
     # Empty known_list entry creates empty schema entry
     assert result["04:333333"] == {}
+
+
+# ── Tests for issue 905: foreign/removed devices must not reappear ────
+
+
+def test_sync_learned_topology_skips_foreign_device_comment() -> None:
+    """A foreign device (_owner != root _owner) must not be re-added to zones
+    from device_comments, even if the scan engine has zone info for it.
+
+    Issue 905: a neighbour's TRV keeps reappearing in the user's schema
+    because the scan engine tracks ALL RF traffic and sync_learned_topology
+    was placing devices from comments without checking ownership.
+    """
+    config: dict[str, Any] = {
+        SZ_OWNER: "me",
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {
+            SZ_ZONES: {
+                "03": {"actuators": ["04:005573"]},
+            }
+        },
+        "04:005573": {SZ_TR_OWNER: "me"},
+        # Foreign device — neighbour's TRV (root entry exists with foreign owner)
+        "04:181617": {SZ_TR_OWNER: "not-me"},
+        SZ_DEVICE_COMMENTS: {
+            "04:005573": "Likely TRV. zone 03. codes: 30C9. RSSI 38.",
+            "04:181617": "Likely TRV. zone 03. codes: 30C9. RSSI 91.",
+            # A new device that WILL be placed from comments (to trigger a change)
+            "04:222222": "Likely TRV. zone 05. codes: 30C9. RSSI 75.",
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {SZ_ZONES: {"03": {"actuators": ["04:005573"]}}},
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    # Our TRV is still in zone 03
+    assert "04:005573" in result["01:123456"][SZ_ZONES]["03"]["actuators"]
+    # New device 04:222222 was placed in zone 05 (passive scan discovery)
+    assert "04:222222" in result["01:123456"][SZ_ZONES]["05"]["actuators"]
+    # Foreign TRV must NOT be added to zone 03 (or any zone)
+    zone_03 = result["01:123456"][SZ_ZONES].get("03", {})
+    assert "04:181617" not in zone_03.get("actuators", [])
+    assert zone_03.get(SZ_SENSOR) != "04:181617"
+    # Check all zones — foreign device should not be in any
+    for zone in result["01:123456"][SZ_ZONES].values():
+        if isinstance(zone, dict):
+            assert "04:181617" not in zone.get("actuators", [])
+            assert zone.get(SZ_SENSOR) != "04:181617"
+
+
+def test_sync_learned_topology_skips_removed_device_comment() -> None:
+    """A device explicitly removed by the user must not be re-added from
+    device_comments on the next sync cycle.
+
+    Issue 905: removing a device from the schema editor didn't clean up
+    its device_comment, so sync_learned_topology kept re-adding it from
+    the comment's zone binding info.
+    """
+    config: dict[str, Any] = {
+        SZ_OWNER: "me",
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {
+            SZ_ZONES: {
+                "03": {"actuators": ["04:005573"]},
+            }
+        },
+        "04:005573": {SZ_TR_OWNER: "me"},
+        # 04:181617 was removed from schema by user — no root entry
+        SZ_DEVICE_COMMENTS: {
+            "04:005573": "Likely TRV. zone 03. codes: 30C9. RSSI 38.",
+            "04:181617": "Likely TRV. zone 03. codes: 30C9. RSSI 91.",
+            # A new device that WILL be placed (to trigger a change)
+            "04:990002": "Likely TRV. zone 05. codes: 30C9. RSSI 70.",
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {SZ_ZONES: {"03": {"actuators": ["04:005573"]}}},
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned, removed_devices={"04:181617"})
+    assert result is not None
+    # Our TRV is still in zone 03
+    assert "04:005573" in result["01:123456"][SZ_ZONES]["03"]["actuators"]
+    # New device was placed (trigger change)
+    assert "04:990002" in result["01:123456"][SZ_ZONES]["05"]["actuators"]
+    # Removed TRV must NOT be re-added to any zone
+    zone_03 = result["01:123456"][SZ_ZONES].get("03", {})
+    assert "04:181617" not in zone_03.get("actuators", [])
+    assert zone_03.get(SZ_SENSOR) != "04:181617"
+    # And no root entry created for it
+    assert "04:181617" not in result
+
+
+def test_sync_learned_topology_skips_unknown_device_comment() -> None:
+    """A device with a comment but no root entry in the config schema CAN
+    be placed into zones — this is the passive scan discovery case.
+
+    Issue 905: the scan engine tracks ALL RF traffic, so comments exist for
+    devices the user has never accepted.  These are NEW devices that should
+    be placed so the user can review them.  Only foreign (different _owner)
+    or explicitly removed devices should be skipped.
+    """
+    config: dict[str, Any] = {
+        SZ_OWNER: "me",
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {},
+        "04:005573": {SZ_TR_OWNER: "me"},
+        SZ_DEVICE_COMMENTS: {
+            # 04:999999 has a comment but no root entry — new device
+            "04:999999": "Likely TRV. zone 03. codes: 30C9. RSSI 91.",
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {SZ_ZONES: {}},
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    # New device SHOULD be placed (passive scan discovery)
+    zones = result["01:123456"].get(SZ_ZONES, {})
+    assert "03" in zones
+    assert "04:999999" in zones["03"].get("actuators", [])
+
+
+def test_sync_learned_topology_removed_device_not_readded_from_learned() -> None:
+    """A device that was explicitly removed must not be re-added from the
+    learned schema's actuator list, even though ramses_rf still references
+    it (no remove API).
+
+    Issue 905: ramses_rf's learned schema still contains removed devices.
+    The _removed set passed to sync_learned_topology prevents step 1b
+    from unioning them back into the config schema's zones.
+    """
+    config: dict[str, Any] = {
+        SZ_OWNER: "me",
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {
+            SZ_ZONES: {
+                "03": {"actuators": ["04:005573"]},
+            }
+        },
+        "04:005573": {SZ_TR_OWNER: "me"},
+        # 04:181617 was removed — no root entry in config
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        # ramses_rf still has the removed device in zone 03,
+        # plus a new device in zone 05 (to trigger a change)
+        "01:123456": {
+            SZ_ZONES: {
+                "03": {"actuators": ["04:005573", "04:181617"]},
+                "05": {"actuators": ["04:990003"]},
+            }
+        },
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned, removed_devices={"04:181617"})
+    assert result is not None
+    # Our TRV is still in zone 03
+    assert "04:005573" in result["01:123456"][SZ_ZONES]["03"]["actuators"]
+    # Removed TRV must NOT be re-added from learned schema
+    zone_03 = result["01:123456"][SZ_ZONES]["03"]
+    assert "04:181617" not in zone_03.get("actuators", [])


### PR DESCRIPTION
## Summary

Fixes https://github.com/ramses-rf/ramses_cc/issues/905

`sync_learned_topology` re-added foreign and removed devices to zones from `device_comments` and the learned schema, because:
- the scan engine tracks ALL RF traffic (including neighbour's devices), so comments with zone bindings exist for foreign devices
- ramses_rf has no `remove_device` API, so the learned schema still references removed devices

### Changes

1. **`schemas.py` step 0b**: skip devices with a foreign `_owner` (root entry exists with `_owner != root_owner`) when building `comment_device_zones`. Devices with no root entry are NOT skipped — that's the passive scan discovery case.

2. **`schemas.py` step 1g**: skip devices in the `_removed` set so they are not re-added from `device_comments`.

3. **`config_flow.py`**: clean up `device_comments` for removed devices and add them to the coordinator's `_removed_devices` set so `sync_learned_topology` doesn't re-add them from the learned schema on the next save cycle.

4. **`services.py`**: clean up `device_comments` in the `remove_device` service.

### Tests

4 regression tests in `test_schemas.py`:
- `test_sync_learned_topology_skips_foreign_device_comment` — foreign device not re-added from comments
- `test_sync_learned_topology_skips_removed_device_comment` — removed device not re-added from comments
- `test_sync_learned_topology_skips_unknown_device_comment` — unknown device IS placed (passive scan discovery still works)
- `test_sync_learned_topology_removed_device_not_readded_from_learned` — removed device not re-added from learned schema

#### Test plan
- [x] `pytest tests/` — 1249 passed, 10 skipped
- [x] `ruff check` + `ruff format` + pre-commit hooks pass
- [x] ha_sim_test R02/R04/R09/R11/R19/R20/R28/R47/R60 — all pass (R19 re-run confirmed timing-only failure under load)