### PR TITLE
fix: use authoritative domain_id for BDR role assignment (issue 931)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1901,9 +1901,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # Build scan_codes map for DHW valve inference (13: devices
             # that send 1100 are boiler relays, not zone actuators)
             scan_codes: dict[str, list[str]] = {}
+            scan_domain_ids: dict[str, tuple[str | None, bool]] = {}
             if self.discovery_manager:
-                scan_codes = self.discovery_manager.get_scan_codes()
+                sc = self.discovery_manager.get_scan_codes()
+                if isinstance(sc, dict):
+                    scan_codes = sc
+                sdi = self.discovery_manager.get_scan_domain_ids()
+                if isinstance(sdi, dict):
+                    scan_domain_ids = sdi
             _LOGGER.debug("sync_learned_topology: scan_codes=%s", scan_codes)
+            _LOGGER.debug("sync_learned_topology: scan_domain_ids=%s", scan_domain_ids)
             _LOGGER.info(
                 "sync_learned_topology: removed_devices=%s", self._removed_devices
             )
@@ -1911,6 +1918,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 config_schema,
                 schema,
                 scan_codes=scan_codes,
+                scan_domain_ids=scan_domain_ids,
                 removed_devices=self._removed_devices,
             )
             _LOGGER.debug("sync_learned_topology: enriched=%s", enriched)

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -226,6 +226,28 @@ class DiscoveryManager:
                 result[dev_id] = list(dev.codes_seen)
         return result
 
