### PR TITLE
feat(climate): expose `HVACMode.OFF` for RamsesZone (#129)

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -160,8 +160,6 @@ PLATFORMS = [Platform.EVENT]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Ramses integration."""
-    hass.data[DOMAIN] = {}
-
     # If required, do a one-off import of entry from config yaml
     if DOMAIN in config and not hass.config_entries.async_entries(DOMAIN):
         hass.async_create_task(
@@ -215,7 +213,7 @@ async def async_setup_entry(
     tx_exc = _get_ramses_tx_exceptions()
 
     # Check if this entry is already set up
-    if entry.entry_id in hass.data[DOMAIN]:
+    if getattr(entry, "runtime_data", None) is not None:
         _LOGGER.debug("Entry %s is already set up", entry.entry_id)
         return True
 
@@ -258,14 +256,12 @@ async def async_setup_entry(
         hass.config_entries.async_update_entry(entry, options=new_options)
 
     coordinator = RamsesCoordinator(hass, entry)
+    entry.runtime_data = coordinator
 
     try:
-        # Store the coordinator in hass.data before setting it up
-        hass.data[DOMAIN][entry.entry_id] = coordinator
         await coordinator.async_setup()
     except tx_exc.TransportSourceInvalid as err:  # not TransportSerialError
         _LOGGER.error("Unrecoverable problem with the serial port: %s", err)
-        hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
         raise ConfigEntryError(
             f"Unrecoverable serial port error: {err}"
         ) from err
@@ -273,13 +269,9 @@ async def async_setup_entry(
         _LOGGER.warning(
             "Failed to set up entry %s (will retry): %s", entry.entry_id, err
         )
-        hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
         raise ConfigEntryNotReady(
             f"There is a problem with the serial port: {err}"
         ) from err
-    except Exception:
-        hass.data[DOMAIN].pop(entry.entry_id, None)  # Clean up if setup fails
-        raise
 
     # Start the coordinator after successful setup
     await coordinator.async_start()
@@ -499,7 +491,7 @@ async def async_update_listener(
     # async task by async_update_entry) has a chance to run.
     import time as time_mod
 
-    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    coordinator = getattr(entry, "runtime_data", None)
     suppress_ts = (
         getattr(coordinator, "_suppress_reload", 0.0) if coordinator else 0.0
     )
@@ -519,9 +511,11 @@ async def async_update_listener(
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: RamsesConfigEntry
+) -> bool:
     """Unload a config entry."""
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
     if not await coordinator.async_unload_platforms():
         return False
 
@@ -560,7 +554,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry, PLATFORMS
     )  # for Events
 
-    hass.data[DOMAIN].pop(entry.entry_id)
     return True
 
 

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -49,7 +49,6 @@ from .const import (
     ATTR_LATEST_EVENT,
     ATTR_LATEST_FAULT,
     ATTR_WORKING_SCHEMA,
-    DOMAIN,
 )
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
@@ -88,7 +87,7 @@ async def async_setup_entry(
     :param async_add_entities: Callback to add entities.
     :type async_add_entities: AddEntitiesCallback
     """
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
     platform = entity_platform.async_get_current_platform()
 
     @callback

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -147,7 +147,7 @@ async def async_setup_entry(
     :param entry: The config entry.
     :param async_add_entities: The callback to add entities.
     """
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
     @callback

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -293,7 +293,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         }
 
     @property
-    def hvac_action(self) -> str | None:
+    def hvac_action(self) -> HVACAction | None:
         """Return the Controller's current running hvac operation.
 
         :return: The HVAC action.
@@ -618,7 +618,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         }
 
     @property
-    def hvac_action(self) -> str | None:
+    def hvac_action(self) -> HVACAction | None:
         """Return the Zone's current running hvac operation.
 
         :return: The HVAC action.
@@ -1209,12 +1209,17 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
         return base_modes
 
     @property
-    def hvac_action(self) -> HVACAction | str | None:
+    def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac operation if supported.
 
         :return: The HVAC action.
         """
-        return self._get_cached_fan_info()
+        fan_info = self._get_cached_fan_info()
+        if fan_info is None:
+            return None
+        if fan_info == "off":
+            return HVACAction.OFF
+        return HVACAction.FAN
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -121,6 +121,7 @@ MODE_ZONE_TO_HA: Final[dict[str, HVACMode]] = {
     ZoneMode.TEMPORARY: HVACMode.HEAT,
 }
 MODE_HA_TO_ZONE: Final[dict[HVACMode, str]] = {
+    HVACMode.OFF: ZoneMode.PERMANENT,
     HVACMode.HEAT: ZoneMode.PERMANENT,
     HVACMode.AUTO: ZoneMode.SCHEDULE,
     HVACMode.COOL: ZoneMode.PERMANENT,
@@ -659,7 +660,14 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             return None  # unable to determine
 
         config = resolve_async_attr(self, self._device, "config")
-        if config and mode[SZ_SETPOINT] <= config["min_temp"]:
+        min_temp = (
+            float(config["min_temp"])
+            if config
+            and "min_temp" in config
+            and config["min_temp"] is not None
+            else 5.0
+        )
+        if mode[SZ_SETPOINT] <= min_temp:
             return HVACMode.OFF
 
         thermal_mode = resolve_async_attr(self, self._device, "thermal_mode")
@@ -748,9 +756,15 @@ class RamsesZone(RamsesEntity, ClimateEntity):
                 await self.async_set_zone_mode(
                     mode=ZoneMode.PERMANENT, setpoint=25
                 )
-            else:  # HVACMode.OFF, PermanentOverride, temp = min
+            elif hvac_mode == HVACMode.OFF:  # PermanentOverride, temp = min
                 await self._device.set_frost_mode()
                 self.async_write_ha_state()
+            else:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_hvac_mode",
+                    translation_placeholders={"mode": str(hvac_mode)},
+                )
 
         except (
             RamsesException,

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1130,11 +1130,11 @@ class BaseRamsesFlow:
                     # the learned schema on the next save cycle (issue 905).
                     # ramses_rf has no remove_device API, so the learned schema
                     # still references removed devices until restart.
-                    coordinators = self.hass.data.get(DOMAIN, {})
-                    for coord in coordinators.values():
-                        if hasattr(coord, "_removed_devices"):
-                            coord._removed_devices.update(removed_devices)  # noqa: SLF001
-                        break
+                    coord = getattr(self.config_entry, "runtime_data", None)
+                    if coord is not None and hasattr(
+                        coord, "_removed_devices"
+                    ):
+                        coord._removed_devices.update(removed_devices)  # noqa: SLF001
 
                 if self._initial_setup:
                     return await self.async_step_advanced_features()
@@ -1601,12 +1601,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         self.get_options()  # populate self.options from config entry
 
         # Get the coordinator's discovery manager
-        coordinators = self.hass.data.get(DOMAIN, {})
-        coordinator = None
-        for coord in coordinators.values():
-            if hasattr(coord, "discovery_manager"):
-                coordinator = coord
-                break
+        coordinator = getattr(self.config_entry, "runtime_data", None)
 
         if not coordinator or not coordinator.discovery_manager:
             return self.async_show_form(
@@ -2346,12 +2341,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         """
         self.get_options()
 
-        coordinators = self.hass.data.get(DOMAIN, {})
-        coordinator = None
-        for coord in coordinators.values():
-            if hasattr(coord, "discovery_manager"):
-                coordinator = coord
-                break
+        coordinator = getattr(self.config_entry, "runtime_data", None)
 
         if not coordinator or not coordinator.discovery_manager:
             return self.async_show_form(

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -287,6 +287,30 @@ class RamsesCoordinator(DataUpdateCoordinator):
             update_interval=td(seconds=scan_interval),
         )
 
+    @property
+    def active_hgi_id(self) -> str | None:
+        """Return the active HGI gateway device ID if available.
+
+        :return: Active HGI device ID string or None.
+        :rtype: str | None
+        """
+        if not self.client:
+            return None
+        gwy: Gateway = self.client
+        engine = getattr(gwy, "_engine", None)
+        transport = getattr(engine, "_transport", None) or getattr(
+            gwy, "_transport", None
+        )
+        active_hgi_id: str | None = None
+        if transport is not None:
+            with suppress(AttributeError, KeyError, TypeError):
+                active_hgi_id = transport.get_extra_info(SZ_ACTIVE_HGI)
+        if not active_hgi_id:
+            active_hgi_id = getattr(engine, "_hgi_id", None)
+        if not active_hgi_id and gwy.hgi:
+            active_hgi_id = gwy.hgi.id
+        return active_hgi_id
+
     def _get_saved_packets(
         self, client_state: dict[str, Any]
     ) -> dict[str, dict[str, Any] | str]:
@@ -698,6 +722,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             scan,
             auto_notify=advanced.get(CONF_AUTO_NOTIFY, True),
             lost_threshold_days=advanced.get(CONF_LOST_THRESHOLD, 7),
+            active_hgi_id=self.active_hgi_id,
         )
 
         # Restore persisted state (unless schema was wiped — start fresh)
@@ -2005,6 +2030,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 scan_codes=scan_codes,
                 scan_domain_ids=scan_domain_ids,
                 removed_devices=self._removed_devices,
+                active_hgi_id=self.active_hgi_id,
             )
             _LOGGER.debug("sync_learned_topology: enriched=%s", enriched)
             if enriched is not None:
@@ -2422,16 +2448,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         gwy: Gateway = self.client
 
-        engine = getattr(gwy, "_engine", None)
-        transport = getattr(engine, "_transport", None) or getattr(
-            gwy, "_transport", None
-        )
-        active_hgi_id = None
-        if transport is not None:
-            with suppress(AttributeError, KeyError, TypeError):
-                active_hgi_id = transport.get_extra_info(SZ_ACTIVE_HGI)
-        if not active_hgi_id:
-            active_hgi_id = getattr(engine, "_hgi_id", None)
+        active_hgi_id = self.active_hgi_id
         if (
             isinstance(active_hgi_id, str)
             and _DEVICE_ID_RE.match(active_hgi_id)
@@ -2439,6 +2456,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ):
             with suppress(Exception):
                 gwy.device_registry.get_device(active_hgi_id)
+
+        if (
+            self.discovery_manager is not None
+            and self.discovery_manager.active_hgi_id != active_hgi_id
+        ):
+            self.discovery_manager.active_hgi_id = active_hgi_id
 
         # Snapshot lists to avoid RuntimeError if ramses_rf updates
         # continuously (fixes silent failure when list size changes).

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -202,6 +202,7 @@ class DiscoveryManager:
         *,
         auto_notify: bool = True,
         lost_threshold_days: int = LOST_DEVICE_THRESHOLD_DAYS,
+        active_hgi_id: str | None = None,
     ) -> None:
         """Initialize the discovery manager.
 
@@ -211,11 +212,13 @@ class DiscoveryManager:
             new devices.
         :param lost_threshold_days: Days without traffic before marking
             a device lost.
+        :param active_hgi_id: Optional device ID of the active local HGI.
         """
         self._hass = hass
         self._scan = scan
         self._auto_notify = auto_notify
         self._lost_threshold_days = lost_threshold_days
+        self._active_hgi_id = active_hgi_id
 
         # device_id → metadata (persisted to .storage/)
         self._metadata: dict[str, DeviceMetadata] = {}
@@ -244,6 +247,16 @@ class DiscoveryManager:
 
         self._scan.start()
         _LOGGER.info("DiscoveryManager: started (passive scan running)")
+
+    @property
+    def active_hgi_id(self) -> str | None:
+        """Return the active local HGI gateway device ID."""
+        return self._active_hgi_id
+
+    @active_hgi_id.setter
+    def active_hgi_id(self, value: str | None) -> None:
+        """Set the active local HGI gateway device ID."""
+        self._active_hgi_id = value
 
     @property
     def scan(self) -> DiscoveryScan:
@@ -495,8 +508,8 @@ class DiscoveryManager:
 
         # Mark devices as REMOVED if in discovery but not in schema
         for device_id, meta in list(self._metadata.items()):
-            # Skip HGI gateways — they're not in the stripped schema
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             if device_id not in schema_device_ids and meta.status in (
                 DiscoveryStatus.ACCEPTED,
@@ -537,8 +550,8 @@ class DiscoveryManager:
         # metadata for them would cause check_for_new_devices to re-notify
         # them after every reload where metadata was lost (issue 917).
         for device_id in scan_devices:
-            # Skip HGI gateways — tracked by scan engine but not discoverable
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             if (
                 device_id not in self._metadata
@@ -1228,12 +1241,9 @@ class DiscoveryManager:
         all_ids = set(engine_devices.keys()) | set(self._metadata.keys())
 
         for device_id in all_ids:
-            # Skip HGI gateways (18:) — they are tracked by the scan
-            # engine but are not discoverable devices.  Without this
-            # skip, get_devices() defaults them to NEW (via
-            # DeviceMetadata()) and the review_discovered form shows
-            # them every cycle, even when marked not_mine (issue 954).
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway — it is managed directly by the
+            # coordinator and auto-registered in the schema.
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             meta = self._metadata.get(device_id, DeviceMetadata())
 
@@ -1442,7 +1452,7 @@ class DiscoveryManager:
             SZ_ZONES,
         )
 
-        lt = likely_type.upper()
+        likely_type_normalized = likely_type.upper()
         resolved_zone = zone_index if zone_index is not None else zone_index
 
         # Helper: inject _comment into a device's own dict entry
@@ -1472,21 +1482,33 @@ class DiscoveryManager:
         # a caller that already set _class (e.g. add_faked_rem) wins.
         def _merge(fragment: dict[str, Any]) -> dict[str, Any]:
             root = fragment.setdefault(device_id, {})
-            root.setdefault(SZ_TR_CLASS, lt)
+            root.setdefault(SZ_TR_CLASS, likely_type_normalized)
             fragment.update(_list_comment())
             return fragment
 
         # ── CTL: Temperature Control System controller ──────────────
-        if lt == "CTL":
+        if likely_type_normalized == "CTL":
             return {
                 SZ_MAIN_TCS: device_id,
-                device_id: _with_comment({SZ_TR_CLASS: lt}),
+                device_id: _with_comment(
+                    {SZ_TR_CLASS: likely_type_normalized}
+                ),
             }
 
-        # ── FAN: HVAC controller ────────────────────────────────
-        if lt == "FAN":
+        # ── FAN: HVAC controller ────────────────────────────────────
+        if likely_type_normalized == "FAN":
             return {
-                device_id: _with_comment({SZ_TR_CLASS: lt, SZ_REMOTES: []}),
+                device_id: _with_comment(
+                    {SZ_TR_CLASS: likely_type_normalized, SZ_REMOTES: []}
+                ),
+            }
+
+        # ── HGI: Hardware Gateway Interface ─────────────────────────
+        if likely_type_normalized == "HGI":
+            return {
+                device_id: _with_comment(
+                    {SZ_TR_CLASS: likely_type_normalized}
+                ),
             }
 
         # ── REM / CO2: HVAC remote or sensor — add to parent FAN ─────
@@ -1507,13 +1529,13 @@ class DiscoveryManager:
         #  is treated as unknown and the device is orphaned to
         #  orphans_hvac rather than incorrectly nested under the TCS.
         _CTL_PREFIXES = ("01:", "23:")
-        if lt in ("REM", "CO2"):
+        if likely_type_normalized in ("REM", "CO2"):
             if bound_to and not bound_to.startswith(_CTL_PREFIXES):
                 return _merge({bound_to: {SZ_REMOTES: [device_id]}})
             return _merge({SZ_ORPHANS_HVAC: [device_id]})
 
         # ── OTB: OpenTherm Bridge — appliance_control for a CTL ─────
-        if lt == "OTB":
+        if likely_type_normalized == "OTB":
             if ctl_id:
                 return _merge(
                     {
@@ -1523,7 +1545,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── BDR: relay — appliance_control, DHW valve, or zone actuator
-        if lt == "BDR":
+        if likely_type_normalized == "BDR":
             if ctl_id and resolved_zone:
                 return _merge(
                     {
@@ -1552,7 +1574,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── DHW: stored hot water sensor ────────────────────────────
-        if lt == "DHW":
+        if likely_type_normalized == "DHW":
             if ctl_id:
                 return _merge(
                     {
@@ -1562,7 +1584,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── TRV / THM / RND: zone sensor ───────────────────────────
-        if lt in ("TRV", "THM", "RND"):
+        if likely_type_normalized in ("TRV", "THM", "RND"):
             if ctl_id and resolved_zone:
                 return _merge(
                     {
@@ -1582,7 +1604,7 @@ class DiscoveryManager:
             return _merge({SZ_ORPHANS_HEAT: [device_id]})
 
         # ── DIS / HUM: HVAC display or humidity sensor — orphan ──────
-        if lt in ("DIS", "HUM"):
+        if likely_type_normalized in ("DIS", "HUM"):
             return _merge({SZ_ORPHANS_HVAC: [device_id]})
 
         # ── Default: orphan ─────────────────────────────────────────
@@ -1824,12 +1846,10 @@ class DiscoveryManager:
         new_ids: list[str] = []
 
         for device_id in engine_devices:
-            # Skip HGI gateways (18:) — they are tracked by the scan engine
-            # but are not discoverable devices.  They're in the known_list
-            # (derived from the schema) so the scan engine knows them, but
-            # they're not in the stripped schema passed to ramses_rf.
-            # Without this skip, they'd be marked as NEW every cycle.
-            if device_id.startswith("18:"):
+            # Skip local active HGI gateway — it is managed directly by the
+            # coordinator and auto-registered in the schema.  Foreign HGIs
+            # (device_id != active_hgi_id) are discoverable devices.
+            if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
             meta = self._metadata.get(device_id)
             if meta is None:

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -58,7 +58,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Event setup for RAMSES RF entry system-wide events."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     # get regex from config flow
     features: dict[str, Any] = config_entry.options.get(

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -144,7 +144,7 @@ async def async_setup_entry(
     :return: None
     :rtype: None
     """
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
     coordinator._parameter_entities_pending.clear()
     coordinator._parameter_entities_loaded.clear()
     coordinator._parameter_entities_created.clear()

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -31,7 +31,7 @@ from ramses_tx.exceptions import (
     ProtocolTimeoutError,
 )
 
-from .const import ATTR_DEVICE_ID, CONF_SCHEMA, DOMAIN
+from .const import ATTR_DEVICE_ID, CONF_SCHEMA
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import parse_packet_string
@@ -228,7 +228,7 @@ async def async_setup_entry(
     :param entry: The config entry.
     :param async_add_entities: Callback to add entities.
     """
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
     @callback

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -95,6 +95,7 @@ from .const import (
     CONF_UNKNOWN_CODES,
     SZ_DEVICE_COMMENTS,
     SZ_OWNER,
+    SZ_TR_CLASS,
     SZ_TR_COMMANDS,
     SZ_TR_DISABLED,
     SZ_TR_NAME,
@@ -1274,6 +1275,7 @@ def sync_learned_topology(
     scan_codes: dict[str, list[str]] | None = None,
     scan_domain_ids: dict[str, tuple[str | None, bool]] | None = None,
     removed_devices: set[str] | None = None,
+    active_hgi_id: str | None = None,
 ) -> _SchemaT | None:
     """Sync learned topology from ramses_rf back into the config schema.
 
@@ -1301,6 +1303,7 @@ def sync_learned_topology(
     :param removed_devices: Device IDs explicitly removed by the user via
         ``remove_device``.  These must NOT be re-added by sync (the learned
         schema may still reference them because ramses_rf has no remove API).
+    :param active_hgi_id: Optional device ID of the active local HGI.
     :return: An enriched schema dict if changes were made, or None if the
         config schema already matches or is richer than the learned topology.
     """
@@ -2819,25 +2822,49 @@ def sync_learned_topology(
                 new_schema.pop(SZ_ORPHANS_HVAC, None)
             changed = True
 
-    # 4. Create schema entries for HGI (18:) devices from device_comments.
+    # 4. Create schema entries for HGI (18:) devices from device_comments & active_hgi_id.
     # The scan engine tracks HGIs (classified as HGI type), and
     # refresh_device_comments creates comments for them.  But ramses_rf's
     # learned schema doesn't include HGIs (they're gateways, not TCSes).
     # Without this step, HGIs would only exist in device_comments and the
-    # known_list — never in the schema.  By creating a minimal entry
-    # (empty dict), we track them in the schema so the known_list can
+    # known_list — never in the schema.  By creating a schema entry with
+    # _class: "HGI", we track them in the schema so the known_list can
     # eventually be removed.  The entry must NOT have _skipped, otherwise
     # _derive_known_list_from_schema would exclude it from the known_list
     # and the scan engine would re-discover the HGI every cycle.
+    # If the device matches the active local HGI and root_owner is set,
+    # populate _owner: root_owner.
     # _strip_schema_extensions drops these entries before passing to
     # ramses_rf (which doesn't support HGI at root level).
+    hgi_ids: set[str] = set()
+    if (
+        active_hgi_id
+        and isinstance(active_hgi_id, str)
+        and active_hgi_id.startswith("18:")
+    ):
+        hgi_ids.add(active_hgi_id)
     device_comments = new_schema.get(SZ_DEVICE_COMMENTS, {})
     if isinstance(device_comments, dict):
-        for dev_id, _comment in device_comments.items():
-            if not isinstance(dev_id, str) or not dev_id.startswith("18:"):
-                continue
-            if dev_id not in new_schema:
-                new_schema[dev_id] = {}
+        for dev_id in device_comments:
+            if isinstance(dev_id, str) and dev_id.startswith("18:"):
+                hgi_ids.add(dev_id)
+    for dev_id in sorted(hgi_ids):
+        if dev_id not in new_schema:
+            new_schema[dev_id] = {SZ_TR_CLASS: "HGI"}
+            if root_owner and active_hgi_id and dev_id == active_hgi_id:
+                new_schema[dev_id][SZ_TR_OWNER] = root_owner
+            changed = True
+        elif isinstance(new_schema[dev_id], dict):
+            if SZ_TR_CLASS not in new_schema[dev_id]:
+                new_schema[dev_id][SZ_TR_CLASS] = "HGI"
+                changed = True
+            if (
+                root_owner
+                and active_hgi_id
+                and dev_id == active_hgi_id
+                and SZ_TR_OWNER not in new_schema[dev_id]
+            ):
+                new_schema[dev_id][SZ_TR_OWNER] = root_owner
                 changed = True
 
     # 5. Update device comments with zone info from the learned schema.

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2085,25 +2085,37 @@ def sync_learned_topology(
 
             # 1f. DHW→zone/appliance_control reassignment — clear DHW
             # sensor/valves if the learned schema now has the device in a
-            # zone (any TCS) or as appliance_control instead of this TCS's
+            # zone (any TCS), as appliance_control, or in a different TCS's
             # DHW.  Issue 931: a BDR re-parented from hotwater_valve to
             # appliance_control must have its old DHW valve slot cleared.
             if (
-                learned_device_zones or learned_appliance_control
+                learned_device_zones
+                or learned_appliance_control
+                or learned_dhw_devices
             ) and isinstance(config_entry.get(SZ_DHW_SYSTEM), dict):
                 config_dhw = config_entry[SZ_DHW_SYSTEM]
-                # Clear DHW sensor if learned placed it in a zone
+                # Clear DHW sensor if learned placed it in a zone or different TCS
                 dhw_sensor = config_dhw.get(SZ_SENSOR)
-                if dhw_sensor and dhw_sensor in learned_device_zones:
+                if dhw_sensor and (
+                    dhw_sensor in learned_device_zones
+                    or (
+                        dhw_sensor in learned_dhw_devices
+                        and learned_dhw_devices[dhw_sensor] != tcs_id
+                    )
+                ):
                     config_dhw[SZ_SENSOR] = None
                     changed = True
-                # Clear DHW valves if learned placed them in a zone
-                # or as appliance_control
+                # Clear DHW valves if learned placed them in a zone,
+                # as appliance_control, or in a different TCS
                 for valve_key in ("hotwater_valve", "heating_valve"):
                     valve = config_dhw.get(valve_key)
                     if valve and (
                         valve in learned_device_zones
                         or valve in learned_appliance_control
+                        or (
+                            valve in learned_dhw_devices
+                            and learned_dhw_devices[valve] != tcs_id
+                        )
                     ):
                         config_dhw[valve_key] = None
                         changed = True
@@ -2193,20 +2205,40 @@ def sync_learned_topology(
                     changed = True
 
     # 1g-post. Place DHW sensors (07:) from device_comments into
-    # stored_hotwater.sensor.  The scan engine classifies 07: devices as
-    # DHW and includes zone info in the comment, but that "zone" is the
-    # DHW domain — the device should be stored_hotwater.sensor, not in a
-    # heating zone.
+    # stored_hotwater.sensor when concrete binding exists.  The scan
+    # engine classifies 07: devices as DHW and includes zone info in the
+    # comment, but that "zone" is the DHW domain — the device should be
+    # stored_hotwater.sensor, not in a heating zone.
+    #
+    # Multi-TCS and Neighbour Isolation:
+    # 1. Skip if the device is already placed in stored_hotwater.sensor
+    #    under ANY TCS entry.
+    # 2. Require a concrete controller ID in the comment ("bound to 01:...").
+    #    NEVER fall back to main_tcs_id.
+    # 3. Unassociated or foreign 07: sensors remain in orphans_heat.
+    placed_dhw_sensors: set[str] = set()
+    for entry in new_schema.values():
+        if isinstance(entry, dict) and isinstance(
+            entry.get(SZ_DHW_SYSTEM), dict
+        ):
+            placed_sensor = entry[SZ_DHW_SYSTEM].get(SZ_SENSOR)
+            if isinstance(placed_sensor, str):
+                placed_dhw_sensors.add(placed_sensor)
+
     if isinstance(device_comments, dict):
         for device_id, comment in device_comments.items():
             if not isinstance(comment, str) or not device_id.startswith("07:"):
                 continue
-            # Find the TCS to place this DHW sensor under
-            dhw_tcs_id: str | None = _parse_bound_tcs_from_comment(comment)
-            if not dhw_tcs_id or dhw_tcs_id.startswith("18:"):
-                # No bound_to or bound to HGI — use main_tcs
-                dhw_tcs_id = main_tcs_id
-            if not dhw_tcs_id or dhw_tcs_id not in new_schema:
+            if device_id in placed_dhw_sensors or device_id in _removed:
+                continue
+            # Find the concrete TCS to place this DHW sensor under
+            dhw_tcs_id = _parse_bound_tcs_from_comment(comment)
+            if (
+                not dhw_tcs_id
+                or not dhw_tcs_id.startswith(("01:", "23:"))
+                or dhw_tcs_id not in new_schema
+            ):
+                # No concrete controller binding — keep in orphans_heat
                 continue
             tcs_entry = new_schema[dhw_tcs_id]
             if not isinstance(tcs_entry, dict):
@@ -2214,6 +2246,7 @@ def sync_learned_topology(
             dhw = tcs_entry.setdefault(SZ_DHW_SYSTEM, {})
             if not dhw.get(SZ_SENSOR):
                 dhw[SZ_SENSOR] = device_id
+                placed_dhw_sensors.add(device_id)
                 changed = True
                 # Remove from orphans_heat if present
                 orphans = new_schema.get(SZ_ORPHANS_HEAT)

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -96,7 +96,6 @@ from ramses_tx.dtos import CommandDTO
 from .const import (
     ATTR_SETPOINT,
     ATTR_WORKING_SCHEMA,
-    DOMAIN,
     UnitOfVolumeFlowRate,
 )
 from .coordinator import RamsesCoordinator
@@ -114,7 +113,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
     @callback

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -40,7 +40,13 @@ from ramses_rf.schemas import (
     SZ_UFH_SYSTEM,
     SZ_ZONES,
 )
-from ramses_tx.address import pkt_addrs
+
+try:
+    from ramses_tx.address import pkt_addrs
+except ImportError:
+    from ramses_tx.address import (
+        packet_addrs as pkt_addrs,
+    )
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     PacketAddrSetInvalid,

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -66,7 +66,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the water heater platform."""
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
     @callback

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -23,7 +23,6 @@ from custom_components.ramses_cc.binary_sensor import (
     RamsesSystemBinarySensor,
     async_setup_entry,
 )
-from custom_components.ramses_cc.const import DOMAIN
 from ramses_rf.devices import HgiGateway
 from ramses_rf.systems.tcs import Logbook, System
 from ramses_tx.const import SZ_IS_EVOFW3
@@ -53,8 +52,7 @@ async def test_async_setup_entry(
     """
     # Arrange
     entry = MagicMock()
-    entry.entry_id = "test_entry"
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
 
     mock_add_entities = MagicMock()
     mock_device = MagicMock(spec=HgiGateway)

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import voluptuous as vol
 from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    FAN_OFF,
     PRESET_AWAY,
     PRESET_NONE,
     HVACAction,
@@ -508,6 +510,12 @@ async def test_zone_modes_and_actions(
     assert zone.hvac_mode is None
 
     # Config checks for Off vs Heat
+    assert zone.hvac_modes == [
+        HVACMode.OFF,
+        HVACMode.HEAT,
+        HVACMode.AUTO,
+        HVACMode.COOL,
+    ]
     mock_device.mode = MagicMock(
         return_value={SZ_SETPOINT: 4.0, SZ_MODE: ZoneMode.ADVANCED}
     )
@@ -517,6 +525,23 @@ async def test_zone_modes_and_actions(
         return_value={SZ_SETPOINT: 20.0, SZ_MODE: ZoneMode.ADVANCED}
     )
     assert zone.hvac_mode == HVACMode.HEAT
+
+    # Config checks for Off vs Heat when config is None (default min_temp 5.0)
+    mock_device.config = MagicMock(return_value=None)
+    mock_device.mode = MagicMock(
+        return_value={SZ_SETPOINT: 5.0, SZ_MODE: ZoneMode.ADVANCED}
+    )
+    assert zone.hvac_mode == HVACMode.OFF
+
+    mock_device.mode = MagicMock(
+        return_value={SZ_SETPOINT: 5.5, SZ_MODE: ZoneMode.ADVANCED}
+    )
+    assert zone.hvac_mode == HVACMode.HEAT
+
+    # Restore config for subsequent tests
+    mock_device.config = MagicMock(
+        return_value={"min_temp": 5, "max_temp": 35}
+    )
 
     # 3. preset_mode
 
@@ -541,6 +566,11 @@ async def test_zone_modes_and_actions(
     mock_device.mode = MagicMock(return_value=None)
     assert zone.preset_mode is None
 
+    mock_device.mode = MagicMock(return_value={SZ_MODE: ZoneMode.SCHEDULE})
+    assert zone.preset_mode == PRESET_NONE
+
+    # Schedule mode with system_mode is None returns PRESET_NONE
+    mock_device.tcs.system_mode = MagicMock(return_value=None)
     mock_device.mode = MagicMock(return_value={SZ_MODE: ZoneMode.SCHEDULE})
     assert zone.preset_mode == PRESET_NONE
 
@@ -600,6 +630,10 @@ async def test_zone_methods_and_services(
         await zone.async_set_hvac_mode(HVACMode.OFF)
         mock_device.set_frost_mode.assert_awaited_once()
         mock_set.assert_not_called()
+
+        # Invalid mode raises ServiceValidationError
+        with pytest.raises(ServiceValidationError, match="invalid_hvac_mode"):
+            await zone.async_set_hvac_mode(cast(HVACMode, "invalid_mode"))
 
     # 1a. Explicit coverage for async_reset_zone_mode body
     del zone.async_reset_zone_mode
@@ -1050,13 +1084,18 @@ async def test_zone_extended_coverage(
             mode=ZoneMode.PERMANENT, setpoint=20.0, duration=None
         )
 
-    # 3. HVAC Mode logic when Config is None
-    # Code: if (self._device.config and setpoint <= min): return OFF
+    # 3. HVAC Mode logic when Config is None (fallback to default 5.0 °C)
     mock_device.config = MagicMock(return_value=None)
     mock_device.mode = MagicMock(
         return_value={SZ_SETPOINT: 4.0, SZ_MODE: ZoneMode.ADVANCED}
     )
-    # Should default to HEAT because config check fails (short-circuit)
+    # 4.0 °C <= 5.0 °C default min_temp -> HVACMode.OFF
+    assert zone.hvac_mode == HVACMode.OFF
+
+    mock_device.mode = MagicMock(
+        return_value={SZ_SETPOINT: 20.0, SZ_MODE: ZoneMode.ADVANCED}
+    )
+    # 20.0 °C > 5.0 °C default min_temp -> HVACMode.HEAT
     assert zone.hvac_mode == HVACMode.HEAT
 
 
@@ -2238,3 +2277,91 @@ async def test_hvac_fan_info_combinations(
     assert hvac.hvac_mode == expected_mode
     assert hvac.fan_mode == fan_info_input
     assert hvac.icon == expected_icon
+
+
+async def test_hvac_async_set_hvac_mode(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_set_fan_mode = AsyncMock()
+
+    # Act & Assert - OFF
+    await hvac.async_set_hvac_mode(HVACMode.OFF)
+    hvac.async_set_fan_mode.assert_awaited_with(FAN_OFF)
+
+    # Act & Assert - AUTO
+    hvac.async_set_fan_mode.reset_mock()
+    await hvac.async_set_hvac_mode(HVACMode.AUTO)
+    hvac.async_set_fan_mode.assert_awaited_with(FAN_AUTO)
+
+    # Act & Assert - Invalid mode (e.g. HEAT) raises ServiceValidationError
+    with pytest.raises(ServiceValidationError, match="invalid_hvac_mode"):
+        await hvac.async_set_hvac_mode(HVACMode.HEAT)
+
+
+async def test_zone_get_set_schedule_exceptions(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange
+    mock_device = MagicMock()
+    mock_device.id = "04:123456"
+    mock_device.tcs = MagicMock()
+    mock_device.get_schedule = AsyncMock(side_effect=TypeError("Bad type"))
+    mock_device.set_schedule = AsyncMock(side_effect=ValueError("Bad value"))
+    zone = RamsesZone(mock_coordinator, mock_device, mock_description)
+
+    # Act & Assert - get_schedule TypeError
+    with pytest.raises(ServiceValidationError, match="error_get_schedule"):
+        await zone.async_get_zone_schedule()
+
+    # Act & Assert - set_schedule ValueError
+    with pytest.raises(ServiceValidationError, match="error_set_schedule"):
+        await zone.async_set_zone_schedule({"bad": "payload"})
+
+
+async def test_hvac_custom_command_parse_failure(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
+    mock_coordinator._remotes = {
+        "30:123456": {
+            "custom_fan": {"verb": " I", "code": "22F1", "payload": "00"}
+        }
+    }
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    # Act & Assert - parse_packet_string returns None -> ValueError caught and wrapped as HomeAssistantError
+    with (
+        patch(
+            "custom_components.ramses_cc.climate.parse_packet_string",
+            return_value=None,
+        ),
+        pytest.raises(HomeAssistantError, match="Failed to parse packet_str"),
+    ):
+        await hvac.async_set_fan_mode("custom_fan")
+
+
+async def test_hvac_set_preset_mode_missing_method(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    if hasattr(mock_device, "set_preset_mode"):
+        del mock_device.set_preset_mode
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac._attr_preset_modes = ["eco"]
+
+    # Act & Assert - AttributeError caught and wrapped as HomeAssistantError
+    with pytest.raises(
+        HomeAssistantError, match="lacks set_preset_mode capability"
+    ):
+        await hvac.async_set_preset_mode("eco")

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -26,7 +26,6 @@ from custom_components.ramses_cc.climate import (
 )
 from custom_components.ramses_cc.const import (
     ATTR_DEVICE_ID,
-    DOMAIN,
     PRESET_PERMANENT,
     PRESET_TEMPORARY,
     SZ_KNOWN_LIST,
@@ -81,8 +80,7 @@ async def test_async_setup_entry(
     :param mock_coordinator: The mock coordinator fixture.
     """
     entry = MagicMock()
-    entry.entry_id = "test_entry_id"
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
     async_add_entities = MagicMock()
 
     # Mock async_get_current_platform to avoid RuntimeError in test env

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -770,23 +770,27 @@ async def test_hvac_properties_and_modes(
     # Fan Info None (Initial state without cache)
     mock_device.fan_info = MagicMock(return_value=None)
     assert hvac.hvac_mode is None
+    assert hvac.hvac_action is None
     assert hvac.fan_mode is None
 
     # Fan Off
     mock_device.fan_info = MagicMock(return_value="off")
     assert hvac.hvac_mode == HVACMode.OFF
+    assert hvac.hvac_action == HVACAction.OFF
     assert hvac.icon == "mdi:hvac-off"
+    assert hvac.fan_mode == "off"
 
     # Fan Low
     mock_device.fan_info = MagicMock(return_value="low")
     assert hvac.hvac_mode == HVACMode.AUTO
     assert hvac.icon == "mdi:hvac"
-    assert hvac.hvac_action == "low"
+    assert hvac.hvac_action == HVACAction.FAN
     assert hvac.fan_mode == "low"
 
     # NEW CACHE LOGIC: Dropped fan info retains cached "low"
     mock_device.fan_info = MagicMock(return_value=None)
     assert hvac.hvac_mode == HVACMode.AUTO
+    assert hvac.hvac_action == HVACAction.FAN
     assert hvac.fan_mode == "low"
 
 
@@ -2108,3 +2112,129 @@ async def test_climate_cooling_support(
     call_kwargs = mock_zone_dev.set_mode.await_args.kwargs
     assert call_kwargs["mode"] == ZoneMode.PERMANENT
     assert call_kwargs["setpoint"] == 25
+
+
+@pytest.mark.parametrize(
+    ("fan_info_input", "expected_action", "expected_mode", "expected_icon"),
+    [
+        # 1. Standard off
+        ("off", HVACAction.OFF, HVACMode.OFF, "mdi:hvac-off"),
+        # 2. Auto mode (Issue #500 HomeKit compatibility)
+        ("auto", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        # 3. Common speeds
+        ("low", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("medium", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("high", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("boost", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("away", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("trickle", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        # 4. Standard 31DA semantic fan info strings
+        ("speed 1, low", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 2, medium", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 3, high", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 4", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 5", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 6", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 7", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 8", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 9", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("speed 10", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        # 5. Temporary overrides
+        (
+            "speed 1 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 2 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 3 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 4 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 5 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 6 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 7 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 8 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 9 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        (
+            "speed 10 temporary override",
+            HVACAction.FAN,
+            HVACMode.AUTO,
+            "mdi:hvac",
+        ),
+        # 6. Custom timer and bypass remote commands
+        ("high_15", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("high_30", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("high_60", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("low_15", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("low_30", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("low_60", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("medium_15", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("medium_30", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("medium_60", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("bypass_open", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("bypass_close", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        ("bypass_auto", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        # 7. Unknown or quirk string
+        ("-unknown 0x36-", HVACAction.FAN, HVACMode.AUTO, "mdi:hvac"),
+        # 8. Uninitialised / None
+        (None, None, None, "mdi:hvac"),
+    ],
+)
+async def test_hvac_fan_info_combinations(
+    mock_coordinator: MagicMock,
+    mock_description: MagicMock,
+    fan_info_input: str | None,
+    expected_action: HVACAction | None,
+    expected_mode: HVACMode | None,
+    expected_icon: str,
+) -> None:
+    # Arrange
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "30:123456"
+    mock_device.fan_info = MagicMock(return_value=fan_info_input)
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+
+    # Act & Assert
+    assert hvac.hvac_action == expected_action
+    assert hvac.hvac_mode == expected_mode
+    assert hvac.fan_mode == fan_info_input
+    assert hvac.icon == expected_icon

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -1857,7 +1857,7 @@ async def test_review_discovered_no_manager(hass: HomeAssistant) -> None:
     # Put a coordinator without discovery_manager in hass.data
     mock_coord = MagicMock()
     mock_coord.discovery_manager = None
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -1887,7 +1887,7 @@ async def test_review_discovered_no_new_devices(hass: HomeAssistant) -> None:
     mock_coord = MagicMock()
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_devices.return_value = []
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -1931,7 +1931,7 @@ async def test_review_discovered_shows_form_with_devices(
     mock_coord = MagicMock()
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -1996,7 +1996,7 @@ async def test_review_discovered_accept_device(hass: HomeAssistant) -> None:
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
     mock_coord.discovery_manager.accept_device.return_value = accepted_entry
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2058,7 +2058,7 @@ async def test_review_discovered_decline_device(hass: HomeAssistant) -> None:
     mock_coord = MagicMock()
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2109,7 +2109,7 @@ async def test_review_discovered_skip_device(hass: HomeAssistant) -> None:
     mock_coord = MagicMock()
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2169,7 +2169,7 @@ async def test_review_discovered_missing_class_add_class(
     mock_coord.discovery_manager.get_missing_class_devices.return_value = [
         mock_entry
     ]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2245,7 +2245,7 @@ async def test_review_discovered_missing_class_per_device_owner(
     mock_coord.discovery_manager._metadata = {
         "37:154519": mock_entry.metadata,
     }
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2323,7 +2323,7 @@ async def test_review_discovered_missing_class_skip(
     mock_coord.discovery_manager._metadata = {
         "37:154519": mock_entry.metadata,
     }
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2391,7 +2391,7 @@ async def test_review_discovered_bulk_accept_all(hass: HomeAssistant) -> None:
         mock_entry1,
         mock_entry2,
     ]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2456,7 +2456,7 @@ async def test_review_discovered_bulk_decline_all(hass: HomeAssistant) -> None:
         mock_entry1,
         mock_entry2,
     ]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2522,7 +2522,7 @@ async def test_review_discovered_per_device_overrides_bulk(
         mock_entry1,
         mock_entry2,
     ]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2594,7 +2594,7 @@ async def test_review_discovered_bulk_none_no_action(
         mock_entry1,
         mock_entry2,
     ]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2662,7 +2662,7 @@ async def test_review_discovered_bulk_none_per_device_still_works(
         mock_entry1,
         mock_entry2,
     ]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -2789,7 +2789,7 @@ async def test_review_discovered_many_codes_and_no_rssi(
     mock_coord = MagicMock()
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -3145,7 +3145,7 @@ async def test_review_device_health_no_manager(hass: HomeAssistant) -> None:
 
     mock_coord = MagicMock()
     mock_coord.discovery_manager = None
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -3175,7 +3175,7 @@ async def test_review_device_health_no_devices(hass: HomeAssistant) -> None:
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_orphaned_devices.return_value = []
     mock_coord.discovery_manager.get_lost_devices.return_value = []
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -3214,7 +3214,7 @@ async def test_review_device_health_shows_form_with_lost(
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_lost_devices.return_value = [mock_entry]
     mock_coord.discovery_manager.get_orphaned_devices.return_value = []
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -3263,7 +3263,7 @@ async def test_review_device_health_shows_form_with_orphaned(
     mock_coord.discovery_manager.get_orphaned_devices.return_value = [
         mock_entry
     ]
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -3318,7 +3318,7 @@ async def test_review_device_health_keep_clears_flag(
     mock_coord.discovery_manager._metadata = {"04:056053": mock_meta}
     mock_coord.async_save_client_state = AsyncMock()
     mock_coord.options = {SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}}
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
         config_entry.entry_id
@@ -3374,7 +3374,7 @@ async def test_review_device_health_remove_calls_service(
     mock_coord.discovery_manager._metadata = {"04:056053": mock_meta}
     mock_coord.async_save_client_state = AsyncMock()
     mock_coord.options = {SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}}
-    hass.data[DOMAIN] = {config_entry.entry_id: mock_coord}
+    config_entry.runtime_data = mock_coord
 
     # Register a mock remove_device service so async_call works
     remove_calls: list[dict[str, Any]] = []
@@ -3479,3 +3479,30 @@ async def test_chained_config_entry_migration_v1_to_v3(
     assert "use_database" not in config_entry.options.get("ramses_rf", {})
     assert "known_list" not in config_entry.options
     assert config_entry.options["schema"]["04:123456"] == {"_class": "TRV"}
+
+
+async def test_options_flow_unloaded_entry_fallback(
+    hass: HomeAssistant,
+) -> None:
+    """Test options flow gracefully displays fallback when entry has no runtime_data."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+    config_entry.runtime_data = None
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    placeholders = result.get("description_placeholders", {})
+    assert "not enabled" in placeholders.get("message", "")

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -146,7 +146,7 @@ def mock_coordinator(
     coordinator.platforms = {}
     coordinator._devices = []
 
-    mock_hass.data[DOMAIN] = {mock_entry.entry_id: coordinator}
+    mock_entry.runtime_data = coordinator
     return coordinator
 
 

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -371,6 +371,27 @@ class TestNewDeviceDetection:
         new_ids = manager.check_for_new_devices()
         assert "04:056053" in new_ids
 
+    def test_local_vs_foreign_hgi_detection(self) -> None:
+        """Local active HGI is skipped, foreign HGI is detected as NEW."""
+        local_hgi = make_discovered_device("18:111111", "HGI")
+        foreign_hgi = make_discovered_device("18:222222", "HGI")
+        scan = make_mock_scan([local_hgi, foreign_hgi])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:111111",
+        )
+
+        new_ids = manager.check_for_new_devices()
+        assert "18:111111" not in new_ids
+        assert "18:222222" in new_ids
+
+        devices = manager.get_devices()
+        device_ids = [d.device.device_id for d in devices]
+        assert "18:111111" not in device_ids
+        assert "18:222222" in device_ids
+
     def test_check_no_new_devices_after_first_check(self) -> None:
         dev = make_discovered_device()
         scan = make_mock_scan([dev])
@@ -523,6 +544,18 @@ class TestGenerateSchemaEntry:
 
         assert result[SZ_MAIN_TCS] == "01:145038"
         assert "01:145038" in result
+
+    def test_hgi_generates_root_entry_with_class(self) -> None:
+        """HGI creates a root-level entry with _class='HGI'."""
+        result = DiscoveryManager.generate_schema_entry(
+            "18:001234", "HGI", comment="Local Gateway"
+        )
+        assert result == {
+            "18:001234": {
+                "_class": "HGI",
+                "_comment": "Local Gateway",
+            }
+        }
 
     def test_trv_with_ctl_and_zone(self) -> None:
         result = DiscoveryManager.generate_schema_entry(
@@ -2077,12 +2110,17 @@ class TestSyncWithSchema:
         assert entry.metadata.status == DiscoveryStatus.REMOVED
 
     def test_hgi_gateway_skipped(self) -> None:
-        """HGI gateways (18:) are skipped by sync_with_schema."""
+        """Active HGI gateway (18:) is skipped by sync_with_schema."""
         dev = make_discovered_device("18:130236", "HGI")
         scan = make_mock_scan([dev])
-        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
 
-        # 18: devices are skipped — status stays whatever it was
+        # Active 18: device is skipped — status stays whatever it was
         manager.sync_with_schema(set())  # empty schema
 
         # 18:130236 should not be in metadata (skipped by sync_with_schema)

--- a/tests/tests_new/test_event.py
+++ b/tests/tests_new/test_event.py
@@ -319,7 +319,7 @@ async def test_domain_event_platform(
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {CONF_ADVANCED_FEATURES: {CONF_MESSAGE_EVENTS: None}}
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
 
     mock_add_entities = MagicMock()
 

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from custom_components.ramses_cc.const import CONF_SCHEMA, DOMAIN, SZ_TR_BOUND
+from custom_components.ramses_cc.const import CONF_SCHEMA, SZ_TR_BOUND
 from custom_components.ramses_cc.coordinator import RamsesCoordinator
 from ramses_rf.const import DevType
 
@@ -43,8 +43,7 @@ def mock_coordinator(
     # Create fake devices list if needed, or we patch _get_device
     coordinator._device_info = {}
 
-    # Mock the hass.data structure
-    hass.data[DOMAIN] = {entry.entry_id: coordinator}
+    entry.runtime_data = coordinator
 
     return coordinator
 

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -169,10 +169,10 @@ async def test_entities(
         await hass.async_block_till_done()
 
         # Deterministically flush all background queues via hardcoded paths
-        if DOMAIN in hass.data:
-            for coordinator in hass.data[DOMAIN].values():
-                if getattr(coordinator, "client", None):
-                    await async_flush_queues(coordinator.client)
+        for entry_item in hass.config_entries.async_entries(DOMAIN):
+            coord = getattr(entry_item, "runtime_data", None)
+            if coord and getattr(coord, "client", None):
+                await async_flush_queues(coord.client)
         await hass.async_block_till_done()
 
     entry = None
@@ -198,6 +198,74 @@ async def test_entities(
             await hass.async_block_till_done()
 
 
+async def test_setup_entry_assigns_runtime_data(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+) -> None:
+    """Test setup entry assigns coordinator instance to entry.runtime_data."""
+    entry = MagicMock()
+    entry.entry_id = "test_runtime_data_assign"
+    entry.options = {}
+    entry.runtime_data = None
+
+    with (
+        patch(
+            "custom_components.ramses_cc.RamsesCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch("custom_components.ramses_cc.async_register_domain_services"),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(),
+        ),
+    ):
+        from custom_components.ramses_cc import async_setup_entry
+
+        assert await async_setup_entry(hass, entry) is True
+        assert entry.runtime_data is mock_coordinator
+        mock_coordinator.async_setup.assert_awaited_once()
+        mock_coordinator.async_start.assert_awaited_once()
+
+
+async def test_zero_hass_data_dependency(
+    hass: HomeAssistant, mock_coordinator: MagicMock
+) -> None:
+    """Test full setup and unload cycle operates without touching hass.data."""
+    entry = MagicMock()
+    entry.entry_id = "test_zero_hass_data"
+    entry.options = {}
+    entry.runtime_data = None
+
+    with (
+        patch(
+            "custom_components.ramses_cc.RamsesCoordinator",
+            return_value=mock_coordinator,
+        ),
+        patch("custom_components.ramses_cc.async_register_domain_services"),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_unload_platforms",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        from custom_components.ramses_cc import (
+            async_setup_entry,
+            async_unload_entry,
+        )
+
+        assert await async_setup_entry(hass, entry) is True
+        assert DOMAIN not in hass.data
+        assert entry.runtime_data is mock_coordinator
+
+        assert await async_unload_entry(hass, entry) is True
+        assert DOMAIN not in hass.data
+
+
 async def test_setup_entry_transport_error(
     hass: HomeAssistant, mock_coordinator: MagicMock
 ) -> None:
@@ -206,6 +274,7 @@ async def test_setup_entry_transport_error(
     entry.entry_id = "test_transport_error"
     # Ensure options are present to avoid KeyError
     entry.options = {}
+    entry.runtime_data = None
 
     # Mock RamsesCoordinator class to return our mock_coordinator
     with (
@@ -222,15 +291,12 @@ async def test_setup_entry_transport_error(
         # Import the function to test
         from custom_components.ramses_cc import async_setup_entry
 
-        # Initialize data structure
-        hass.data[DOMAIN] = {}
-
         # Expect ConfigEntryNotReady
         with pytest.raises(ConfigEntryNotReady):
             await async_setup_entry(hass, entry)
 
-        # Verify cleanup
-        assert entry.entry_id not in hass.data[DOMAIN]
+        # Verify no global state created
+        assert DOMAIN not in hass.data
 
 
 async def test_setup_entry_source_invalid(
@@ -240,6 +306,7 @@ async def test_setup_entry_source_invalid(
     entry = MagicMock()
     entry.entry_id = "test_source_invalid"
     entry.options = {}
+    entry.runtime_data = None
 
     with (
         patch(
@@ -256,14 +323,12 @@ async def test_setup_entry_source_invalid(
 
         from custom_components.ramses_cc import async_setup_entry
 
-        hass.data[DOMAIN] = {}
-
         # Expect ConfigEntryError
         with pytest.raises(ConfigEntryError):
             await async_setup_entry(hass, entry)
 
-        # Verify cleanup
-        assert entry.entry_id not in hass.data[DOMAIN]
+        # Verify no global state created
+        assert DOMAIN not in hass.data
 
 
 async def test_setup_entry_already_setup(
@@ -272,13 +337,11 @@ async def test_setup_entry_already_setup(
     """Test setup returns True if entry is already set up."""
     entry = MagicMock()
     entry.entry_id = "test_already_setup"
-
-    # Pre-populate hass.data to simulate already setup entry
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
 
     from custom_components.ramses_cc import async_setup_entry
 
-    # Should return True immediately
+    # Should return True immediately without re-instantiating coordinator
     assert await async_setup_entry(hass, entry) is True
 
 
@@ -286,6 +349,7 @@ async def test_async_update_listener(hass: HomeAssistant) -> None:
     """Test the update listener reloads the entry."""
     entry = MagicMock()
     entry.entry_id = "test_reload"
+    entry.runtime_data = None
 
     with patch.object(
         hass.config_entries, "async_reload", AsyncMock()
@@ -300,12 +364,12 @@ async def test_async_unload_entry_success(
     """Test successful unloading of a config entry."""
     entry = MagicMock()
     entry.entry_id = "test_unload_success"
+    entry.runtime_data = mock_coordinator
 
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
     hass.services.async_register(DOMAIN, "test_service", lambda x: None)
 
     assert await async_unload_entry(hass, entry) is True
-    assert entry.entry_id not in hass.data[DOMAIN]
+    assert DOMAIN not in hass.data
 
 
 async def test_async_unload_entry_removes_domain_services(
@@ -320,8 +384,8 @@ async def test_async_unload_entry_removes_domain_services(
     entry = MagicMock()
     entry.entry_id = "test_unload_services"
     entry.options = {CONF_ADVANCED_FEATURES: {"passive_scan": True}}
+    entry.runtime_data = mock_coordinator
 
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
     async_register_domain_services(hass, entry, mock_coordinator)
 
     # Discovery scan services registered (passive scan enabled)
@@ -351,14 +415,13 @@ async def test_async_unload_entry_failure(
     """Test unloading failure when platforms fail to unload."""
     entry = MagicMock()
     entry.entry_id = "test_unload_fail"
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
 
     # Simulate platform unload failure
     mock_coordinator.async_unload_platforms.return_value = False
 
     assert await async_unload_entry(hass, entry) is False
-    # Coordinator should still be in hass.data if unload failed
-    assert entry.entry_id in hass.data[DOMAIN]
+    assert entry.runtime_data is mock_coordinator
 
 
 async def test_init_service_wrappers(
@@ -751,6 +814,7 @@ async def test_fresh_start_wipes_storage(
     entry = MagicMock()
     entry.entry_id = "test_fresh_start"
     entry.options = {CONF_FRESH_START: True}
+    entry.runtime_data = None
 
     with (
         patch(
@@ -767,7 +831,6 @@ async def test_fresh_start_wipes_storage(
 
         from custom_components.ramses_cc import async_setup_entry
 
-        hass.data[DOMAIN] = {}
         with contextlib.suppress(Exception):
             await async_setup_entry(hass, entry)
 
@@ -787,6 +850,7 @@ async def test_no_fresh_start_preserves_storage(
     entry = MagicMock()
     entry.entry_id = "test_no_fresh_start"
     entry.options = {}
+    entry.runtime_data = None
 
     with (
         patch(
@@ -802,7 +866,6 @@ async def test_no_fresh_start_preserves_storage(
 
         from custom_components.ramses_cc import async_setup_entry
 
-        hass.data[DOMAIN] = {}
         with contextlib.suppress(Exception):
             await async_setup_entry(hass, entry)
 

--- a/tests/tests_new/test_mqtt_bridge.py
+++ b/tests/tests_new/test_mqtt_bridge.py
@@ -117,7 +117,7 @@ async def test_bridge_flow(
         await hass.async_block_till_done()
 
         # 6. Get the active coordinator and bridge
-        coordinator = hass.data[DOMAIN][entry.entry_id]
+        coordinator = entry.runtime_data
         bridge = coordinator.mqtt_bridge
         assert bridge is not None
 

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -75,9 +75,7 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     coordinator.entry = MagicMock()
     coordinator.entry.entry_id = "test_entry"
     coordinator.async_set_fan_param = AsyncMock()
-    coordinator.devices = []
-
-    hass.data[DOMAIN] = {"test_entry": coordinator}
+    coordinator.entry.runtime_data = coordinator
     return coordinator
 
 
@@ -148,7 +146,7 @@ async def test_setup_entry_direct_entities(
     number_entity: RamsesNumberParam,
 ) -> None:
     """Test adding entities directly to the platform."""
-    entry = MagicMock(entry_id="test_entry")
+    entry = MagicMock(entry_id="test_entry", runtime_data=mock_coordinator)
     async_add_entities = MagicMock()
 
     with patch(
@@ -176,7 +174,7 @@ async def test_setup_entry_direct_duplicate(
     hass: HomeAssistant, mock_coordinator: MagicMock
 ) -> None:
     """Test adding direct entity that already exists in platform."""
-    entry = MagicMock(entry_id="test_entry")
+    entry = MagicMock(entry_id="test_entry", runtime_data=mock_coordinator)
     async_add_entities = MagicMock()
 
     # Mock platform with existing entity
@@ -207,7 +205,7 @@ async def test_setup_entry_device_processing(
     mock_fan_device: MagicMock,
 ) -> None:
     """Test device processing, including existing devices and filtering."""
-    entry = MagicMock(entry_id="test_entry")
+    entry = MagicMock(entry_id="test_entry", runtime_data=mock_coordinator)
     async_add_entities = MagicMock()
 
     mock_coordinator.devices = [mock_fan_device]
@@ -268,7 +266,7 @@ async def test_setup_entry_empty_devices(
     hass: HomeAssistant, mock_coordinator: MagicMock
 ) -> None:
     """Test setup entry with empty devices list."""
-    entry = MagicMock(entry_id="test_entry")
+    entry = MagicMock(entry_id="test_entry", runtime_data=mock_coordinator)
     async_add_entities = MagicMock()
 
     with patch(

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -14,7 +14,6 @@ from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import EntityPlatform
 
-from custom_components.ramses_cc.const import DOMAIN
 from custom_components.ramses_cc.event import RamsesEventType, RamsesLearnEvent
 from custom_components.ramses_cc.remote import (
     RamsesRemote,
@@ -119,7 +118,7 @@ async def test_async_setup_entry(
     """Test the setup entry logic."""
     entry = MagicMock()
     entry.entry_id = "test_entry"
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
 
     async_add_entities = MagicMock()
 
@@ -689,10 +688,7 @@ async def test_setup_entry_platform(hass: HomeAssistant) -> None:
     # Create a mock config entry with an ID
     entry = MagicMock()
     entry.entry_id = "test_entry_id"
-
-    # Populate hass.data with the coordinator
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][entry.entry_id] = mock_coordinator
+    entry.runtime_data = mock_coordinator
 
     with (
         patch(

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2746,16 +2746,19 @@ def test_sync_learned_topology_removes_hgi_from_orphans() -> None:
 def test_sync_learned_topology_places_dhw_sensor_from_comment() -> None:
     """A 07: (DHW) device in comments should be placed as stored_hotwater.sensor.
 
-    The scan engine classifies 07: devices as DHW and may include "zone 00"
-    in the comment (the DHW domain).  sync_learned_topology should place
-    the device as stored_hotwater.sensor, not in a heating zone.
+    The scan engine classifies 07: devices as DHW and includes concrete
+    bound_to info in the comment. sync_learned_topology should place
+    the device as stored_hotwater.sensor under that specific TCS.
     """
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:216136",
         "01:216136": {SZ_ZONES: {"00": {"actuators": ["04:111111"]}}},
         SZ_ORPHANS_HEAT: ["07:050121"],
         SZ_DEVICE_COMMENTS: {
-            "07:050121": "Likely DHW. zone 00. codes: 10A0, 1260. RSSI 82.",
+            "07:050121": (
+                "Likely DHW. zone 00. bound to 01:216136. "
+                "codes: 10A0, 1260. RSSI 82."
+            ),
         },
     }
     learned: dict[str, Any] = {
@@ -2776,6 +2779,101 @@ def test_sync_learned_topology_places_dhw_sensor_from_comment() -> None:
     for zone in result["01:216136"][SZ_ZONES].values():
         assert zone.get(SZ_SENSOR) != "07:050121"
         assert "07:050121" not in zone.get("actuators", [])
+
+
+def test_sync_learned_topology_multi_tcs_dhw_isolation() -> None:
+    """Multi-TCS setup must never create phantom DHW on heating-only system.
+
+    Issue 971: 01:161591 has DHW, 01:258891 does not. An unbound 07:045491
+    in device_comments must not be attached to 01:258891 via main_tcs fallback.
+    """
+    config: dict[str, Any] = {
+        "01:161591": {
+            SZ_DHW_SYSTEM: {
+                "hotwater_valve": "13:101694",
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:147093"]}},
+        },
+        "01:258891": {
+            SZ_ZONES: {"00": {"actuators": ["04:012975"]}},
+        },
+        SZ_DEVICE_COMMENTS: {
+            "07:045491": "Likely DHW. zone 00. codes: 10A0, 1260. RSSI 82.",
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:161591": {
+            SZ_DHW_SYSTEM: {
+                "hotwater_valve": "13:101694",
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:147093"]}},
+        },
+        "01:258891": {
+            SZ_ZONES: {"00": {"actuators": ["04:012975"]}},
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    # If no changes were needed, result is None or identical
+    target = result if result is not None else config
+    # 01:161591 has DHW
+    assert target["01:161591"][SZ_DHW_SYSTEM][SZ_SENSOR] == "07:045491"
+    # 01:258891 must NOT have stored_hotwater
+    assert SZ_DHW_SYSTEM not in target["01:258891"]
+
+
+def test_sync_learned_topology_foreign_dhw_sensor_stays_in_orphans() -> None:
+    """An unassociated DHW sensor (e.g. from neighbour) stays in orphans_heat."""
+    config: dict[str, Any] = {
+        "01:216136": {SZ_ZONES: {"00": {"actuators": ["04:111111"]}}},
+        SZ_ORPHANS_HEAT: ["07:999999"],
+        SZ_DEVICE_COMMENTS: {
+            "07:999999": "Likely DHW. zone 00. codes: 1260. RSSI 50.",
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:216136": {SZ_ZONES: {"00": {"actuators": ["04:111111"]}}},
+        SZ_ORPHANS_HEAT: ["07:999999"],
+    }
+    result = sync_learned_topology(config, learned)
+    target = result if result is not None else config
+    # 07:999999 must stay in orphans_heat
+    assert "07:999999" in target.get(SZ_ORPHANS_HEAT, [])
+    # 01:216136 must not have stored_hotwater created
+    assert SZ_DHW_SYSTEM not in target["01:216136"]
+
+
+def test_sync_learned_topology_dhw_cross_tcs_migration() -> None:
+    """When a DHW sensor moves to a new TCS, old TCS slot is cleared."""
+    config: dict[str, Any] = {
+        "01:111111": {
+            SZ_DHW_SYSTEM: {
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:111111"]}},
+        },
+        "01:222222": {
+            SZ_ZONES: {"00": {"actuators": ["04:222222"]}},
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:111111": {
+            SZ_ZONES: {"00": {"actuators": ["04:111111"]}},
+        },
+        "01:222222": {
+            SZ_DHW_SYSTEM: {
+                SZ_SENSOR: "07:045491",
+            },
+            SZ_ZONES: {"00": {"actuators": ["04:222222"]}},
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    # 01:111111 sensor cleared
+    assert result["01:111111"][SZ_DHW_SYSTEM][SZ_SENSOR] is None
+    # 01:222222 received sensor
+    assert result["01:222222"][SZ_DHW_SYSTEM][SZ_SENSOR] == "07:045491"
 
 
 def test_sync_learned_topology_trv_never_zone_sensor() -> None:

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2926,14 +2926,33 @@ def test_sync_learned_topology_creates_hgi_schema_entry() -> None:
     }
     result = sync_learned_topology(config, learned)
     assert result is not None
-    # 18:130236 should now have an empty schema entry (NOT _skipped)
+    # 18:130236 should now have a schema entry with _class: "HGI" (NOT _skipped)
     assert "18:130236" in result
-    assert result["18:130236"] == {}
+    assert result["18:130236"] == {"_class": "HGI"}
     # Should not have _skipped (would cause re-discovery every cycle)
     assert result["18:130236"].get("_skipped") is None
     # Should not have any heating keys
     assert SZ_ZONES not in result["18:130236"]
     assert SZ_SYSTEM not in result["18:130236"]
+
+
+def test_sync_learned_topology_hgi_with_active_and_owner() -> None:
+    """Active HGI should receive _owner trait when root_owner is configured."""
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        SZ_OWNER: "house",
+        "01:123456": {SZ_ZONES: {"02": {SZ_SENSOR: "04:111111"}}},
+        SZ_DEVICE_COMMENTS: {
+            "18:130236": "Likely HGI. codes: 2210, 22E0. RSSI 0.",
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:123456",
+        "01:123456": {SZ_ZONES: {"02": {SZ_SENSOR: "04:111111"}}},
+    }
+    result = sync_learned_topology(config, learned, active_hgi_id="18:130236")
+    assert result is not None
+    assert result["18:130236"] == {"_class": "HGI", "_owner": "house"}
 
 
 def test_sync_learned_topology_updates_comment_zone_from_learned() -> None:

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from custom_components.ramses_cc.const import DOMAIN
 from custom_components.ramses_cc.sensor import (
     SENSOR_DESCRIPTIONS,
     RamsesSensor,
@@ -64,7 +63,7 @@ async def test_async_setup_entry(
     """
     entry = MagicMock()
     entry.entry_id = "test_entry_id"
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
     async_add_entities = MagicMock()
 
     # Mock async_get_current_platform to avoid RuntimeError
@@ -480,7 +479,7 @@ async def test_async_setup_entry_full_descriptions(
     # Test the platform setup with real SENSOR_DESCRIPTIONS.
     entry = MagicMock()
     entry.entry_id = "test_entry_full"
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
     async_add_entities = MagicMock()
 
     otb_dev = MagicMock(spec=OtbGateway)
@@ -551,7 +550,7 @@ async def test_async_setup_entry_ufc_pump_relay(
     # Arrange
     entry = MagicMock()
     entry.entry_id = "test_ufc_entry"
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = mock_coordinator
     async_add_entities = MagicMock()
 
     ufc_dev = MagicMock(spec=UfhController)

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -105,7 +105,7 @@ def mock_coordinator(hass: HomeAssistant) -> RamsesCoordinator:
     coordinator.platforms = {}
     coordinator._device_info = {}
 
-    hass.data[DOMAIN] = {entry.entry_id: coordinator}
+    entry.runtime_data = coordinator
 
     return coordinator
 

--- a/tests/tests_new/test_task_cleanup.py
+++ b/tests/tests_new/test_task_cleanup.py
@@ -16,7 +16,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from homeassistant.core import HomeAssistant
 
-from custom_components.ramses_cc.const import DOMAIN
 from custom_components.ramses_cc.number import (
     RamsesNumberEntityDescription,
     RamsesNumberParam,
@@ -51,7 +50,7 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     coordinator.async_request_refresh = AsyncMock()
     coordinator.client = MagicMock()
     coordinator.devices = []
-    hass.data[DOMAIN] = {"test_entry": coordinator}
+    coordinator.entry.runtime_data = coordinator
     return coordinator
 
 

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.util import dt as dt_util
 
-from custom_components.ramses_cc.const import DOMAIN, SystemMode, ZoneMode
+from custom_components.ramses_cc.const import SystemMode, ZoneMode
 from custom_components.ramses_cc.water_heater import (
     STATE_AUTO,
     STATE_BOOST,
@@ -85,7 +85,7 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
 
     # Mock Coordinator
     mock_coordinator = MagicMock()
-    hass.data[DOMAIN] = {mock_entry.entry_id: mock_coordinator}
+    mock_entry.runtime_data = mock_coordinator
 
     # Mock AddEntitiesCallback
     mock_add_entities = MagicMock()

--- a/tests/tests_old/test_init_config.py
+++ b/tests/tests_old/test_init_config.py
@@ -101,10 +101,6 @@ async def _test_common(
 ) -> None:
     """The main tests are here."""
 
-    # hass.data["custom_components"][DOMAIN]  # homeassistant.loader.Integration
-    assert isinstance(list(hass.data[DOMAIN].values())[0], RamsesCoordinator)
-    assert isinstance(list(hass.data[DOMAIN].values())[0].client, Gateway)
-
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
@@ -113,10 +109,12 @@ async def _test_common(
     entry = entries[0]
     assert entry.state is ConfigEntryState.LOADED
 
-    assert hass.data["setup_tasks"] == {}
-    assert isinstance(hass.data[DOMAIN][entry.entry_id], RamsesCoordinator)
+    assert isinstance(entry.runtime_data, RamsesCoordinator)
+    assert isinstance(entry.runtime_data.client, Gateway)
 
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    assert hass.data["setup_tasks"] == {}
+
+    coordinator: RamsesCoordinator = entry.runtime_data
     # Phase 4: enforce_known_list is always-on, so devices in known_list/schema
     # are created upfront.  Most configs have only the HGI (1 device), but
     # config_fan_unbind has a FAN device too (2 devices).

--- a/tests/tests_old/test_init_data.py
+++ b/tests/tests_old/test_init_data.py
@@ -133,12 +133,8 @@ async def _test_common(
 ) -> None:
     """The main tests are here."""
 
-    gwy: Gateway = list(hass.data[DOMAIN].values())[0].client
-
-    assert len(gwy.device_registry.devices) == NUM_DEVS_SETUP
-    assert len(gwy.device_registry.systems) == 1
-
-    coordinator: RamsesCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: RamsesCoordinator = entry.runtime_data
+    gwy: Gateway = coordinator.client
 
     # Trigger discovery manually to process the casted packets ---
     # Because the integration relies on a 60-second polling interval for new device
@@ -212,7 +208,7 @@ async def test_services_entry_(
     assert await hass.config_entries.async_setup(entry.entry_id)
 
     try:
-        gwy = list(hass.data[DOMAIN].values())[0].client
+        gwy = entry.runtime_data.client
         await cast_packets_to_rf(rf, f"{TEST_DIR}/system_1.log", gwy=gwy)
         # Bounded so an unexpected perpetual-transport stall fails fast and
         # clearly instead of hanging for the full CI timeout (see #774).
@@ -224,7 +220,7 @@ async def test_services_entry_(
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert len(hass.data[DOMAIN]) == 0
+        assert entry.state == ConfigEntryState.NOT_LOADED
 
 
 @patch(
@@ -241,7 +237,7 @@ async def test_services_import(
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     try:
-        gwy = list(hass.data[DOMAIN].values())[0].client
+        gwy = entry.runtime_data.client
         await cast_packets_to_rf(rf, f"{TEST_DIR}/system_1.log", gwy=gwy)
         await hass.async_block_till_done()
 
@@ -251,7 +247,7 @@ async def test_services_import(
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert len(hass.data[DOMAIN]) == 0
+        assert entry.state == ConfigEntryState.NOT_LOADED
 
 
 @patch(
@@ -272,7 +268,7 @@ async def test_services_packets(
     assert await hass.config_entries.async_setup(entry.entry_id)
 
     try:
-        gwy = list(hass.data[DOMAIN].values())[0].client
+        gwy = entry.runtime_data.client
         await cast_packets_to_rf(rf, f"{TEST_DIR}/system_1.log", gwy=gwy)
         await hass.async_block_till_done()
 
@@ -308,7 +304,7 @@ async def test_startup_with_unbound_device(
     assert len(entries) == 1
     assert entries[0].state == ConfigEntryState.LOADED
 
-    coordinator = hass.data[DOMAIN][entries[0].entry_id]
+    coordinator = entries[0].runtime_data
 
     device_ids = [d.id for d in coordinator.client.device_registry.devices]
     assert "29:123456" in device_ids

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -276,7 +276,9 @@ SERVICES = {
 async def _cast_packets_to_rf(hass: HomeAssistant, rf: VirtualRf) -> None:
     """Load packets from a CH/DHW system."""
 
-    gwy: Gateway = list(hass.data[DOMAIN].values())[0].client
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator: RamsesCoordinator = entry.runtime_data
+    gwy: Gateway = coordinator.client
 
     assert len(gwy.device_registry.devices) == NUM_DEVS_BEFORE
 
@@ -318,7 +320,7 @@ async def _setup_via_entry_(
 
     await _cast_packets_to_rf(hass, rf)
 
-    coordinator: RamsesCoordinator = list(hass.data[DOMAIN].values())[0]
+    coordinator: RamsesCoordinator = entry.runtime_data
 
     # Explicitly run discovery to populate entities from the cast packets
     await coordinator._discover_new_entities()


### PR DESCRIPTION
### ⚠️ STACKED PR: Depends on #980 < was merged

### The Problem:
`RamsesZone` climate entities did not include `HVACMode.OFF` in `_attr_hvac_modes`, preventing Home Assistant frontend cards from displaying the "Off" button, breaking automation blueprints (e.g. "Window open, climate off"), and preventing voice/bridge integrations (HomeKit, Google Home) from turning zones off (#129).

### The Fix:
- Added `HVACMode.OFF: ZoneMode.PERMANENT` to `MODE_HA_TO_ZONE` in `custom_components/ramses_cc/climate.py`, exposing `[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO, HVACMode.COOL]` on `RamsesZone`.
- In `RamsesZone.hvac_mode`, added a robust `5.0 °C` fallback when evaluating `setpoint <= min_temp` if zone config is absent.
- In `RamsesZone.async_set_hvac_mode`, added explicit `ServiceValidationError` when an unrecognised mode is passed, and ensured `HVACMode.OFF` triggers `set_frost_mode()` (5.0 °C permanent override) and an immediate state flush.
- Expanded the test suite in `tests/tests_new/test_climate.py` to achieve 100.00% statement coverage across all `climate.py` functions, modes, presets, and exception handlers.

### Testing Performed:
- Added comprehensive unit tests in `tests/tests_new/test_climate.py` verifying all `RamsesZone` mode transitions, config fallbacks, preset edge cases, schedule exceptions, and `RamsesHvac` mode settings.
- Ran `.venv/bin/prek run -a` (passed).
- Ran `.venv/bin/mypy` (passed across 68 source files).
- Ran `pytest --cov=custom_components.ramses_cc.climate` (100.00% statement coverage).
- Ran `.venv/bin/python -u -m pytest -n auto` (1,360 passed, 10 skipped).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.