### PR TITLE
fix(fan_handler): use background task for poll loop to not block startup (issue 937)

### DIFF
--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import Callable
+from datetime import timedelta as td
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
 
 from ramses_rf.const import DevType
 from ramses_rf.devices import Device, HvacRemoteBase, HvacVentilator
@@ -34,8 +35,6 @@ class RamsesFanHandler:
         self.coordinator = coordinator
         self.hass = coordinator.hass
         self._fan_bound_to_remote: dict[str, DeviceIdT] = {}
-        # Periodic 2411 polling tasks, keyed by device_id
-        self._fan_param_poll_tasks: dict[str, asyncio.Task[Any]] = {}
 
     def find_param_entity(self, device_id: str, param_id: str) -> RamsesEntity | None:
         """Find a parameter entity by device ID and parameter ID.
@@ -313,37 +312,31 @@ class RamsesFanHandler:
 
         ramses_rf 0.58.3+ removed the discovery poll that used to refresh 2411
         parameter values daily.  Without periodic polling, values go stale
-        after the initial sweep at startup.  This task re-requests all
-        parameters every 6 hours.  See ramses_cc issue 851.
+        after the initial sweep at startup.  This schedules a timer-based
+        callback every 6 hours.  See ramses_cc issue 851.
+
+        Uses ``async_track_time_interval`` (the HA-idiomatic pattern, also
+        used by the coordinator for discovery and state-save timers) rather
+        than a ``while True`` + ``asyncio.sleep`` loop.  The timer callback
+        is fire-and-forget — it never blocks startup and is automatically
+        cleaned up via ``entry.async_on_unload`` when the config entry is
+        unloaded.
 
         :param device: The FAN device to poll periodically.
         """
         dev_id = device.id
-        # Cancel any existing poll task for this device
-        existing = self._fan_param_poll_tasks.get(dev_id)
-        if existing is not None and not existing.done():
-            _LOGGER.debug("Param poll task already running for %s", dev_id)
-            return
 
-        async def _poll_loop() -> None:
-            """Periodically request all 2411 parameters from the device."""
-            interval = 6 * 60 * 60  # 6 hours
-            while True:
-                await asyncio.sleep(interval)
-                _LOGGER.debug("Periodic 2411 poll for %s", dev_id)
-                call: dict[str, Any] = {"device_id": dev_id}
-                try:
-                    self.coordinator.get_all_fan_params(call)
-                except Exception as err:
-                    _LOGGER.debug("Periodic param poll failed for %s: %s", dev_id, err)
+        async def _poll_params(_: Any) -> None:
+            """Request all 2411 parameters from the device."""
+            _LOGGER.debug("Periodic 2411 poll for %s", dev_id)
+            call: dict[str, Any] = {"device_id": dev_id}
+            try:
+                self.coordinator.get_all_fan_params(call)
+            except Exception as err:
+                _LOGGER.debug("Periodic param poll failed for %s: %s", dev_id, err)
 
-        self._fan_param_poll_tasks[dev_id] = self.hass.async_create_task(_poll_loop())
-
-    def _stop_param_polling(self, device_id: str) -> None:
-        """Stop periodic 2411 parameter polling for a device.
-
-        :param device_id: The device ID to stop polling.
-        """
-        task = self._fan_param_poll_tasks.pop(device_id, None)
-        if task is not None and not task.done():
-            task.cancel()
+        # async_track_time_interval returns a cancel callable.  Register it
+        # for automatic cleanup on config entry unload — no manual
+        # _stop_param_polling needed.
+        cancel_cb = async_track_time_interval(self.hass, _poll_params, td(hours=6))
+        self.coordinator.entry.async_on_unload(cancel_cb)

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -1,6 +1,7 @@
 """Tests for the Fan Handler aspect of RamsesCoordinator (2411 logic, parameters)."""
 
 import logging
