### PR TITLE
Fix HGI re-discovery (987) and orphaned notification suppression (988)

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1619,15 +1619,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # for new devices.  This stashes schema_device_ids so that
         # check_for_new_devices can suppress notifications for devices
         # that are already in the schema but lost their metadata (issue 917).
+        # NOTE: use _extract_schema_device_ids (unstripped) so that HGI
+        # (18:) entries are included — _strip_and_orchestrate drops them
+        # because ramses_rf doesn't need them, but discovery tracking
+        # must know they're in the schema (issue 987).
         config_schema_for_sync = self.options.get(CONF_SCHEMA, {})
         if isinstance(config_schema_for_sync, dict):
             from .coordinator import RamsesCoordinator
 
-            stripped = RamsesCoordinator._strip_schema_extensions(
+            schema_device_ids = RamsesCoordinator._extract_schema_device_ids(
                 config_schema_for_sync
-            )
-            schema_device_ids = (
-                RamsesCoordinator._extract_device_ids_from_stripped(stripped)
             )
             coordinator.discovery_manager.sync_with_schema(schema_device_ids)
 
@@ -2386,6 +2387,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         if user_input is not None:
             # Process each device — "keep" clears the flag, "remove" calls
             # the remove_device service for full cleanup.
+            config_schema = dict(self.options.get(CONF_SCHEMA, {}))
             removed_any = False
             for entry in lost_devices:
                 device_id = entry.device.device_id
@@ -2403,13 +2405,25 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         device_id,
                     )
                 elif action == "keep":
-                    # Clear LOST status → back to ACCEPTED, clear orphaned
+                    # Clear LOST status → back to ACCEPTED, clear orphaned.
+                    # Set _suppress_not_seen in the schema so future
+                    # orphaned notifications are suppressed (issue 988).
+                    # An INFO log is still emitted once every
+                    # threshold_days as a gentle reminder.
                     meta = coordinator.discovery_manager._metadata.get(
                         device_id
                     )
                     if meta:
                         meta.status = DiscoveryStatus.ACCEPTED
                         meta.orphaned = None
+                    # Mark in schema to suppress future notifications
+                    # Default: 7 days (then re-notify if still not seen).
+                    # User can set True (forever) or a different number
+                    # of days manually in the schema.
+                    dev_entry = config_schema.get(device_id)
+                    if isinstance(dev_entry, dict):
+                        dev_entry["_suppress_not_seen"] = 7
+                        config_schema[device_id] = dev_entry
 
             for entry in orphaned_only:
                 device_id = entry.device.device_id
@@ -2427,12 +2441,19 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         device_id,
                     )
                 elif action == "keep":
-                    # Clear orphaned flag — device is still there, just quiet
+                    # Clear orphaned flag and set _suppress_not_seen in
+                    # the schema so check_orphaned_devices doesn't re-notify
+                    # on the next checkpoint cycle (issue 988).  An INFO
+                    # log is still emitted once every threshold_days.
                     meta = coordinator.discovery_manager._metadata.get(
                         device_id
                     )
                     if meta:
                         meta.orphaned = None
+                    dev_entry = config_schema.get(device_id)
+                    if isinstance(dev_entry, dict):
+                        dev_entry["_suppress_not_seen"] = 7
+                        config_schema[device_id] = dev_entry
 
             # Save discovery metadata to .storage via coordinator's save
             # cycle (export_state is called in async_save_client_state)
@@ -2443,6 +2464,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # so refresh self.options from the coordinator to avoid
                 # overwriting with stale data, then save normally
                 self.options = dict(coordinator.options)
+            else:
+                # No removals — update schema in self.options with
+                # _suppress_not_seen flags set by "keep" actions
+                self.options[CONF_SCHEMA] = config_schema
 
             return self._async_save()
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -744,11 +744,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Sync discovery metadata with current schema: mark devices as
         # REMOVED if in discovery but not in schema (manually removed).
         # Ensures they will be re-discovered if still present.
+        # NOTE: use _extract_schema_device_ids (unstripped) so that HGI
+        # (18:) entries are included — _strip_and_orchestrate drops them
+        # because ramses_rf doesn't need them, but discovery tracking
+        # must know they're in the schema (issue 987).
         schema = self.options.get(CONF_SCHEMA, {})
-        stripped_schema = self._strip_schema_extensions(schema)
-        schema_device_ids = self._extract_device_ids_from_stripped(
-            stripped_schema
-        )
+        schema_device_ids = self._extract_schema_device_ids(schema)
         self.discovery_manager.sync_with_schema(schema_device_ids)
 
         # Schedule periodic checkpoint + check for new/lost devices.
