### PR TITLE
fix: restore contradiction detection + skip low-confidence HVAC mismatches

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -767,6 +767,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         schema = self.options.get(CONF_SCHEMA, {})
         schema_device_ids = self._extract_schema_device_ids(schema)
         self.discovery_manager.sync_with_schema(schema_device_ids)
+        # Check ramses_rf known_list for contradiction-based class changes
+        # (e.g. FAN→DIS) before running mismatch checks, so rf-flagged
+        # mismatches are included in the notification.
+        self._check_rf_contradictions()
         # Check for mismatches between discovery and schema
         # (schema is authoritative — this only logs warnings + notification)
         if isinstance(schema, dict):
@@ -1900,7 +1904,65 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self._schema_updated_debounce_task = None
         if self._skip_topology_sync:
             return
+        # Check for contradiction-based reclassifications in ramses_rf's
+        # known_list (e.g. a FAN that is actually a DIS).  ramses_rf
+        # updates the known_list class in-memory; we surface it to the
+        # discovery manager so the user gets a persistent notification.
+        self._check_rf_contradictions()
         await self.async_save_client_state()
+
+    def _check_rf_contradictions(self) -> None:
+        """Check ramses_rf known_list for contradiction-based class changes.
+
+        ramses_rf's HvacTopologyHandler detects when a device's message
+        patterns contradict its known_list class (e.g. a FAN that only
+        sends RQ 31DA / I 22F1 is actually a DIS).  It updates the
+        known_list class in-memory and emits a topology event.
+
+        This method compares the ramses_rf known_list classes with the
+        config entry schema's _class values.  When a mismatch is found,
+        it flags ``class_mismatch`` on the discovery manager's device
+        metadata so the existing persistent notification system fires.
+
+        This is needed because:
+        1. The scan engine does not re-classify known devices
+           (``_is_known`` short-circuits re-classification), so the
+           scan engine's ``likely_type`` stays frozen at the initial
+           (possibly wrong) value.
+        2. ramses_rf's HvacTopologyHandler has proper contradiction
+           detection with thresholds (3+ non-FAN packets) and _locked
+           trait support — much more reliable than the scan engine's
+           per-packet _classify.
+        """
+        if not self.client or not self.discovery_manager:
+            return
+
+        rf_known = self.client.config.known_list
+        if not isinstance(rf_known, dict):
+            return
+        config_schema = self.options.get(CONF_SCHEMA, {})
+        if not isinstance(config_schema, dict):
+            return
+        for dev_id, traits in rf_known.items():
+            if not isinstance(traits, dict):
+                continue
+            rf_class = traits.get("class")
+            if not isinstance(rf_class, str) or not rf_class:
+                continue
+            schema_entry = config_schema.get(dev_id)
+            if not isinstance(schema_entry, dict):
+                continue
+            schema_class = schema_entry.get(SZ_TR_CLASS)
+            if not isinstance(schema_class, str) or not schema_class:
+                continue
+            rf_class_norm = _normalize_class_slug(rf_class)
+            schema_class_norm = _normalize_class_slug(schema_class)
+            if rf_class_norm.upper() != schema_class_norm.upper():
+                # ramses_rf suggests a different class than the schema
+                self.discovery_manager.flag_class_mismatch(
+                    dev_id,
+                    f"schema={schema_class_norm}, rf_suggests={rf_class_norm}",
+                )
 
     async def _async_save_on_unload(self) -> None:
         """Save client state during unload, skipping topology sync.
@@ -2641,6 +2703,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
             await self._async_update_device(zone)
         # Run mismatch checks immediately (Phase 3c)
         if self.discovery_manager:
+            # Check ramses_rf known_list for contradiction-based class
+            # changes before running mismatch checks, so rf-flagged
+            # mismatches are included in the notification.
+            self._check_rf_contradictions()
             schema = self.options.get(CONF_SCHEMA, {})
             if isinstance(schema, dict):
                 self.discovery_manager.check_all_mismatches(

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -580,6 +580,15 @@ class DiscoveryManager:
         If they differ, logs a WARNING and sets ``class_mismatch`` on the
         device's metadata so the discovery UI can flag it.
 
+        **HVAC devices are skipped** — the scan engine's ``likely_type``
+        for HVAC prefixes (29:, 32:, 37:, 63:) is unreliable because
+        these prefixes are ambiguous (REM, CO2, HUM, DIS, FAN all share
+        them) and classification depends on which packet was seen first.
+        HVAC class mismatches are detected by ``_check_rf_contradictions``
+        instead, which reads from ramses_rf's known_list (updated by the
+        HvacTopologyHandler with proper threshold-based contradiction
+        detection).
+
         The schema is authoritative — this method does NOT modify the
         schema.  It only warns the user that discovery suggests a
         different class.
@@ -591,6 +600,14 @@ class DiscoveryManager:
 
         scan_devices = {d.device_id: d for d in self._scan.get_devices()}
         mismatches: list[tuple[str, str, str]] = []
+
+        # HVAC device prefixes — likely_type is unreliable for these
+        # because 37:/29: are ambiguous (REM, CO2, HUM, DIS, FAN all
+        # share these prefixes) and the scan engine's classification
+        # depends on which packet was seen first.  HVAC class mismatches
+        # are detected by _check_rf_contradictions instead.
+        _hvac_prefixes = ("29:", "32:", "37:", "63:")
+        _hvac_class_slugs = {"FAN", "REM", "CO2", "HUM", "DIS", "VCS"}
 
         for device_id, dev in scan_devices.items():
             # Skip HGI gateways — they're not classified by the scan engine
@@ -609,15 +626,35 @@ class DiscoveryManager:
             # (e.g. 'ventilator' -> 'FAN')
             schema_class_norm = _normalize_class_slug(schema_class)
 
-            # Get the scan engine's likely_type
-            scan_type = str(dev.likely_type) if dev.likely_type else ""
-            if not scan_type or scan_type == "DEV":
-                continue  # unknown/generic — not a meaningful mismatch
-
             # Skip if the user already dismissed this mismatch ("Keep")
             existing_meta = self._metadata.get(device_id)
             if existing_meta and existing_meta.class_mismatch_dismissed:
                 continue  # user decided — don't re-flag
+
+            # Skip _locked devices — user has pinned the class
+            if schema_entry.get("_locked") is True:
+                continue
+
+            # Skip HVAC devices with low/medium confidence — the scan
+            # engine's likely_type for HVAC prefixes (29:, 32:, 37:, 63:)
+            # is unreliable when based on a prefix fallback (e.g. 37: →
+            # REM is a guess, not evidence).  HVAC devices with "high"
+            # confidence are NOT skipped — either a VC pair matched
+            # (specific evidence) or the scan engine re-classified after
+            # 3+ contradictions (threshold-based, reliable).
+            # HVAC class mismatches are also detected by
+            # _check_rf_contradictions (reads from ramses_rf's known_list).
+            is_hvac = (
+                device_id[:3] in _hvac_prefixes
+                or schema_class_norm.upper() in _hvac_class_slugs
+            )
+            if is_hvac and dev.confidence != "high":
+                continue
+
+            # Get the scan engine's likely_type
+            scan_type = str(dev.likely_type) if dev.likely_type else ""
+            if not scan_type or scan_type == "DEV":
+                continue  # unknown/generic — not a meaningful mismatch
 
             # Compare (both should be DevType slugs like 'FAN', 'REM', etc.)
             if scan_type.upper() != schema_class_norm.upper():
@@ -674,6 +711,34 @@ class DiscoveryManager:
                 self._warned_mismatches.clear()
 
         return len(mismatches)
+
+    def flag_class_mismatch(self, device_id: str, description: str) -> None:
+        """Flag a device as having a class mismatch (external source).
+
+        Used by the coordinator when ramses_rf's contradiction detection
+        suggests a different class than the schema's _class.  This sets
+        the ``class_mismatch`` metadata so the existing persistent
+        notification and review_discovered flow can surface it to the
+        user.
+
+        :param device_id: The device ID with the mismatch.
+        :param description: Human-readable description of the mismatch.
+        """
+        meta = self._metadata.get(device_id, DeviceMetadata())
+        if meta.class_mismatch_dismissed:
+            return  # user already dismissed this
+        if meta.class_mismatch != description:
+            meta.class_mismatch = description
+            self._metadata[device_id] = meta
+            if device_id not in self._warned_mismatches:
+                _LOGGER.warning(
+                    "DiscoveryManager: class mismatch for %s — %s. "
+                    "Schema is authoritative; update _class in the "
+                    "schema if the suggested classification is correct.",
+                    device_id,
+                    description,
+                )
+                self._warned_mismatches.add(device_id)
 
     def get_mismatched_devices(self) -> list[DiscoveredDeviceEntry]:
         """Get devices that have a class mismatch flag set.
