### PR TITLE
feat: subscribe to ramses_rf topology events for near-real-time schema sync (Step 5)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -132,7 +132,19 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Step 5: this polling loop is now a safety net for the event-driven
+# schema_updated callback (see _on_rf_schema_updated).  It still covers
+# periodic packet-state persistence (a separate concern from topology
+# sync) and any topology change that doesn't go through
+# DeviceRegistry.handle_topology_event.  Once the event-driven path is
+# verified reliable via ha_sim_test, this can be increased to 15-30 min.
 SAVE_STATE_INTERVAL: Final[td] = td(minutes=5)
+# Step 5: trailing-debounce window for the ramses_rf schema_updated
+# callback.  Coalesces bursts of topology events into a single save.
+# 2 seconds is long enough to absorb a multi-zone 000C sequence or a
+# discovery scan processing several 1FC9 packets, short enough that a
+# user-initiated binding is reflected in the config entry near-real-time.
+_SCHEMA_UPDATED_DEBOUNCE: Final[td] = td(seconds=2)
 _DEVICE_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[0-9A-F]{2}:[0-9A-F]{6}$", re.I)
 # _HEAT_PREFIXES and _TCS_ORPHAN_PREFIXES are imported from .schemas
 # (single definition shared with strip_traits_for_validation).
@@ -197,6 +209,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self._skip_discovery_save: bool = False
         self._discovery_filter_ids: set[str] | None = None
         self._skip_discovery_restore: bool = False
+        # Step 5: trailing-debounce task for the ramses_rf schema_updated
+        # callback.  Coalesces bursts of topology events (e.g. a discovery
+        # scan processing many 1FC9 packets) into a single save cycle.
+        # Cancelled on unload and rescheduled on each new event.
+        self._schema_updated_debounce_task: asyncio.Task[None] | None = None
         # Device IDs explicitly removed by the user via remove_device.
         # sync_learned_topology must NOT re-add these (ramses_rf has no
         # remove_device API, so the learned schema still references them).
@@ -611,6 +628,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         if self.client:
             self.entry.async_on_unload(self.client.add_msg_handler(_on_packet))
