### PR TITLE
Clean up System schema config translations

### DIFF
--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -9,14 +9,14 @@
             "invalid_regex": "Invalid regular expression: {error_detail}",
             "invalid_schema": "Invalid schema: {error_detail}",
             "invalid_traits": "Invalid device traits: {error_detail}",
-            "discovery_failed": "Failed to auto detect MQTT gateway device (no packets captured during observation window). Please configure manually once address is known. Defaulting to {default_id}."
+            "discovery_failed": "Failed to auto detect MQTT gateway device (no packets captured during observation window). Please configure manually once the address is known. Defaulting to {default_id}."
         },
         "step": {
             "init": {
                 "menu_options": {
                     "choose_serial_port": "Serial port",
                     "config": "Gateway configuration",
-                    "schema": "System schema and known devices",
+                    "schema": "System schema",
                     "advanced_features": "Advanced features",
                     "packet_log": "Packet log",
                     "review_discovered": "Review discovered devices",
@@ -66,18 +66,14 @@
                 }
             },
             "schema": {
-                "title": "System schema and known devices",
+                "title": "System schemas",
                 "description": "Refer to the configuration section in the [wiki]({wiki_url}) for further details and examples of system schema configuration.",
                 "data": {
-                    "schema": "System schema(s)",
-                    "known_list": "Known device IDs",
-                    "enforce_known_list": "Accept packets from known devices IDs only",
+                    "schema": "System schema",
                     "log_all_mqtt": "Log Tx + all MQTT traffic"
                 },
                 "data_description": {
                     "schema": "A mapping of system device IDs to their respective schemas. This should describe your complete system(s), including zones with sensors, as YAML.",
-                    "known_list": "A mapping of known device IDs and optionally their traits.",
-                    "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. HA Restart required.",
                     "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console."
                 }
             },
@@ -143,7 +139,7 @@
                 "menu_options": {
                     "choose_serial_port": "Serial port",
                     "config": "Gateway configuration",
-                    "schema": "System schema and known devices",
+                    "schema": "System schema",
                     "advanced_features": "Advanced features",
                     "packet_log": "Packet log",
                     "review_discovered": "Review discovered devices",
@@ -184,18 +180,14 @@
                 }
             },
             "schema": {
-                "title": "System schema and known devices",
+                "title": "System schema",
                 "description": "Refer to the configuration section in the [wiki]({wiki_url}) for further details and examples of system schema configuration.",
                 "data": {
-                    "schema": "System schema(s)",
-                    "known_list": "Known device IDs",
-                    "enforce_known_list": "Accept packets from known devices IDs only",
+                    "schema": "System schema",
                     "log_all_mqtt": "Log Tx + all MQTT traffic"
                 },
                 "data_description": {
                   "schema": "A mapping of system device IDs to their respective schemas. This should describe your complete system(s), including zones with sensors, as YAML.",
-                  "known_list": "A mapping of known device IDs and optionally their traits.",
-                  "enforce_known_list": "Recommended once you have entered all your device IDs as the RAMSES II protocol does not include error correction and corrupt device IDs are common. After activating, clear the discovered system schemas cache before restarting.",
                   "log_all_mqtt": "Show all subscribed topics from MQTT broker in system console."
                 }
             },