@@ -1215,6 +1280,17 @@ class DiscoveryManager:
             "orphaned": self.check_orphaned_devices(schema),
             "name_mismatch": self.check_name_mismatches(schema, zones),
         }
+        # Also count rf-flagged mismatches (from _check_rf_contradictions)
+        # that check_class_mismatches may have missed (scan engine doesn't
+        # re-classify known devices, so likely_type may agree with schema
+        # even when ramses_rf's known_list suggests a different class).
+        rf_flagged = [
+            d_id
+            for d_id, meta in self._metadata.items()
+            if meta.class_mismatch and d_id not in self._warned_mismatches
+        ]
+        if rf_flagged:
+            counts["class_mismatch"] += len(rf_flagged)
         total = sum(counts.values())
         if total > 0:
             self._send_mismatch_notification(counts)

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -5708,3 +5708,131 @@ class TestMigrateRemCommandsToFan:
         # Bad command not copied to FAN
         fan_cmds = result["30:160000"].get(SZ_TR_COMMANDS, {})
         assert "bad" not in fan_cmds
+
+
+class TestCheckRfContradictions:
+    """Tests for _check_rf_contradictions (issue 1000).
+
+    Verifies that the coordinator detects when ramses_rf's known_list
+    suggests a different class than the config entry schema's _class
+    (e.g. FAN→DIS reclassification) and flags it on the discovery
+    manager so a persistent notification fires.
+    """
+
+    def test_mismatch_flagged_when_rf_suggests_dis(
+        self, mock_coordinator: RamsesCoordinator
+    ) -> None:
+        """When ramses_rf known_list has class=DIS but schema has _class=FAN,
+        flag_class_mismatch should be called."""
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        # Set up: ramses_rf known_list says DIS, schema says FAN
+        mock_coordinator.client.config.known_list = {
+            "37:169161": {"class": "DIS"},
+        }
+        mock_coordinator.options = {
+            CONF_SCHEMA: {
+                "37:169161": {SZ_TR_CLASS: "FAN"},
+            },
+        }
+        mock_coordinator.discovery_manager = MagicMock()
+        mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
+
+        mock_coordinator._check_rf_contradictions()
+
+        mock_coordinator.discovery_manager.flag_class_mismatch.assert_called_once_with(
+            "37:169161",
+            "schema=FAN, rf_suggests=DIS",
+        )
+
+    def test_no_mismatch_when_classes_agree(
+        self, mock_coordinator: RamsesCoordinator
+    ) -> None:
+        """When ramses_rf known_list and schema agree, no mismatch is flagged."""
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        mock_coordinator.client.config.known_list = {
+            "37:169161": {"class": "FAN"},
+        }
+        mock_coordinator.options = {
+            CONF_SCHEMA: {
+                "37:169161": {SZ_TR_CLASS: "FAN"},
+            },
+        }
+        mock_coordinator.discovery_manager = MagicMock()
+        mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
+
+        mock_coordinator._check_rf_contradictions()
+
+        mock_coordinator.discovery_manager.flag_class_mismatch.assert_not_called()
+
+    def test_no_mismatch_when_device_not_in_schema(
+        self, mock_coordinator: RamsesCoordinator
+    ) -> None:
+        """Device in ramses_rf known_list but not in schema is skipped."""
+        mock_coordinator.client.config.known_list = {
+            "37:999999": {"class": "DIS"},
+        }
+        mock_coordinator.options = {CONF_SCHEMA: {}}
+        mock_coordinator.discovery_manager = MagicMock()
+        mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
+
+        mock_coordinator._check_rf_contradictions()
+
+        mock_coordinator.discovery_manager.flag_class_mismatch.assert_not_called()
+
+    def test_no_op_when_no_client(
+        self, mock_coordinator: RamsesCoordinator
+    ) -> None:
+        """No client → no crash, no flag."""
+        mock_coordinator.client = None
+        mock_coordinator.discovery_manager = MagicMock()
+        # Should not raise
+        mock_coordinator._check_rf_contradictions()
+
+    def test_no_op_when_no_discovery_manager(
+        self, mock_coordinator: RamsesCoordinator
+    ) -> None:
+        """No discovery_manager → no crash, no flag."""
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        mock_coordinator.client.config.known_list = {
+            "37:169161": {"class": "DIS"},
+        }
+        mock_coordinator.options = {
+            CONF_SCHEMA: {"37:169161": {SZ_TR_CLASS: "FAN"}},
+        }
+        mock_coordinator.discovery_manager = None
+        # Should not raise
+        mock_coordinator._check_rf_contradictions()
+
+    def test_locked_device_still_flagged(
+        self, mock_coordinator: RamsesCoordinator
+    ) -> None:
+        """A _locked device whose class still changed in ramses_rf is flagged.
+
+        The _locked trait suppresses the reclassification EVENT in
+        ramses_rf (no SSOT update), so the known_list class should stay
+        as FAN.  But if somehow the known_list class IS different (e.g.
+        user manually changed it), the mismatch is still flagged —
+        _locked only suppresses the automatic reclassification, not the
+        mismatch check.
+        """
+        from custom_components.ramses_cc.const import SZ_TR_CLASS
+
+        mock_coordinator.client.config.known_list = {
+            "37:169161": {"class": "DIS"},
+        }
+        mock_coordinator.options = {
+            CONF_SCHEMA: {
+                "37:169161": {SZ_TR_CLASS: "FAN", "_locked": True},
+            },
+        }
+        mock_coordinator.discovery_manager = MagicMock()
+        mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
+
+        mock_coordinator._check_rf_contradictions()
+
+        # Mismatch is still flagged — _locked only prevents the SSOT
+        # update in ramses_rf, not the coordinator's mismatch check
+        mock_coordinator.discovery_manager.flag_class_mismatch.assert_called_once()

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1462,54 +1462,85 @@ class TestCheckForNewDevicesReReport:
 
 
 class TestCheckClassMismatches:
-    """Tests for DiscoveryManager.check_class_mismatches."""
+    """Tests for DiscoveryManager.check_class_mismatches.
+
+    Note: HVAC devices (29:, 32:, 37:, 63:) are skipped by
+    check_class_mismatches because the scan engine's likely_type is
+    unreliable for ambiguous HVAC prefixes.  HVAC class mismatches are
+    detected by _check_rf_contradictions instead.  These tests use
+    non-HVAC devices (04: TRV, 01: CTL) where likely_type is reliable.
+    """
 
     def test_no_mismatch_when_classes_match(self) -> None:
         """No mismatch when schema _class matches scan likely_type."""
-        dev = make_discovered_device("32:153289", "FAN")
+        dev = make_discovered_device("04:056053", "TRV")
         scan = make_mock_scan([dev])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
-        schema = {"32:153289": {"_class": "FAN", "remotes": []}}
+        schema = {"04:056053": {"_class": "TRV"}}
         count = manager.check_class_mismatches(schema)
         assert count == 0
         # No class_mismatch set on metadata
-        meta = manager._metadata.get("32:153289")
+        meta = manager._metadata.get("04:056053")
         assert meta is None or meta.class_mismatch is None
 
     def test_mismatch_detected(self) -> None:
         """Mismatch detected when schema _class differs from scan likely_type."""
