### PR TITLE
fix: foreign HGI re-prompted every discovery cycle (issue 954)

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -1185,6 +1185,13 @@ class DiscoveryManager:
         all_ids = set(engine_devices.keys()) | set(self._metadata.keys())
 
         for device_id in all_ids:
+            # Skip HGI gateways (18:) — they are tracked by the scan
+            # engine but are not discoverable devices.  Without this
+            # skip, get_devices() defaults them to NEW (via
+            # DeviceMetadata()) and the review_discovered form shows
+            # them every cycle, even when marked not_mine (issue 954).
+            if device_id.startswith("18:"):
+                continue
             meta = self._metadata.get(device_id, DeviceMetadata())
 
             if status is not None and meta.status != status:


### PR DESCRIPTION
## Summary

- `get_devices()` defaulted 18: devices to `DeviceMetadata()` (status=NEW) when no metadata existed
- `sync_with_schema` and `check_for_new_devices` both skip 18: devices, so metadata is never created for them
- But `get_devices()` included them with NEW status, causing the `review_discovered` form to show foreign HGIs every cycle
- This persisted across restarts because the HGI was never given ACCEPTED metadata

## Changes

Add the same `startswith("18:")` skip to `get_devices()` that already exists in `sync_with_schema` (line 493) and `check_for_new_devices` (line 1775).

#### Test plan

- [x] `prek run -a` passes
- [x] `pytest tests/` — 1294 passed, 10 skipped (1 pre-existing failure in `test_evo_control.py::test_namespace`, unrelated)