+
+        # Step 5: subscribe to ramses_rf topology events so schema changes
+        # (binding, class promotion, circuit creation) are written back to
+        # the config entry near-real-time instead of waiting up to
+        # SAVE_STATE_INTERVAL for the polling fallback.  The callback is
+        # debounced (see _on_rf_schema_updated) and the polling loop below
+        # stays as a reduced-frequency safety net.
+        if self.client:
+            self.client.set_schema_updated_callback(self._on_rf_schema_updated)
+            self.entry.async_on_unload(self._unregister_schema_updated_callback)
 
         # Keep the dedicated interval for saving client state to disk
         self.entry.async_on_unload(
@@ -1698,6 +1725,72 @@ class RamsesCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("Coordinator: HA stop event, cancelling pending tasks")
         await self.service_handler.async_cleanup()
 
+    def _unregister_schema_updated_callback(self) -> None:
+        """Unregister the ramses_rf schema_updated callback (Step 5).
+
+        Called on config entry unload.  Clears the callback so ramses_rf
+        doesn't invoke it after the coordinator is gone.  Safe to call
+        even if ``self.client`` is already None (e.g. setup failed
+        before the gateway was created).
+        """
+        if self.client:
+            self.client.set_schema_updated_callback(None)
+
+    def _on_rf_schema_updated(self, schema: dict[str, Any]) -> None:
+        """Callback from ramses_rf when topology/schema changes (Step 5).
+
+        Registered with ``Gateway.set_schema_updated_callback()`` in
+        ``async_start``.  ramses_rf fires this on every successful
+        topology mutation (BIND_DEVICE, UPDATE_DEVICE_CLASS,
+        UPDATE_TRAITS, CREATE_CONTROLLER, CREATE_CIRCUIT) after
+        ``DeviceRegistry.handle_topology_event`` has applied it.
+
+        Debounced: coalesces bursts of topology events (e.g. a discovery
+        scan processing many 1FC9 packets, or a multi-zone 000C sequence)
+        into a single ``async_save_client_state`` call.  The schema dict
+        passed in is intentionally discarded in favour of re-fetching via
+        ``self.client.get_state()`` inside the save cycle — keeps a
+        single code path and avoids drift between the event schema and
+        the state-save schema.
+
+        :param schema: The latest system schema dict from ramses_rf
+            (unused here — see note above).
+        :type schema: dict[str, Any]
+        """
+        if self._skip_topology_sync:
+            # Coordinator is unloading/reloading — ignore stale events
+            # that were in flight before unload set the guard.
+            return
+        if self._schema_updated_debounce_task is not None:
+            self._schema_updated_debounce_task.cancel()
+        self._schema_updated_debounce_task = self.hass.async_create_task(
+            self._debounced_topology_sync()
+        )
+
+    async def _debounced_topology_sync(self) -> None:
+        """Trailing-debounce worker for ``_on_rf_schema_updated``.
+
+        Waits ``_SCHEMA_UPDATED_DEBOUNCE`` seconds, then runs a single
+        ``async_save_client_state`` cycle.  If a new topology event
+        arrives during the wait, the caller cancels this task and
+        starts a fresh one — so only the last event in a burst actually
+        triggers a save.
+        """
+        try:
+            await asyncio.sleep(_SCHEMA_UPDATED_DEBOUNCE.total_seconds())
+        except asyncio.CancelledError:
+            # Superseded by a newer event (or cancelled on unload).
+            # The caller that cancelled us owns the handle and will
+            # either reschedule or leave it cleared.
+            return
+        # We survived the debounce window without being cancelled —
+        # clear the handle and run the save.  A new event arriving
+        # after this point will schedule a fresh debounce.
+        self._schema_updated_debounce_task = None
+        if self._skip_topology_sync:
+            return
+        await self.async_save_client_state()
+
     async def _async_save_on_unload(self) -> None:
         """Save client state during unload, skipping topology sync.
 
@@ -1720,6 +1813,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
         be lost and devices would re-appear as NEW after reload.
         """
         self._skip_topology_sync = True
+
+        # Step 5: cancel any in-flight debounced topology sync so it
+        # doesn't race with this unload save.  The _skip_topology_sync
+        # guard above would also suppress it, but cancelling is cleaner
+        # and avoids a stray async_save_client_state after unload.
+        if self._schema_updated_debounce_task is not None:
+            self._schema_updated_debounce_task.cancel()
+            self._schema_updated_debounce_task = None
 
         # Compute the set of device IDs still in the schema.
         # Use entry.options (live) not self.options (stale copy).

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -148,6 +148,8 @@ def mock_client():
     client = AsyncMock()
     client.start = AsyncMock()
     client.add_msg_handler = MagicMock()
+    # Step 5: set_schema_updated_callback is a sync method on Gateway
+    client.set_schema_updated_callback = MagicMock()
     return client
 
 
@@ -451,6 +453,9 @@ async def test_async_start_with_packet_handler(
     # Confirm the packet handler is registered
     assert mock_client.add_msg_handler.call_count == 1
     handler = mock_client.add_msg_handler.call_args[0][0]
+
+    # Step 5: schema_updated callback should also be registered
+    assert mock_client.set_schema_updated_callback.call_count == 1
 
     # Mock a packet
     mock_dto = MagicMock()
@@ -869,6 +874,96 @@ async def test_save_client_state_unload_uses_config_schema(
     assert "main_tcs" not in saved_schema, (
         "Learned topology leaked into cache on unload"
     )
+
+
+@pytest.mark.asyncio
+async def test_schema_updated_callback_debounces_burst(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Step 5: a burst of schema_updated events coalesces into a single
+    async_save_client_state call after the debounce window.
+
+    The first event schedules a debounce task.  Subsequent events cancel
+    and reschedule it.  Only after the debounce window elapses without a
+    new event does async_save_client_state run.
+    """
+    mock_coordinator.async_save_client_state = AsyncMock()
+    mock_coordinator._skip_topology_sync = False
+
+    # Override the mock's async_create_task to actually schedule coros
+    # on the real event loop (the default mock closes them immediately).
+    loop = asyncio.get_event_loop()
+    cast(Any, mock_coordinator.hass).async_create_task = loop.create_task
+
+    # Patch the debounce constant to 0 so the task runs immediately
+    with patch(
+        "custom_components.ramses_cc.coordinator._SCHEMA_UPDATED_DEBOUNCE",
+        td(seconds=0),
+    ):
+        # Fire 3 events in rapid succession (a burst)
+        mock_coordinator._on_rf_schema_updated({"main_tcs": "01:145038"})
+        mock_coordinator._on_rf_schema_updated({"main_tcs": "01:145038"})
+        mock_coordinator._on_rf_schema_updated({"main_tcs": "01:145038"})
+
+        # Allow the debounced task to run (yield to event loop)
+        await asyncio.sleep(0.01)
+
+    # Only one save should have been triggered (the last event in the burst)
+    assert mock_coordinator.async_save_client_state.await_count == 1, (
+        f"Expected 1 save after burst, got "
+        f"{mock_coordinator.async_save_client_state.await_count}"
+    )
+    # The debounce handle should be cleared after the save
+    assert mock_coordinator._schema_updated_debounce_task is None
+
+
+@pytest.mark.asyncio
+async def test_schema_updated_callback_skipped_during_unload(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Step 5: events arriving while _skip_topology_sync is True (unload)
+    are ignored — no debounce task is scheduled, no save runs.
+    """
+    mock_coordinator.async_save_client_state = AsyncMock()
+    mock_coordinator._skip_topology_sync = True
+
+    mock_coordinator._on_rf_schema_updated({"main_tcs": "01:145038"})
+
+    # No debounce task should have been created
+    assert mock_coordinator._schema_updated_debounce_task is None
+    # No save should have run
+    assert mock_coordinator.async_save_client_state.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_schema_updated_callback_cancelled_on_unload(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Step 5: _async_save_on_unload cancels any in-flight debounce task
+    so it doesn't race with the unload's own save.
+    """
+    mock_coordinator.async_save_client_state = AsyncMock()
+    mock_coordinator._skip_topology_sync = False
+    mock_coordinator.options = {CONF_SCHEMA: {}}
+    cast(Any, mock_coordinator.store).async_save = AsyncMock()
+    mock_coordinator._remotes = {}
+    mock_coordinator._entities = {}
+    cast(Any, mock_coordinator.client).get_state = MagicMock(return_value=({}, {}))
+
+    # Schedule a debounce task (don't let it run yet)
+    with patch(
+        "custom_components.ramses_cc.coordinator.asyncio.sleep", new=AsyncMock()
+    ):
+        mock_coordinator._on_rf_schema_updated({"main_tcs": "01:145038"})
+        assert mock_coordinator._schema_updated_debounce_task is not None
+
+        # Now trigger unload — should cancel the debounce task
+        await mock_coordinator._async_save_on_unload()
+
+    # The debounce handle should be cleared by unload
+    assert mock_coordinator._schema_updated_debounce_task is None
+    # The unload's own save should have run (once)
+    assert mock_coordinator.async_save_client_state.await_count == 1
 
 
 def self_resolving_async_mock(*args: Any) -> Any:


### PR DESCRIPTION
## Summary

- Register `Gateway.set_schema_updated_callback()` in `async_start` to write topology changes (binding, class promotion, circuit creation) back to the config entry within seconds instead of waiting up to 5 minutes for the polling fallback
- The callback is debounced (2s trailing) to coalesce bursts of topology events (e.g. a discovery scan processing many 1FC9 packets) into a single `async_save_client_state` call
- The existing polling loop is kept as a safety net (can be reduced to 15-30 min once the event-driven path is verified reliable in production)
- The debounce task is cancelled on unload to avoid racing with the unload's own save
- Guards on the existing `_skip_topology_sync` flag to ignore stale events during unload/reload

This implements Phase 4 Step 5, unblocked by ramses_rf PR 997 (event bus & handshake, shipped in 0.59.3).

#### Test plan

- [x] Unit tests: burst debouncing (3 events → 1 save), skip_topology_sync guard, debounce cancellation on unload
- [x] `prek run -a`, `ruff`, `mypy`, `pytest` (1144 passed, 10 skipped, 0 failures)
- [x] ha_sim_test R62: schema updates within 10s of device accept (event-driven, not 5-min poll), burst coalescing, both TRVs in final schema — 5/5 PASS
- [x] Full ha_sim_test suite (64 recipes): 398/408 passed, 10 pre-existing failures unrelated to Step 5 (R22/R20/R26/R36/R40 — all pass in isolation, fail in full suite due to state pollution)