@@ -241,8 +233,7 @@
                 "data": {
                     "clear_schema": "Clear schema (cached + config entry — full fresh start)",
                     "clear_packets": "Clear system state (recent packets)",
-                    "clear_discovery": "Clear discovery state (found devices list)",
-                    "clear_known_list": "Clear known devices list (fresh start)"
+                    "clear_discovery": "Clear discovery state (found devices list)"
                 }
             },
             "review_discovered": {
@@ -261,7 +252,7 @@
 
         "bind_device": {
             "name": "Bind a Device",
-            "description": "Bind a device to a CH/DHW controller or a fan/ventilation unit. The device will be either a sensor (e.g. temperature, humidity, etc.) or a remote (e.g. a 4-way switch). It must be included in the known_list and correctly configured with an appropriate class and faking enabled.",
+            "description": "Bind a device to a CH/DHW controller or a fan/ventilation unit. The device will be either a sensor (e.g. temperature, humidity, etc.) or a remote (e.g. a 4-way switch). It must be 'yours' in the System schema and correctly configured with an appropriate class and _faked: True.",
             "fields": {
                 "device_id": {
                     "name": "Supplicant device_id",
@@ -294,11 +285,11 @@
 
         "discover_known_devices": {
             "name": "Discover Known Devices",
-            "description": "Send RQ discovery messages from the HGI to devices in the known_list that are not yet registered or not yet promoted to their expected class. Useful after cache clear or when setting up a new system.",
+            "description": "Send RQ discovery messages from the HGI to devices in the 'System schema' that are not yet registered or not yet promoted to their expected class. Useful after cache clear or when setting up a new system.",
             "fields": {
                 "device_id": {
                     "name": "Device ID",
-                    "description": "Optional: discover a single device. If omitted, all known_list devices are queried."
+                    "description": "Optional: discover a single device. If omitted, all 'my' devices are queried."
                 }
             }
         },
@@ -401,7 +392,7 @@
         },
         "remove_device": {
             "name": "Remove Device",
-            "description": "Remove a device from the schema, known_list, and HA device registry. Useful when a device has been replaced, is no longer present, or was added by mistake. The HGI gateway cannot be removed.",
+            "description": "Remove a device from the schema and HA device registry. Useful when a device has been replaced, is no longer present, or was added by mistake. The HGI gateway cannot be removed.",
             "fields": {
                 "device_id": {
                     "name": "Device ID",
@@ -740,7 +731,7 @@
 
         "put_room_temp": {
             "name": "Announce a Room temperature",
-            "description": "Announce the measured room temperature of an evohome zone sensor. The device must be faked (in the known_list), and should be bound to a CH/DHW controller as a zone sensor.",
+            "description": "Announce the measured room temperature of an evohome zone sensor. The device must be set as _faked: True in the System schema, and should be bound to a CH/DHW controller as a zone sensor.",
             "fields": {
                 "temperature": {
                     "name": "Temperature",
@@ -751,7 +742,7 @@
 
         "put_dhw_temp": {
             "name": "Announce a DHW temperature",
-            "description": "Announce the measured temperature of an evohome DHW sensor. The device must be faked (in the known_list), and should be bound to a CH/DHW controller as a DHW sensor.",
+            "description": "Announce the measured temperature of an evohome DHW sensor. The device must be set up as _faked: True in the System schema, and should be bound to a CH/DHW controller as a DHW sensor.",
             "fields": {
                 "temperature": {
                     "name": "Temperature",
@@ -762,7 +753,7 @@
 
         "put_co2_level": {
             "name": "Announce an Indoor CO2 level",
-            "description": "Announce the measured CO2 level of a indoor sensor (experimental). The device must faked (in the known_list), and should be bound to a fan/ventilation unit as a CO2 sensor.",
+            "description": "Announce the measured CO2 level of a indoor sensor (experimental). The device must _faked: True in the System schema, and should be bound to a fan/ventilation unit as a CO2 sensor.",
             "fields": {
                 "co2_level": {
                     "name": "CO2 level",
@@ -773,7 +764,7 @@
 
         "put_indoor_humidity": {
             "name": "Announce an Indoor relative humidity",
-            "description": "Announce the measured relative humidity of a indoor sensor (experimental). The device must be faked (in the known_list), and should be bound to a fan/ventilation unit as a humidity sensor.",
+            "description": "Announce the measured relative humidity of a indoor sensor (experimental). The device must be set up as _faked: True in the System schema, and should be bound to a fan/ventilation unit as a humidity sensor.",
             "fields": {
                 "indoor_humidity": {
                     "name": "Indoor humidity",
@@ -825,7 +816,7 @@
 
         "send_command": {
             "name": "Send a Remote command",
-            "description": "Sends a RAMSES command as if from a remote. This is a convenience wrapper for HA's own `send_command` service call. The device must be faked (in the known_list), and should be bound to a fan/ventilation unit as a switch.",
+            "description": "Sends a RAMSES command as if from a remote. This is a convenience wrapper for HA's own `send_command` service call. The device must be set up as _faked: True in the System schema, and should be bound to a fan/ventilation unit as a switch.",
             "fields": {
                 "command": {
                     "name": "Command name",

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -252,7 +252,7 @@
 
         "bind_device": {
             "name": "Bind a Device",
-            "description": "Bind a device to a CH/DHW controller or a fan/ventilation unit. The device will be either a sensor (e.g. temperature, humidity, etc.) or a remote (e.g. a 4-way switch). It must be 'yours' in the System schema and correctly configured with an appropriate class and _faked: True.",
+            "description": "Bind a device to a CH/DHW controller or a fan/ventilation unit. The device will be either a sensor (e.g. temperature, humidity, etc.) or a remote (e.g. a 4-way switch). It must be 'yours' in the System schema and correctly configured with an appropriate class and _faked: true.",
             "fields": {
                 "device_id": {
                     "name": "Supplicant device_id",
@@ -731,7 +731,7 @@
 
         "put_room_temp": {
             "name": "Announce a Room temperature",
-            "description": "Announce the measured room temperature of an evohome zone sensor. The device must be set as _faked: True in the System schema, and should be bound to a CH/DHW controller as a zone sensor.",
+            "description": "Announce the measured room temperature of an evohome zone sensor. The device must be set as _faked: true in the System schema, and should be bound to a CH/DHW controller as a zone sensor.",
             "fields": {
                 "temperature": {
                     "name": "Temperature",
@@ -742,7 +742,7 @@
 
         "put_dhw_temp": {
             "name": "Announce a DHW temperature",
-            "description": "Announce the measured temperature of an evohome DHW sensor. The device must be set up as _faked: True in the System schema, and should be bound to a CH/DHW controller as a DHW sensor.",
+            "description": "Announce the measured temperature of an evohome DHW sensor. The device must be set up as _faked: true in the System schema, and should be bound to a CH/DHW controller as a DHW sensor.",
             "fields": {
                 "temperature": {
                     "name": "Temperature",
@@ -753,7 +753,7 @@
 
         "put_co2_level": {
             "name": "Announce an Indoor CO2 level",
-            "description": "Announce the measured CO2 level of a indoor sensor (experimental). The device must _faked: True in the System schema, and should be bound to a fan/ventilation unit as a CO2 sensor.",
+            "description": "Announce the measured CO2 level of a indoor sensor (experimental). The device must _faked: true in the System schema, and should be bound to a fan/ventilation unit as a CO2 sensor.",
             "fields": {
                 "co2_level": {
                     "name": "CO2 level",
@@ -764,7 +764,7 @@
 
         "put_indoor_humidity": {
             "name": "Announce an Indoor relative humidity",
-            "description": "Announce the measured relative humidity of a indoor sensor (experimental). The device must be set up as _faked: True in the System schema, and should be bound to a fan/ventilation unit as a humidity sensor.",
+            "description": "Announce the measured relative humidity of a indoor sensor (experimental). The device must be set up as _faked: true in the System schema, and should be bound to a fan/ventilation unit as a humidity sensor.",
             "fields": {
                 "indoor_humidity": {
                     "name": "Indoor humidity",
@@ -816,7 +816,7 @@
 
         "send_command": {
             "name": "Send a Remote command",
-            "description": "Sends a RAMSES command as if from a remote. This is a convenience wrapper for HA's own `send_command` service call. The device must be set up as _faked: True in the System schema, and should be bound to a fan/ventilation unit as a switch.",
+            "description": "Sends a RAMSES command as if from a remote. This is a convenience wrapper for HA's own `send_command` service call. The device must be set up as _faked: true in the System schema, and should be bound to a fan/ventilation unit as a switch.",
             "fields": {
                 "command": {
                     "name": "Command name",

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -742,7 +742,7 @@
 
         "put_dhw_temp": {
             "name": "Pas Warmtapwatertemperatuur aan",
-            "description": "Stel een nieuwe temperatuur in voor een evohome warmwater-sensor. De sensor moet als `_faked: True` in het `Systeemschema` staan, en als warmwater-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
+            "description": "Stel een nieuwe temperatuur in voor een evohome warmwater-sensor. De sensor moet als `_faked: true` in het `Systeemschema` staan, en als warmwater-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
             "fields": {
                 "temperature": {
                     "name": "Temperatuur",
@@ -753,7 +753,7 @@
 
         "put_co2_level": {
             "name": "Pas CO2-waarde aan",
-            "description": "Stel een nieuwe CO2-waarde in voor een ruimtesensor (experimenteel). De sensor moet als `_faked: True` in het `Systeemschema` staan, en als CO2-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
+            "description": "Stel een nieuwe CO2-waarde in voor een ruimtesensor (experimenteel). De sensor moet als `_faked: true` in het `Systeemschema` staan, en als CO2-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
             "fields": {
                 "co2_level": {
                     "name": "CO2-niveau",
@@ -764,7 +764,7 @@
 
         "put_indoor_humidity": {
             "name": "Pas Relatieve vochtigheid aan",
-            "description": "Stel een nieuwe waarde in voor de relatieve vochtigheid in een ruimte (experimenteel). De sensor moet als `_faked: True` in het `Systeemschema` staan, en als RV-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
+            "description": "Stel een nieuwe waarde in voor de relatieve vochtigheid in een ruimte (experimenteel). De sensor moet als `_faked: true` in het `Systeemschema` staan, en als RV-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
             "fields": {
                 "indoor_humidity": {
                     "name": "Relatieve vochtigheid",
@@ -816,7 +816,7 @@
 
         "send_command": {
             "name": "Verstuur Afstandsbediening-commando",
-            "description": "Verstuurt een RAMSES commando alsof afkomstig van een afstandsbediening. Dit is een makkelijke actie voor HA's eigen `send_command` actie. Het apparaat moet in het 'Systeemschema' als _faked: True staan en als schakelaar zijn gekoppeld aan een fan/ventilatie-unit.",
+            "description": "Verstuurt een RAMSES commando alsof afkomstig van een afstandsbediening. Dit is een makkelijke actie voor HA's eigen `send_command` actie. Het apparaat moet in het 'Systeemschema' staan als _faked: true en als schakelaar zijn gekoppeld aan een fan/ventilatie-unit.",
             "fields": {
                 "command": {
                     "name": "Commando",

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -16,7 +16,7 @@
                 "menu_options": {
                     "choose_serial_port": "Seriële poort",
                     "config": "Gateway-configuratie",
-                    "schema": "Systeemschema en erkende apparaten",
+                    "schema": "Systeemschema",
                     "advanced_features": "Geavanceerde instellingen",
                     "packet_log": "Packet-log",
                     "review_discovered": "Bekijk ontdekte apparaten",
@@ -66,18 +66,14 @@
                 }
             },
             "schema": {
-                "title": "Systeemschema en erkende devices",
+                "title": "Systeemschema",
                 "description": "Zie voor meer info en voorbeelden de [wiki]({wiki_url}) onder het kopje Configuration.",
                 "data": {
-                    "schema": "Systeemschema(s)",
-                    "known_list": "Erkende device_id's",
-                    "enforce_known_list": "Accepteer alleen berichten van erkende device ID's",
+                    "schema": "Systeemschema",
                     "log_all_mqtt": "Log Tx + alle MQTT-topics"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's inclusief Zones met Sensors, als YAML.",
-                    "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
-                    "enforce_known_list": "Aanbevolen om in te schakelen zodra alle device_id's zijn ingevuld. Het RAMSES II-protocol biedt namelijk geen foutcorrectie en corrupte device_id's komen vaak voor. Wis wel 1x de systeem-cache nadat je deze optie activeert.",
                     "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole."
                 }
             },
@@ -143,7 +139,7 @@
                 "menu_options": {
                     "choose_serial_port": "Seriële poort",
                     "config": "Gateway-configuratie",
-                    "schema": "Systeemschema en erkende devices",
+                    "schema": "Systeemschema",
                     "advanced_features": "Geavanceerde opties",
                     "packet_log": "Packet-log",
                     "review_discovered": "Bekijk ontdekte apparaten",
@@ -184,18 +180,14 @@
                 }
             },
             "schema": {
-                "title": "Systeemschema en erkende apparaten",
+                "title": "Systeemschema",
                 "description": "Zie voor meer info en voorbeelden de [wiki]({wiki_url}) onder het kopje Configuration.",
                 "data": {
-                    "schema": "Systeemschema('s)",
-                    "known_list": "Erkende device_id's",
-                    "enforce_known_list": "Accepteer alleen berichten van erkende device ID's",
+                    "schema": "Systeemschema",
                     "log_all_mqtt": "Log Tx + alle MQTT-topics"
                 },
                 "data_description": {
                     "schema": "Een mapping van systeem device-ID's naar hun schema's inclusief Zones met hun Sensors, als YAML.",
-                    "known_list": "Een mapping van erkende device-ID's en (optioneel) hun kenmerken.",
-                    "enforce_known_list": "Aanbevolen zodra alle device-ID's zijn ingevuld, omdat het RAMSES II-protocol geen foutcorrectie biedt en corrupte device-ID's vaak voorkomen. Vereist HA herstart!",
                     "log_all_mqtt": "Toon alle topics van de MQTT broker in de systeemconsole."
                 }
             },
@@ -239,10 +231,9 @@
                 "title": "Cache beheren",
                 "description": "De geselecteerde caches worden direct gewist als je op [Verzenden] klikt. Herlaad daarna de integratie na grote aanpassingen in het systeemschema of de configuratie. Beide schuifjes naar links = niets wissen",
                 "data": {
-                    "clear_schema": "Wis ontdekte systeemschema('s)",
+                    "clear_schema": "Wis ontdekte systeemschema",
                     "clear_packets": "Wis systeemtoestand (recente berichten)",
-                    "clear_discovery": "Wis discovery-state (gevonden apparaten)",
-                    "clear_known_list": "Wis bekende apparaten lijst (nieuwe start)"
+                    "clear_discovery": "Wis discovery-state (gevonden apparaten)"
                 }
             },
             "review_discovered": {
@@ -261,7 +252,7 @@
 
         "bind_device": {
             "name": "Koppel een apparaat",
-            "description": "Koppel een apparaat aan een CH/DHW controller of aan een fan/WTW-eenheid. Het te koppelen apparaat is een sensor (bijv. temperatuur, relatieve vochtigheid, etc.) of een afstandsbediening (bijv. een 4-knops RF-schakelaar). En het moet vermeld staan in de `known_list`, correct geconfigureerd met de juiste apparaat-klasse en met `faking` ingeschakeld.",
+            "description": "Koppel een apparaat aan een CH/DHW controller of aan een fan/WTW-eenheid. Het te koppelen apparaat is een sensor (bijv. temperatuur, relatieve vochtigheid, etc.) of een afstandsbediening (bijv. een 4-knops RF-schakelaar). En het moet vermeld staan in het `Systeemschema`, correct geconfigureerd met de juiste apparaat-klasse en met `faking` ingeschakeld.",
             "fields": {
                 "device_id": {
                     "name": "Device_id van het apparaat",
@@ -294,17 +285,17 @@
 
         "discover_known_devices": {
             "name": "Ontdek bekende apparaten",
-            "description": "Stuur RQ discovery berichten vanuit de HGI naar apparaten in de known_list die nog niet geregistreerd of nog niet gepromoveerd zijn naar hun verwachte klasse. Handig na cache wis of bij nieuwe installatie.",
+            "description": "Stuur RQ discovery berichten vanuit de HGI naar apparaten in het Systeemschema die nog niet geregistreerd of nog niet gepromoveerd zijn naar hun verwachte klasse. Handig na cache wis of bij nieuwe installatie.",
             "fields": {
                 "device_id": {
                     "name": "Apparaat-ID",
-                    "description": "Optioneel: ontdek een enkel apparaat. Indien weggelaten worden alle known_list apparaten bevraagd."
+                    "description": "Optioneel: ontdek een enkel apparaat. Indien weggelaten worden alle 'eigen' apparaten bevraagd."
                 }
             }
         },
         "remove_device": {
             "name": "Apparaat verwijderen",
-            "description": "Verwijder een apparaat uit de schema, known_list en HA apparaat-register. Handig wanneer een apparaat vervangen is, niet meer aanwezig is, of per ongeluk is toegevoegd. De HGI gateway kan niet verwijderd worden.",
+            "description": "Verwijder een apparaat uit de Systeemschema en HA apparaat-register. Handig wanneer een apparaat vervangen is, niet meer aanwezig is, of per ongeluk is toegevoegd. De HGI gateway kan niet verwijderd worden.",
             "fields": {
                 "device_id": {
                     "name": "Apparaat-ID",
@@ -740,7 +731,7 @@
 
         "put_room_temp": {
             "name": "Pas Ruimtetemperatuur aan",
-            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone-thermostaat. De thermostaat moet als `faked` in de `known_list` staan, en als zone-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
+            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone-thermostaat. De thermostaat moet als `_faked-True` in het `Systeemschema` staan, en als zone-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
             "fields": {
                 "temperature": {
                     "name": "Temperatuur",
@@ -751,7 +742,7 @@
 
         "put_dhw_temp": {
             "name": "Pas Warmtapwatertemperatuur aan",
-            "description": "Stel een nieuwe temperatuur in voor een evohome warmwater-sensor. De sensor moet als `faked` in de `known_list` staan, en als warmwater-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
+            "description": "Stel een nieuwe temperatuur in voor een evohome warmwater-sensor. De sensor moet als `_faked: True` in het `Systeemschema` staan, en als warmwater-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
             "fields": {
                 "temperature": {
                     "name": "Temperatuur",
@@ -762,7 +753,7 @@
 
         "put_co2_level": {
             "name": "Pas CO2-waarde aan",
-            "description": "Stel een nieuwe CO2-waarde in voor een ruimtesensor (experimenteel). De sensor moet als `faked` in de `known_list` staan, en als CO2-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
+            "description": "Stel een nieuwe CO2-waarde in voor een ruimtesensor (experimenteel). De sensor moet als `_faked: True` in het `Systeemschema` staan, en als CO2-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
             "fields": {
                 "co2_level": {
                     "name": "CO2-niveau",
@@ -773,7 +764,7 @@
 
         "put_indoor_humidity": {
             "name": "Pas Relatieve vochtigheid aan",
-            "description": "Stel een nieuwe waarde in voor de relatieve vochtigheid in een ruimte (experimenteel). De sensor moet als `faked` in de `known_list` staan, en als RV-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
+            "description": "Stel een nieuwe waarde in voor de relatieve vochtigheid in een ruimte (experimenteel). De sensor moet als `_faked: True` in het `Systeemschema` staan, en als RV-sensor zijn gekoppeld aan een fan/ventilatie-eenheid.",
             "fields": {
                 "indoor_humidity": {
                     "name": "Relatieve vochtigheid",
@@ -825,7 +816,7 @@
 
         "send_command": {
             "name": "Verstuur Afstandsbediening-commando",
-            "description": "Verstuurt een RAMSES commando alsof afkomstig van een afstandsbediening. Dit is een makkelijke actie voor HA's eigen `send_command` actie. Het apparaat moet in de `known_list` als `faked` staan en als schakelaar zijn gekoppeld aan een fan/ventilatie-unit.",
+            "description": "Verstuurt een RAMSES commando alsof afkomstig van een afstandsbediening. Dit is een makkelijke actie voor HA's eigen `send_command` actie. Het apparaat moet in het 'Systeemschema' als _faked: True staan en als schakelaar zijn gekoppeld aan een fan/ventilatie-unit.",
             "fields": {
                 "command": {
                     "name": "Commando",


### PR DESCRIPTION
To match 0.59.7 config flow:
- singular "System schema"
- remove " and known_list" from config pane title
- remove unused known_list box title strings
- replace "configured as faked" by "as _faked: true"