@@ -775,11 +776,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if not self.discovery_manager:
             return
         # Sync discovery metadata with the scan's device list
+        # NOTE: use _extract_schema_device_ids (unstripped) so that HGI
+        # (18:) entries are included — _strip_and_orchestrate drops them
+        # because ramses_rf doesn't need them, but discovery tracking
+        # must know they're in the schema (issue 987).
         schema = self.options.get(CONF_SCHEMA, {})
-        stripped_schema = self._strip_schema_extensions(schema)
-        schema_device_ids = self._extract_device_ids_from_stripped(
-            stripped_schema
-        )
+        schema_device_ids = self._extract_schema_device_ids(schema)
         self.discovery_manager.sync_with_schema(schema_device_ids)
         # Check for mismatches between discovery and schema
         # (schema is authoritative — this only logs warnings + notification)

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -98,6 +98,12 @@ class DeviceMetadata:
     # scan engine for longer than the orphan threshold.  Cleared when
     # traffic is seen again.
     orphaned: str | None = None
+    # ISO timestamp of the last INFO log for a suppressed-orphaned device.
+    # Used when the schema entry has ``_suppress_not_seen: True``: the
+    # persistent notification is suppressed, but an INFO log is emitted
+    # once every ``orphan_threshold_days`` as a gentle reminder (e.g. in
+    # case batteries died).  Cleared when traffic is seen again.
+    last_orphaned_log: str | None = None
     # Set when a zone's schema _name differs from the runtime name
     # reported by the controller via 0004 packets.  The controller's
     # name is authoritative for _name — the user can set _alias for a
@@ -120,6 +126,7 @@ class DeviceMetadata:
             "missing_class": self.missing_class,
             "missing_class_dismissed": self.missing_class_dismissed,
             "orphaned": self.orphaned,
+            "last_orphaned_log": self.last_orphaned_log,
             "name_mismatch": self.name_mismatch,
         }
 
@@ -145,6 +152,7 @@ class DeviceMetadata:
             missing_class=data.get("missing_class"),
             missing_class_dismissed=data.get("missing_class_dismissed", False),
             orphaned=data.get("orphaned"),
+            last_orphaned_log=data.get("last_orphaned_log"),
             name_mismatch=data.get("name_mismatch"),
         )
 
@@ -933,10 +941,91 @@ class DiscoveryManager:
                 )
 
             if last_seen < threshold:
-                meta = self._metadata.get(device_id, DeviceMetadata())
+                existing_meta = self._metadata.get(device_id)
+                meta = existing_meta or DeviceMetadata()
+
+                # Check if the user has suppressed notifications for
+                # this device via the schema key ``_suppress_not_seen``.
+                # Accepted values:
+                #   True  → suppress forever (INFO log every threshold_days)
+                #   N(int)→ suppress for N days from last_seen, then re-notify
+                # Suppressed devices are not added to the orphaned list
+                # (so no persistent notification), but an INFO log is
+                # emitted once every ``threshold_days`` as a gentle
+                # reminder (e.g. in case batteries died).  Issue 988.
+                suppress_val = schema_entry.get("_suppress_not_seen")
+                suppress_forever = suppress_val is True
+                suppress_days: int | None = None
+                if isinstance(suppress_val, (int, float)) and not isinstance(
+                    suppress_val, bool
+                ):
+                    suppress_days = int(suppress_val)
+
+                if suppress_forever or suppress_days is not None:
+                    # Check if suppress period has expired (for int mode)
+                    if suppress_days is not None:
+                        suppress_threshold = now - td(days=suppress_days)
+                        if last_seen < suppress_threshold:
+                            # Suppress expired — remove key from schema so
+                            # normal orphaned handling takes over (notify
+                            # every cycle until user re-dismisses or device
+                            # returns).  For True (forever) we never reach
+                            # this branch.
+                            schema_entry.pop("_suppress_not_seen", None)
+                            meta.orphaned = (
+                                f"last seen {last_seen_str} "
+                                f"(>{threshold_days} days, suppress expired)"
+                            )
+                            meta.last_orphaned_log = None
+                            self._metadata[device_id] = meta
+                            orphaned.append(device_id)
+                            _LOGGER.info(
+                                "DiscoveryManager: suppress expired for %s "
+                                "(not seen > %d days), re-notifying",
+                                device_id,
+                                suppress_days,
+                            )
+                            continue
+
+                    # Still within suppress period
+                    meta.orphaned = None  # no notification
+                    # Check if we should log a periodic reminder
+                    last_log = meta.last_orphaned_log
+                    should_log = True
+                    if last_log:
+                        try:
+                            last_log_dt = dt.fromisoformat(last_log)
+                            if last_log_dt.tzinfo is None:
+                                last_log_dt = last_log_dt.replace(
+                                    tzinfo=dt_util.get_default_time_zone()
+                                )
+                            if last_log_dt > threshold:
+                                should_log = False
+                        except (ValueError, TypeError):
+                            pass  # invalid timestamp → log again
+                    if should_log:
+                        meta.last_orphaned_log = now.isoformat()
+                        suppress_desc = (
+                            "forever"
+                            if suppress_forever
+                            else f"{suppress_days}d"
+                        )
+                        _LOGGER.info(
+                            "DiscoveryManager: device %s not seen since %s "
+                            "(> %d days, suppressed %s)",
+                            device_id,
+                            last_seen_str,
+                            threshold_days,
+                            suppress_desc,
+                        )
+                    self._metadata[device_id] = meta
+                    continue
+
+                # Not suppressed — flag as orphaned (triggers notification)
                 meta.orphaned = (
                     f"last seen {last_seen_str} (>{threshold_days} days)"
                 )
