### PR TITLE
fix(discovery): characterise HGI devices during discovery and sync (#970)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -287,6 +287,30 @@ class RamsesCoordinator(DataUpdateCoordinator):
             update_interval=td(seconds=scan_interval),
         )
 
+    @property
+    def active_hgi_id(self) -> str | None:
+        """Return the active HGI gateway device ID if available.
+
+        :return: Active HGI device ID string or None.
+        :rtype: str | None
+        """
+        if not self.client:
+            return None
+        gwy: Gateway = self.client
+        engine = getattr(gwy, "_engine", None)
+        transport = getattr(engine, "_transport", None) or getattr(
+            gwy, "_transport", None
+        )
+        active_hgi_id: str | None = None
+        if transport is not None:
+            with suppress(AttributeError, KeyError, TypeError):
+                active_hgi_id = transport.get_extra_info(SZ_ACTIVE_HGI)
+        if not active_hgi_id:
+            active_hgi_id = getattr(engine, "_hgi_id", None)
+        if not active_hgi_id and gwy.hgi:
+            active_hgi_id = gwy.hgi.id
+        return active_hgi_id
+
     def _get_saved_packets(
         self, client_state: dict[str, Any]
     ) -> dict[str, dict[str, Any] | str]:
@@ -698,6 +722,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             scan,
             auto_notify=advanced.get(CONF_AUTO_NOTIFY, True),
             lost_threshold_days=advanced.get(CONF_LOST_THRESHOLD, 7),
+            active_hgi_id=self.active_hgi_id,
         )
 
         # Restore persisted state (unless schema was wiped — start fresh)
@@ -2005,6 +2030,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 scan_codes=scan_codes,
                 scan_domain_ids=scan_domain_ids,
                 removed_devices=self._removed_devices,
+                active_hgi_id=self.active_hgi_id,
             )
             _LOGGER.debug("sync_learned_topology: enriched=%s", enriched)
             if enriched is not None:
@@ -2422,16 +2448,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         gwy: Gateway = self.client
 
-        engine = getattr(gwy, "_engine", None)
-        transport = getattr(engine, "_transport", None) or getattr(
-            gwy, "_transport", None
-        )
-        active_hgi_id = None
-        if transport is not None:
-            with suppress(AttributeError, KeyError, TypeError):
-                active_hgi_id = transport.get_extra_info(SZ_ACTIVE_HGI)
-        if not active_hgi_id:
-            active_hgi_id = getattr(engine, "_hgi_id", None)
+        active_hgi_id = self.active_hgi_id
         if (
             isinstance(active_hgi_id, str)
             and _DEVICE_ID_RE.match(active_hgi_id)
@@ -2439,6 +2456,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ):
             with suppress(Exception):
                 gwy.device_registry.get_device(active_hgi_id)
+
+        if (
+            self.discovery_manager is not None
+            and self.discovery_manager.active_hgi_id != active_hgi_id
+        ):
+            self.discovery_manager.active_hgi_id = active_hgi_id
 
         # Snapshot lists to avoid RuntimeError if ramses_rf updates
         # continuously (fixes silent failure when list size changes).

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -202,6 +202,7 @@ class DiscoveryManager:
         *,
         auto_notify: bool = True,
         lost_threshold_days: int = LOST_DEVICE_THRESHOLD_DAYS,
+        active_hgi_id: str | None = None,
     ) -> None:
         """Initialize the discovery manager.
 
@@ -211,11 +212,13 @@ class DiscoveryManager:
             new devices.
         :param lost_threshold_days: Days without traffic before marking
             a device lost.
+        :param active_hgi_id: Optional device ID of the active local HGI.
         """
         self._hass = hass
         self._scan = scan
         self._auto_notify = auto_notify
         self._lost_threshold_days = lost_threshold_days
+        self._active_hgi_id = active_hgi_id
 
         # device_id → metadata (persisted to .storage/)
         self._metadata: dict[str, DeviceMetadata] = {}
@@ -244,6 +247,16 @@ class DiscoveryManager:
 
         self._scan.start()
         _LOGGER.info("DiscoveryManager: started (passive scan running)")