+    def get_scan_domain_ids(self) -> dict[str, tuple[str | None, bool]]:
+        """Return a mapping of device_id → (domain_id, is_authoritative).
+
+        The domain_id (FC/FA/F9) is the authoritative tag from the
+        scan engine: ``FC`` = appliance_control, ``FA`` = hotwater_valve,
+        ``F9`` = heating_valve.  ``is_authoritative`` is True when the
+        domain_id was set from a ``000C`` binding table entry (confident),
+        False when set from a ``3B00``/``3EF0`` fallback hint (hedged).
+
+        Used by sync_learned_topology to place BDR relays based on
+        authoritative domain evidence rather than the ambiguous ``1100``
+        code heuristic.  Issue 931.
+
+        :return: A dict mapping device_id to a ``(domain_id,
+            is_authoritative)`` tuple.  Devices with no domain_id are
+            included with ``(None, False)``.
+        """
+        result: dict[str, tuple[str | None, bool]] = {}
+        for dev_id, dev in self._scan._devices.items():
+            result[dev_id] = (dev.domain_id, dev.is_authoritative_domain)
+        return result
+
     def refresh_device_comments(
         self,
         existing_comments: dict[str, str],
@@ -292,10 +314,19 @@ class DiscoveryManager:
             if not dev.zone_idx and not dev.bound_to:
                 # No binding info — still create a basic comment if missing
                 # or if it lacks the auto-generated suffix.
-                # Exception: if the device has a schema_role (e.g.
-                # hotwater_valve), we must rebuild the comment to suppress
-                # the scan engine's FC domain hint.  Issue 834.
-                if comment and self._COMMENT_SUFFIX in comment and schema_role is None:
+                # Exceptions that force a rebuild:
+                # - schema_role is set (e.g. hotwater_valve): suppress the
+                #   scan engine's FC domain hint.  Issue 834.
+                # - is_authoritative_domain is True: a 000C binding has
+                #   been captured since the comment was last built — the
+                #   comment must be rebuilt to show the confident domain
+                #   classification instead of the hedged hint.  Issue 931.
+                if (
+                    comment
+                    and self._COMMENT_SUFFIX in comment
+                    and schema_role is None
+                    and not dev.is_authoritative_domain
+                ):
                     continue  # existing comment, no new info to add
                 likely_type = dev.likely_type or "unknown"
                 new_comment = self._build_comment(
@@ -1043,15 +1074,33 @@ class DiscoveryManager:
         if zone_idx:
             parts.append(f"zone {zone_idx}")
 
-        # Domain ID (FC = appliance_control, issue 834)
-        # The scan engine's domain_id is a hint from 3B00/3EF0 broadcasts.
-        # Both appliance_control and hotwater_valve relays send these codes,
+        # Domain ID (FC = appliance_control, FA = hotwater_valve,
+        # F9 = heating_valve, issue 834/931).
+        # The scan engine's domain_id can be authoritative (from 000C
+        # binding table) or a non-authoritative hint (from 3B00/3EF0).
+        # Both appliance_control and hotwater_valve relays send 3B00/3EF0,
         # so the hint is ambiguous.  If the schema has already placed this
         # device as hotwater_valve, suppress the FC hint — the schema is
         # the SSOT and the user has confirmed the placement.
         domain_id = getattr(dev, "domain_id", None) if dev else None
-        if domain_id == "FC" and schema_role != "hotwater_valve":
-            parts.append("domain FC (appliance_control)")
+        is_auth = getattr(dev, "is_authoritative_domain", False) if dev else False
+        if domain_id and schema_role != "hotwater_valve":
+            if is_auth:
+                # Authoritative — from 000C binding table
+                domain_names = {
+                    "FC": "appliance_control",
+                    "FA": "hotwater_valve",
+                    "F9": "heating_valve",
+                }
+                name = domain_names.get(domain_id, domain_id)
+                parts.append(f"domain {domain_id} ({name})")
+            elif domain_id == "FC":
+                # Non-authoritative hint from 3B00/3EF0 — ambiguous
+                parts.append(
+                    "domain FC hint from 3B00/3EF0 — could be "
+                    "appliance_control or hotwater_valve; awaiting "
+                    "000C binding"
+                )
 
         # Packet codes seen
         codes = getattr(dev, "codes_seen", None) if dev else None

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1143,10 +1143,81 @@ def migrate_known_list_traits(
     return new_schema
 
 
+def _is_device_placed_elsewhere_in_learned(
+    learned_schema: _SchemaT | None,
+    device_id: str,
+    tcs_id: str,
+    valve_key: str,
+) -> bool:
+    """Check if a device is placed in a structural location in the learned schema.
+
+    Returns True if *device_id* is placed in any structural location in the
+    learned schema **other than** the ``valve_key`` slot of ``tcs_id``.
+    Structural locations are: zones (sensor/actuators), DHW sensor/valves,
+    and ``system.appliance_control``.  Orphan lists are NOT structural —
+    a device in ``orphans_heat`` is not "placed".
+
+    Used by step 1c of ``sync_learned_topology`` to distinguish re-parenting
+    (device moved from ``hotwater_valve`` to ``appliance_control`` or a zone)
+    from the not-yet-discovered case (device absent from the learned schema
+    or only in orphans).  Without this check, a user's manual valve
+    placement is nulled out whenever the learned schema has ``valve=None``,
+    even when ramses_rf simply hasn't captured a ``000C`` binding yet.
+    Issue 931.
+
+    :param learned_schema: The learned topology from ``gateway.schema()``.
+    :param device_id: The device ID to search for.
+    :param tcs_id: The TCS ID whose ``valve_key`` slot to exclude.
+    :param valve_key: The valve slot (``hotwater_valve`` or
+        ``heating_valve``) to exclude.
+    :return: True if the device is placed elsewhere in a structural
+        location, False otherwise.
+    """
+    if not isinstance(learned_schema, dict) or not device_id:
+        return False
+
+    for l_tcs_id, l_entry in learned_schema.items():
+        if not isinstance(l_entry, dict):
+            continue
+        if l_tcs_id in (SZ_ORPHANS_HEAT, SZ_ORPHANS_HVAC, SZ_MAIN_TCS):
+            continue
+
+        # system.appliance_control
+        sys_entry = l_entry.get(SZ_SYSTEM, {})
+        if isinstance(sys_entry, dict):
+            ac = sys_entry.get(SZ_APPLIANCE_CONTROL)
+            if ac == device_id:
+                return True
+
+        # zones (sensor / actuators)
+        for zone in l_entry.get(SZ_ZONES, {}).values():
+            if not isinstance(zone, dict):
+                continue
+            if zone.get(SZ_SENSOR) == device_id:
+                return True
+            for act in zone.get(SZ_ACTUATORS, []):
+                if act == device_id:
+                    return True
+
+        # DHW sensor / valves (exclude the current valve_key slot)
+        l_dhw = l_entry.get(SZ_DHW_SYSTEM, {})
+        if isinstance(l_dhw, dict):
+            if l_dhw.get(SZ_SENSOR) == device_id:
+                return True
+            for vk in ("hotwater_valve", "heating_valve"):
+                if l_tcs_id == tcs_id and vk == valve_key:
+                    continue  # this is the slot we're checking
+                if l_dhw.get(vk) == device_id:
+                    return True
+
+    return False
+
+
 def sync_learned_topology(
     config_schema: _SchemaT,
     learned_schema: _SchemaT,
     scan_codes: dict[str, list[str]] | None = None,
+    scan_domain_ids: dict[str, tuple[str | None, bool]] | None = None,
     removed_devices: set[str] | None = None,
 ) -> _SchemaT | None:
     """Sync learned topology from ramses_rf back into the config schema.
@@ -1165,6 +1236,13 @@ def sync_learned_topology(
 
     :param config_schema: The current config entry schema (user intent).
     :param learned_schema: The learned topology from ``gateway.schema()``.
+    :param scan_codes: Mapping of device_id → codes_seen from the scan
+        engine.  Used for fallback heuristic inference.
+    :param scan_domain_ids: Mapping of device_id → ``(domain_id,
+        is_authoritative)`` from the scan engine.  ``domain_id`` is
+        ``FC``/``FA``/``F9``; ``is_authoritative`` is True when sourced
+        from a ``000C`` binding.  Used for authoritative BDR role
+        assignment.  Issue 931.
     :param removed_devices: Device IDs explicitly removed by the user via
         ``remove_device``.  These must NOT be re-added by sync (the learned
         schema may still reference them because ramses_rf has no remove API).
@@ -1373,9 +1451,13 @@ def sync_learned_topology(
     #   learned_device_zones: device_id -> (tcs_id, zone_idx) — from learned schema
     #   comment_device_zones:  device_id -> (tcs_id, zone_idx) — from device comments
     #   learned_dhw_devices:  device_id -> tcs_id
+    #   learned_appliance_control: set of device_ids placed as
+    #     appliance_control in any TCS (issue 931: DHW→appliance_control
+    #     re-parenting must clear the old DHW valve slot).
     learned_device_zones: dict[str, tuple[str, str]] = {}
     comment_device_zones: dict[str, tuple[str, str]] = {}
     learned_dhw_devices: dict[str, str] = {}
+    learned_appliance_control: set[str] = set()
 
     # 0a. Extract zone info from learned schema (ramses_rf's active discovery)
     if learned_schema and type(learned_schema) is dict:
@@ -1404,6 +1486,14 @@ def sync_learned_topology(
                     valve = learned_dhw_entry.get(valve_key)
                     if isinstance(valve, str):
                         learned_dhw_devices[valve] = tcs_id
+            # Track appliance_control placements (issue 931: a BDR
+            # re-parented from hotwater_valve to appliance_control must
+            # have its old DHW valve slot cleared in step 1f).
+            learned_sys = learned_entry.get(SZ_SYSTEM, {})
+            if isinstance(learned_sys, dict):
+                ac = learned_sys.get(SZ_APPLIANCE_CONTROL)
+                if isinstance(ac, str):
+                    learned_appliance_control.add(ac)
 
     # 0b. Extract zone info from device comments (passive scan/discovery manager)
     # This is important for passive scan mode where ramses_rf doesn't actively
@@ -1832,7 +1922,12 @@ def sync_learned_topology(
                 # Sync valve assignments (hotwater_valve, heating_valve).
                 # When the learned schema has valve=None (e.g. after
                 # re-parenting a BDR from hotwater_valve to
-                # appliance_control), remove the valve from the config too.
+                # appliance_control), remove the valve from the config
+                # too — but only if the device has been actively placed
+                # elsewhere in the learned schema.  If the device is
+                # simply not yet discovered (absent from the learned
+                # schema or only in orphans), preserve the user's manual
+                # placement.  Issue 931.
                 for valve_key in ("hotwater_valve", "heating_valve"):
                     learned_valve = learned_dhw.get(valve_key)
                     if learned_valve:
@@ -1844,8 +1939,15 @@ def sync_learned_topology(
                             config_dhw[valve_key] = learned_valve
                             changed = True
                     elif valve_key in config_dhw and config_dhw[valve_key]:
-                        config_dhw[valve_key] = None
-                        changed = True
+                        placed_device = config_dhw[valve_key]
+                        if _is_device_placed_elsewhere_in_learned(
+                            learned_schema,
+                            placed_device,
+                            tcs_id,
+                            valve_key,
+                        ):
+                            config_dhw[valve_key] = None
+                            changed = True
 
             # 1d. Sync TCS-level orphans (only remove devices now in zones)
             learned_tcs_orphans = set(learned_entry.get(SZ_ORPHANS, []))
@@ -1901,10 +2003,12 @@ def sync_learned_topology(
                                 del cz["actuators"]
                             changed = True
 
-            # 1f. DHW→zone reassignment — clear DHW sensor/valves if the
-            # learned schema now has the device in a zone (any TCS) instead
-            # of this TCS's DHW.
-            if learned_device_zones and isinstance(
+            # 1f. DHW→zone/appliance_control reassignment — clear DHW
+            # sensor/valves if the learned schema now has the device in a
+            # zone (any TCS) or as appliance_control instead of this TCS's
+            # DHW.  Issue 931: a BDR re-parented from hotwater_valve to
+            # appliance_control must have its old DHW valve slot cleared.
+            if (learned_device_zones or learned_appliance_control) and isinstance(
                 config_entry.get(SZ_DHW_SYSTEM), dict
             ):
                 config_dhw = config_entry[SZ_DHW_SYSTEM]
@@ -1914,9 +2018,13 @@ def sync_learned_topology(
                     config_dhw[SZ_SENSOR] = None
                     changed = True
                 # Clear DHW valves if learned placed them in a zone
+                # or as appliance_control
                 for valve_key in ("hotwater_valve", "heating_valve"):
                     valve = config_dhw.get(valve_key)
-                    if valve and valve in learned_device_zones:
+                    if valve and (
+                        valve in learned_device_zones
+                        or valve in learned_appliance_control
+                    ):
                         config_dhw[valve_key] = None
                         changed = True
 
@@ -2203,22 +2311,41 @@ def sync_learned_topology(
                 new_schema.pop(SZ_ORPHANS_HEAT, None)
             changed = True
 
-    # 2b. Infer DHW valves from scan codes — 13: devices that send 1100
-    # (TPI params with domain_id 00) are boiler relays (hotwater_valve or
-    # heating_valve), not zone actuators.  In passive scan mode, the HGI
-    # doesn't query 000C with zone_type 0E (HTG), so the only way to
-    # identify DHW valves is from the 1100 code they broadcast.
-    # This moves such devices from orphans_heat to stored_hotwater.
-    if scan_codes:
+    # 2b. Place BDRs (13:) and OTBs (10:) from orphans_heat using
+    # authoritative domain_id from the scan engine's 000C binding table.
+    # The 000C binding is the authoritative source for domain assignment:
+    #   - domain FA → hotwater_valve (DHW relay, HTG slot 00)
+    #   - domain F9 → heating_valve (heating relay, HTG slot 01)
+    #   - domain FC → appliance_control (boiler relay / OTB, APP slot)
+    # Only authoritative domain_id (from 000C, is_authoritative=True) is
+    # used for auto-placement.  Non-authoritative hints (3B00/3EF0) are
+    # NOT used here — they are ambiguous (both appliance_control and
+    # hotwater_valve relays send 3EF0).  See issue 931.
+    # The old heuristic keyed on "1100" in scan_codes, but 1100 is boiler
+    # parameters broadcast by the appliance_control, not a DHW-valve-
+    # specific signal — it caused false assignments in multi-BDR systems.
+    if scan_domain_ids and isinstance(scan_domain_ids, dict):
         heat_orphans = set(new_schema.get(SZ_ORPHANS_HEAT, []))
-        dhw_valves_in_orphans = {
-            dev_id
-            for dev_id in heat_orphans
-            if isinstance(dev_id, str)
-            and dev_id.startswith("13:")
-            and "1100" in scan_codes.get(dev_id, [])
-        }
-        if dhw_valves_in_orphans:
+        # Build sets of orphaned BDRs/OTBs by authoritative domain_id
+        fa_bdrs: set[str] = set()  # hotwater_valve candidates
+        f9_bdrs: set[str] = set()  # heating_valve candidates
+        fc_relays: set[str] = set()  # appliance_control candidates
+        for dev_id in heat_orphans:
+            if not isinstance(dev_id, str):
+                continue
+            if not dev_id.startswith(("13:", "10:")):
+                continue
+            domain_id, is_auth = scan_domain_ids.get(dev_id, (None, False))
+            if not is_auth or not domain_id:
+                continue
+            if domain_id == "FA" and dev_id.startswith("13:"):
+                fa_bdrs.add(dev_id)
+            elif domain_id == "F9" and dev_id.startswith("13:"):
+                f9_bdrs.add(dev_id)
+            elif domain_id == "FC":
+                fc_relays.add(dev_id)
+
+        if fa_bdrs or f9_bdrs or fc_relays:
             # Find the main TCS entry
             main_tcs = new_schema.get(SZ_MAIN_TCS)
             target_tcs_id: str | None = (
@@ -2239,31 +2366,60 @@ def sync_learned_topology(
             )
             if target_tcs_id:
                 tcs_entry = new_schema[target_tcs_id]
-                dhw = tcs_entry.setdefault(SZ_DHW_SYSTEM, {})
-                for dev_id in sorted(dhw_valves_in_orphans):
-                    # Assign to hotwater_valve first, then heating_valve
-                    if not dhw.get("hotwater_valve"):
-                        dhw["hotwater_valve"] = dev_id
-                        _LOGGER.info(
-                            "sync_learned_topology: inferred %s as "
-                            "hotwater_valve (sends 1100, was orphan)",
-                            dev_id,
-                        )
-                    elif not dhw.get("heating_valve"):
-                        dhw["heating_valve"] = dev_id
-                        _LOGGER.info(
-                            "sync_learned_topology: inferred %s as "
-                            "heating_valve (sends 1100, was orphan)",
-                            dev_id,
-                        )
+                # Place DHW valves (FA → hotwater_valve, F9 → heating_valve)
+                if fa_bdrs or f9_bdrs:
+                    dhw = tcs_entry.setdefault(SZ_DHW_SYSTEM, {})
+                    for dev_id in sorted(fa_bdrs):
+                        if not dhw.get("hotwater_valve"):
+                            dhw["hotwater_valve"] = dev_id
+                            heat_orphans.discard(dev_id)
+                            changed = True
+                            _LOGGER.info(
+                                "sync_learned_topology: placed %s as "
+                                "hotwater_valve (domain FA from 000C, "
+                                "was orphan)",
+                                dev_id,
+                            )
+                    for dev_id in sorted(f9_bdrs):
+                        if not dhw.get("heating_valve"):
+                            dhw["heating_valve"] = dev_id
+                            heat_orphans.discard(dev_id)
+                            changed = True
+                            _LOGGER.info(
+                                "sync_learned_topology: placed %s as "
+                                "heating_valve (domain F9 from 000C, "
+                                "was orphan)",
+                                dev_id,
+                            )
+                # Place appliance_control (FC → system.appliance_control)
+                if fc_relays:
+                    config_sys = tcs_entry.setdefault(SZ_SYSTEM, {})
+                    existing_app = config_sys.get(SZ_APPLIANCE_CONTROL)
+                    for dev_id in sorted(fc_relays):
+                        if existing_app and existing_app != dev_id:
+                            _LOGGER.debug(
+                                "sync_learned_topology: %s has domain FC "
+                                "but appliance_control already set to %s",
+                                dev_id,
+                                existing_app,
+                            )
+                            continue
+                        if existing_app != dev_id:
+                            config_sys[SZ_APPLIANCE_CONTROL] = dev_id
+                            existing_app = dev_id
+                            heat_orphans.discard(dev_id)
+                            changed = True
+                            _LOGGER.info(
+                                "sync_learned_topology: placed %s as "
+                                "appliance_control (domain FC from 000C, "
+                                "was orphan)",
+                                dev_id,
+                            )
+                if heat_orphans != set(new_schema.get(SZ_ORPHANS_HEAT, [])):
+                    if heat_orphans:
+                        new_schema[SZ_ORPHANS_HEAT] = sorted(heat_orphans)
                     else:
-                        continue  # both valves already set
-                    heat_orphans.discard(dev_id)
-                    changed = True
-                if heat_orphans:
-                    new_schema[SZ_ORPHANS_HEAT] = sorted(heat_orphans)
-                else:
-                    new_schema.pop(SZ_ORPHANS_HEAT, None)
+                        new_schema.pop(SZ_ORPHANS_HEAT, None)
 
     # 2c. Infer appliance_control from scan codes — 10: devices that send
     # 3220 (boiler parameters) or 3EF0 (actuator cycle) are OpenTherm

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -1384,8 +1384,61 @@ def test_sync_dhw_to_zone_valve_move() -> None:
     assert "13:120242" in result["01:216136"][SZ_ZONES]["01"]["actuators"]
 
 
-def test_sync_infer_dhw_valve_from_scan_codes() -> None:
-    """13: device in orphans_heat with 1100 in scan_codes → hotwater_valve."""
+def test_sync_manual_valve_placement_preserved_when_not_discovered() -> None:
+    """Manual hotwater_valve placement preserved when not yet discovered.
+
+    The learned schema has no DHW valve (ramses_rf hasn't captured a
+    000C binding yet), but the user manually placed a BDR as
+    hotwater_valve.  The sync must NOT null out the manual placement —
+    the device is not placed elsewhere in the learned schema, so it's
+    "not yet discovered", not "re-parented".  Issue 931.
+    """
+    config: dict[str, Any] = {
+        "01:216136": {
+            SZ_ZONES: {"01": {}},
+            SZ_DHW_SYSTEM: {"hotwater_valve": "13:042605"},
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:216136": {
+            SZ_ZONES: {"01": {}},
+            # No DHW system in learned — device not yet discovered
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    # Manual placement preserved (device not placed elsewhere)
+    if result is not None:
+        assert result["01:216136"][SZ_DHW_SYSTEM]["hotwater_valve"] == "13:042605"
+
+
+def test_sync_manual_valve_placement_nulled_when_reparented() -> None:
+    """Manual hotwater_valve placement nulled when device re-parented.
+
+    The learned schema has the device placed as appliance_control (it
+    was re-parented from hotwater_valve to appliance_control).  The sync
+    must null out the old hotwater_valve placement.  Issue 931.
+    """
+    config: dict[str, Any] = {
+        "01:216136": {
+            SZ_ZONES: {"01": {}},
+            SZ_DHW_SYSTEM: {"hotwater_valve": "13:042605"},
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:216136": {
+            SZ_ZONES: {"01": {}},
+            SZ_SYSTEM: {SZ_APPLIANCE_CONTROL: "13:042605"},
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    # Re-parented: hotwater_valve nulled, appliance_control set
+    assert result["01:216136"][SZ_DHW_SYSTEM]["hotwater_valve"] is None
+    assert result["01:216136"][SZ_SYSTEM][SZ_APPLIANCE_CONTROL] == "13:042605"
+
+
+def test_sync_infer_dhw_valve_from_scan_domain_ids() -> None:
+    """13: in orphans_heat with authoritative domain FA → hotwater_valve."""
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:216136",
         "01:216136": {
@@ -1401,21 +1454,21 @@ def test_sync_infer_dhw_valve_from_scan_codes() -> None:
         },
         SZ_ORPHANS_HEAT: ["13:042605", "04:111111"],
     }
-    scan_codes: dict[str, list[str]] = {
-        "13:042605": ["1100", "3B00", "0008"],
-        "04:111111": ["30C9", "3150"],
+    scan_domain_ids: dict[str, tuple[str | None, bool]] = {
+        "13:042605": ("FA", True),  # authoritative 000C → hotwater_valve
+        "04:111111": (None, False),
     }
-    result = sync_learned_topology(config, learned, scan_codes=scan_codes)
+    result = sync_learned_topology(config, learned, scan_domain_ids=scan_domain_ids)
     assert result is not None
     # 13:042605 moved from orphans_heat to stored_hotwater.hotwater_valve
     assert result["01:216136"][SZ_DHW_SYSTEM]["hotwater_valve"] == "13:042605"
     assert "13:042605" not in result.get(SZ_ORPHANS_HEAT, [])
-    # 04:111111 stays in orphans_heat (no 1100)
+    # 04:111111 stays in orphans_heat (no domain_id)
     assert "04:111111" in result.get(SZ_ORPHANS_HEAT, [])
 
 
 def test_sync_infer_dhw_valve_both_slots() -> None:
-    """Two 13: devices with 1100 → hotwater_valve + heating_valve."""
+    """Two 13: devices with FA/F9 → hotwater_valve + heating_valve."""
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:216136",
         "01:216136": {
@@ -1431,11 +1484,11 @@ def test_sync_infer_dhw_valve_both_slots() -> None:
         },
         SZ_ORPHANS_HEAT: ["13:042605", "13:042606"],
     }
-    scan_codes: dict[str, list[str]] = {
-        "13:042605": ["1100"],
-        "13:042606": ["1100"],
+    scan_domain_ids: dict[str, tuple[str | None, bool]] = {
+        "13:042605": ("FA", True),
+        "13:042606": ("F9", True),
     }
-    result = sync_learned_topology(config, learned, scan_codes=scan_codes)
+    result = sync_learned_topology(config, learned, scan_domain_ids=scan_domain_ids)
     assert result is not None
     dhw = result["01:216136"][SZ_DHW_SYSTEM]
     assert dhw["hotwater_valve"] == "13:042605"
@@ -1444,7 +1497,7 @@ def test_sync_infer_dhw_valve_both_slots() -> None:
 
 
 def test_sync_infer_dhw_valve_no_scan_codes() -> None:
-    """Without scan_codes, 13: in orphans_heat stays as orphan."""
+    """Without scan_domain_ids, 13: in orphans_heat stays as orphan."""
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:216136",
         "01:216136": {
@@ -1460,14 +1513,14 @@ def test_sync_infer_dhw_valve_no_scan_codes() -> None:
         },
         SZ_ORPHANS_HEAT: ["13:042605"],
     }
-    # No scan_codes → no inference
+    # No scan_domain_ids → no inference
     result = sync_learned_topology(config, learned)
     # orphans_heat unchanged (learned matches config)
     assert result is None or "13:042605" in result.get(SZ_ORPHANS_HEAT, [])
 
 
 def test_sync_infer_dhw_valve_existing_hotwater_preserved() -> None:
-    """If hotwater_valve already set, 13: with 1100 goes to heating_valve."""
+    """If hotwater_valve already set, 13: with F9 goes to heating_valve."""
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:216136",
         "01:216136": {
@@ -1485,14 +1538,66 @@ def test_sync_infer_dhw_valve_existing_hotwater_preserved() -> None:
         },
         SZ_ORPHANS_HEAT: ["13:042605"],
     }
-    scan_codes: dict[str, list[str]] = {
-        "13:042605": ["1100"],
+    scan_domain_ids: dict[str, tuple[str | None, bool]] = {
+        "13:042605": ("F9", True),
     }
-    result = sync_learned_topology(config, learned, scan_codes=scan_codes)
+    result = sync_learned_topology(config, learned, scan_domain_ids=scan_domain_ids)
     assert result is not None
     dhw = result["01:216136"][SZ_DHW_SYSTEM]
     assert dhw["hotwater_valve"] == "13:999999"  # preserved
     assert dhw["heating_valve"] == "13:042605"  # inferred
+    assert "13:042605" not in result.get(SZ_ORPHANS_HEAT, [])
+
+
+def test_sync_infer_dhw_valve_non_authoritative_not_placed() -> None:
+    """Non-authoritative domain hint (3EF0) does NOT auto-place.  Issue 931."""
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {
+            SZ_SYSTEM: {},
+            SZ_ZONES: {"01": {}},
+        },
+        SZ_ORPHANS_HEAT: ["13:042605"],
+    }
+    learned: dict[str, Any] = {
+        "01:216136": {
+            SZ_SYSTEM: {},
+            SZ_ZONES: {"01": {}},
+        },
+        SZ_ORPHANS_HEAT: ["13:042605"],
+    }
+    # FC from 3EF0 hint (not authoritative) — must NOT auto-place
+    scan_domain_ids: dict[str, tuple[str | None, bool]] = {
+        "13:042605": ("FC", False),
+    }
+    result = sync_learned_topology(config, learned, scan_domain_ids=scan_domain_ids)
+    # Should stay as orphan — non-authoritative hint is ambiguous
+    assert result is None or "13:042605" in result.get(SZ_ORPHANS_HEAT, [])
+
+
+def test_sync_infer_appliance_control_from_domain_fc() -> None:
+    """13: BDR with authoritative domain FC → appliance_control.  Issue 931."""
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:216136",
+        "01:216136": {
+            SZ_SYSTEM: {},
+            SZ_ZONES: {"01": {}},
+        },
+        SZ_ORPHANS_HEAT: ["13:042605"],
+    }
+    learned: dict[str, Any] = {
+        "01:216136": {
+            SZ_SYSTEM: {},
+            SZ_ZONES: {"01": {}},
+        },
+        SZ_ORPHANS_HEAT: ["13:042605"],
+    }
+    scan_domain_ids: dict[str, tuple[str | None, bool]] = {
+        "13:042605": ("FC", True),
+    }
+    result = sync_learned_topology(config, learned, scan_domain_ids=scan_domain_ids)
+    assert result is not None
+    assert result["01:216136"][SZ_SYSTEM][SZ_APPLIANCE_CONTROL] == "13:042605"
     assert "13:042605" not in result.get(SZ_ORPHANS_HEAT, [])
 
 


### PR DESCRIPTION
## Summary

Replace the wrong `"1100" in scan_codes` heuristic with authoritative `domain_id` from the scan engine's `000C` binding table for BDR/OTB role assignment.

- **`get_scan_domain_ids()`** added to `DiscoveryManager` — surfaces `domain_id` and `is_authoritative_domain` from the scan engine (the RX path integrity gap: the scan engine tracked `domain_id` but never exposed it to `ramses_cc`).
- **Step 2b rewritten** — places BDRs (`13:`) and OTBs (`10:`) from `orphans_heat` using authoritative domain: `FA` → `hotwater_valve`, `F9` → `heating_valve`, `FC` → `appliance_control`. Only authoritative domain (from `000C`) is used; non-authoritative hints (`3B00`/`3EF0`) are not used for auto-placement.
- **Manual-place-nulling bug fixed** (step 1c) — a user's manual valve placement is no longer nulled when the device is simply not yet discovered. The nulling only fires when the device has been actively re-parented elsewhere.
- **Step 1f extended** — clears DHW valves when the device is re-parented to `appliance_control` (was only handling zone reassignment).
- **Comment staleness fixed** (4a) — `refresh_device_comments` skip logic now rebuilds when `is_authoritative_domain` is True (a `000C` arrived since the comment was last built).
- **`_build_comment`** distinguishes authoritative vs hint domain: authoritative shows `"domain FC (appliance_control)"`, hint shows `"domain FC hint from 3B00/3EF0 — could be appliance_control or hotwater_valve; awaiting 000C binding"`.

## Context

Issue 931: a DHW relay BDR (`13:042605`) was never auto-discovered as `stored_hotwater.hotwater_valve` because:
1. `ramses_cc` keyed on `"1100" in scan_codes` — but `1100` is boiler parameters broadcast by the appliance_control, not a DHW-valve signal.
2. The authoritative `domain_id` was tracked by the `ramses_rf` scan engine but never surfaced to `ramses_cc`.
3. The user's manual placement was being nulled out by step 1c whenever the learned schema had `valve=None` (device not yet discovered).

Depends on the `ramses_rf` half: https://github.com/ramses-rf/ramses_rf/pull/1033 (adds `is_authoritative_domain` to `DiscoveredDevice`).

## Test plan

- [x] ramses_cc tests: 1274 passed, 10 skipped
- [x] ruff clean
- [x] mypy clean
- [x] Replaced 4 old `1100`-heuristic tests with `domain_id`-based tests
- [x] Added 4 new tests: non-auth not placed, FC→appliance_control, manual placement preserved, manual placement nulled when reparented
- [x] ha_sim_test regression recipe (to be added separately)