### PR TITLE
fix: refresh zone device names in sync_topology (issue 947)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2496,12 +2496,20 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         Also runs the discovery mismatch checks (Phase 3c) so mismatches
         are detected immediately rather than waiting for the 30-minute
-        checkpoint.
+        checkpoint, and refreshes zone device names so 0004 zone_name
+        packets are reflected in the device registry without waiting for
+        the next discovery cycle.
 
         :param _: Unused service call argument.
         """
         _LOGGER.info("Manual topology sync requested (sync_topology service)")
         await self.async_save_client_state()
+        # Refresh zone device names — 0004 zone_name packets may have
+        # updated zone_state.name since the zone was first created from
+        # the cached schema (issue 822, 947).  Without this, the device
+        # registry keeps the old name until the next discovery cycle.
+        for zone in self._zones:
+            await self._async_update_device(zone)
         # Run mismatch checks immediately (Phase 3c)
         if self.discovery_manager:
             schema = self.options.get(CONF_SCHEMA, {})


### PR DESCRIPTION
## Summary
- `sync_topology` only called `async_save_client_state` + `check_all_mismatches`, but didn't refresh zone device names
- Zone names arrive via 0004 packets which may update `zone_state.name` after the zone device was first created from the cached schema
- Without this refresh, the device registry keeps the old name until the next discovery cycle (every 5 minutes)
- Now `sync_topology` iterates `self._zones` and calls `_async_update_device`, same as `_discover_new_entities` does
- `_async_update_device`'s guard makes this a cheap no-op once the real name is in place

This was part of the issue 947 work but was pushed after PR 950 was merged.

#### Test plan
- [x] R76 recipe passes (verifies 0004 packet → device registry name update via sync_topology)
- [x] Full ha_sim_test suite passes (R75 8/8, R76 4/4)