-        dev = make_discovered_device("32:153289", "DIS")
+        dev = make_discovered_device("04:056053", "TRV")
         scan = make_mock_scan([dev])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
-        schema = {"32:153289": {"_class": "FAN", "remotes": []}}
+        schema = {"04:056053": {"_class": "CTL"}}
         count = manager.check_class_mismatches(schema)
         assert count == 1
-        meta = manager._metadata.get("32:153289")
+        meta = manager._metadata.get("04:056053")
         assert meta is not None
         assert meta.class_mismatch is not None
-        assert "FAN" in meta.class_mismatch
-        assert "DIS" in meta.class_mismatch
+        assert "CTL" in meta.class_mismatch
+        assert "TRV" in meta.class_mismatch
 
     def test_mismatch_cleared_when_resolved(self) -> None:
         """Mismatch flag cleared when classes match again."""
-        dev = make_discovered_device("32:153289", "FAN")
+        dev = make_discovered_device("04:056053", "TRV")
         scan = make_mock_scan([dev])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
         # First: create a mismatch
-        manager._metadata["32:153289"] = DeviceMetadata(
-            class_mismatch="schema=FAN, discovery=DIS"
+        manager._metadata["04:056053"] = DeviceMetadata(
+            class_mismatch="schema=CTL, discovery=TRV"
         )
 
-        # Now the scan says FAN and schema says FAN — mismatch resolved
-        schema = {"32:153289": {"_class": "FAN", "remotes": []}}
+        # Now the scan says TRV and schema says TRV — mismatch resolved
+        schema = {"04:056053": {"_class": "TRV"}}
         count = manager.check_class_mismatches(schema)
         assert count == 0
-        meta = manager._metadata.get("32:153289")
+        meta = manager._metadata.get("04:056053")
         assert meta is not None
         assert meta.class_mismatch is None
+
+    def test_hvac_devices_skipped_when_low_confidence(self) -> None:
+        """HVAC devices with low/medium confidence are skipped — likely_type
+        is unreliable when based on prefix fallback."""
+        dev = make_discovered_device("32:153289", "DIS")
+        dev.confidence = "medium"  # prefix fallback, not evidence-based
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN", "remotes": []}}
+        count = manager.check_class_mismatches(schema)
+        assert count == 0  # skipped — low confidence
+
+    def test_hvac_devices_checked_when_high_confidence(self) -> None:
+        """HVAC devices with high confidence are NOT skipped — either a VC
+        pair matched or the scan engine re-classified after 3+ contradictions."""
+        dev = make_discovered_device("32:153289", "DIS")
+        dev.confidence = "high"  # re-classified after threshold
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        schema = {"32:153289": {"_class": "FAN", "remotes": []}}
+        count = manager.check_class_mismatches(schema)
+        assert count == 1  # not skipped — high confidence
 
     def test_no_mismatch_for_device_not_in_schema(self) -> None:
         """No mismatch check for devices not in the schema."""
@@ -1523,11 +1554,11 @@ class TestCheckClassMismatches:
 
     def test_no_mismatch_for_device_without_class(self) -> None:
         """No mismatch check for schema entries without _class."""
-        dev = make_discovered_device("32:153289", "FAN")
+        dev = make_discovered_device("04:056053", "TRV")
         scan = make_mock_scan([dev])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
-        schema = {"32:153289": {"remotes": []}}  # no _class
+        schema = {"04:056053": {}}  # no _class
         count = manager.check_class_mismatches(schema)
         assert count == 0
 
@@ -1543,36 +1574,36 @@ class TestCheckClassMismatches:
 
     def test_no_mismatch_for_unknown_scan_type(self) -> None:
         """No mismatch when scan type is DEV (generic/unknown)."""
-        dev = make_discovered_device("32:153289", "DEV")
+        dev = make_discovered_device("04:056053", "DEV")
         scan = make_mock_scan([dev])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
-        schema = {"32:153289": {"_class": "FAN", "remotes": []}}
+        schema = {"04:056053": {"_class": "TRV"}}
         count = manager.check_class_mismatches(schema)
         assert count == 0
 
     def test_mismatch_with_entity_slug_normalized(self) -> None:
-        """Schema _class='ventilator' is normalized to 'FAN' before comparison."""
-        dev = make_discovered_device("32:153289", "FAN")
+        """Schema _class='radiator_valve' is normalized to 'TRV' before comparison."""
+        dev = make_discovered_device("04:056053", "TRV")
         scan = make_mock_scan([dev])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
-        # Schema has entity slug 'ventilator', scan says 'FAN'
-        # After normalization, both are 'FAN' — no mismatch
-        schema = {"32:153289": {"_class": "ventilator", "remotes": []}}
+        # Schema has entity slug 'radiator_valve', scan says 'TRV'
+        # After normalization, both are 'TRV' — no mismatch
+        schema = {"04:056053": {"_class": "radiator_valve"}}
         count = manager.check_class_mismatches(schema)
         assert count == 0
 
     def test_multiple_mismatches(self) -> None:
         """Multiple devices with mismatches are all detected."""
-        dev1 = make_discovered_device("32:153289", "DIS")
-        dev2 = make_discovered_device("37:168270", "CO2")
+        dev1 = make_discovered_device("04:056053", "TRV")
+        dev2 = make_discovered_device("01:216136", "CTL")
         scan = make_mock_scan([dev1, dev2])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
 
         schema = {
-            "32:153289": {"_class": "FAN", "remotes": []},
-            "37:168270": {"_class": "REM"},
+            "04:056053": {"_class": "CTL"},  # schema says CTL, scan says TRV
+            "01:216136": {"_class": "TRV"},  # schema says TRV, scan says CTL
         }
         count = manager.check_class_mismatches(schema)
         assert count == 2
@@ -2162,12 +2193,12 @@ class TestCheckAllMismatches:
 
     def test_notification_sent_when_mismatches_found(self) -> None:
         recent = (dt.now() - td(days=1)).isoformat()
-        dev = make_discovered_device("32:153289", "DIS", last_seen=recent)
+        dev = make_discovered_device("04:056053", "TRV", last_seen=recent)
         scan = make_mock_scan([dev])
         hass = make_mock_hass()
         manager = DiscoveryManager(hass, scan, auto_notify=False)
 
-        schema = {"32:153289": {"_class": "FAN"}}
+        schema = {"04:056053": {"_class": "CTL"}}
         with patch(
             "custom_components.ramses_cc.discovery.async_create_notification"
         ) as mock_create:


### PR DESCRIPTION
## Summary

- Restores `_check_rf_contradictions` in `coordinator.py` and `flag_class_mismatch` in `discovery.py`, which compare ramses_rf's `known_list` with the schema to detect HVAC class mismatches (e.g. FAN→DIS)
- `check_class_mismatches` skips HVAC devices with `confidence != "high"` — eliminates false positives from prefix fallback classifications (e.g. 37: → REM is a guess, not evidence)
- High-confidence HVAC devices (VC pair match or re-classified after contradiction threshold) are still checked
- `check_all_mismatches` counts rf-flagged mismatches alongside scan-engine mismatches for the notification
- Tests updated: HVAC device tests use non-HVAC devices (04:, 01:) for `likely_type` comparison; new tests for low/high confidence HVAC skip logic; `TestCheckRfContradictions` restored

Depends on: https://github.com/ramses-rf/ramses_rf/pull/1089 (ramses_rf scan engine re-classification)

See: https://github.com/ramses-rf/ramses_cc/issues/1000

Related issue: https://github.com/ramses-rf/ramses_cc/issues/1003 (foreign-owned device notification — separate issue, not addressed here)

#### Test plan

- [x] All 612 ramses_cc tests pass
- [x] R79 (FAN→DIS reclassification) passes in ha-sim (7/7 checks)
- [x] False positives gone on hass (CO2→REM and REM→FAN no longer flagged)