### PR TITLE
docs: add deferred logging rule to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ All contributions (whether written by human contributors or generated via AI cod
 * **Line Constraints**: PEP 8 compliance (code ≤ 79 characters, docstrings/comments ≤ 72 characters).
 * **EXEMPTION (Raw Data)**: Raw RF packets, hex strings, routing dictionaries, and timestamped packet logs are strictly exempt from line limits to preserve readability and grep-ability.
 * **String Literals**: Prefer double quotes (`"`) for all string literals.
+* **Deferred Logging**: Always use standard deferred `%`-formatting across all log levels and logger instances (e.g., `_LOGGER.debug(...)`, `_LOGGER.info(...)`, `_LOGGER.warning(...)`) instead of `f-strings` to prevent string evaluation and interpolation overhead when logging is disabled or filtered.
 
 ### 2. Typing & Type Safety
 * **Strict Type Safety**: 100% compliance with `mypy`. Do not introduce untyped definitions (`Any`) without strong technical justification.


### PR DESCRIPTION
### The Problem:
`CONTRIBUTING.md` did not explicitly document the deferred logging requirement (`%`-formatting for loggers), creating an inconsistency with `ramses_rf` coding standards and Home Assistant core best practices.

### The Fix:
Add the deferred logging rule to Section 1 (Code Style & Conventions) in `CONTRIBUTING.md`.

### Testing Performed:
- Pre-commit checks (`prek run -a`) verified clean.
- Test suite (`pytest`) and typing (`mypy`) passed (1,295 passed, 0 failed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.