### PR TITLE
feat(discovery): notify on zone name mismatch between schema and controller

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -73,6 +73,7 @@ from .const import (
     SZ_OWNER,
     SZ_PACKETS,
     SZ_TR_CLASS,
+    SZ_TR_NAME,
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
 )
@@ -1551,6 +1552,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         if isinstance(config_schema_check, dict):
             coordinator.discovery_manager.check_class_mismatches(config_schema_check)
             coordinator.discovery_manager.check_missing_class(config_schema_check)
+            coordinator.discovery_manager.check_name_mismatches(
+                config_schema_check,
+                zones=coordinator._zones,  # noqa: SLF001
+            )
 
         new_devices = coordinator.discovery_manager.get_devices(
             status=DiscoveryStatus.NEW
@@ -1559,8 +1564,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         missing_class_devices = (
             coordinator.discovery_manager.get_missing_class_devices()
         )
+        name_mismatch_devices = (
+            coordinator.discovery_manager.get_name_mismatch_devices()
+        )
         # Deduplicate: a device could appear in multiple categories — only
-        # show it once.  Priority: NEW > class_mismatch > missing_class.
+        # show it once.  Priority: NEW > class_mismatch > missing_class >
+        # name_mismatch.
         new_ids = {d.device.device_id for d in new_devices}
         mismatched_only = [
             e for e in mismatched_devices if e.device.device_id not in new_ids
@@ -1569,8 +1578,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         missing_class_only = [
             e for e in missing_class_devices if e.device.device_id not in seen_ids
         ]
+        seen_ids |= {e.device.device_id for e in missing_class_only}
+        name_mismatch_only = [
+            e for e in name_mismatch_devices if e.device.device_id not in seen_ids
+        ]
         devices = new_devices
-        if not devices and not mismatched_only and not missing_class_only:
+        if (
+            not devices
+            and not mismatched_only
+            and not missing_class_only
+            and not name_mismatch_only
+        ):
             # If the user already submitted the form, close it.
             # Otherwise show the "no devices" message once.
             if user_input is not None:
@@ -1792,6 +1810,46 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             # User added a class — clear any prior dismissal
                             meta.missing_class_dismissed = False
 
+            # Process name mismatch zones (schema _name differs from
+            # controller's 0004 name).  The controller is authoritative
+            # for _name — the user can update _name to match, or use
+            # _alias for a custom display name.  No dismiss option.
+            for entry in name_mismatch_only:
+                device_id = entry.device.device_id
+                action = user_input.get(f"name_mismatch_{device_id}", "skip")
+                if action == "update_name":
+                    nm = entry.metadata.name_mismatch or ""
+                    ctrl_name = (
+                        nm.split("controller=")[1] if "controller=" in nm else None
+                    )
+                    if ctrl_name:
+                        # zone_id is "<ctl_id>_<zone_idx>"
+                        parts = device_id.rsplit("_", 1)
+                        if len(parts) == 2:
+                            ctl_id, zone_idx = parts
+                            ctl_entry = config_schema.get(ctl_id)
+                            if isinstance(ctl_entry, dict):
+                                ctl_zones = ctl_entry.get("zones")
+                                if isinstance(ctl_zones, dict):
+                                    zone_entry = ctl_zones.get(zone_idx)
+                                    if isinstance(zone_entry, dict):
+                                        zone_entry[SZ_TR_NAME] = ctrl_name
+                                        changed = True
+                                        _LOGGER.info(
+                                            "review_discovered: updated _name "
+                                            "for zone %s to %r (controller "
+                                            "authoritative, issue 947)",
+                                            device_id,
+                                            ctrl_name,
+                                        )
+                # Clear the name_mismatch flag for both "update_name"
+                # and "skip".  For "skip", the flag will be re-set on the
+                # next checkpoint by check_name_mismatches (no dismiss —
+                # the schema _name should match the controller).
+                meta = coordinator.discovery_manager._metadata.get(device_id)
+                if meta:
+                    meta.name_mismatch = None
+
             if changed:
                 self.options[CONF_SCHEMA] = order_schema(config_schema)
 
@@ -1868,6 +1926,21 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 mc = entry.metadata.missing_class or ""
                 disc_cls = mc.split("discovery=")[1] if "discovery=" in mc else "?"
                 lines.append(f"| `{d.device_id}` | {disc_cls} | {d.confidence} |")
+
+        if name_mismatch_only:
+            if lines:
+                lines.append("\n")
+            lines.append(f"**{len(name_mismatch_only)} zone(s) with name mismatch:**\n")
+            lines.append("| Zone | Schema _name | Controller reports |")
+            lines.append("|------|-------------|-------------------|")
+            for entry in name_mismatch_only:
+                d = entry.device
+                nm = entry.metadata.name_mismatch or ""
+                schema_name = (
+                    nm.split("schema=")[1].split(",")[0] if "schema=" in nm else "?"
+                )
+                ctrl_name = nm.split("controller=")[1] if "controller=" in nm else "?"
+                lines.append(f"| `{d.device_id}` | {schema_name} | {ctrl_name} |")
 
         if not lines:
             lines.append("No new devices or mismatches to review.")
@@ -2035,6 +2108,44 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     },
                 )
             ] = selector.TextSelector()
