### PR TITLE
fix: foreign-owned devices no longer flagged as new

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -915,14 +915,92 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
     @staticmethod
     def _extract_schema_device_ids(schema: dict[str, Any]) -> set[str]:
-        """Extract all device IDs from a schema dict (for migration checks).
+        """Extract ALL device IDs from a schema dict.
 
-        Delegates to the same logic as ``_derive_known_list_from_schema``
-        but returns only the device ID set.
+        Returns every device ID referenced in the schema, including
+        foreign-owned devices (``_owner`` != root ``_owner``).  This is
+        used by the discovery manager to check whether a device is
+        already in the schema (and thus should NOT be flagged as "new").
+
+        Unlike ``_derive_known_list_from_schema``, this does NOT exclude
+        foreign-owned devices — they are in the schema, just not in the
+        known_list passed to ramses_rf.  Excluding them here would cause
+        them to be re-flagged as "new device discovered" on every scan
+        cycle (issue 1003).
+
+        :param schema: The global schema dict (may contain extension keys).
+        :return: Set of all device IDs in the schema.
         """
-        # Reuse the derivation logic, just take the keys
-        derived = RamsesCoordinator._derive_known_list_from_schema(schema)
-        return set(derived.keys())
+        device_ids: set[str] = set()
+
+        # Main TCS (the CTL)
+        if ctl_id := schema.get(SZ_MAIN_TCS):
+            device_ids.add(ctl_id)
+
+        for key, value in schema.items():
+            # Skip non-device-id keys and our extension keys
+            if key in _SCHEMA_EXTENSION_KEYS:
+                continue
+            if key in (
+                SZ_MAIN_TCS,
+                SZ_ORPHANS_HEAT,
+                SZ_ORPHANS_HVAC,
+                "transport_constructor",
+            ):
+                continue
+            if not _DEVICE_ID_RE.match(str(key)):
+                continue
+
+            # key is a device_id (CTL or FAN)
+            device_ids.add(str(key))
+
+            if not isinstance(value, dict):
+                continue
+
+            # Heat TCS structure
+            if isinstance(value.get(SZ_SYSTEM), dict):
+                if app_id := value[SZ_SYSTEM].get(SZ_APPLIANCE_CONTROL):
+                    device_ids.add(app_id)
+
+            if isinstance(value.get(SZ_DHW_SYSTEM), dict):
+                dhw = value[SZ_DHW_SYSTEM]
+                if sensor_id := dhw.get(SZ_SENSOR):
+                    device_ids.add(sensor_id)
+                if valve_id := dhw.get(SZ_DHW_VALVE):
+                    device_ids.add(valve_id)
+                if valve_id := dhw.get(SZ_HTG_VALVE):
+                    device_ids.add(valve_id)
+
+            if isinstance(value.get(SZ_UFH_SYSTEM), dict):
+                for ufc_id in value[SZ_UFH_SYSTEM]:
+                    if _DEVICE_ID_RE.match(str(ufc_id)):
+                        device_ids.add(str(ufc_id))
+
+            if isinstance(value.get(SZ_ZONES), dict):
+                for zone_data in value[SZ_ZONES].values():
+                    if not isinstance(zone_data, dict):
+                        continue
+                    if sensor_id := zone_data.get(SZ_SENSOR):
+                        device_ids.add(sensor_id)
+                    for act_id in zone_data.get(SZ_ACTUATORS, []):
+                        device_ids.add(act_id)
+
+            for orphan_id in value.get(SZ_ORPHANS, []):
+                device_ids.add(orphan_id)
+
+            # HVAC structure
+            for remote_id in value.get(SZ_REMOTES, []):
+                device_ids.add(remote_id)
+            for sensor_id in value.get(SZ_SENSORS, []):
+                device_ids.add(sensor_id)
+
+        # Global orphans
+        for orphan_id in schema.get(SZ_ORPHANS_HEAT, []):
+            device_ids.add(orphan_id)
+        for orphan_id in schema.get(SZ_ORPHANS_HVAC, []):
+            device_ids.add(orphan_id)
+
+        return device_ids
 
     @staticmethod
     def _strip_schema_extensions(schema: dict[str, Any]) -> dict[str, Any]:
@@ -1022,75 +1100,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         :param schema: The global schema dict (may contain extension keys).
         :return: A known_list dict suitable for ``GatewayConfig.known_list``.
         """
