### PR TITLE
refactor: update gateway internal attribute references from _gwy to _gateway (ramses-rf/ramses_rf#1039)

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -210,7 +210,7 @@ class RamsesLogbookBinarySensor(RamsesBinarySensor):
                 tcs = getattr(self._device, "_tcs", None)
                 if tcs and hasattr(tcs, "get_faultlog"):
                     await tcs.get_faultlog(limit=1, force_refresh=True)
-                elif tcs and hasattr(tcs, "_gwy"):
+                elif tcs and hasattr(tcs, "_gateway"):
                     cmd = CommandDTO(
                         verb="RQ",
                         addr1="18:000730",
@@ -219,7 +219,7 @@ class RamsesLogbookBinarySensor(RamsesBinarySensor):
                         code="0418",
                         payload="00",
                     )
-                    await tcs._gwy.async_send_cmd(cmd)
+                    await tcs._gateway.async_send_cmd(cmd)
             except Exception as err:
                 _LOGGER.debug(
                     "Failed to poll active_faults for %s: %s",
@@ -278,7 +278,7 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
         :return: Dictionary of attributes for the gateway.
         :rtype: dict[str, Any]
         """
-        gwy: Gateway = self._device._gwy
+        gwy: Gateway = self._device._gateway
         engine = getattr(gwy, "_engine", None)
         gwy_config = getattr(gwy, "config", getattr(gwy, "_gwy_config", None))
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -198,7 +198,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
                     code="2E04",
                     payload="FF",
                 )
-                await self._device._gwy.async_send_cmd(cmd)
+                await self._device._gateway.async_send_cmd(cmd)
             except Exception as err:
                 _LOGGER.debug(
                     "Failed to poll system_mode for %s: %s",
@@ -529,7 +529,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
                     code="2349",
                     payload=self._device.idx,
                 )
-                await self._device._gwy.async_send_cmd(cmd)
+                await self._device._gateway.async_send_cmd(cmd)
             except Exception as err:
                 _LOGGER.debug(
                     "Failed to poll mode for %s: %s",
@@ -1233,7 +1233,7 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                 cmd = parse_packet_string(packet_str)
                 if cmd is None:
                     raise ValueError(f"Failed to parse packet_str: {packet_str}")
-                await self._device._gwy.async_send_cmd(
+                await self._device._gateway.async_send_cmd(
                     cmd, num_repeats=2, priority=Priority.HIGH
                 )
                 self.async_write_ha_state()
@@ -1265,7 +1265,7 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                 if cmd is None:
                     raise ValueError(f"Failed to parse cmd_str: {cmd_str}")
 
-                await self._device._gwy.async_send_cmd(
+                await self._device._gateway.async_send_cmd(
                     cmd, num_repeats=2, priority=Priority.HIGH
                 )
                 self.async_write_ha_state()

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -261,7 +261,7 @@ class RamsesFanHandler:
                             payload="00",
                         )
                         _LOGGER.debug("Poll 10D0 filter_remaining for %s", device.id)
-                        await device._gwy.async_send_cmd(cmd)
+                        await device._gateway.async_send_cmd(cmd)
                     except Exception as err:
                         _LOGGER.debug(
                             "Failed to poll filter_remaining for %s: %s",

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -14,9 +14,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.59.5",
+      "ramses-rf==0.59.6",
       "serialx>=1.6.0"
     ],
     "single_config_entry": true,
-    "version": "0.59.5"
+    "version": "0.59.6"
   }

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -149,7 +149,7 @@ def _build_packet_from_template(
         # Fallback to HGI gateway ID
         client = coordinator.client
         if client:
-            hgi = getattr(client, "_gwy", None)
+            hgi = getattr(client, "_gateway", None) or client
             if hgi:
                 hgi_dev = getattr(hgi, "_hgi", None) or getattr(hgi, "hgi", None)
                 if hgi_dev:

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -166,7 +166,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
                     payload="00",
                 )
                 try:
-                    await self._device._gwy.async_send_cmd(cmd)
+                    await self._device._gateway.async_send_cmd(cmd)
                     _LOGGER.debug("Polled %s for %s", code, self._device.id)
                 except Exception as err:
                     _LOGGER.debug(

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
   aioesphomeapi         >= 45.7.0                # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.59.5                # as per: manifest.json latest:
+  ramses-rf             == 0.59.6                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.8.2                 # required by config_flow > homeassistant.components.usb, see issue #623

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -362,7 +362,7 @@ async def test_gateway_binary_sensor_attrs(
     gwy._engine._exclude = {}
     gwy._engine._transport.get_extra_info.return_value = True
 
-    mock_device._gwy = gwy
+    mock_device._gateway = gwy
 
     sensor: RamsesGatewayBinarySensor = RamsesGatewayBinarySensor(
         mock_coordinator, mock_device, description
@@ -462,10 +462,10 @@ async def test_logbook_async_added_to_hass(
     mock_device._tcs.get_faultlog.assert_awaited_once_with(limit=1, force_refresh=True)
 
     # Arrange (Missing get_faultlog)
-    # 2. active_faults is None, tcs lacks get_faultlog but has _gwy
+    # 2. active_faults is None, tcs lacks get_faultlog but has _gateway
     del mock_device._tcs.get_faultlog
-    mock_device._tcs._gwy = MagicMock()
-    mock_device._tcs._gwy.async_send_cmd = AsyncMock()
+    mock_device._tcs._gateway = MagicMock()
+    mock_device._tcs._gateway.async_send_cmd = AsyncMock()
     mock_cmd.return_value = "mock_cmd"
 
     # Act
@@ -484,11 +484,11 @@ async def test_logbook_async_added_to_hass(
         code="0418",
         payload="00",
     )
-    mock_device._tcs._gwy.async_send_cmd.assert_awaited_once_with("mock_cmd")
+    mock_device._tcs._gateway.async_send_cmd.assert_awaited_once_with("mock_cmd")
 
     # Act (Exception handling)
     # 3. Exception handling
-    mock_device._tcs._gwy.async_send_cmd.side_effect = Exception("Boom")
+    mock_device._tcs._gateway.async_send_cmd.side_effect = Exception("Boom")
     with patch(
         "custom_components.ramses_cc.binary_sensor."
         "RamsesBinarySensor.async_added_to_hass"

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1282,8 +1282,8 @@ async def test_hvac_set_fan_mode_custom_command_variations(
     mock_device.get_bound_rem.return_value = "37:111111"
 
     # Explicitly mock the gateway and its async send command
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     # Inject parameterized custom command into the mocked coordinator.
     # Phase 4: commands live in coordinator._remotes (populated from schema
@@ -1298,7 +1298,7 @@ async def test_hvac_set_fan_mode_custom_command_variations(
         await hvac.async_set_fan_mode(fan_mode)
 
         # Verify it was transmitted via the gateway
-        mock_device._gwy.async_send_cmd.assert_awaited_once()
+        mock_device._gateway.async_send_cmd.assert_awaited_once()
         # Verify the fallback 2-byte default method was NOT called
         mock_device.set_fan_mode.assert_not_called()
         # Verify the state was written
@@ -1308,7 +1308,7 @@ async def test_hvac_set_fan_mode_custom_command_variations(
             await hvac.async_set_fan_mode(fan_mode)
 
         # Verify it aborted before sending
-        mock_device._gwy.async_send_cmd.assert_not_called()
+        mock_device._gateway.async_send_cmd.assert_not_called()
 
 
 async def test_hvac_set_fan_mode_reads_from_remotes(
@@ -1318,8 +1318,8 @@ async def test_hvac_set_fan_mode_reads_from_remotes(
     mock_device = MagicMock(spec=HvacVentilator)
     mock_device.id = "30:123456"
     mock_device.get_bound_rem.return_value = "37:111111"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     # Set up _remotes (schema _commands) with a custom command for "low"
     mock_coordinator._remotes = {
@@ -1334,8 +1334,8 @@ async def test_hvac_set_fan_mode_reads_from_remotes(
     await hvac.async_set_fan_mode("low")
 
     # Should have sent the command from _remotes (schema _commands)
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
-    sent_cmd = mock_device._gwy.async_send_cmd.call_args[0][0]
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_device._gateway.async_send_cmd.call_args[0][0]
     assert "000406" in str(sent_cmd), "Should use _remotes command"
     mock_device.set_fan_mode.assert_not_called()
 
@@ -1347,8 +1347,8 @@ async def test_hvac_set_fan_mode_rem_not_faked_raises(
     mock_device = MagicMock(spec=HvacVentilator)
     mock_device.id = "30:123456"
     mock_device.get_bound_rem.return_value = "37:111111"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     mock_coordinator._remotes = {
         "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
@@ -1368,7 +1368,7 @@ async def test_hvac_set_fan_mode_rem_not_faked_raises(
         await hvac.async_set_fan_mode("low")
 
     # Should NOT have sent the command
-    mock_device._gwy.async_send_cmd.assert_not_awaited()
+    mock_device._gateway.async_send_cmd.assert_not_awaited()
 
 
 async def test_hvac_set_fan_mode_rem_faked_sends(
@@ -1378,8 +1378,8 @@ async def test_hvac_set_fan_mode_rem_faked_sends(
     mock_device = MagicMock(spec=HvacVentilator)
     mock_device.id = "30:123456"
     mock_device.get_bound_rem.return_value = "37:111111"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     mock_coordinator._remotes = {
         "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
@@ -1398,7 +1398,7 @@ async def test_hvac_set_fan_mode_rem_faked_sends(
     await hvac.async_set_fan_mode("low")
 
     # Should have sent the command
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
     mock_device.set_fan_mode.assert_not_called()
 
 
@@ -1414,8 +1414,8 @@ async def test_hvac_set_fan_mode_rem_not_found_sends(
     mock_device = MagicMock(spec=HvacVentilator)
     mock_device.id = "30:123456"
     mock_device.get_bound_rem.return_value = "37:111111"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     mock_coordinator._remotes = {
         "37:111111": {"low": "W 37:111111 30:123456 22F1 000406"}
@@ -1432,7 +1432,7 @@ async def test_hvac_set_fan_mode_rem_not_found_sends(
     await hvac.async_set_fan_mode("low")
 
     # Should have sent the command (no is_faked check possible)
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -1450,8 +1450,8 @@ async def test_set_fan_mode_with_fan_commands_override(
     mock_device = MagicMock(spec=HvacVentilator)
     mock_device.id = "30:123456"
     mock_device.get_bound_rem.return_value = "37:111111"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
     mock_device.set_fan_mode = AsyncMock()
 
     # FAN has _commands as dict template (Phase 3b format)
@@ -1469,8 +1469,8 @@ async def test_set_fan_mode_with_fan_commands_override(
     await hvac.async_set_fan_mode("boost")
 
     # Should have sent via async_send_cmd (FAN template), NOT native
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
-    cmd = mock_device._gwy.async_send_cmd.call_args.args[0]
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
+    cmd = mock_device._gateway.async_send_cmd.call_args.args[0]
     assert "000706" in str(cmd), "Should use FAN template"
     mock_device.set_fan_mode.assert_not_called()
 
@@ -1485,8 +1485,8 @@ async def test_set_fan_mode_with_rem_commands_override(
     mock_device = MagicMock(spec=HvacVentilator)
     mock_device.id = "30:123456"
     mock_device.get_bound_rem.return_value = "37:111111"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
     mock_device.set_fan_mode = AsyncMock()
 
     # FAN has no _commands; REM has packet string
@@ -1507,8 +1507,8 @@ async def test_set_fan_mode_with_rem_commands_override(
     await hvac.async_set_fan_mode("low")
 
     # Should have sent via async_send_cmd (REM packet string), NOT native
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
-    sent_cmd = mock_device._gwy.async_send_cmd.call_args[0][0]
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_device._gateway.async_send_cmd.call_args[0][0]
     assert "000406" in str(sent_cmd), "Should use REM command"
     mock_device.set_fan_mode.assert_not_called()
 
@@ -1549,8 +1549,8 @@ async def test_set_fan_mode_fan_commands_wins_over_rem_and_native(
     mock_device = MagicMock(spec=HvacVentilator)
     mock_device.id = "30:123456"
     mock_device.get_bound_rem.return_value = "37:111111"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
     mock_device.set_fan_mode = AsyncMock()
 
     mock_coordinator._remotes = {
@@ -1574,8 +1574,8 @@ async def test_set_fan_mode_fan_commands_wins_over_rem_and_native(
     await hvac.async_set_fan_mode("low")
 
     # FAN template should win (payload 000406)
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
-    cmd = mock_device._gwy.async_send_cmd.call_args.args[0]
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
+    cmd = mock_device._gateway.async_send_cmd.call_args.args[0]
     assert "000406" in str(cmd), "FAN template should win"
     assert "000999" not in str(cmd), "REM command should not be used"
     mock_device.set_fan_mode.assert_not_called()
@@ -1690,8 +1690,8 @@ async def test_set_fan_mode_standard_mode_not_intercepted(
     mock_device.id = "30:123456"
     mock_device.get_bound_rem = MagicMock(return_value="37:111111")
     mock_device.set_fan_mode = AsyncMock()
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     # _remotes has a custom command, but NOT for "low"
     mock_coordinator._remotes = {
@@ -1705,7 +1705,7 @@ async def test_set_fan_mode_standard_mode_not_intercepted(
 
     # Standard path: set_fan_mode called, async_send_cmd NOT called
     mock_device.set_fan_mode.assert_awaited_once_with("low")
-    mock_device._gwy.async_send_cmd.assert_not_called()
+    mock_device._gateway.async_send_cmd.assert_not_called()
 
 
 async def test_set_fan_mode_custom_command_sends_via_gateway(
@@ -1716,8 +1716,8 @@ async def test_set_fan_mode_custom_command_sends_via_gateway(
     mock_device.id = "30:123456"
     mock_device.get_bound_rem = MagicMock(return_value="37:111111")
     mock_device.set_fan_mode = AsyncMock()
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     mock_coordinator._remotes = {
         "37:111111": {"boost": "W 37:111111 30:123456 22F1 000406"}
@@ -1729,7 +1729,7 @@ async def test_set_fan_mode_custom_command_sends_via_gateway(
     await hvac.async_set_fan_mode("boost")
 
     # Intercept path: async_send_cmd called, set_fan_mode NOT called
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
     mock_device.set_fan_mode.assert_not_called()
     hvac.async_write_ha_state.assert_called_once()
 
@@ -1742,8 +1742,8 @@ async def test_set_fan_mode_custom_command_from_remotes(
     mock_device.id = "30:123456"
     mock_device.get_bound_rem = MagicMock(return_value="37:111111")
     mock_device.set_fan_mode = AsyncMock()
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     mock_coordinator._remotes = {
         "37:111111": {"boost": "W 37:111111 30:123456 22F1 000AAA"}
@@ -1756,8 +1756,8 @@ async def test_set_fan_mode_custom_command_from_remotes(
 
     await hvac.async_set_fan_mode("boost")
 
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
-    sent_cmd = mock_device._gwy.async_send_cmd.call_args[0][0]
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
+    sent_cmd = mock_device._gateway.async_send_cmd.call_args[0][0]
     assert "000AAA" in str(sent_cmd), "Should use _remotes command"
 
 
@@ -1769,8 +1769,8 @@ async def test_set_fan_mode_validation_uses_dynamic_fan_modes(
     mock_device.id = "30:123456"
     mock_device.get_bound_rem = MagicMock(return_value="37:111111")
     mock_device.set_fan_mode = AsyncMock()
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     mock_coordinator._remotes = {
         "37:111111": {"my_custom_mode": "W 37:111111 30:123456 22F1 000406"}
@@ -1784,7 +1784,7 @@ async def test_set_fan_mode_validation_uses_dynamic_fan_modes(
     # raise ServiceValidationError.
     await hvac.async_set_fan_mode("my_custom_mode")
 
-    mock_device._gwy.async_send_cmd.assert_awaited_once()
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
     mock_device.set_fan_mode.assert_not_called()
 
 
@@ -1862,8 +1862,8 @@ async def test_controller_async_added_to_hass(
     """Test RamsesController.async_added_to_hass polling logic."""
     mock_device = MagicMock(spec=Evohome)
     mock_device.id = "01:123456"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     controller = RamsesController(mock_coordinator, mock_device, mock_description)
 
@@ -1882,10 +1882,10 @@ async def test_controller_async_added_to_hass(
         code="2E04",
         payload="FF",
     )
-    mock_device._gwy.async_send_cmd.assert_awaited_once_with("mock_cmd")
+    mock_device._gateway.async_send_cmd.assert_awaited_once_with("mock_cmd")
 
     # 2. Exception handling
-    mock_device._gwy.async_send_cmd.side_effect = Exception("Boom")
+    mock_device._gateway.async_send_cmd.side_effect = Exception("Boom")
     with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
         await controller.async_added_to_hass()
 
@@ -1912,8 +1912,8 @@ async def test_zone_async_added_to_hass(
     mock_device.idx = "01"
     mock_device.tcs = MagicMock()
     mock_device.tcs.id = "01:123456"
-    mock_device._gwy = MagicMock()
-    mock_device._gwy.async_send_cmd = AsyncMock()
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
 
     zone = RamsesZone(mock_coordinator, mock_device, mock_description)
 
@@ -1932,10 +1932,10 @@ async def test_zone_async_added_to_hass(
         code="2349",
         payload="01",
     )
-    mock_device._gwy.async_send_cmd.assert_awaited_once_with("mock_cmd")
+    mock_device._gateway.async_send_cmd.assert_awaited_once_with("mock_cmd")
 
     # 2. Exception handling
-    mock_device._gwy.async_send_cmd.side_effect = Exception("Boom")
+    mock_device._gateway.async_send_cmd.side_effect = Exception("Boom")
     with patch("custom_components.ramses_cc.climate.RamsesEntity.async_added_to_hass"):
         await zone.async_added_to_hass()
 

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -1267,7 +1267,7 @@ def test_build_packet_from_template_hgi_fallback() -> None:
     gwy._hgi = hgi
     coordinator = MagicMock()
     coordinator.client = MagicMock()
-    coordinator.client._gwy = gwy
+    coordinator.client._gateway = gwy
 
     cmd_def = {"verb": "W", "code": "22F7", "payload": "0000EF"}
     result = _build_packet_from_template(cmd_def, fan, coordinator)

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -135,8 +135,8 @@ def mock_device_gwy():
     """Fixture for a mocked device."""
     device = MagicMock()
     device.id = "01:123455"
-    device._gwy = MagicMock()
-    device._gwy.async_send_cmd = AsyncMock()
+    device._gateway = MagicMock()
+    device._gateway.async_send_cmd = AsyncMock()
     return device
 
 
@@ -205,7 +205,7 @@ async def test_async_update_push_driven(
     with caplog.at_level(logging.DEBUG):
         await entity_push_driven.async_update()
         # No commands sent
-        entity_push_driven._device._gwy.async_send_cmd.assert_not_called()
+        entity_push_driven._device._gateway.async_send_cmd.assert_not_called()
         # No polling logs
         assert "Polled" not in caplog.text
 
@@ -221,8 +221,9 @@ async def test_async_update_poll_driven_success(
         await entity_poll_driven.async_update()
 
         # Check that commands were sent for each poll_code
-        assert entity_poll_driven._device._gwy.async_send_cmd.call_count == 2
-        calls = entity_poll_driven._device._gwy.async_send_cmd.call_args_list
+        mock_send = entity_poll_driven._device._gateway.async_send_cmd
+        assert mock_send.call_count == 2
+        calls = mock_send.call_args_list
         assert calls[0][0][0] == CommandDTO(
             verb="RQ",
             addr1="18:000730",
@@ -253,7 +254,7 @@ async def test_async_update_poll_driven_failure(
     assert entity_poll_driven.should_poll is True
 
     # Force an error in async_send_cmd
-    entity_poll_driven._device._gwy.async_send_cmd = AsyncMock(
+    entity_poll_driven._device._gateway.async_send_cmd = AsyncMock(
         side_effect=Exception("Connection error")
     )
 
@@ -261,7 +262,8 @@ async def test_async_update_poll_driven_failure(
         await entity_poll_driven.async_update()
 
         # Commands were attempted
-        assert entity_poll_driven._device._gwy.async_send_cmd.call_count == 2
+        mock_send = entity_poll_driven._device._gateway.async_send_cmd
+        assert mock_send.call_count == 2
 
         # Errors were logged
         assert "Poll 0001 for 01:123455 failed: Connection error" in caplog.text
@@ -277,7 +279,8 @@ async def test_async_update_no_poll_codes(
 
     with caplog.at_level(logging.DEBUG):
         await entity_poll_driven_no_codes.async_update()
-        entity_poll_driven_no_codes._device._gwy.async_send_cmd.assert_not_called()
+        mock_send_no = entity_poll_driven_no_codes._device._gateway.async_send_cmd
+        mock_send_no.assert_not_called()
         assert "Polled" not in caplog.text
 
 

--- a/tests/tests_new/test_virtual_rf/test_helpers.py
+++ b/tests/tests_new/test_virtual_rf/test_helpers.py
@@ -16,7 +16,9 @@ async def test_ensure_fakeable_modifies_class() -> None:
             pass  # Skip normal init
 
     dev = DummyDevice()
-    dev._gwy = MagicMock()  # Mock the gateway so BindingManager can find async_send_cmd
+    dev._gateway = (
+        MagicMock()
+    )  # Mock the gateway so BindingManager can find async_send_cmd
 
     # Create a dummy Fakeable class to patch in
     class MockFakeable:
@@ -48,7 +50,9 @@ async def test_ensure_fakeable_calls_make_fake() -> None:
             pass
 
     dev = DummyDevice()
-    dev._gwy = MagicMock()  # Mock the gateway so BindingManager can find async_send_cmd
+    dev._gateway = (
+        MagicMock()
+    )  # Mock the gateway so BindingManager can find async_send_cmd
 
     class MockFakeable:
         pass
@@ -77,7 +81,8 @@ async def test_ensure_fakeable_idempotent() -> None:
             pass
 
     dev = FakeableDevice()
-    # Does not need _gwy mocked because it returns early before BindingManager instantiation
+    # Does not need _gateway mocked because it returns early before
+    # BindingManager instantiation
 
     with patch("tests.virtual_rf.helpers.Fakeable", MockFakeable):
         # Should simply return without error or modification

--- a/tests/virtual_rf/helpers.py
+++ b/tests/virtual_rf/helpers.py
@@ -23,7 +23,7 @@ def ensure_fakeable(dev: Device, make_fake: bool = True) -> None:
     # Initialize the new BindingManager.
     # It requires the device and a CommandDispatcher (the gateway's async_send_cmd)
     cast(Any, dev)._bind_context = BindingManager(
-        dev, cast(Any, dev._gwy.async_send_cmd)
+        dev, cast(Any, dev._gateway.async_send_cmd)
     )
 
     if make_fake:


### PR DESCRIPTION
### ⚠️ Linked Upstream PR: ramses-rf/ramses_rf#1055 < was merged in _rf 0.59.6

### The Problem:
`ramses_rf` in ramses-rf/ramses_rf#1055 (part of ramses-rf/ramses_rf#1039) expands internal gateway attribute references across all core classes from `_gwy` to `_gateway`. Downstream entities and tests in `ramses_cc` accessing `_gwy` directly need to be updated to match the upstream attribute naming.

> [!NOTE]
> **Dependency on upstream `ramses_rf` release**: This PR requires upstream `ramses_rf` PR ramses-rf/ramses_rf#1055 and a subsequent package release bump of `ramses_rf` before upstream CI tests will pass against release versions.

### The Fix:
- Updated internal gateway attribute references from `_gwy` to `_gateway` across integration entities and handlers (`sensor.py`, `fan_handler.py`, `binary_sensor.py`, `climate.py`, `remote.py`).
- Updated unit and integration test fixtures in `tests/tests_new/` and `tests/virtual_rf/` to reference `_gateway`.

### Testing Performed:
- Verified `prek run -a`, `ruff check .`, and `ruff format --check .` pass cleanly.
- Verified `mypy` passes cleanly across all 21 source files with 0 issues.
- Executed `pytest tests/tests_new -n auto` against editable upstream `ramses_rf` (1,191 passed, 10 skipped, 3 snapshots passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
