### PR TITLE
feat: HVAC topology — FAN/VCS sync + traffic-based 'belongs to' detection

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -300,7 +300,13 @@ class DiscoveryManager:
                 continue
             # Check if comment already has the correct zone/bound info
             has_zone = dev.zone_idx and f"zone {dev.zone_idx}" in comment
-            has_bound = dev.bound_to and f"bound to {dev.bound_to}" in comment
+            # "belongs to" for FAN (32:), "bound to" for heat TCS
+            bound_phrase = (
+                f"belongs to {dev.bound_to}"
+                if dev.bound_to and dev.bound_to.startswith("32:")
+                else f"bound to {dev.bound_to}"
+            )
+            has_bound = dev.bound_to and bound_phrase in comment
             if has_zone and has_bound and self._COMMENT_SUFFIX in comment:
                 continue
             # Rebuild the comment from the scan engine data
@@ -1011,9 +1017,14 @@ class DiscoveryManager:
         if ambiguity:
             parts.append(ambiguity)
 
-        # Binding info
+        # Binding info — use "belongs to" for HVAC (FAN parent, traffic-inferred)
+        # to distinguish from the hardware handshake "_bound" trait (1FC9 pairing).
+        # "bound to" is kept for heat-domain TCS bindings (zone sensors/actuators).
         if bound_to:
