### PR TITLE
fix(schemas): isolate DHW topology in multi-controller systems (#971)

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2085,25 +2085,37 @@ def sync_learned_topology(
 
             # 1f. DHW→zone/appliance_control reassignment — clear DHW
             # sensor/valves if the learned schema now has the device in a
-            # zone (any TCS) or as appliance_control instead of this TCS's
+            # zone (any TCS), as appliance_control, or in a different TCS's
             # DHW.  Issue 931: a BDR re-parented from hotwater_valve to
             # appliance_control must have its old DHW valve slot cleared.
             if (
-                learned_device_zones or learned_appliance_control
+                learned_device_zones
+                or learned_appliance_control
+                or learned_dhw_devices
             ) and isinstance(config_entry.get(SZ_DHW_SYSTEM), dict):
                 config_dhw = config_entry[SZ_DHW_SYSTEM]
-                # Clear DHW sensor if learned placed it in a zone
+                # Clear DHW sensor if learned placed it in a zone or different TCS
                 dhw_sensor = config_dhw.get(SZ_SENSOR)
-                if dhw_sensor and dhw_sensor in learned_device_zones:
+                if dhw_sensor and (
+                    dhw_sensor in learned_device_zones
+                    or (
+                        dhw_sensor in learned_dhw_devices
+                        and learned_dhw_devices[dhw_sensor] != tcs_id
+                    )
+                ):
                     config_dhw[SZ_SENSOR] = None
                     changed = True
-                # Clear DHW valves if learned placed them in a zone
-                # or as appliance_control
+                # Clear DHW valves if learned placed them in a zone,
+                # as appliance_control, or in a different TCS
                 for valve_key in ("hotwater_valve", "heating_valve"):
                     valve = config_dhw.get(valve_key)
                     if valve and (
                         valve in learned_device_zones
                         or valve in learned_appliance_control
+                        or (
+                            valve in learned_dhw_devices
+                            and learned_dhw_devices[valve] != tcs_id
+                        )
                     ):
                         config_dhw[valve_key] = None
                         changed = True
@@ -2193,20 +2205,40 @@ def sync_learned_topology(
                     changed = True
 
     # 1g-post. Place DHW sensors (07:) from device_comments into
-    # stored_hotwater.sensor.  The scan engine classifies 07: devices as
-    # DHW and includes zone info in the comment, but that "zone" is the
-    # DHW domain — the device should be stored_hotwater.sensor, not in a
-    # heating zone.
+    # stored_hotwater.sensor when concrete binding exists.  The scan
+    # engine classifies 07: devices as DHW and includes zone info in the
+    # comment, but that "zone" is the DHW domain — the device should be
+    # stored_hotwater.sensor, not in a heating zone.
+    #
+    # Multi-TCS and Neighbour Isolation:
+    # 1. Skip if the device is already placed in stored_hotwater.sensor
+    #    under ANY TCS entry.
+    # 2. Require a concrete controller ID in the comment ("bound to 01:...").
+    #    NEVER fall back to main_tcs_id.
+    # 3. Unassociated or foreign 07: sensors remain in orphans_heat.
+    placed_dhw_sensors: set[str] = set()
+    for entry in new_schema.values():
+        if isinstance(entry, dict) and isinstance(
+            entry.get(SZ_DHW_SYSTEM), dict
+        ):
+            placed_sensor = entry[SZ_DHW_SYSTEM].get(SZ_SENSOR)
+            if isinstance(placed_sensor, str):
+                placed_dhw_sensors.add(placed_sensor)
+
     if isinstance(device_comments, dict):
         for device_id, comment in device_comments.items():
             if not isinstance(comment, str) or not device_id.startswith("07:"):
                 continue
-            # Find the TCS to place this DHW sensor under
-            dhw_tcs_id: str | None = _parse_bound_tcs_from_comment(comment)
-            if not dhw_tcs_id or dhw_tcs_id.startswith("18:"):
-                # No bound_to or bound to HGI — use main_tcs
-                dhw_tcs_id = main_tcs_id
-            if not dhw_tcs_id or dhw_tcs_id not in new_schema:
+            if device_id in placed_dhw_sensors or device_id in _removed:
+                continue
+            # Find the concrete TCS to place this DHW sensor under
+            dhw_tcs_id = _parse_bound_tcs_from_comment(comment)
+            if (
+                not dhw_tcs_id
+                or not dhw_tcs_id.startswith(("01:", "23:"))
+                or dhw_tcs_id not in new_schema
+            ):
+                # No concrete controller binding — keep in orphans_heat
                 continue
             tcs_entry = new_schema[dhw_tcs_id]
             if not isinstance(tcs_entry, dict):
@@ -2214,6 +2246,7 @@ def sync_learned_topology(
             dhw = tcs_entry.setdefault(SZ_DHW_SYSTEM, {})
             if not dhw.get(SZ_SENSOR):
                 dhw[SZ_SENSOR] = device_id
+                placed_dhw_sensors.add(device_id)
                 changed = True
                 # Remove from orphans_heat if present
                 orphans = new_schema.get(SZ_ORPHANS_HEAT)

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2746,16 +2746,19 @@ def test_sync_learned_topology_removes_hgi_from_orphans() -> None:
 def test_sync_learned_topology_places_dhw_sensor_from_comment() -> None:
     """A 07: (DHW) device in comments should be placed as stored_hotwater.sensor.
 
-    The scan engine classifies 07: devices as DHW and may include "zone 00"
-    in the comment (the DHW domain).  sync_learned_topology should place
-    the device as stored_hotwater.sensor, not in a heating zone.
+    The scan engine classifies 07: devices as DHW and includes concrete
+    bound_to info in the comment. sync_learned_topology should place
+    the device as stored_hotwater.sensor under that specific TCS.
     """
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:216136",
         "01:216136": {SZ_ZONES: {"00": {"actuators": ["04:111111"]}}},
         SZ_ORPHANS_HEAT: ["07:050121"],
         SZ_DEVICE_COMMENTS: {
-            "07:050121": "Likely DHW. zone 00. codes: 10A0, 1260. RSSI 82.",
+            "07:050121": (
+                "Likely DHW. zone 00. bound to 01:216136. "
+                "codes: 10A0, 1260. RSSI 82."
+            ),
         },
     }
     learned: dict[str, Any] = {
@@ -2776,6 +2779,101 @@ def test_sync_learned_topology_places_dhw_sensor_from_comment() -> None:
     for zone in result["01:216136"][SZ_ZONES].values():
         assert zone.get(SZ_SENSOR) != "07:050121"
         assert "07:050121" not in zone.get("actuators", [])
+
+
+def test_sync_learned_topology_multi_tcs_dhw_isolation() -> None:
+    """Multi-TCS setup must never create phantom DHW on heating-only system.
+
+    Issue 971: 01:161591 has DHW, 01:258891 does not. An unbound 07:045491
+    in device_comments must not be attached to 01:258891 via main_tcs fallback.
+    """
+    config: dict[str, Any] = {
+        "01:161591": {
+            SZ_DHW_SYSTEM: {
+                "hotwater_valve": "13:101694",
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:147093"]}},
+        },
+        "01:258891": {
+            SZ_ZONES: {"00": {"actuators": ["04:012975"]}},
+        },
+        SZ_DEVICE_COMMENTS: {
+            "07:045491": "Likely DHW. zone 00. codes: 10A0, 1260. RSSI 82.",
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:161591": {
+            SZ_DHW_SYSTEM: {
+                "hotwater_valve": "13:101694",
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:147093"]}},
+        },
+        "01:258891": {
+            SZ_ZONES: {"00": {"actuators": ["04:012975"]}},
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    # If no changes were needed, result is None or identical
+    target = result if result is not None else config
+    # 01:161591 has DHW
+    assert target["01:161591"][SZ_DHW_SYSTEM][SZ_SENSOR] == "07:045491"
+    # 01:258891 must NOT have stored_hotwater
+    assert SZ_DHW_SYSTEM not in target["01:258891"]
+
+
+def test_sync_learned_topology_foreign_dhw_sensor_stays_in_orphans() -> None:
+    """An unassociated DHW sensor (e.g. from neighbour) stays in orphans_heat."""
+    config: dict[str, Any] = {
+        "01:216136": {SZ_ZONES: {"00": {"actuators": ["04:111111"]}}},
+        SZ_ORPHANS_HEAT: ["07:999999"],
+        SZ_DEVICE_COMMENTS: {
+            "07:999999": "Likely DHW. zone 00. codes: 1260. RSSI 50.",
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:216136": {SZ_ZONES: {"00": {"actuators": ["04:111111"]}}},
+        SZ_ORPHANS_HEAT: ["07:999999"],
+    }
+    result = sync_learned_topology(config, learned)
+    target = result if result is not None else config
+    # 07:999999 must stay in orphans_heat
+    assert "07:999999" in target.get(SZ_ORPHANS_HEAT, [])
+    # 01:216136 must not have stored_hotwater created
+    assert SZ_DHW_SYSTEM not in target["01:216136"]
+
+
+def test_sync_learned_topology_dhw_cross_tcs_migration() -> None:
+    """When a DHW sensor moves to a new TCS, old TCS slot is cleared."""
+    config: dict[str, Any] = {
+        "01:111111": {
+            SZ_DHW_SYSTEM: {
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:111111"]}},
+        },
+        "01:222222": {
+            SZ_ZONES: {"00": {"actuators": ["04:222222"]}},
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:111111": {
+            SZ_ZONES: {"00": {"actuators": ["04:111111"]}},
+        },
+        "01:222222": {
+            SZ_DHW_SYSTEM: {
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:222222"]}},
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    # 01:111111 sensor cleared
+    assert result["01:111111"][SZ_DHW_SYSTEM][SZ_SENSOR] is None
+    # 01:222222 received sensor
+    assert result["01:222222"][SZ_DHW_SYSTEM][SZ_SENSOR] == "07:045491"
 
 
 def test_sync_learned_topology_trv_never_zone_sensor() -> None:


### PR DESCRIPTION
### ⚠️ Dependency Note:
This PR requires the corresponding changes in ramses-rf/ramses_rf#1069 to be merged and released with a `ramses_rf` version bump before the `ramses_cc` CI suite will pass against upstream releases.

### The Problem:
In multi-controller (multi-TCS) setups (issue #971), step `1g-post` in `sync_learned_topology` iterated over `device_comments` for `07:` DHW sensors. If no `bound to 01:...` was present in the comment, it fell back to `main_tcs_id` and called `setdefault("stored_hotwater", {})`. This created phantom `stored_hotwater` blocks on heating-only controllers (e.g. downstairs heating systems without hot water) and stored them in Home Assistant entity storage. Additionally, step `1g-post` failed to check if the sensor was already placed in another controller's `stored_hotwater`.

### The Fix:
- **`sync_learned_topology` Step 1g-post**:
  - Added `placed_dhw_sensors` pre-filter scanning all TCS entries in `new_schema` to skip sensors already placed.
  - Required a concrete controller binding in device comments (`bound to 01:...` or `bound to 23:...`) present in `new_schema`.
  - Removed fallback to `main_tcs_id`; unassociated or neighbour `07:` sensors remain safely in `orphans_heat` without fabricating `stored_hotwater`.
- **`sync_learned_topology` Step 1f**:
  - Added cross-TCS DHW migration handling so that when a sensor or valve moves between controllers, the old controller's slot is cleared.
- Added comprehensive unit tests in `tests/tests_new/test_schemas.py` covering multi-TCS DHW isolation, unassociated neighbour sensor isolation, and cross-TCS migration.

### Testing Performed:
- Ran `.venv/bin/prek run -a` (all checks passed).
- Ran `.venv/bin/ruff check --select D` (all checks passed).
- Ran `.venv/bin/mypy custom_components/ramses_cc/schemas.py` (0 issues).
- Ran full test suite via `.venv/bin/pytest -n auto` (1,308 passed, 10 skipped, 3 snapshots passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.