### PR TITLE
fix: update REM _commands comment after Phase 3b migration

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1459,7 +1459,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
                         and "_comment" not in rem_cmds
                     ):
                         rem_cmds["_comment"] = (
-                            "Commands on REM (Phase 3a) — deprecated, use FAN"
+                            "Commands were moved to FAN — consider removing "
+                            "from REM, or keep as downgrade backup"
                         )
                         rem_entry[SZ_TR_COMMANDS] = rem_cmds
                         changed = True


### PR DESCRIPTION
## Summary

- The old REM `_comment` ("Commands on REM (Phase 3a) — deprecated, use FAN") was misleading — the Phase 3b migration already copies commands to the FAN as dict templates
- Updated to: "Commands were moved to FAN — consider removing from REM, or keep as downgrade backup"
- This also explains why users (e.g. silverailscolo in issue 995) tried to manually move commands to the FAN — the old wording suggested they hadn't been moved yet

#### Test plan

- [x] `pytest tests/tests_new/test_coordinator.py -k 'migrate or rem_commands or phase3b'` — 12 passed
- [x] No tests assert the exact comment text