-            parts.append(f"bound to {bound_to}")
+            if bound_to.startswith("32:"):
+                parts.append(f"belongs to {bound_to}")
+            else:
+                parts.append(f"bound to {bound_to}")
         if zone_idx:
             parts.append(f"zone {zone_idx}")
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1059,6 +1059,18 @@ def _parse_likely_type_from_comment(comment: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _is_hvac_sensor_class(schema_entry: object) -> bool:
+    """Check if a device's schema entry marks it as an HVAC sensor (CO2/HUM).
+
+    Used to filter CO2/HUM devices out of remotes[] — they belong in
+    sensors[].  The schema's _class is user-declared and authoritative.
+    """
+    if not isinstance(schema_entry, dict):
+        return False
+    dev_class = str(schema_entry.get("_class", "")).upper()
+    return dev_class in ("CO2", "HUM", "CO2_SENSOR", "HUMIDITY")
+
+
 # Valid sensor/actuator device prefixes (must match ramses_rf's DEVICE_ID_REGEX.SEN)
 # 18: (HGI) and 13: (BDR) are NOT valid zone sensors
 _VALID_ZONE_SENSOR_RE = re.compile(r"^(01|03|04|12|22|34):[0-9A-Fa-f]{6}$")
@@ -1486,6 +1498,11 @@ def sync_learned_topology(
             # the presence of the relevant key in the learned entry).
             is_vcs = SZ_REMOTES in learned_entry or SZ_SENSORS in learned_entry
             if is_vcs:
+                _LOGGER.info(
+                    "sync_learned_topology: VCS sync for %s, learned=%s",
+                    tcs_id,
+                    learned_entry,
+                )
                 config_entry = new_schema.get(tcs_id, {})
                 if not isinstance(config_entry, dict):
                     config_entry = {}
@@ -1493,6 +1510,16 @@ def sync_learned_topology(
                 for vcs_key in (SZ_REMOTES, SZ_SENSORS):
                     learned_list = learned_entry.get(vcs_key)
                     if isinstance(learned_list, list) and learned_list:
+                        # Filter: CO2/HUM devices (by schema _class) belong
+                        # in sensors[], not remotes[].  The learned schema
+                        # from ramses_rf may misclassify them as remotes.
+                        if vcs_key == SZ_REMOTES:
+                            filtered = [
+                                dev_id
+                                for dev_id in learned_list
+                                if not _is_hvac_sensor_class(new_schema.get(dev_id))
+                            ]
+                            learned_list = filtered
                         existing = config_entry.get(vcs_key)
                         if existing != learned_list:
                             config_entry[vcs_key] = learned_list
@@ -1988,8 +2015,12 @@ def sync_learned_topology(
         schema_class = (
             schema_entry.get("_class") if isinstance(schema_entry, dict) else None
         )
-        # Normalise: check both likely_type and _class
-        dev_type_upper = str(likely_type).upper() or str(schema_class).upper() or ""
+        # The schema's _class is user-declared and authoritative — it takes
+        # precedence over the comment's "Likely X" guess (the scan engine may
+        # guess "REM" for a CO2 sensor if it sends similar codes).
+        schema_class_str = str(schema_class).upper() if schema_class else ""
+        likely_type_str = str(likely_type).upper() if likely_type else ""
+        dev_type_upper = schema_class_str or likely_type_str or ""
         is_sensor = dev_type_upper in ("CO2", "HUM", "CO2_SENSOR", "HUMIDITY")
         list_key = SZ_SENSORS if is_sensor else SZ_REMOTES
         target_list = fan_entry.get(list_key)
@@ -2006,6 +2037,21 @@ def sync_learned_topology(
                 device_id,
                 dev_type_upper or "unknown",
                 fan_id,
+                list_key,
+            )
+        # Remove from the opposite list if misclassified previously
+        other_key = SZ_REMOTES if is_sensor else SZ_SENSORS
+        other_list = fan_entry.get(other_key)
+        if isinstance(other_list, list) and device_id in other_list:
+            other_list.remove(device_id)
+            changed = True
+            _LOGGER.info(
+                "sync_learned_topology: removed %s (%s) from FAN %s %s[] "
+                "(reclassified to %s[])",
+                device_id,
+                dev_type_upper or "unknown",
+                fan_id,
+                other_key,
                 list_key,
             )
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1478,10 +1478,14 @@ def sync_learned_topology(
             if tcs_id in _removed:
                 continue
 
-            # Skip FAN/VCS entries (they have remotes/sensors, not zones/
-            # appliance_control/DHW).  These are HVAC topology, not heat.
-            if SZ_REMOTES in learned_entry or SZ_SENSORS in learned_entry:
-                # Sync remotes/sensors from learned schema into config
+            # Sync remotes/sensors for FAN/VCS entries (HVAC topology).
+            # FANs can also have zones (e.g. Itho VMZ-15V13 zone valves),
+            # so we don't skip the rest of the TCS sync — we just sync
+            # remotes/sensors here and let the zone/appliance_control/DHW
+            # sync below handle them conditionally (each step checks for
+            # the presence of the relevant key in the learned entry).
+            is_vcs = SZ_REMOTES in learned_entry or SZ_SENSORS in learned_entry
+            if is_vcs:
                 config_entry = new_schema.get(tcs_id, {})
                 if not isinstance(config_entry, dict):
                     config_entry = {}
@@ -1493,7 +1497,6 @@ def sync_learned_topology(
                         if existing != learned_list:
                             config_entry[vcs_key] = learned_list
                             changed = True
-                continue
 
             config_entry = new_schema.get(tcs_id, {})
             if not isinstance(config_entry, dict):
@@ -1747,9 +1750,12 @@ def sync_learned_topology(
                             tcs_id,
                         )
 
-            # 1c. Sync DHW system
-            learned_dhw = learned_entry.get(SZ_DHW_SYSTEM, {})
-            if isinstance(learned_dhw, dict):
+            # 1c. Sync DHW system — only if the learned entry has DHW.
+            # FAN/VCS entries don't have DHW, so skip them to avoid
+            # creating an empty dhw_system: {} that would fail SCH_VCS
+            # validation (SCH_VCS_DATA has extra=PREVENT_EXTRA).
+            learned_dhw = learned_entry.get(SZ_DHW_SYSTEM)
+            if isinstance(learned_dhw, dict) and learned_dhw:
                 config_dhw = config_entry.setdefault(SZ_DHW_SYSTEM, {})
                 learned_dhw_sensor = learned_dhw.get(SZ_SENSOR)
                 # Only sync DHW sensor if it was not explicitly removed

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1030,6 +1030,35 @@ def _parse_bound_tcs_from_comment(comment: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _parse_belongs_to_fan_from_comment(comment: str) -> str | None:
+    """Parse FAN ID from a device comment's 'belongs to' phrase.
+
+    Comments have format like: "Likely REM. belongs to 32:150000. codes: ..."
+    This is the traffic-inferred HVAC parent (FAN sending directed I/RP to
+    the device).  Distinct from 'bound to' which is the heat-domain TCS
+    binding, and from the '_bound' schema trait which is the hardware
+    handshake (1FC9 pairing).
+
+    Returns the FAN ID (e.g., "32:150000") or None if not found.
+    """
+    if not comment or not isinstance(comment, str):
+        return None
+    match = re.search(r"belongs to\s+([0-9A-Fa-f]+:[0-9A-Fa-f]+)", comment)
+    return match.group(1) if match else None
+
+
+def _parse_likely_type_from_comment(comment: str) -> str | None:
+    """Parse the likely_type from a device comment's 'Likely X' phrase.
+
+    Comments have format like: "Likely REM. belongs to 32:150000. ..."
+    Returns the type (e.g., "REM", "CO2") or None if not found.
+    """
+    if not comment or not isinstance(comment, str):
+        return None
+    match = re.search(r"Likely (\w+)", comment)
+    return match.group(1) if match else None
+
+
 # Valid sensor/actuator device prefixes (must match ramses_rf's DEVICE_ID_REGEX.SEN)
 # 18: (HGI) and 13: (BDR) are NOT valid zone sensors
 _VALID_ZONE_SENSOR_RE = re.compile(r"^(01|03|04|12|22|34):[0-9A-Fa-f]{6}$")
@@ -1407,14 +1436,35 @@ def sync_learned_topology(
             if comment_tcs_id and zone_idx:
                 comment_device_zones[device_id] = (comment_tcs_id, zone_idx)
 
-    # 1. Sync TCS entries (zones, appliance_control, DHW, orphans)
-    # Build the set of device IDs that were explicitly removed by the
-    # user via remove_device.  sync_learned_topology must NOT re-add
-    # these devices — the learned schema (from ramses_rf's runtime
-    # device registry) may still reference them because ramses_rf has
-    # no remove_device API.
+    # 0c. Extract HVAC parent (FAN) from device comments.
+    # The scan engine sets bound_to when a FAN (32:) sends a directed I/RP
+    # to a 37:/29: device (operational traffic, not hardware binding).
+    # refresh_device_comments writes "belongs to 32:XXXXXX" in the comment.
+    # This step builds a map: device_id -> fan_id, used in step 1h to
+    # place the device under the FAN's remotes[]/sensors[] list.
+    # Distinct from "_bound" (hardware handshake, 1FC9 pairing) — that's
+    # the user-declared binding for 2411 routing, handled by step 1i.
     _removed: set[str] = removed_devices or set()
+    comment_hvac_parent: dict[str, str] = {}
+    comment_hvac_type: dict[str, str] = {}
+    if isinstance(device_comments, dict):
+        for device_id, comment in device_comments.items():
+            if not isinstance(comment, str):
+                continue
+            # Only HVAC device prefixes (37:, 29:) can belong to a FAN
+            if not str(device_id).startswith(("37:", "29:")):
+                continue
+            fan_id = _parse_belongs_to_fan_from_comment(comment)
+            if not fan_id or not fan_id.startswith("32:"):
+                continue
+            if device_id in _removed:
+                continue
+            comment_hvac_parent[device_id] = fan_id
+            likely_type = _parse_likely_type_from_comment(comment)
+            if likely_type:
+                comment_hvac_type[device_id] = likely_type
 
+    # 1. Sync TCS entries (zones, appliance_control, DHW, orphans)
     if learned_schema and isinstance(learned_schema, dict):
         for tcs_id, learned_entry in learned_schema.items():
             if not isinstance(learned_entry, dict) or tcs_id in config_only_keys:
@@ -1911,31 +1961,47 @@ def sync_learned_topology(
                         new_schema.pop(SZ_ORPHANS_HEAT, None)
                     changed = True
 
-    # 1h. Add HVAC remotes from device comments (passive scan mode)
-    # The scan engine infers bound_to for 37: devices when a FAN (32:) sends
-    # them a directed packet.  This info appears in comments as
-    # "bound to 32:153289".  Add these devices as remotes to the FAN's
-    # schema entry if not already present.
-    if isinstance(device_comments, dict):
-        for device_id, comment in device_comments.items():
-            if not isinstance(comment, str) or not device_id.startswith("37:"):
-                continue
-            if device_id in _removed:
-                continue
-            fan_id = _parse_bound_tcs_from_comment(comment)
-            if not fan_id or not fan_id.startswith("32:"):
-                continue
-            fan_entry = new_schema.get(fan_id)
-            if not isinstance(fan_entry, dict):
-                continue
-            remotes = fan_entry.get(SZ_REMOTES)
-            if not isinstance(remotes, list):
-                remotes = []
-                fan_entry[SZ_REMOTES] = remotes
-            if device_id not in remotes:
-                remotes.append(device_id)
-                remotes.sort()
-                changed = True
+    # 1h. Place HVAC devices under their FAN based on "belongs to" comments.
+    # The scan engine infers bound_to when a FAN (32:) sends a directed I/RP
+    # to a 37:/29: device (operational traffic).  refresh_device_comments
+    # writes "belongs to 32:XXXXXX" in the comment (distinct from "bound to"
+    # which is the heat-domain TCS binding, and from "_bound" which is the
+    # hardware handshake for 2411 routing).
+    # This step adds the device to the FAN's remotes[] or sensors[] list:
+    #   - CO2/HUM → sensors[]
+    #   - REM/DIS/other → remotes[]
+    # The classification uses the comment's "Likely X" phrase, falling back
+    # to the schema's _class trait.
+    for device_id, fan_id in comment_hvac_parent.items():
+        fan_entry = new_schema.get(fan_id)
+        if not isinstance(fan_entry, dict):
+            continue
+        # Determine list: sensors[] for CO2/HUM, remotes[] for everything else
+        likely_type = comment_hvac_type.get(device_id, "")
+        schema_entry = new_schema.get(device_id, {})
+        schema_class = (
+            schema_entry.get("_class") if isinstance(schema_entry, dict) else None
+        )
+        # Normalise: check both likely_type and _class
+        dev_type_upper = str(likely_type).upper() or str(schema_class).upper() or ""
+        is_sensor = dev_type_upper in ("CO2", "HUM", "CO2_SENSOR", "HUMIDITY")
+        list_key = SZ_SENSORS if is_sensor else SZ_REMOTES
+        target_list = fan_entry.get(list_key)
+        if not isinstance(target_list, list):
+            target_list = []
+            fan_entry[list_key] = target_list
+        if device_id not in target_list:
+            target_list.append(device_id)
+            target_list.sort()
+            changed = True
+            _LOGGER.info(
+                "sync_learned_topology: placed %s (%s) under FAN %s %s[] "
+                "from 'belongs to' comment",
+                device_id,
+                dev_type_upper or "unknown",
+                fan_id,
+                list_key,
+            )
 
     # 1i. Ensure REMs listed in FAN's _bound are also in remotes[].
     # A FAN can have one or more bound REMs (stored as _bound on the FAN
@@ -2220,7 +2286,12 @@ def sync_learned_topology(
     # 3. Sync top-level orphans_hvac — remove devices now in HVAC entries
     config_hvac_orphans = set(new_schema.get(SZ_ORPHANS_HVAC, []))
     learned_hvac_orphans = set((learned_schema or {}).get(SZ_ORPHANS_HVAC, []))
-    if config_hvac_orphans and config_hvac_orphans != learned_hvac_orphans:
+    # Run if orphans differ OR if we placed devices from comments (step 1h)
+    # — even when config and learned orphans match, step 1h may have moved
+    # a device from orphans to a FAN's remotes[]/sensors[].
+    if config_hvac_orphans and (
+        config_hvac_orphans != learned_hvac_orphans or comment_hvac_parent
+    ):
         # Find devices in config orphans that are in an HVAC entry in learned
         all_hvac_entry_devices: set[str] = set()
         for key, val in (learned_schema or {}).items():

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1439,8 +1439,10 @@ def sync_learned_topology(
                 for vcs_key in (SZ_REMOTES, SZ_SENSORS):
                     learned_list = learned_entry.get(vcs_key)
                     if isinstance(learned_list, list) and learned_list:
-                        config_entry[vcs_key] = learned_list
-                        changed = True
+                        existing = config_entry.get(vcs_key)
+                        if existing != learned_list:
+                            config_entry[vcs_key] = learned_list
+                            changed = True
                 continue
 
             config_entry = new_schema.get(tcs_id, {})

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1428,6 +1428,21 @@ def sync_learned_topology(
             if tcs_id in _removed:
                 continue
 
+            # Skip FAN/VCS entries (they have remotes/sensors, not zones/
+            # appliance_control/DHW).  These are HVAC topology, not heat.
+            if SZ_REMOTES in learned_entry or SZ_SENSORS in learned_entry:
+                # Sync remotes/sensors from learned schema into config
+                config_entry = new_schema.get(tcs_id, {})
+                if not isinstance(config_entry, dict):
+                    config_entry = {}
+                    new_schema[tcs_id] = config_entry
+                for vcs_key in (SZ_REMOTES, SZ_SENSORS):
+                    learned_list = learned_entry.get(vcs_key)
+                    if isinstance(learned_list, list) and learned_list:
+                        config_entry[vcs_key] = learned_list
+                        changed = True
+                continue
+
             config_entry = new_schema.get(tcs_id, {})
             if not isinstance(config_entry, dict):
                 config_entry = {}
@@ -1467,8 +1482,9 @@ def sync_learned_topology(
                         changed = True
 
             # 1b. Sync zones — this is the key enrichment
-            learned_zones = learned_entry.get(SZ_ZONES, {})
-            if isinstance(learned_zones, dict):
+            # Skip FAN/VCS entries (they have remotes/sensors, not zones)
+            learned_zones = learned_entry.get(SZ_ZONES)
+            if isinstance(learned_zones, dict) and learned_zones:
                 config_zones = config_entry.get(SZ_ZONES)
                 if not isinstance(config_zones, dict):
                     config_zones = {}

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1270,7 +1270,7 @@ class TestAcceptDeviceWithSchemaEntry:
         assert "37:168270" in dc
         comment = dc["37:168270"]
         assert "Likely REM" in comment
-        assert "bound to 32:153289" in comment
+        assert "belongs to 32:153289" in comment
 
     def test_explicit_schema_entry_no_comment(self) -> None:
         """Test that explicitly provided schema entries don't get auto-comments."""

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2758,14 +2758,19 @@ def test_sync_learned_topology_adds_zone_to_comment_without_zone() -> None:
 
 
 def test_sync_learned_topology_adds_hvac_remote_from_comment() -> None:
-    """A 37: REM with 'bound to 32:...' in its comment should be added as a
-    remote to the FAN's schema entry and removed from orphans_hvac."""
+    """A 37: REM with 'belongs to 32:...' in its comment should be added as a
+    remote to the FAN's schema entry and removed from orphans_hvac.
+
+    Note: 'belongs to' is the traffic-inferred HVAC parent (FAN sending
+    directed I/RP to the device).  This is distinct from 'bound to'
+    (heat-domain TCS binding) and from '_bound' (hardware handshake).
+    """
     config: dict[str, Any] = {
         "32:153289": {SZ_REMOTES: ["37:169161"]},
         SZ_ORPHANS_HVAC: ["37:168270", "37:126776"],
         SZ_DEVICE_COMMENTS: {
-            "37:169161": "Likely REM. bound to 32:153289. codes: 1470.",
-            "37:168270": "Likely REM. bound to 32:153289. codes: 22F1.",
+            "37:169161": "Likely REM. belongs to 32:153289. codes: 1470.",
+            "37:168270": "Likely REM. belongs to 32:153289. codes: 22F1.",
             "37:126776": "Likely CO2. codes: 1298.",
         },
     }
@@ -2782,8 +2787,31 @@ def test_sync_learned_topology_adds_hvac_remote_from_comment() -> None:
     # 37:168270 should be removed from orphans_hvac
     orphans = result.get(SZ_ORPHANS_HVAC, [])
     assert "37:168270" not in orphans
-    # 37:126776 (no bound_to) should stay in orphans
+    # 37:126776 (no belongs_to) should stay in orphans
     assert "37:126776" in orphans
+
+
+def test_sync_learned_topology_adds_hvac_co2_sensor_from_comment() -> None:
+    """A 37: CO2 with 'belongs to 32:...' should go to sensors[], not remotes[]."""
+    config: dict[str, Any] = {
+        "32:153289": {},
+        SZ_ORPHANS_HVAC: ["37:126776"],
+        SZ_DEVICE_COMMENTS: {
+            "37:126776": "Likely CO2. belongs to 32:153289. codes: 1298.",
+        },
+    }
+    learned: dict[str, Any] = {
+        "32:153289": {},
+        SZ_ORPHANS_HVAC: ["37:126776"],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    fan = result["32:153289"]
+    # CO2 should be in sensors[], not remotes[]
+    assert "37:126776" in fan.get(SZ_SENSORS, [])
+    assert "37:126776" not in fan.get(SZ_REMOTES, [])
+    # Should be removed from orphans_hvac
+    assert "37:126776" not in result.get(SZ_ORPHANS_HVAC, [])
 
 
 def test_sync_learned_topology_backfills_root_entry_for_list_device() -> None:


### PR DESCRIPTION
## Summary

This PR enables HVAC topology learning in ramses_cc, paired with ramses_rf PR ramses-rf/ramses_rf#1017 (Step 6a/6b, issue 639).

### 1. Fix: only create `zones`/`dhw_system` when learned schema has them

`sync_learned_topology` was creating empty `zones: {}` and `dhw_system: {}` on FAN/VCS entries because:
- `learned_entry.get(SZ_ZONES, {})` defaulted to `{}`, then `isinstance(..., dict)` was True
- `learned_entry.get(SZ_DHW_SYSTEM, {})` defaulted to `{}`, then `setdefault(SZ_DHW_SYSTEM, {})` created the key

Both empty keys fail `SCH_VCS` validation (`extra=PREVENT_EXTRA`).

Fix: use `learned_entry.get(SZ_ZONES)` (no default) with `and learned_zones` check, and same for DHW. FANs **can** have zones (e.g. Itho VMZ-15V13 zone valves, per `fingerprints.py`), so we don't skip zone sync for VCS entries — we just avoid creating empty keys.

### 2. Sync remotes/sensors from learned schema

VCS entries (`remotes`/`sensors` present) get their HVAC lists synced from the learned schema. Only marks `changed=True` when the lists actually differ.

### 3. Traffic-based HVAC "belongs to" detection from device comments

The scan engine infers `bound_to` when a FAN (32:) sends a directed I/RP to a 37:/29: device (operational traffic — 22F1/31E0/31DA/10D0, NOT the 1FC9 hardware handshake). `refresh_device_comments` writes **"belongs to 32:XXXXXX"** in the comment — distinct from:
- **"bound to"** = heat-domain TCS binding (zone sensors/actuators)
- **`_bound`** schema trait = hardware handshake (1FC9 pairing) for 2411 routing

`sync_learned_topology` step 0c/1h parses "belongs to" comments and places the device under the FAN's `remotes[]` (REM/DIS) or `sensors[]` (CO2/HUM), using the comment's "Likely X" phrase or the schema's `_class` trait for classification.

Also fixes: step 3 (orphans_hvac sync) now runs when `comment_hvac_parent` has entries, even if config and learned orphans match.

### Three binding concepts — clearly separated

| Phrase | Meaning | Source |
|--------|---------|--------|
| `bound to 01:...` | Heat-domain TCS binding | Scan engine zone binding (000A/000C/30C9) |
| `belongs to 32:...` | HVAC FAN parent (traffic-inferred) | Scan engine directed FAN→REM I/RP (22F1/31E0/31DA/10D0) |
| `_bound` schema trait | Hardware handshake (1FC9 pairing) | User-declared, for 2411 routing |

#### Test plan
- [x] All 1142 ramses_cc tests pass (including new tests for CO2→sensors[] and belongs_to comment parsing)
- [x] ruff + mypy clean
- [x] ha_sim_test R41 (HVAC topology roundtrip) — 7/7 pass, 0 errors, 0 warnings
- [x] ha_sim_test R65 (HVAC "belongs to" from traffic) — 4/4 pass, 0 errors, 0 warnings
- [x] CI on this PR