### PR TITLE
fix: exclude foreign-owner devices from discovery

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -734,7 +734,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # must know they're in the schema (issue 987).
         schema = self.options.get(CONF_SCHEMA, {})
         schema_device_ids = self._extract_schema_device_ids(schema)
-        self.discovery_manager.sync_with_schema(schema_device_ids)
+        foreign_device_ids = self._extract_foreign_device_ids(schema)
+        self.discovery_manager.sync_with_schema(
+            schema_device_ids, foreign_device_ids
+        )
 
         # Schedule periodic checkpoint + check for new/lost devices.
         # Use 5 min interval for now — TODO: replace with a real-time
@@ -766,7 +769,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # must know they're in the schema (issue 987).
         schema = self.options.get(CONF_SCHEMA, {})
         schema_device_ids = self._extract_schema_device_ids(schema)
-        self.discovery_manager.sync_with_schema(schema_device_ids)
+        foreign_device_ids = self._extract_foreign_device_ids(schema)
+        self.discovery_manager.sync_with_schema(
+            schema_device_ids, foreign_device_ids
+        )
         # Check ramses_rf known_list for contradiction-based class changes
         # (e.g. FAN→DIS) before running mismatch checks, so rf-flagged
         # mismatches are included in the notification.
@@ -1005,6 +1011,27 @@ class RamsesCoordinator(DataUpdateCoordinator):
             device_ids.add(orphan_id)
 
         return device_ids
+
+    @staticmethod
+    def _extract_foreign_device_ids(schema: dict[str, Any]) -> set[str]:
+        """Extract device IDs with a foreign _owner (neighbour's devices).
+
+        These are excluded from discovery — the scan engine sees all RF
+        traffic, but foreign devices should not be offered for review.
+        """
+        root_owner = schema.get(SZ_OWNER)
+        if not root_owner:
+            return set()
+        foreign: set[str] = set()
+        for key, value in schema.items():
+            if (
+                isinstance(value, dict)
+                and _DEVICE_ID_RE.match(str(key))
+                and isinstance(value.get(SZ_TR_OWNER), str)
+                and value[SZ_TR_OWNER] != root_owner
+            ):
+                foreign.add(str(key))
+        return foreign
 
     @staticmethod
     def _strip_schema_extensions(schema: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -240,6 +240,7 @@ class DiscoveryManager:
         # after a reload where .storage/ wasn't updated before teardown
         # (issue 917).
         self._schema_device_ids: set[str] = set()
+        self._foreign_device_ids: set[str] = set()
 
         # Track which mismatches we've already warned about (to avoid
         # repeating the WARNING every checkpoint cycle).  Cleared when
@@ -489,7 +490,11 @@ class DiscoveryManager:
             len(self._metadata),
         )
 
-    def sync_with_schema(self, schema_device_ids: set[str]) -> None:
+    def sync_with_schema(
+        self,
+        schema_device_ids: set[str],
+        foreign_device_ids: set[str] | None = None,
+    ) -> None:
         """Sync discovery metadata with the current schema.
 
         Compares the scan's device list (what the system actually sees)
@@ -497,10 +502,15 @@ class DiscoveryManager:
         but not in the schema are marked as NEW for review.
 
         :param schema_device_ids: Set of device IDs currently in the schema.
+        :param foreign_device_ids: Set of device IDs with a foreign _owner
+            (neighbour's devices).  These are excluded from discovery —
+            they appear in the scan engine (it sees all RF traffic) but
+            should not be offered for review/acceptance.
         """
         # Stash for check_for_new_devices (issue 917: prevents re-notifying
         # devices that are already in the schema but lost their metadata).
         self._schema_device_ids = schema_device_ids
+        self._foreign_device_ids = foreign_device_ids or set()
 
         _LOGGER.info(
             "DiscoveryManager: sync_with_schema with schema_device_ids=%s",
@@ -518,6 +528,20 @@ class DiscoveryManager:
         for device_id, meta in list(self._metadata.items()):
             # Skip local active HGI gateway
             if self._active_hgi_id and device_id == self._active_hgi_id:
+                continue
+            # Remove foreign-owner devices from discovery metadata —
+            # they should not appear in the discovery UI at all.
+            if device_id in self._foreign_device_ids:
+                if meta.status != DiscoveryStatus.REMOVED:
+                    meta.status = DiscoveryStatus.REMOVED
+                    meta.enabled = False
+                    self._metadata[device_id] = meta
+                    self._notified.discard(device_id)
+                    _LOGGER.info(
+                        "DiscoveryManager: foreign-owner device %s "
+                        "removed from discovery",
+                        device_id,
+                    )
                 continue
             if device_id not in schema_device_ids and meta.status in (
                 DiscoveryStatus.ACCEPTED,
@@ -560,6 +584,11 @@ class DiscoveryManager:
         for device_id in scan_devices:
             # Skip local active HGI gateway
             if self._active_hgi_id and device_id == self._active_hgi_id:
+                continue
+            # Skip foreign-owner devices (neighbour's devices) — the
+            # scan engine sees all RF traffic, but foreign devices
+            # should not be offered for discovery/review.
+            if device_id in self._foreign_device_ids:
                 continue
             if (
                 device_id not in self._metadata
@@ -2028,6 +2057,11 @@ class DiscoveryManager:
             # coordinator and auto-registered in the schema.  Foreign HGIs
             # (device_id != active_hgi_id) are discoverable devices.
             if self._active_hgi_id and device_id == self._active_hgi_id:
+                continue
+            # Skip foreign-owner devices (neighbour's devices) — the
+            # scan engine sees all RF traffic, but foreign devices
+            # should not be offered for discovery/review.
+            if device_id in self._foreign_device_ids:
                 continue
             meta = self._metadata.get(device_id)
             if meta is None:


### PR DESCRIPTION
see https://github.com/ramses-rf/ramses_cc/issues/1003

## Summary

- The scan engine sees all RF traffic, including neighbour's devices. Foreign-owner devices (with `_owner != root _owner`) were filtered from the learned schema by `_strip_and_orchestrate` (PR 998), but the **discovery manager** still picked them up from the scan engine and marked them as NEW — offering them for review/acceptance in the discovery UI.
- This PR passes `foreign_device_ids` to `sync_with_schema` and `check_for_new_devices` so they skip foreign-owner devices entirely.
- Also marks any existing foreign-device metadata as REMOVED during `sync_with_schema` (cleans up stale NEW status from before this fix).

## Root cause

1. `_derive_known_list_from_schema` excludes foreign devices from the known_list (line 1122-1123)
2. `_extract_schema_device_ids` uses the same logic, so foreign devices are NOT in `schema_device_ids`
3. `sync_with_schema` sees the foreign device in the scan but not in `schema_device_ids`, so it adds it as NEW
4. The user sees the neighbour's device in the discovery UI

## Seen on hass (my dev HA env)

`37:154519` (neighbour's FAN, `_owner: not-me`) was showing up as `status=new` in discovery metadata despite PR 998's foreign-owner fix in `_strip_and_orchestrate`.

#### Test plan

- [x] All 1351 ramses_cc tests pass
- [x] Deploy to hass and verify 37:154519 no longer appears as NEW in discovery