-        # Collect all device IDs from the schema structure
-        device_ids: set[str] = set()
-
-        # Main TCS (the CTL)
-        if ctl_id := schema.get(SZ_MAIN_TCS):
-            device_ids.add(ctl_id)
-
-        for key, value in schema.items():
-            # Skip non-device-id keys and our extension keys
-            if key in _SCHEMA_EXTENSION_KEYS:
-                continue
-            if key in (
-                SZ_MAIN_TCS,
-                SZ_ORPHANS_HEAT,
-                SZ_ORPHANS_HVAC,
-                "transport_constructor",
-            ):
-                continue
-            if not _DEVICE_ID_RE.match(str(key)):
-                continue
-
-            # key is a device_id (CTL or FAN)
-            device_ids.add(str(key))
-
-            if not isinstance(value, dict):
-                continue
-
-            # Heat TCS structure
-            if isinstance(value.get(SZ_SYSTEM), dict):
-                if app_id := value[SZ_SYSTEM].get(SZ_APPLIANCE_CONTROL):
-                    device_ids.add(app_id)
-
-            if isinstance(value.get(SZ_DHW_SYSTEM), dict):
-                dhw = value[SZ_DHW_SYSTEM]
-                if sensor_id := dhw.get(SZ_SENSOR):
-                    device_ids.add(sensor_id)
-                if valve_id := dhw.get(SZ_DHW_VALVE):
-                    device_ids.add(valve_id)
-                if valve_id := dhw.get(SZ_HTG_VALVE):
-                    device_ids.add(valve_id)
-
-            if isinstance(value.get(SZ_UFH_SYSTEM), dict):
-                for ufc_id in value[SZ_UFH_SYSTEM]:
-                    if _DEVICE_ID_RE.match(str(ufc_id)):
-                        device_ids.add(str(ufc_id))
-
-            if isinstance(value.get(SZ_ZONES), dict):
-                for zone_data in value[SZ_ZONES].values():
-                    if not isinstance(zone_data, dict):
-                        continue
-                    if sensor_id := zone_data.get(SZ_SENSOR):
-                        device_ids.add(sensor_id)
-                    for act_id in zone_data.get(SZ_ACTUATORS, []):
-                        device_ids.add(act_id)
-
-            for orphan_id in value.get(SZ_ORPHANS, []):
-                device_ids.add(orphan_id)
-
-            # HVAC structure
-            for remote_id in value.get(SZ_REMOTES, []):
-                device_ids.add(remote_id)
-            for sensor_id in value.get(SZ_SENSORS, []):
-                device_ids.add(sensor_id)
-
-        # Global orphans
-        for orphan_id in schema.get(SZ_ORPHANS_HEAT, []):
-            device_ids.add(orphan_id)
-        for orphan_id in schema.get(SZ_ORPHANS_HVAC, []):
-            device_ids.add(orphan_id)
+        # Collect all device IDs from the schema structure.
+        # Reuse _extract_schema_device_ids (which includes foreign-owned
+        # devices) and then filter below.
+        device_ids = RamsesCoordinator._extract_schema_device_ids(schema)
 
         # Build the known_list.
         # _skipped devices are excluded (foreign/neighbour — filter rejects).

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -3479,6 +3479,25 @@ class TestExtractSchemaDeviceIds:
         assert "18:149488" in result
         assert "32:153289" in result
 
+    def test_includes_foreign_owned_devices(self) -> None:
+        """Foreign-owned devices are included (issue 1003).
+
+        A device with _owner != root _owner is excluded from the
+        known_list (for ramses_rf) but MUST be included in
+        _extract_schema_device_ids so the discovery manager knows it's
+        already in the schema and doesn't flag it as "new".
+        """
+        schema = {
+            "_owner": "me",
+            "main_tcs": "01:145038",
+            "01:145038": {},
+            "orphans_hvac": ["37:154519"],
+            "37:154519": {"_class": "FAN", "_owner": "not-me"},
+        }
+        result = RamsesCoordinator._extract_schema_device_ids(schema)
+        assert "01:145038" in result
+        assert "37:154519" in result  # foreign but still in schema
+
 
 # ───────────────────────────────────────────────────────────────────────
 # Coordinator: _derive_known_list_from_schema


### PR DESCRIPTION
## Summary

- `_extract_schema_device_ids` now returns ALL device IDs in the schema, including foreign-owned devices (`_owner` != root `_owner`)
- Previously it delegated to `_derive_known_list_from_schema`, which excludes foreign devices — causing `check_for_new_devices` to flag them as NEW on every scan cycle
- The two concerns are now separated:
  - `_derive_known_list_from_schema`: excludes foreign devices (correct, for ramses_rf's known_list)
  - `_extract_schema_device_ids`: includes ALL schema device IDs (for discovery's "is this already configured?" check)
- Refactored `_derive_known_list_from_schema` to call `_extract_schema_device_ids` for device ID collection, eliminating duplicated schema-walking logic

Fixes https://github.com/ramses-rf/ramses_cc/issues/1003

#### Test plan

- [x] All 1256 ramses_cc tests pass
- [x] `test_includes_foreign_owned_devices` verifies a device with `_owner: not-me` in `orphans_hvac` is included
- [x] Deployed to hass: 37:154519 (`_owner: not-me`) no longer flagged as "new device discovered"
- [x] Log shows: `device 37:154519 is in schema but had NEW status, marked as ACCEPTED`