+from collections.abc import Callable
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -123,6 +124,11 @@ async def test_fan_setup_callbacks_execution(
     """Test execution of the initialization callbacks."""
     mock_fan_device.set_initialized_callback = MagicMock()
 
+    # Track cancel callbacks registered via async_on_unload so we can
+    # clean up timers that async_track_time_interval creates.
+    cancel_callbacks: list[Callable[[], None]] = []
+    mock_coordinator.entry.async_on_unload = lambda cb: cancel_callbacks.append(cb)
+
     # Call setup
     await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
@@ -142,6 +148,10 @@ async def test_fan_setup_callbacks_execution(
         await coro
 
         assert mock_get_params.called
+
+    # Clean up any timers registered via async_track_time_interval
+    for cancel_cb in cancel_callbacks:
+        cancel_cb()
 
 
 async def test_fan_setup_already_initialized(
@@ -513,6 +523,10 @@ async def test_fan_setup_callbacks_exception(
     """Test exception handling during initialization callback (get_all_fan_params fails)."""
     mock_fan_device.set_initialized_callback = MagicMock()
 
+    # Track cancel callbacks so timers can be cleaned up
+    cancel_callbacks: list[Callable[[], None]] = []
+    mock_coordinator.entry.async_on_unload = lambda cb: cancel_callbacks.append(cb)
+
     await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
     init_lambda = mock_fan_device.set_initialized_callback.call_args[0][0]
 
@@ -526,6 +540,10 @@ async def test_fan_setup_callbacks_exception(
 
         # Execute lambda
         await init_lambda()
+
+    # Clean up timers registered via async_track_time_interval
+    for cancel_cb in cancel_callbacks:
+        cancel_cb()
 
     assert "Failed to request parameters for device" in caplog.text
 
@@ -546,6 +564,10 @@ async def test_fan_setup_already_initialized_exception(
     if hasattr(mock_fan_device, "set_initialized_callback"):
         del mock_fan_device.set_initialized_callback
 
+    # Track cancel callbacks so timers can be cleaned up
+    cancel_callbacks: list[Callable[[], None]] = []
+    mock_coordinator.entry.async_on_unload = lambda cb: cancel_callbacks.append(cb)
+
     with (
         patch("custom_components.ramses_cc.number.create_parameter_entities"),
         patch.object(mock_coordinator, "get_all_fan_params") as mock_get_params,
@@ -553,6 +575,10 @@ async def test_fan_setup_already_initialized_exception(
         mock_get_params.side_effect = RuntimeError("Request Failed")
 
         await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
+
+    # Clean up timers registered via async_track_time_interval
+    for cancel_cb in cancel_callbacks:
+        cancel_cb()
 
     assert "Failed to request parameters for device" in caplog.text
 


### PR DESCRIPTION
## Summary

The periodic 2411 parameter poll loop introduced in 0.59.4 (commit `a96103f`, issue 851) used a `while True` + `asyncio.sleep` loop created via `hass.async_create_task()`. This blocked HA's startup phase because `async_create_task` creates a **tracked** task that HA waits for, but the loop never completes — HA hangs at "waiting for tasks" and eventually gives up with a warning.

Replace the manual loop with **`async_track_time_interval`**, which is the HA-idiomatic pattern for periodic callbacks (already used 3x in `coordinator.py` for discovery, state-save, and checkpoint timers). The timer callback is fire-and-forget — it never blocks startup, and the cancel callable is registered via `entry.async_on_unload()` for automatic cleanup on config entry unload.

This also removes the now-unnecessary `_fan_param_poll_tasks` dict and `_stop_param_polling` method (cleanup is automatic).

See: https://github.com/ramses-rf/ramses_cc/issues/937

#### Test plan

- [x] `prek run -a` passes (ruff, codespell, mypy --strict, datetime aliases)
- [x] `pytest .` — 1267 passed, 10 skipped (1 pre-existing failure in `test_evo_control::test_namespace` deselected, unrelated to this change)
- [x] All 21 fan handler tests pass (updated 2 tests to clean up timers via `async_on_unload` mock)