### PR TITLE
fix: check_for_lost_devices respects _suppress_not_seen (issue 988)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -784,7 +784,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 schema, zones=self._zones
             )
         self.discovery_manager.check_for_new_devices()
-        self.discovery_manager.check_for_lost_devices()
+        self.discovery_manager.check_for_lost_devices(
+            schema if isinstance(schema, dict) else None
+        )
         await self.async_save_client_state()
 
     async def _async_stop_discovery_scan(self) -> None:

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -2100,12 +2100,21 @@ class DiscoveryManager:
 
         return new_ids
 
-    def check_for_lost_devices(self) -> list[str]:
+    def check_for_lost_devices(
+        self, schema: dict[str, Any] | None = None
+    ) -> list[str]:
         """Check for accepted devices that haven't been seen recently.
 
         Marks devices as LOST if they haven't been seen for the
         configured threshold. Returns the list of newly lost device IDs.
 
+        If *schema* is provided, devices with ``_suppress_not_seen: True``
+        in their schema entry are skipped (issue 988 — the user has
+        explicitly dismissed the "not seen" notification for this device).
+
+        :param schema: The current config entry schema (with _ traits).
+            If ``None``, the ``_suppress_not_seen`` check is skipped
+            (backward compatibility for callers that don't pass it).
         :return: List of device IDs that were marked as lost.
         """
         now = dt.now()
@@ -2114,6 +2123,15 @@ class DiscoveryManager:
         for device_id, meta in self._metadata.items():
             if meta.status != DiscoveryStatus.ACCEPTED or not meta.enabled:
                 continue
+
+            # Respect _suppress_not_seen from schema (issue 988)
+            if schema is not None:
+                schema_entry = schema.get(device_id)
+                if (
+                    isinstance(schema_entry, dict)
+                    and schema_entry.get("_suppress_not_seen") is True
+                ):
+                    continue
 
             engine_dev = next(
                 (


### PR DESCRIPTION
## Summary

- `check_for_lost_devices()` now accepts the schema and skips devices with `_suppress_not_seen: True`, consistent with `check_orphaned_devices()` which already respects this key
- Without this fix, devices that the user has explicitly dismissed via "Keep (dismiss flag)" were still being marked as LOST and triggering notifications on every checkpoint cycle
- The coordinator's `_async_discovery_checkpoint` now passes the config entry schema to `check_for_lost_devices`

This is a follow-up to the original issue 988 fix (PR 1006) which only added `_suppress_not_seen` support to `check_orphaned_devices` but missed `check_for_lost_devices`.

Fixes https://github.com/ramses-rf/ramses_cc/issues/988

#### Test plan

- [x] Unit tests pass (`test_discovery_manager.py`, `test_coordinator.py` — 437 passed)
- [x] Deployed to hass: `18:149488` (inactive HGI) no longer marked lost after restart
- [x] R78 (ha_sim_test) passes — verifies `_suppress_not_seen` survives restart