+
+        # Add form fields for name mismatch zones.
+        # The controller's 0004 name is authoritative for _name.
+        # The user can update _name to match, or use _alias for a custom
+        # display name.  No dismiss option — the schema _name should
+        # match the controller (issue 947).
+        for entry in name_mismatch_only:
+            d = entry.device
+            device_id = d.device_id
+            nm = entry.metadata.name_mismatch or ""
+            schema_name = (
+                nm.split("schema=")[1].split(",")[0] if "schema=" in nm else "?"
+            )
+            ctrl_name = nm.split("controller=")[1] if "controller=" in nm else "?"
+            field_label = (
+                f"{device_id} | schema _name={schema_name} → "
+                f"controller reports {ctrl_name}"
+            )
+            form_fields[
+                vol.Required(
+                    f"name_mismatch_{device_id}",
+                    default="update_name",
+                    description={"label": field_label},
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        {
+                            "value": "update_name",
+                            "label": f"Update _name to {ctrl_name}",
+                        },
+                        {
+                            "value": "skip",
+                            "label": "Skip (will re-appear next checkpoint)",
+                        },
+                    ],
+                )
+            )
 
         return self.async_show_form(
             step_id="review_discovered",

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -721,7 +721,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Check for mismatches between discovery and schema
         # (schema is authoritative — this only logs warnings + notification)
         if isinstance(schema, dict):
-            self.discovery_manager.check_all_mismatches(schema)
+            self.discovery_manager.check_all_mismatches(schema, zones=self._zones)
         self.discovery_manager.check_for_new_devices()
         self.discovery_manager.check_for_lost_devices()
         await self.async_save_client_state()
@@ -2506,7 +2506,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if self.discovery_manager:
             schema = self.options.get(CONF_SCHEMA, {})
             if isinstance(schema, dict):
-                self.discovery_manager.check_all_mismatches(schema)
+                self.discovery_manager.check_all_mismatches(schema, zones=self._zones)
 
     async def async_send_packet(self, call: ServiceCall) -> None:
         """Delegate to Service Handler.

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -33,6 +33,7 @@ from .const import (
     SZ_TR_CLASS,
     SZ_TR_COMMENT,
     SZ_TR_FAKED,
+    SZ_TR_NAME,
     SZ_TR_OWNER,
 )
 
@@ -97,6 +98,12 @@ class DeviceMetadata:
     # scan engine for longer than the orphan threshold.  Cleared when
     # traffic is seen again.
     orphaned: str | None = None
+    # Set when a zone's schema _name differs from the runtime name
+    # reported by the controller via 0004 packets.  The controller's
+    # name is authoritative for _name — the user can set _alias for a
+    # custom display name.  No dismiss option: the schema _name should
+    # be updated to match the controller (issue 947).
+    name_mismatch: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict for JSON storage."""
@@ -113,6 +120,7 @@ class DeviceMetadata:
             "missing_class": self.missing_class,
             "missing_class_dismissed": self.missing_class_dismissed,
             "orphaned": self.orphaned,
+            "name_mismatch": self.name_mismatch,
         }
 
     @classmethod
@@ -135,6 +143,7 @@ class DeviceMetadata:
             missing_class=data.get("missing_class"),
             missing_class_dismissed=data.get("missing_class_dismissed", False),
             orphaned=data.get("orphaned"),
+            name_mismatch=data.get("name_mismatch"),
         )
 
 
@@ -221,6 +230,8 @@ class DiscoveryManager:
         # repeating the WARNING every checkpoint cycle).  Cleared when
         # a mismatch is resolved or changes.
         self._warned_mismatches: set[str] = set()