+                meta.last_orphaned_log = None
                 self._metadata[device_id] = meta
                 orphaned.append(device_id)
                 _LOGGER.debug(
@@ -945,11 +1034,24 @@ class DiscoveryManager:
                     last_seen_str,
                 )
             else:
-                # Seen recently — clear orphaned flag
+                # Seen recently — clear orphaned flag and last_orphaned_log.
+                # Also remove _suppress_not_seen from the schema so that
+                # if the device goes quiet again later, the user gets a
+                # fresh orphaned notification (issue 988).
                 existing_meta = self._metadata.get(device_id)
-                if existing_meta and existing_meta.orphaned:
+                if existing_meta and (
+                    existing_meta.orphaned or existing_meta.last_orphaned_log
+                ):
                     existing_meta.orphaned = None
+                    existing_meta.last_orphaned_log = None
                     self._metadata[device_id] = existing_meta
+                if schema_entry.get("_suppress_not_seen"):
+                    schema_entry.pop("_suppress_not_seen", None)
+                    _LOGGER.info(
+                        "DiscoveryManager: device %s seen again, "
+                        "cleared _suppress_not_seen from schema",
+                        device_id,
+                    )
 
         if orphaned:
             _LOGGER.info(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -3465,6 +3465,20 @@ class TestExtractSchemaDeviceIds:
         assert "01:123456" in result
         assert "04:654321" in result
 
+    def test_includes_hgi_entries(self) -> None:
+        """HGI (18:) entries are included — needed for discovery sync
+        (issue 987).  _strip_and_orchestrate drops them, but
+        _extract_schema_device_ids operates on the unstripped schema."""
+        schema = {
+            "18:130236": {"_class": "HGI", "_owner": "me"},
+            "18:149488": {"_class": "HGI", "_owner": "not-me"},
+            "32:153289": {"_class": "FAN"},
+        }
+        result = RamsesCoordinator._extract_schema_device_ids(schema)
+        assert "18:130236" in result
+        assert "18:149488" in result
+        assert "32:153289" in result
+
 
 # ───────────────────────────────────────────────────────────────────────
 # Coordinator: _derive_known_list_from_schema

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1940,6 +1940,147 @@ class TestCheckOrphanedDevices:
         assert meta is not None
         assert meta.orphaned is None
 
+    def test_suppress_not_seen_skips_notification(self) -> None:
+        """Device with _suppress_not_seen in schema is not added to
+        the orphaned notification list (issue 988)."""
+
+        old_date = (dt.now() - td(days=30)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV", "_suppress_not_seen": True}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is None  # no notification flag
+        # last_orphaned_log should be set (periodic INFO log)
+        assert meta.last_orphaned_log is not None
+
+    def test_suppress_not_seen_logs_periodically(self) -> None:
+        """When _suppress_not_seen is set, INFO log is emitted only once
+        per threshold_days, not on every checkpoint cycle (issue 988)."""
+
+        old_date = (dt.now() - td(days=30)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # First check — should log (last_orphaned_log is None)
+        schema = {"04:056053": {"_class": "TRV", "_suppress_not_seen": True}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        first_log = meta.last_orphaned_log
+        assert first_log is not None
+
+        # Second check — should NOT log again (within threshold)
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0
+        meta = manager._metadata.get("04:056053")
+        assert meta.last_orphaned_log == first_log  # unchanged
+
+    def test_suppress_not_seen_cleared_when_seen_again(self) -> None:
+        """last_orphaned_log and _suppress_not_seen are cleared when
+        device is seen again, so a future orphaned episode gets a
+        fresh notification (issue 988)."""
+
+        recent_date = (dt.now() - td(days=1)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=recent_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Device was suppressed-orphans, now seen again
+        manager._metadata["04:056053"] = DeviceMetadata(
+            orphaned="old", last_orphaned_log="2026-01-01T00:00:00"
+        )
+        schema = {"04:056053": {"_class": "TRV", "_suppress_not_seen": True}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is None
+        assert meta.last_orphaned_log is None  # cleared
+        # _suppress_not_seen should be removed from the schema entry
+        assert "_suppress_not_seen" not in schema["04:056053"]
+
+    def test_suppress_not_seen_logs_again_after_threshold(self) -> None:
+        """After threshold_days since last log, a new INFO log is emitted."""
+
+        old_date = (dt.now() - td(days=30)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Set last_orphaned_log to 10 days ago — should log again
+        old_log = (dt.now() - td(days=10)).isoformat()
+        manager._metadata["04:056053"] = DeviceMetadata(
+            last_orphaned_log=old_log
+        )
+        schema = {"04:056053": {"_class": "TRV", "_suppress_not_seen": True}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.last_orphaned_log != old_log  # updated
+        assert meta.orphaned is None  # still no notification
+
+    def test_suppress_not_seen_int_days_still_suppressed(self) -> None:
+        """_suppress_not_seen: 14 suppresses for 14 days from last_seen.
+        Device not seen for 10 days, threshold=7, suppress=14 -> still
+        within suppress period (10 < 14)."""
+
+        old_date = (dt.now() - td(days=10)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV", "_suppress_not_seen": 14}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0  # suppressed
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is None  # no notification
+
+    def test_suppress_not_seen_int_days_expired(self) -> None:
+        """_suppress_not_seen: 14 re-notifies after 14 days from last_seen.
+        Device not seen for 20 days, threshold=7, suppress=14 -> expired
+        (20 > 14), so notification re-appears."""
+
+        old_date = (dt.now() - td(days=20)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV", "_suppress_not_seen": 14}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 1  # suppress expired, re-notified
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is not None  # notification flag set
+        assert "suppress expired" in meta.orphaned
+        # Key removed from schema so next checkpoint uses normal orphaned
+        # handling (no re-evaluation of expired suppress)
+        assert "_suppress_not_seen" not in schema["04:056053"]
+
+    def test_suppress_not_seen_true_forever(self) -> None:
+        """_suppress_not_seen: True suppresses forever, even after 100
+        days."""
+
+        old_date = (dt.now() - td(days=100)).isoformat()
+        dev = make_discovered_device("04:056053", "TRV", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"04:056053": {"_class": "TRV", "_suppress_not_seen": True}}
+        count = manager.check_orphaned_devices(schema, threshold_days=7)
+        assert count == 0  # suppressed forever
+        meta = manager._metadata.get("04:056053")
+        assert meta is not None
+        assert meta.orphaned is None  # no notification
+
     def test_hgi_not_orphaned(self) -> None:
         scan = make_mock_scan([])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)


### PR DESCRIPTION
## Summary

- **Issue #987 **: HGI (`18:`) devices were re-discovered and re-notified every 5-minute checkpoint cycle because `_strip_and_orchestrate` drops them from the schema (correct for ramses_rf), but `_extract_device_ids_from_stripped` then operated on the already-stripped schema, so HGI IDs were never in `schema_device_ids`. Fixed by using `_extract_schema_device_ids` (unstripped) for discovery sync at all three call sites.
- **Issue #988 **: Orphaned device notifications re-appeared every checkpoint cycle after dismissal. Added a per-device schema key `_suppress_not_seen` that controls suppression:
  - `True`: suppress forever, INFO log every `threshold_days` as a battery reminder
  - `N` (int): suppress for N days from `last_seen`, then auto-remove key and re-notify
  - Default from "Keep (dismiss flag)" in `review_device_health`: 7 days
- The key is auto-removed when the device is seen again OR when the int suppress period expires.
- Added `last_orphaned_log` to `DeviceMetadata` to throttle INFO logs to once per `threshold_days`.

#### Test plan
- [x] 1264 pytests pass (10 skipped), +8 new suppress tests + 1 HGI extraction test
- [x] ha_sim_test R77 (HGI not re-discovered): 3/3 checks pass
- [x] ha_sim_test R78 (suppress_not_seen persists + no re-notify): 4/4 checks pass
- [x] Live on `hass`: `18:149488` no longer marked REMOVED, `29:176861` still notifies (not yet dismissed)