### PR TITLE
fix: use background task for schema_updated debounce (issue 930)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1764,8 +1764,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return
         if self._schema_updated_debounce_task is not None:
             self._schema_updated_debounce_task.cancel()
-        self._schema_updated_debounce_task = self.hass.async_create_task(
-            self._debounced_topology_sync()
+        # Use async_create_background_task (not async_create_task) so the
+        # 2-second debounce sleep does not block hass.async_block_till_done()
+        # — otherwise every test fixture that casts packets and calls
+        # async_block_till_done() pays a ~2s penalty (issue 930).
+        self._schema_updated_debounce_task = self.hass.async_create_background_task(
+            self._debounced_topology_sync(),
+            "ramses_cc:debounced_topology_sync",
         )
 
     async def _debounced_topology_sync(self) -> None:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -90,7 +90,7 @@ def mock_hass() -> MagicMock:
     # async_create_task must return an awaitable (Future).
     # CRITICAL: It must also 'close' the coro passed to it to prevent
     # RuntimeWarnings.
-    def _create_task(coro: Any) -> asyncio.Future[Any]:
+    def _create_task(coro: Any, *args: Any, **kwargs: Any) -> asyncio.Future[Any]:
         if asyncio.iscoroutine(coro):
             coro.close()  # Prevent "coro was never awaited" warning
         f: asyncio.Future[Any] = asyncio.Future()
@@ -98,6 +98,7 @@ def mock_hass() -> MagicMock:
         return f
 
     hass.async_create_task = MagicMock(side_effect=_create_task)
+    hass.async_create_background_task = MagicMock(side_effect=_create_task)
     return hass
 
 
@@ -890,10 +891,14 @@ async def test_schema_updated_callback_debounces_burst(
     mock_coordinator.async_save_client_state = AsyncMock()
     mock_coordinator._skip_topology_sync = False
 
-    # Override the mock's async_create_task to actually schedule coros
-    # on the real event loop (the default mock closes them immediately).
+    # Override the mock's async_create_background_task to actually schedule
+    # coros on the real event loop (the default mock closes them immediately).
+    # async_create_background_task takes (coro, name) but loop.create_task
+    # only takes (coro), so wrap it.
     loop = asyncio.get_event_loop()
-    cast(Any, mock_coordinator.hass).async_create_task = loop.create_task
+    cast(Any, mock_coordinator.hass).async_create_background_task = (
+        lambda coro, name=None: loop.create_task(coro)
+    )
 
     # Patch the debounce constant to 0 so the task runs immediately
     with patch(


### PR DESCRIPTION
## Summary

- PR 921 introduced a 2-second debounced topology sync task via `hass.async_create_task()`. Because `async_create_task` tracks the task, `hass.async_block_till_done()` waits for the 2-second `asyncio.sleep` to complete before returning.
- This added ~2s to every `test_services` fixture setup (60+ parametrized tests), doubling CI runtime from ~190s to ~345s.
- Switch to `hass.async_create_background_task()`, which explicitly does not block `async_block_till_done()`. The debounce task is a long-lived background operation (like the polling interval), not a short-lived task that should block the current batch.

### Before/after (local, full suite)

| | Before (PR 921) | After (this PR) |
|---|---|---|
| Total runtime | ~230s | ~78s |
| test_services setup | ~2.5s each | ~0.65s each |

### CI timing (Testing workflow)

| | Before | After (expected) |
|---|---|---|
| Runtime | ~345s | ~190s |

Fixes https://github.com/ramses-rf/ramses_cc/issues/930

#### Test plan
- [x] `pytest` — 1265 passed, 10 skipped, 78s
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [x] Step 5 debounce tests pass (burst, skip-during-unload, cancel-on-unload)