+        # Separate set for name mismatches (zone IDs, not device IDs).
+        self._warned_name_mismatches: set[str] = set()
 
         # Notification ID for the "new devices" notification
         self._notification_id = f"{DOMAIN}_discovery"
@@ -914,16 +925,144 @@ class DiscoveryManager:
 
         return len(orphaned)
 
-    def check_all_mismatches(self, schema: dict[str, Any]) -> dict[str, int]:
+    def check_name_mismatches(
+        self, schema: dict[str, Any], zones: list[Any] | None = None
+    ) -> int:
+        """Check for zone name mismatches between schema and controller.
+
+        For each zone in the ramses_rf client, compares the schema's
+        ``_name`` with the runtime name reported by the controller via
+        0004 packets (``zone.zone_state.name``).  If they differ, sets
+        ``name_mismatch`` on the zone's metadata.
+
+        The controller's 0004 name is authoritative for ``_name``.
+        Users who want a custom display name should use ``_alias``
+        (which overrides ``_name`` for display).  There is no dismiss
+        option — the schema ``_name`` should be updated to match the
+        controller (issue 947).
+
+        :param schema: The current config entry schema (with _ traits).
+        :param zones: The coordinator's list of ramses_rf Zone objects.
+            If ``None``, the check is skipped (no zones to compare).
+        :return: Number of name mismatches found.
+        """
+        if zones is None:
+            return 0
+
+        mismatches: list[tuple[str, str, str]] = []
+
+        for zone in zones:
+            zone_id = str(zone.id)  # e.g. "01:150000_03"
+            runtime_name = getattr(zone.zone_state, "name", None)
+            if not runtime_name:
+                continue  # no 0004 name received yet — nothing to compare
+
+            # Find the schema's _name for this zone.
+            # zone_id is "<ctl_id>_<zone_idx>", e.g. "01:150000_03".
+            # Schema stores zones under schema[ctl_id]["zones"][zone_idx].
+            parts = zone_id.rsplit("_", 1)
+            if len(parts) != 2:
+                continue
+            ctl_id, zone_idx = parts
+            ctl_entry = schema.get(ctl_id)
+            if not isinstance(ctl_entry, dict):
+                continue
+            ctl_zones = ctl_entry.get("zones")
+            if not isinstance(ctl_zones, dict):
+                continue
+            zone_entry = ctl_zones.get(zone_idx)
+            if not isinstance(zone_entry, dict):
+                continue
+            schema_name = zone_entry.get(SZ_TR_NAME)
+            if not isinstance(schema_name, str) or not schema_name:
+                continue  # no _name in schema — nothing to compare
+
+            if schema_name != runtime_name:
+                meta = self._metadata.get(zone_id, DeviceMetadata())
+                meta.name_mismatch = f"schema={schema_name}, controller={runtime_name}"
+                self._metadata[zone_id] = meta
+                mismatches.append((zone_id, schema_name, runtime_name))
+                _LOGGER.debug(
+                    "DiscoveryManager: name mismatch for zone %s — "
+                    "schema has _name=%r but controller reports %r. "
+                    "Update _name in the schema to match, or use _alias "
+                    "for a custom display name.",
+                    zone_id,
+                    schema_name,
+                    runtime_name,
+                )
+            else:
+                # Mismatch resolved — clear the flag
+                existing_meta = self._metadata.get(zone_id)
+                if existing_meta and existing_meta.name_mismatch:
+                    existing_meta.name_mismatch = None
+                    self._metadata[zone_id] = existing_meta
+
+        if mismatches:
+            # Only WARN once per zone — subsequent checks log at DEBUG.
+            # This avoids log spam every checkpoint cycle for persistent
+            # mismatches.  The notification (via _send_mismatch_notification)
+            # uses a fixed notification_id so HA updates it in-place rather
+            # than creating duplicates.
+            new_mismatches = [
+                (d, s, t)
+                for d, s, t in mismatches
+                if d not in self._warned_name_mismatches
+            ]
+            if new_mismatches:
+                _LOGGER.warning(
+                    "DiscoveryManager: %d zone(s) have name mismatches "
+                    "between schema and controller: %s",
+                    len(new_mismatches),
+                    ", ".join(f"{d} ({s}→{t})" for d, s, t in new_mismatches),
+                )
+                self._warned_name_mismatches.update(d for d, _, _ in new_mismatches)
+            else:
+                _LOGGER.debug(
+                    "DiscoveryManager: %d persistent name mismatch(s) "
+                    "(already warned): %s",
+                    len(mismatches),
+                    ", ".join(d for d, _, _ in mismatches),
+                )
+        else:
+            # All name mismatches resolved — clear the warned set
+            if self._warned_name_mismatches:
+                _LOGGER.info("DiscoveryManager: all name mismatches resolved")
+                self._warned_name_mismatches.clear()
+
+        return len(mismatches)
+
+    def get_name_mismatch_devices(self) -> list[DiscoveredDeviceEntry]:
+        """Get zones that have a name mismatch flag set.
+
+        These are zones whose schema ``_name`` differs from the
+        controller's 0004-reported name.  The review_discovered step
+        shows them so the user can update ``_name`` or add ``_alias``.
+
+        :return: List of device entries with name_mismatch set.
+        """
+        result: list[DiscoveredDeviceEntry] = []
+        for entry in self.get_devices():
+            if entry.metadata.name_mismatch:
+                result.append(entry)
+        return result
+
+    def check_all_mismatches(
+        self, schema: dict[str, Any], zones: list[Any] | None = None
+    ) -> dict[str, int]:
         """Run all mismatch checks and send a persistent notification if needed.
 
-        Convenience method that calls all four checks:
+        Convenience method that calls all five checks:
         - check_class_mismatches
         - check_bound_mismatches
         - check_missing_class
         - check_orphaned_devices
+        - check_name_mismatches (requires *zones*)
 
         :param schema: The current config entry schema (with _ traits).
+        :param zones: The coordinator's list of ramses_rf Zone objects.
+            Passed to :meth:`check_name_mismatches`.  If ``None``, the
+            name mismatch check is skipped.
         :return: Dict with counts per check type.
         """
         counts = {
@@ -931,6 +1070,7 @@ class DiscoveryManager:
             "bound_mismatch": self.check_bound_mismatches(schema),
             "missing_class": self.check_missing_class(schema),
             "orphaned": self.check_orphaned_devices(schema),
+            "name_mismatch": self.check_name_mismatches(schema, zones),
         }
         total = sum(counts.values())
         if total > 0:
@@ -981,6 +1121,16 @@ class DiscoveryManager:
             for entry in orphaned:
                 lines.append(
                     f"- `{entry.device.device_id}` — {entry.metadata.orphaned}"
+                )
+            lines.append("")
+
+        name_mm = [e for e in self.get_devices() if e.metadata.name_mismatch]
+        if counts.get("name_mismatch") and name_mm:
+            lines.append(f"**{counts['name_mismatch']} zone name mismatch(es):**\n")
+            for entry in name_mm:
+                lines.append(
+                    f"- `{entry.device.device_id}` — {entry.metadata.name_mismatch}"
+                    " (update _name, or use _alias for a custom display name)"
                 )
             lines.append("")
 

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1945,6 +1945,7 @@ class TestCheckAllMismatches:
             "bound_mismatch": 0,
             "missing_class": 0,
             "orphaned": 0,
+            "name_mismatch": 0,
         }
 
     def test_multiple_mismatch_types(self) -> None:
@@ -2146,3 +2147,298 @@ class TestGetLostDevices:
 
         result = manager.get_lost_devices()
         assert result == []
+
+
+class TestNameMismatch:
+    """Tests for zone name mismatch detection (issue 947)."""
+
+    def _make_zone(self, zone_id: str, runtime_name: str | None = None) -> MagicMock:
+        """Create a mock Zone with the given runtime name.
+
+        :param zone_id: Zone ID like "01:150000_03".
+        :param runtime_name: The name from 0004 packets (zone_state.name).
+        """
+        zone = MagicMock()
+        zone.id = zone_id
+        zone.zone_state = MagicMock()
+        zone.zone_state.name = runtime_name
+        return zone
+
+    def test_mismatch_detected_when_schema_differs_from_controller(self) -> None:
+        """Schema _name='Lounge' but controller reports 'Kitchen' → mismatch."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Lounge"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        count = manager.check_name_mismatches(schema, zones=zones)
+
+        assert count == 1
+        meta = manager._metadata.get("01:150000_03")
+        assert meta is not None
+        assert meta.name_mismatch is not None
+        assert "Lounge" in meta.name_mismatch
+        assert "Kitchen" in meta.name_mismatch
+
+    def test_no_mismatch_when_names_match(self) -> None:
+        """Schema _name='Kitchen' and controller reports 'Kitchen' → OK."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Kitchen"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        count = manager.check_name_mismatches(schema, zones=zones)
+
+        assert count == 0
+        meta = manager._metadata.get("01:150000_03")
+        assert meta is None or meta.name_mismatch is None
+
+    def test_no_mismatch_when_no_runtime_name(self) -> None:
+        """No 0004 name received yet (zone_state.name=None) → skip."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Lounge"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name=None)]
+
+        count = manager.check_name_mismatches(schema, zones=zones)
+
+        assert count == 0
+
+    def test_no_mismatch_when_no_schema_name(self) -> None:
+        """Schema has no _name for the zone → skip (nothing to compare)."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        count = manager.check_name_mismatches(schema, zones=zones)
+
+        assert count == 0
+
+    def test_no_mismatch_when_zones_is_none(self) -> None:
+        """No zones provided → skip (coordinator not ready)."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {"01:150000": {"zones": {"03": {"_name": "Lounge"}}}}
+
+        count = manager.check_name_mismatches(schema, zones=None)
+
+        assert count == 0
+
+    def test_mismatch_cleared_when_resolved(self) -> None:
+        """Previously mismatched zone now matches → flag cleared."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Pre-set a mismatch flag
+        manager._metadata["01:150000_03"] = DeviceMetadata(
+            name_mismatch="schema=Lounge, controller=Kitchen"
+        )
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Kitchen"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        count = manager.check_name_mismatches(schema, zones=zones)
+
+        assert count == 0
+        meta = manager._metadata.get("01:150000_03")
+        assert meta is not None
+        assert meta.name_mismatch is None
+
+    def test_multiple_zones_one_mismatch(self) -> None:
+        """Multiple zones, only one has a mismatch."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Lounge"},
+                    "04": {"_name": "Hallway"},
+                },
+            },
+        }
+        zones = [
+            self._make_zone("01:150000_03", runtime_name="Lounge"),  # match
+            self._make_zone("01:150000_04", runtime_name="Office"),  # mismatch
+        ]
+
+        count = manager.check_name_mismatches(schema, zones=zones)
+
+        assert count == 1
+        assert manager._metadata["01:150000_04"].name_mismatch is not None
+        assert manager._metadata.get("01:150000_03") is None or (
+            manager._metadata["01:150000_03"].name_mismatch is None
+        )
+
+    def test_name_mismatch_in_check_all_mismatches(self) -> None:
+        """check_all_mismatches includes name_mismatch in counts."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Lounge"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        counts = manager.check_all_mismatches(schema, zones=zones)
+
+        assert counts["name_mismatch"] == 1
+
+    def test_name_mismatch_metadata_round_trip(self) -> None:
+        """name_mismatch survives to_dict/from_dict serialization."""
+        meta = DeviceMetadata(name_mismatch="schema=Lounge, controller=Kitchen")
+        d = meta.to_dict()
+        assert d["name_mismatch"] == "schema=Lounge, controller=Kitchen"
+
+        restored = DeviceMetadata.from_dict(d)
+        assert restored.name_mismatch == "schema=Lounge, controller=Kitchen"
+
+    def test_name_mismatch_default_none(self) -> None:
+        """name_mismatch defaults to None."""
+        meta = DeviceMetadata()
+        assert meta.name_mismatch is None
+        d = meta.to_dict()
+        assert d["name_mismatch"] is None
+
+    def test_get_name_mismatch_devices(self) -> None:
+        """get_name_mismatch_devices returns only mismatched zones."""
+        dev = make_discovered_device("01:150000_03", "CTL")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager._metadata["01:150000_03"] = DeviceMetadata(
+            name_mismatch="schema=Lounge, controller=Kitchen"
+        )
+        manager._metadata["01:150000_04"] = DeviceMetadata()
+
+        result = manager.get_name_mismatch_devices()
+
+        assert len(result) == 1
+        assert result[0].device.device_id == "01:150000_03"
+
+    def test_warned_name_mismatches_avoids_spam(self) -> None:
+        """Second check with same mismatch doesn't re-warn at WARNING level."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Lounge"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        # First check — should warn and add to _warned_name_mismatches
+        with patch("custom_components.ramses_cc.discovery._LOGGER") as mock_logger:
+            manager.check_name_mismatches(schema, zones=zones)
+            # WARNING should have been called (new mismatch)
+            warning_calls = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if "name mismatch" in str(c).lower()
+            ]
+            assert len(warning_calls) == 1
+            assert "01:150000_03" in manager._warned_name_mismatches
+
+        # Second check — same mismatch, should NOT warn at WARNING level
+        with patch("custom_components.ramses_cc.discovery._LOGGER") as mock_logger:
+            count = manager.check_name_mismatches(schema, zones=zones)
+            # Count is still 1 (mismatch still exists)
+            assert count == 1
+            # But no WARNING call — only DEBUG
+            warning_calls = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if "name mismatch" in str(c).lower()
+            ]
+            assert len(warning_calls) == 0
+            # DEBUG should have been called instead
+            debug_calls = [
+                c
+                for c in mock_logger.debug.call_args_list
+                if "persistent name mismatch" in str(c).lower()
+            ]
+            assert len(debug_calls) == 1
+
+    def test_warned_name_mismatches_cleared_when_resolved(self) -> None:
+        """Warned set cleared when all name mismatches are resolved."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Lounge"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        # First check — creates mismatch
+        manager.check_name_mismatches(schema, zones=zones)
+        assert "01:150000_03" in manager._warned_name_mismatches
+
+        # Fix the schema _name to match controller
+        schema["01:150000"]["zones"]["03"]["_name"] = "Kitchen"
+
+        # Second check — mismatch resolved
+        count = manager.check_name_mismatches(schema, zones=zones)
+        assert count == 0
+        assert "01:150000_03" not in manager._warned_name_mismatches
+
+    def test_name_mismatch_re_flagged_after_skip(self) -> None:
+        """After 'skip' in review, mismatch is re-detected next checkpoint."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        schema = {
+            "01:150000": {
+                "zones": {
+                    "03": {"_name": "Lounge"},
+                },
+            },
+        }
+        zones = [self._make_zone("01:150000_03", runtime_name="Kitchen")]
+
+        # First check — mismatch detected
+        manager.check_name_mismatches(schema, zones=zones)
+        assert manager._metadata["01:150000_03"].name_mismatch is not None
+
+        # Simulate "skip" in review — flag is cleared
+        manager._metadata["01:150000_03"].name_mismatch = None
+        # Also clear from warned set so the re-detection warns again
+        manager._warned_name_mismatches.clear()
+
+        # Second check — mismatch re-detected (no dismiss)
+        count = manager.check_name_mismatches(schema, zones=zones)
+        assert count == 1
+        assert manager._metadata["01:150000_03"].name_mismatch is not None


### PR DESCRIPTION
## Summary

- Detects when a zone's schema `_name` differs from the controller's 0004-reported name and notifies the user via the existing "Schema mismatches detected" persistent notification
- The review_discovered config flow step shows the mismatch with an option to "Update _name" to match the controller, or "Skip" (re-appears next checkpoint — no dismiss)
- The controller's 0004 name is authoritative for `_name`; users who want a custom display name should use `_alias` (which overrides `_name` for display)
- Spam avoidance: WARN once per zone, then drop to DEBUG (same pattern as `check_class_mismatches`)

### Changes

- **`discovery.py`**: Added `name_mismatch` field to `DeviceMetadata`, `check_name_mismatches(schema, zones)` method, `get_name_mismatch_devices()`, `_warned_name_mismatches` set, name mismatch section in `_send_mismatch_notification`, `name_mismatch` in `check_all_mismatches` counts
- **`coordinator.py`**: Both `check_all_mismatches` call sites now pass `zones=self._zones`
- **`config_flow.py`**: Review discovered devices step runs `check_name_mismatches`, shows name mismatch summary table + form fields, processes "update_name" action (writes controller name to `schema[ctl_id]["zones"][zone_idx]["_name"]`)
- **`tests/tests_new/test_discovery_manager.py`**: 14 new tests in `TestNameMismatch` class covering detection, no-mismatch cases, clearing, multiple zones, `check_all_mismatches` integration, metadata round-trip, spam avoidance, re-flagging after skip

Depends on ramses_rf PR 1035 (0004 polling fix) for the 0004 packets to actually arrive. < was merged into _rf master/0.59.6

Refs: https://github.com/ramses-rf/ramses_cc/issues/947

#### Test plan

- [x] `pytest tests/tests_new/test_discovery_manager.py` — 185 passed
- [x] `pytest tests/tests_new/test_schemas.py` — 169 passed
- [x] `ruff check` + `ruff format` — clean
- [x] `mypy --strict` on `discovery.py` — clean (coordinator/config_flow have pre-existing errors only)
- [x] ha_sim_test R76 recipe: 6/6 checks pass (schema name, device registry, mismatch detection, polling schedule, no unexpected errors/warnings)