### PR TITLE
fix: use live entry.options in discovery checkpoints to stop missing_class loop

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -732,7 +732,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # (18:) entries are included — _strip_and_orchestrate drops them
         # because ramses_rf doesn't need them, but discovery tracking
         # must know they're in the schema (issue 987).
-        schema = self.options.get(CONF_SCHEMA, {})
+        # Use self.entry.options (live) — see _async_discovery_checkpoint.
+        schema = self.entry.options.get(CONF_SCHEMA, {})
         schema_device_ids = self._extract_schema_device_ids(schema)
         foreign_device_ids = self._extract_foreign_device_ids(schema)
         self.discovery_manager.sync_with_schema(
@@ -767,7 +768,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # (18:) entries are included — _strip_and_orchestrate drops them
         # because ramses_rf doesn't need them, but discovery tracking
         # must know they're in the schema (issue 987).
-        schema = self.options.get(CONF_SCHEMA, {})
+        # IMPORTANT: use self.entry.options (live) not self.options (stale
+        # copy from __init__).  When the user accepts devices or adds
+        # _class via the review_discovered form, the config entry is
+        # updated but the reload is suppressed (accept flow).  Using the
+        # stale copy would cause check_missing_class to re-flag devices
+        # whose _class was just written (issue 984).
+        schema = self.entry.options.get(CONF_SCHEMA, {})
         schema_device_ids = self._extract_schema_device_ids(schema)
         foreign_device_ids = self._extract_foreign_device_ids(schema)
         self.discovery_manager.sync_with_schema(
@@ -1527,7 +1534,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
         Uses ``async_update_entry`` with ``_suppress_reload`` to avoid
         triggering a coordinator reload while the remote entity is mid-call.
         """
-        schema = self.options.get(CONF_SCHEMA, {})
+        # Use self.entry.options (live) — see _async_discovery_checkpoint.
+        schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(schema, dict):
             return
         # Use deepcopy so the new schema's entries are separate objects
@@ -1557,7 +1565,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             entry[SZ_TR_COMMANDS] = cmds
         elif SZ_TR_COMMANDS in entry:
             del entry[SZ_TR_COMMANDS]
-        new_options = dict(self.options)
+        new_options = dict(self.entry.options)
         new_options[CONF_SCHEMA] = new_schema
         self.options = new_options
         self._suppress_reload = time.time()
@@ -1980,7 +1988,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
         rf_known = self.client.config.known_list
         if not isinstance(rf_known, dict):
             return
-        config_schema = self.options.get(CONF_SCHEMA, {})
+        # Use self.entry.options (live) — see _async_discovery_checkpoint.
+        config_schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(config_schema, dict):
             return
         for dev_id, traits in rf_known.items():
@@ -2087,7 +2096,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Skip during unload (fresh start / reload) so we don't overwrite a
         # freshly-cleared schema with stale learned topology.
         if not self._skip_topology_sync:
-            config_schema = self.options.get(CONF_SCHEMA, {})
+            # Use self.entry.options (live) not self.options (stale copy
+            # from __init__).  When the user adds _class via the
+            # review_discovered form, the config entry is updated but the
+            # reload is suppressed.  Using the stale copy here would cause
+            # sync_learned_topology to overwrite the user's _class changes
+            # with the stale schema (missing _class), re-triggering the
+            # missing_class loop on every checkpoint (issue 984).
+            config_schema = self.entry.options.get(CONF_SCHEMA, {})
             # Refresh device_comments with latest scan engine zone bindings.
             # Scan engine may have learned zone_index from broadcast traffic
             # (where dst is --:------) not captured when first accepted.
@@ -2189,7 +2205,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     _LOGGER.info(
                         "Learned topology is richer than config, syncing back"
                     )
-                    new_options = dict(self.options)
+                    new_options = dict(self.entry.options)
                     new_options[CONF_SCHEMA] = enriched
                     self.options = new_options
                     # Suppress the reload that async_update_entry would
@@ -2228,7 +2244,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 config_schema = self._migrate_rem_commands_to_fan(
                     config_schema
                 )
-                new_options = dict(self.options)
+                new_options = dict(self.entry.options)
                 new_options[CONF_SCHEMA] = config_schema
                 self.options = new_options
                 self._suppress_reload = time.time()
@@ -2256,7 +2272,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             "No topology changes, but remotes synced to "
                             "schema _commands — persisting"
                         )
-                        new_options = dict(self.options)
+                        new_options = dict(self.entry.options)
                         new_options[CONF_SCHEMA] = migrated_schema
                         self.options = new_options
                         self._suppress_reload = time.time()
@@ -2275,13 +2291,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # cleared config schema on the next restart.  The learned schema
             # from the dying coordinator is stale topology that the user may
             # have just cleared — it must not survive in the cache.
-            schema = self.options.get(CONF_SCHEMA, {})
+            # Use self.entry.options (live) — see _async_discovery_checkpoint.
+            schema = self.entry.options.get(CONF_SCHEMA, {})
 
         # Update _devices_with_commands to reflect the current schema state.
         # This tracks which devices have _commands so that on the next save
         # cycle, _sync_remotes_to_schema can skip devices that previously
         # had _commands but no longer do (user deletion → no resurrection).
-        current_schema = self.options.get(CONF_SCHEMA, {})
+        current_schema = self.entry.options.get(CONF_SCHEMA, {})
         if isinstance(current_schema, dict):
             self._devices_with_commands = {
                 dev_id
@@ -2747,7 +2764,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # changes before running mismatch checks, so rf-flagged
             # mismatches are included in the notification.
             self._check_rf_contradictions()
-            schema = self.options.get(CONF_SCHEMA, {})
+            # Use self.entry.options (live) — see _async_discovery_checkpoint.
+            schema = self.entry.options.get(CONF_SCHEMA, {})
             if isinstance(schema, dict):
                 self.discovery_manager.check_all_mismatches(
                     schema, zones=self._zones

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -5749,11 +5749,13 @@ class TestCheckRfContradictions:
         mock_coordinator.client.config.known_list = {
             "37:169161": {"class": "DIS"},
         }
-        mock_coordinator.options = {
+        schema = {
             CONF_SCHEMA: {
                 "37:169161": {SZ_TR_CLASS: "FAN"},
             },
         }
+        mock_coordinator.options = schema
+        mock_coordinator.entry.options = schema
         mock_coordinator.discovery_manager = MagicMock()
         mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
 
@@ -5773,11 +5775,13 @@ class TestCheckRfContradictions:
         mock_coordinator.client.config.known_list = {
             "37:169161": {"class": "FAN"},
         }
-        mock_coordinator.options = {
+        schema = {
             CONF_SCHEMA: {
                 "37:169161": {SZ_TR_CLASS: "FAN"},
             },
         }
+        mock_coordinator.options = schema
+        mock_coordinator.entry.options = schema
         mock_coordinator.discovery_manager = MagicMock()
         mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
 
@@ -5792,7 +5796,9 @@ class TestCheckRfContradictions:
         mock_coordinator.client.config.known_list = {
             "37:999999": {"class": "DIS"},
         }
-        mock_coordinator.options = {CONF_SCHEMA: {}}
+        schema = {CONF_SCHEMA: {}}
+        mock_coordinator.options = schema
+        mock_coordinator.entry.options = schema
         mock_coordinator.discovery_manager = MagicMock()
         mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
 
@@ -5818,9 +5824,11 @@ class TestCheckRfContradictions:
         mock_coordinator.client.config.known_list = {
             "37:169161": {"class": "DIS"},
         }
-        mock_coordinator.options = {
+        schema = {
             CONF_SCHEMA: {"37:169161": {SZ_TR_CLASS: "FAN"}},
         }
+        mock_coordinator.options = schema
+        mock_coordinator.entry.options = schema
         mock_coordinator.discovery_manager = None
         # Should not raise
         mock_coordinator._check_rf_contradictions()
@@ -5842,11 +5850,13 @@ class TestCheckRfContradictions:
         mock_coordinator.client.config.known_list = {
             "37:169161": {"class": "DIS"},
         }
-        mock_coordinator.options = {
+        schema = {
             CONF_SCHEMA: {
                 "37:169161": {SZ_TR_CLASS: "FAN", "_locked": True},
             },
         }
+        mock_coordinator.options = schema
+        mock_coordinator.entry.options = schema
         mock_coordinator.discovery_manager = MagicMock()
         mock_coordinator.discovery_manager.flag_class_mismatch = MagicMock()
 


### PR DESCRIPTION
## Summary

The coordinator's `self.options` is a `deepcopy` snapshot from `__init__` that becomes stale when the config flow updates the config entry without triggering a reload (e.g. when the user accepts devices or adds `_class` via the `review_discovered` form — the reload is suppressed by the accept flow).

This caused two problems:

1. **`check_missing_class` re-flagged the same devices every 5-minute checkpoint** because it read the stale schema (no `_class`) instead of the live config entry schema (with `_class` just added by the user). The user kept seeing the same 3 TRVs re-prompted in an endless loop.

2. **`sync_learned_topology` overwrote the user's `_class` changes**: it read the stale schema, merged learned topology into it, and wrote the result back via `async_update_entry` — overwriting the `_class` that the user just added. This ensured the `_class` never survived to the next checkpoint even though the user kept clicking "add_class".

### Root cause trace

From the user's log (https://github.com/ramses-rf/ramses_cc/issues/984#issuecomment-5357048378):

```
14:41:12 review_discovered: added _class=TRV for 04:208992
14:41:12 review_discovered: added _class=TRV for 04:034682
14:41:12 review_discovered: added _class=TRV for 04:056675
14:44:22 review_discovered: added _class=TRV for 04:208992  ← same devices!
14:44:22 review_discovered: added _class=TRV for 04:034682
14:44:22 review_discovered: added _class=TRV for 04:056675
14:54:12 review_discovered: added _class=TRV for 04:208992  ← still looping!
```

The user clicked "add_class" three times for the same devices over 13 minutes. Each time, `_class` was written to the config entry, but the next checkpoint read from the stale `self.options` (no `_class`) and re-flagged them. Worse, `sync_learned_topology` then wrote the stale schema back to the config entry, erasing the user's changes.

### Fix

Use `self.entry.options` (the live config entry options) instead of `self.options` (the stale snapshot) in all discovery-related and schema-write-back code paths:

- `_async_discovery_checkpoint` (check_missing_class, check_all_mismatches)
- `_async_start_discovery_scan` (sync_with_schema)
- `_check_rf_contradictions`
- `sync_learned_topology` (read base + all three write-back paths)
- `_sync_remotes_to_schema` (read base + write-back)
- post-reload `check_all_mismatches`
- `async_save_client_state` unload path + `_devices_with_commands` tracking

Tests updated to set both `mock_coordinator.options` and `mock_coordinator.entry.options` for `TestCheckRfContradictions`.

#### Test plan
- [x] All 1360 ramses_cc tests pass
- [x] User verifies the missing_class loop is resolved (devices no longer re-prompted after clicking "add_class")