+
+    @property
+    def active_hgi_id(self) -> str | None:
+        """Return the active local HGI gateway device ID."""
+        return self._active_hgi_id
+
+    @active_hgi_id.setter
+    def active_hgi_id(self, value: str | None) -> None:
+        """Set the active local HGI gateway device ID."""
+        self._active_hgi_id = value
 
     @property
     def scan(self) -> DiscoveryScan:
@@ -495,8 +508,8 @@ class DiscoveryManager:
 
         # Mark devices as REMOVED if in discovery but not in schema
         for device_id, meta in list(self._metadata.items()):
-            # Skip HGI gateways — they're not in the stripped schema
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             if device_id not in schema_device_ids and meta.status in (
                 DiscoveryStatus.ACCEPTED,
@@ -537,8 +550,8 @@ class DiscoveryManager:
         # metadata for them would cause check_for_new_devices to re-notify
         # them after every reload where metadata was lost (issue 917).
         for device_id in scan_devices:
-            # Skip HGI gateways — tracked by scan engine but not discoverable
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             if (
                 device_id not in self._metadata
@@ -1228,12 +1241,9 @@ class DiscoveryManager:
         all_ids = set(engine_devices.keys()) | set(self._metadata.keys())
 
         for device_id in all_ids:
-            # Skip HGI gateways (18:) — they are tracked by the scan
-            # engine but are not discoverable devices.  Without this
-            # skip, get_devices() defaults them to NEW (via
-            # DeviceMetadata()) and the review_discovered form shows
-            # them every cycle, even when marked not_mine (issue 954).
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway — it is managed directly by the
+            # coordinator and auto-registered in the schema.
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             meta = self._metadata.get(device_id, DeviceMetadata())
 
@@ -1442,7 +1452,7 @@ class DiscoveryManager:
             SZ_ZONES,
         )
 
-        lt = likely_type.upper()
+        likely_type_normalized = likely_type.upper()
         resolved_zone = zone_index if zone_index is not None else zone_index
 
         # Helper: inject _comment into a device's own dict entry
@@ -1472,21 +1482,33 @@ class DiscoveryManager:
         # a caller that already set _class (e.g. add_faked_rem) wins.
         def _merge(fragment: dict[str, Any]) -> dict[str, Any]:
             root = fragment.setdefault(device_id, {})
-            root.setdefault(SZ_TR_CLASS, lt)
+            root.setdefault(SZ_TR_CLASS, likely_type_normalized)
             fragment.update(_list_comment())
             return fragment
 
         # ── CTL: Temperature Control System controller ──────────────
-        if lt == "CTL":
+        if likely_type_normalized == "CTL":
             return {
                 SZ_MAIN_TCS: device_id,
-                device_id: _with_comment({SZ_TR_CLASS: lt}),
+                device_id: _with_comment(
+                    {SZ_TR_CLASS: likely_type_normalized}
+                ),
             }
 
-        # ── FAN: HVAC controller ────────────────────────────────
-        if lt == "FAN":
+        # ── FAN: HVAC controller ────────────────────────────────────
+        if likely_type_normalized == "FAN":
             return {
-                device_id: _with_comment({SZ_TR_CLASS: lt, SZ_REMOTES: []}),
+                device_id: _with_comment(
+                    {SZ_TR_CLASS: likely_type_normalized, SZ_REMOTES: []}
+                ),
+            }
+
+        # ── HGI: Hardware Gateway Interface ─────────────────────────
+        if likely_type_normalized == "HGI":
+            return {
+                device_id: _with_comment(
+                    {SZ_TR_CLASS: likely_type_normalized}
+                ),
             }
 
         # ── REM / CO2: HVAC remote or sensor — add to parent FAN ─────
@@ -1507,13 +1529,13 @@ class DiscoveryManager:
         #  is treated as unknown and the device is orphaned to
         #  orphans_hvac rather than incorrectly nested under the TCS.
         _CTL_PREFIXES = ("01:", "23:")
-        if lt in ("REM", "CO2"):
+        if likely_type_normalized in ("REM", "CO2"):
             if bound_to and not bound_to.startswith(_CTL_PREFIXES):
                 return _merge({bound_to: {SZ_REMOTES: [device_id]}})
             return _merge({SZ_ORPHANS_HVAC: [device_id]})
 
         # ── OTB: OpenTherm Bridge — appliance_control for a CTL ─────
-        if lt == "OTB":
+        if likely_type_normalized == "OTB":
             if ctl_id:
                 return _merge(
                     {
@@ -1523,7 +1545,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── BDR: relay — appliance_control, DHW valve, or zone actuator
-        if lt == "BDR":
+        if likely_type_normalized == "BDR":
             if ctl_id and resolved_zone:
                 return _merge(
                     {
@@ -1552,7 +1574,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── DHW: stored hot water sensor ────────────────────────────
-        if lt == "DHW":
+        if likely_type_normalized == "DHW":
             if ctl_id:
                 return _merge(
                     {
@@ -1562,7 +1584,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── TRV / THM / RND: zone sensor ───────────────────────────
-        if lt in ("TRV", "THM", "RND"):
+        if likely_type_normalized in ("TRV", "THM", "RND"):
             if ctl_id and resolved_zone:
                 return _merge(
                     {
@@ -1582,7 +1604,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── DIS / HUM: HVAC display or humidity sensor — orphan ──────
-        if lt in ("DIS", "HUM"):
+        if likely_type_normalized in ("DIS", "HUM"):
             return _merge({SZ_ORPHANS_HVAC: [device_id]})
 
         # ── Default: orphan ─────────────────────────────────────────
@@ -1824,12 +1846,10 @@ class DiscoveryManager:
         new_ids: list[str] = []
 
         for device_id in engine_devices:
-            # Skip HGI gateways (18:) — they are tracked by the scan engine
-            # but are not discoverable devices.  They're in the known_list
-            # (derived from the schema) so the scan engine knows them, but
-            # they're not in the stripped schema passed to ramses_rf.
-            # Without this skip, they'd be marked as NEW every cycle.
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway — it is managed directly by the
+            # coordinator and auto-registered in the schema.  Foreign HGIs
+            # (device_id != active_hgi_id) are discoverable devices.
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             meta = self._metadata.get(device_id)
             if meta is None:

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -95,6 +95,7 @@ from .const import (
     CONF_UNKNOWN_CODES,
     SZ_DEVICE_COMMENTS,
     SZ_OWNER,
+    SZ_TR_CLASS,
     SZ_TR_COMMANDS,
     SZ_TR_DISABLED,
     SZ_TR_NAME,
@@ -1274,6 +1275,7 @@ def sync_learned_topology(
     scan_codes: dict[str, list[str]] | None = None,
     scan_domain_ids: dict[str, tuple[str | None, bool]] | None = None,
     removed_devices: set[str] | None = None,
+    active_hgi_id: str | None = None,
 ) -> _SchemaT | None:
     """Sync learned topology from ramses_rf back into the config schema.
 
@@ -1301,6 +1303,7 @@ def sync_learned_topology(
     :param removed_devices: Device IDs explicitly removed by the user via
         ``remove_device``.  These must NOT be re-added by sync (the learned
         schema may still reference them because ramses_rf has no remove API).
+    :param active_hgi_id: Optional device ID of the active local HGI.
     :return: An enriched schema dict if changes were made, or None if the
         config schema already matches or is richer than the learned topology.
     """
@@ -2819,25 +2822,49 @@ def sync_learned_topology(
                 new_schema.pop(SZ_ORPHANS_HVAC, None)
             changed = True
 
-    # 4. Create schema entries for HGI (18:) devices from device_comments.
+    # 4. Create schema entries for HGI (18:) devices from device_comments & active_hgi_id.
     # The scan engine tracks HGIs (classified as HGI type), and
     # refresh_device_comments creates comments for them.  But ramses_rf's
     # learned schema doesn't include HGIs (they're gateways, not TCSes).
     # Without this step, HGIs would only exist in device_comments and the
-    # known_list — never in the schema.  By creating a minimal entry
-    # (empty dict), we track them in the schema so the known_list can
+    # known_list — never in the schema.  By creating a schema entry with
+    # _class: "HGI", we track them in the schema so the known_list can
     # eventually be removed.  The entry must NOT have _skipped, otherwise
     # _derive_known_list_from_schema would exclude it from the known_list
     # and the scan engine would re-discover the HGI every cycle.
+    # If the device matches the active local HGI and root_owner is set,
+    # populate _owner: root_owner.
     # _strip_schema_extensions drops these entries before passing to
     # ramses_rf (which doesn't support HGI at root level).
+    hgi_ids: set[str] = set()
+    if (
+        active_hgi_id
+        and isinstance(active_hgi_id, str)
+        and active_hgi_id.startswith("18:")
+    ):
+        hgi_ids.add(active_hgi_id)
     device_comments = new_schema.get(SZ_DEVICE_COMMENTS, {})
     if isinstance(device_comments, dict):
-        for dev_id, _comment in device_comments.items():
-            if not isinstance(dev_id, str) or not dev_id.startswith("18:"):
-                continue
-            if dev_id not in new_schema:
-                new_schema[dev_id] = {}
+        for dev_id in device_comments:
+            if isinstance(dev_id, str) and dev_id.startswith("18:"):
+                hgi_ids.add(dev_id)
+    for dev_id in sorted(hgi_ids):
+        if dev_id not in new_schema:
+            new_schema[dev_id] = {SZ_TR_CLASS: "HGI"}
+            if root_owner and active_hgi_id and dev_id == active_hgi_id:
+                new_schema[dev_id][SZ_TR_OWNER] = root_owner
+            changed = True
+        elif isinstance(new_schema[dev_id], dict):
+            if SZ_TR_CLASS not in new_schema[dev_id]:
+                new_schema[dev_id][SZ_TR_CLASS] = "HGI"
+                changed = True
+            if (
+                root_owner
+                and active_hgi_id
+                and dev_id == active_hgi_id
+                and SZ_TR_OWNER not in new_schema[dev_id]
+            ):
+                new_schema[dev_id][SZ_TR_OWNER] = root_owner
                 changed = True
 
     # 5. Update device comments with zone info from the learned schema.

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -40,7 +40,13 @@ from ramses_rf.schemas import (
     SZ_UFH_SYSTEM,
     SZ_ZONES,
 )
-from ramses_tx.address import pkt_addrs
+
+try:
+    from ramses_tx.address import pkt_addrs
+except ImportError:
+    from ramses_tx.address import (
+        packet_addrs as pkt_addrs,
+    )
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     PacketAddrSetInvalid,

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -371,6 +371,27 @@ class TestNewDeviceDetection:
         new_ids = manager.check_for_new_devices()
         assert "04:056053" in new_ids
 
+    def test_local_vs_foreign_hgi_detection(self) -> None:
+        """Local active HGI is skipped, foreign HGI is detected as NEW."""
+        local_hgi = make_discovered_device("18:111111", "HGI")
+        foreign_hgi = make_discovered_device("18:222222", "HGI")
+        scan = make_mock_scan([local_hgi, foreign_hgi])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:111111",
+        )
+
+        new_ids = manager.check_for_new_devices()
+        assert "18:111111" not in new_ids
+        assert "18:222222" in new_ids
+
+        devices = manager.get_devices()
+        device_ids = [d.device.device_id for d in devices]
+        assert "18:111111" not in device_ids
+        assert "18:222222" in device_ids
+
     def test_check_no_new_devices_after_first_check(self) -> None:
         dev = make_discovered_device()
         scan = make_mock_scan([dev])
@@ -523,6 +544,18 @@ class TestGenerateSchemaEntry:
 
         assert result[SZ_MAIN_TCS] == "01:145038"
         assert "01:145038" in result
+
+    def test_hgi_generates_root_entry_with_class(self) -> None:
+        """HGI creates a root-level entry with _class='HGI'."""
+        result = DiscoveryManager.generate_schema_entry(
+            "18:001234", "HGI", comment="Local Gateway"
+        )
+        assert result == {
+            "18:001234": {
+                "_class": "HGI",
+                "_comment": "Local Gateway",
+            }
+        }
 
     def test_trv_with_ctl_and_zone(self) -> None:
         result = DiscoveryManager.generate_schema_entry(
@@ -2077,12 +2110,17 @@ class TestSyncWithSchema:
         assert entry.metadata.status == DiscoveryStatus.REMOVED
 
     def test_hgi_gateway_skipped(self) -> None:
-        """HGI gateways (18:) are skipped by sync_with_schema."""
+        """Active HGI gateway (18:) is skipped by sync_with_schema."""
         dev = make_discovered_device("18:130236", "HGI")
         scan = make_mock_scan([dev])
-        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
 
-        # 18: devices are skipped — status stays whatever it was
+        # Active 18: device is skipped — status stays whatever it was
         manager.sync_with_schema(set())  # empty schema
 
         # 18:130236 should not be in metadata (skipped by sync_with_schema)

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2926,14 +2926,33 @@ def test_sync_learned_topology_creates_hgi_schema_entry() -> None:
     }
     result = sync_learned_topology(config, learned)
     assert result is not None
-    # 18:130236 should now have an empty schema entry (NOT _skipped)
+    # 18:130236 should now have a schema entry with _class: "HGI" (NOT _skipped)
     assert "18:130236" in result
-    assert result["18:130236"] == {}
+    assert result["18:130236"] == {"_class": "HGI"}
     # Should not have _skipped (would cause re-discovery every cycle)
     assert result["18:130236"].get("_skipped") is None
     # Should not have any heating keys
     assert SZ_ZONES not in result["18:130236"]
     assert SZ_SYSTEM not in result["18:130236"]
+
+
+def test_sync_learned_topology_hgi_with_active_and_owner() -> None:
+    """Active HGI should receive _owner trait when root_owner is configured."""
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        SZ_OWNER: "house",
+        "01:123456": {SZ_ZONES: {"02": {SZ_SENSOR: "04:111111"}}},
+        SZ_DEVICE_COMMENTS: {
+            "18:130236": "Likely HGI. codes: 2210, 22E0. RSSI 0.",
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {SZ_ZONES: {"02": {SZ_SENSOR: "04:111111"}}},
+    }
+    result = sync_learned_topology(config, learned, active_hgi_id="18:130236")
+    assert result is not None
+    assert result["18:130236"] == {"_class": "HGI", "_owner": "house"}
 
 
 def test_sync_learned_topology_updates_comment_zone_from_learned() -> None:


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #973 < was merged

### The Problem:
HGI gateway devices (`18:`) were not fully characterised during passive discovery and topology synchronization (issue #970):
1. `DiscoveryManager.generate_schema_entry` lacked an explicit branch for `likely_type == "HGI"`, falling through to HVAC orphan placement and using a truncated identifier `lt`.
2. `DiscoveryManager.check_for_new_devices`, `sync_with_schema`, and `get_devices` unconditionally skipped all `18:` device IDs, suppressing foreign HGI discovery while leaving local HGIs uncharacterised.
3. `sync_learned_topology` Step 4 created bare empty dicts `18:xxxxxx: {}` without `_class: "HGI"` and without `_owner` assignments for the active local gateway.

### The Fix:
1. **Schema Generation & Naming**: Renamed `lt` to `likely_type_normalized` and added an explicit `likely_type_normalized == "HGI"` handler returning `{device_id: _with_comment({SZ_TR_CLASS: likely_type_normalized})}`.
2. **Local vs Foreign HGI Discovery**: Added `active_hgi_id` tracking to `DiscoveryManager` and updated device checks to only skip `device_id == self._active_hgi_id`.
3. **Topology Synchronization**: Enhanced `sync_learned_topology` Step 4 to populate `{SZ_TR_CLASS: "HGI"}` for all HGI entries and assign `_owner: root_owner` when `device_id == active_hgi_id`.
4. **Coordinator Integration**: Added public `active_hgi_id` property to `RamsesCoordinator` and passed `active_hgi_id` to `DiscoveryManager` and `sync_learned_topology`.

### Testing Performed:
- Added `test_hgi_generates_root_entry_with_class`, `test_local_vs_foreign_hgi_detection`, and `test_sync_learned_topology_hgi_with_active_and_owner`.
- Verified formatting and linting with `.venv/bin/prek run -a` and docstrings with `.venv/bin/ruff check --select D <files>`.
- Verified type checking with `.venv/bin/mypy`.
- Verified full test suite (`.venv/bin/python -u -m pytest -n auto` -> 1311 passed, 10 skipped, 0 failures).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.