### PR TITLE
fix: ramses_rf 0.59.7 API renames (pkt_addrs, _gwy, src_count, zone_idx)

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -219,7 +219,7 @@ class RamsesLogbookBinarySensor(RamsesBinarySensor):
                         code="0418",
                         payload="00",
                     )
-                    await tcs._gwy.async_send_cmd(cmd)
+                    await tcs._gateway.async_send_cmd(cmd)
             except Exception as err:
                 _LOGGER.debug(
                     "Failed to poll active_faults for %s: %s",
@@ -278,7 +278,7 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
         :return: Dictionary of attributes for the gateway.
         :rtype: dict[str, Any]
         """
-        gwy: Gateway = self._device._gwy
+        gwy: Gateway = self._device._gateway
         engine = getattr(gwy, "_engine", None)
         gwy_config = getattr(gwy, "config", getattr(gwy, "_gwy_config", None))
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -198,7 +198,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
                     code="2E04",
                     payload="FF",
                 )
-                await self._device._gwy.async_send_cmd(cmd)
+                await self._device._gateway.async_send_cmd(cmd)
             except Exception as err:
                 _LOGGER.debug(
                     "Failed to poll system_mode for %s: %s",
@@ -529,7 +529,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
                     code="2349",
                     payload=self._device.idx,
                 )
-                await self._device._gwy.async_send_cmd(cmd)
+                await self._device._gateway.async_send_cmd(cmd)
             except Exception as err:
                 _LOGGER.debug(
                     "Failed to poll mode for %s: %s",
@@ -1233,7 +1233,7 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                 cmd = parse_packet_string(packet_str)
                 if cmd is None:
                     raise ValueError(f"Failed to parse packet_str: {packet_str}")
-                await self._device._gwy.async_send_cmd(
+                await self._device._gateway.async_send_cmd(
                     cmd, num_repeats=2, priority=Priority.HIGH
                 )
                 self.async_write_ha_state()
@@ -1265,7 +1265,7 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                 if cmd is None:
                     raise ValueError(f"Failed to parse cmd_str: {cmd_str}")
 
-                await self._device._gwy.async_send_cmd(
+                await self._device._gateway.async_send_cmd(
                     cmd, num_repeats=2, priority=Priority.HIGH
                 )
                 self.async_write_ha_state()

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1889,9 +1889,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 if len(d.codes_seen) > 4:
                     codes += f" (+{len(d.codes_seen) - 4})"
                 rssi = f"{d.rssi:.0f}" if d.rssi is not None else "—"
-                pkt_count = d.src_count + d.dst_count
+                pkt_count = d.source_count + d.destination_count
                 lines.append(
-                    f"| `{d.device_id}` | {d.likely_type or '?'} | {d.confidence} | {rssi} | {codes} | {d.bound_to or '—'} | {d.zone_idx or '—'} | {'yes' if d.is_battery else 'no'} | {pkt_count} |"
+                    f"| `{d.device_id}` | {d.likely_type or '?'} | {d.confidence} | {rssi} | {codes} | {d.bound_to or '—'} | {d.zone_index or '—'} | {'yes' if d.is_battery else 'no'} | {pkt_count} |"
                 )
 
         if mismatched_only:
@@ -1994,11 +1994,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 desc_parts.append(f"conf={d.confidence}")
             if d.bound_to:
                 desc_parts.append(f"bound={d.bound_to}")
-            if d.zone_idx:
-                desc_parts.append(f"zone={d.zone_idx}")
+            if d.zone_index:
+                desc_parts.append(f"zone={d.zone_index}")
             if d.is_battery:
                 desc_parts.append("battery")
-            pkt_count = d.src_count + d.dst_count
+            pkt_count = d.source_count + d.destination_count
             desc_parts.append(f"pkts={pkt_count}")
             field_label = " | ".join(desc_parts)
 

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -343,7 +343,7 @@ class DiscoveryManager:
             # Previously only updated comments for devices with zone_idx or
             # bound_to, but this left newly discovered devices without comments.
             comment = result.get(dev_id, "")
-            if not dev.zone_idx and not dev.bound_to:
+            if not dev.zone_index and not dev.bound_to:
                 # No binding info — still create a basic comment if missing
                 # or if it lacks the auto-generated suffix.
                 # Exceptions that force a rebuild:
@@ -369,7 +369,7 @@ class DiscoveryManager:
                     changed = True
                 continue
             # Check if comment already has the correct zone/bound info
-            has_zone = dev.zone_idx and f"zone {dev.zone_idx}" in comment
+            has_zone = dev.zone_index and f"zone {dev.zone_index}" in comment
             # "belongs to" for FAN (32:), "bound to" for heat TCS
             bound_phrase = (
                 f"belongs to {dev.bound_to}"
@@ -385,7 +385,7 @@ class DiscoveryManager:
                 dev,
                 likely_type,
                 dev.bound_to,
-                dev.zone_idx,
+                dev.zone_index,
                 schema_role=schema_role,
             )
             if new_comment != comment:
@@ -427,7 +427,7 @@ class DiscoveryManager:
                     else dev_entry.get(SZ_TR_CLASS, "unknown")
                 )
                 likely_type = likely_type or "unknown"
-                zone_idx = engine_dev.zone_idx if engine_dev else None
+                zone_idx = engine_dev.zone_index if engine_dev else None
                 new_comment = self._build_comment(
                     engine_dev or _SchemaOnlyDevice(dev_id, likely_type),
                     likely_type,
@@ -1584,7 +1584,7 @@ class DiscoveryManager:
             dev = entry.device if entry else None
             likely_type = dev.likely_type if dev else "unknown"
             bound_to = dev.bound_to if dev else None
-            zone_idx = dev.zone_idx if dev else None
+            zone_idx = dev.zone_index if dev else None
             domain_id = getattr(dev, "domain_id", None) if dev else None
 
             # Build a descriptive comment from scan engine data so the user
@@ -1870,8 +1870,8 @@ class DiscoveryManager:
             line = f"- `{dev.device_id}` ({dev.likely_type}"
             if dev.confidence:
                 line += f", {dev.confidence}"
-            if dev.zone_idx:
-                line += f", zone={dev.zone_idx}"
+            if dev.zone_index:
+                line += f", zone={dev.zone_index}"
             if dev.bound_to:
                 line += f", bound to {dev.bound_to}"
             if dev.is_battery:

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -244,7 +244,7 @@ class RamsesFanHandler:
                             payload="00",
                         )
                         _LOGGER.debug("Poll 10D0 filter_remaining for %s", device.id)
-                        await device._gwy.async_send_cmd(cmd)
+                        await device._gateway.async_send_cmd(cmd)
                     except Exception as err:
                         _LOGGER.debug(
                             "Failed to poll filter_remaining for %s: %s",

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -149,7 +149,7 @@ def _build_packet_from_template(
         # Fallback to HGI gateway ID
         client = coordinator.client
         if client:
-            hgi = getattr(client, "_gwy", None)
+            hgi = getattr(client, "_gateway", None) or getattr(client, "_gwy", None)
             if hgi:
                 hgi_dev = getattr(hgi, "_hgi", None) or getattr(hgi, "hgi", None)
                 if hgi_dev:

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -166,7 +166,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
                     payload="00",
                 )
                 try:
-                    await self._device._gwy.async_send_cmd(cmd)
+                    await self._device._gateway.async_send_cmd(cmd)
                     _LOGGER.debug("Polled %s for %s", code, self._device.id)
                 except Exception as err:
                     _LOGGER.debug(

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -38,7 +38,7 @@ from ramses_rf.schemas import (
     SZ_UFH_SYSTEM,
     SZ_ZONES,
 )
-from ramses_tx.address import pkt_addrs
+from ramses_tx.address import packet_addrs as pkt_addrs
 from ramses_tx.dtos import CommandDTO
 from ramses_tx.exceptions import (
     PacketAddrSetInvalid,


### PR DESCRIPTION
## Summary

Fixes ramses_cc startup failure on ramses_rf 0.59.7+ by updating all references to renamed internal attributes.

## Problem

ramses_rf 0.59.7 renamed several internal attributes as part of the "pythonic naming" refactor (issue 1039, PRs 1051/1058/1060):

| Old name | New name | Location |
|----------|----------|----------|
| `pkt_addrs()` | `packet_addrs()` | `ramses_tx.address` |
| `_gwy` | `_gateway` | device base class |
| `src_count` | `source_count` | `DiscoveredDevice` |
| `dst_count` | `destination_count` | `DiscoveredDevice` |
| `zone_idx` | `zone_index` | `DiscoveredDevice` |

These renames broke ramses_cc startup with:
```
ImportError: cannot import name 'pkt_addrs' from 'ramses_tx.address'
AttributeError: 'HgiGateway' object has no attribute '_gwy'
```

## Solution

Updated all references in ramses_cc to use the new names. For `remote.py`, kept a fallback to the old name (`_gwy`) for backward compatibility with older ramses_rf versions.

## Testing

Verified on hass (port 8123) with ramses_rf 0.59.7+master:
- ✅ ramses_cc loads cleanly (no ImportError, no AttributeError)
- ✅ ramses_extras loads cleanly (dependency on ramses_cc satisfied)
- ✅ 2411 parameter polling works
- ✅ Traffic Analyser card loads
- ✅ All pre-commit hooks pass (ruff, codespell)

## Risk

**LOW** — These are straightforward rename updates. The `remote.py` fallback ensures backward compatibility with older ramses_rf versions.