### PR TITLE
Fix issue 88: EventEntity fires for all messages when no regex configured

### DIFF
--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -252,7 +252,10 @@ class RamsesRegexEvent(RamsesEvent):
             #     )
 
             # filter msg by advanced_config regex, fire an event if a match
-            if regex and regex.search(f"{msg!r}"):
+            # If no regex is configured, fire for all messages (so that
+            # downstream listeners like ramses_extras hvac_fan_card can
+            # receive 31DA/10D0 data without explicit regex configuration).
+            if regex is None or regex.search(f"{msg!r}"):
                 event_data = {
                     "type": RamsesEventType.REGEX,
                     "device_id": msg.src.id,


### PR DESCRIPTION
## Summary
- The `RamsesRegexEvent` entity only fired events when a regex was configured via `CONF_MESSAGE_EVENTS` in advanced features
- If no regex was set, `message_events_regex` was `None`, and the check `if regex and regex.search()` was always `False` — the EventEntity never fired any events
- This meant downstream listeners (like ramses_extras `hvac_fan_card`, which relies on `event.ramses_cc_regex_event` to receive 31DA/10D0 fan data) never received any data, and the card showed no values

## Fix
If no regex is configured (`regex is None`), fire for **all** messages. When a regex IS configured, only fire for matching messages (unchanged).

This is the ramses_cc side of the fix for ramses_extras issue 88 (hvac fan card doesn't show values).

#### Test plan
- [ ] All existing event tests pass (`pytest tests/ -x -q -k event`)
- [ ] Manual: verify `event.ramses_cc_regex_event` fires when no regex configured
- [ ] Manual: verify ramses_extras hvac_fan_card shows values after this fix
- [ ] Manual: verify regex filtering still works when a regex IS configured

Related: https://github.com/wimpie70/ramses_extras/issues/88