### PR TITLE
fix: add defensive guard for raw packet strings under FAN _commands (#995)

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -1303,32 +1303,44 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                 # Commands live in schema _commands (handled above via
                 # remotes, which are populated from schema).
 
-            # Check FAN dict templates first (highest priority)
-            if fan_mode in fan_commands and _is_command_dict(
-                fan_commands[fan_mode]
-            ):
+            # Check FAN commands first (highest priority: dict template or
+            # raw string fallback)
+            if fan_mode in fan_commands:
                 cmd_def = fan_commands[fan_mode]
-                packet_str = _build_packet_from_template(
-                    cmd_def, self._device, self.coordinator
-                )
-                _LOGGER.info(
-                    "Intercepted fan_mode '%s'; building from FAN template: "
-                    "%s",
-                    fan_mode,
-                    packet_str,
-                )
-
-                # parse_packet_string parses both CLI and raw packet formats
-                cmd = parse_packet_string(packet_str)
-                if cmd is None:
-                    raise ValueError(
-                        f"Failed to parse packet_str: {packet_str}"
+                if _is_command_dict(cmd_def):
+                    packet_str = _build_packet_from_template(
+                        cmd_def, self._device, self.coordinator
                     )
-                await self._device._gateway.async_send_cmd(
-                    cmd, num_repeats=2, priority=Priority.HIGH
-                )
-                self.async_write_ha_state()
-                return
+                    _LOGGER.info(
+                        "Intercepted fan_mode '%s'; building from FAN "
+                        "template: %s",
+                        fan_mode,
+                        packet_str,
+                    )
+                elif isinstance(cmd_def, str):
+                    packet_str = cmd_def
+                    _LOGGER.info(
+                        "Intercepted fan_mode '%s'; using raw packet "
+                        "string from FAN _commands: %s",
+                        fan_mode,
+                        packet_str,
+                    )
+                else:
+                    packet_str = None
+
+                if packet_str is not None:
+                    # parse_packet_string parses both CLI and raw packet
+                    # formats
+                    cmd = parse_packet_string(packet_str)
+                    if cmd is None:
+                        raise ValueError(
+                            f"Failed to parse packet_str: {packet_str}"
+                        )
+                    await self._device._gateway.async_send_cmd(
+                        cmd, num_repeats=2, priority=Priority.HIGH
+                    )
+                    self.async_write_ha_state()
+                    return
 
             # Check REM packet strings (Phase 3a fallback)
             if fan_mode in rem_commands:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1422,6 +1422,37 @@ class RamsesCoordinator(DataUpdateCoordinator):
             if not isinstance(entry, dict) or entry.get(SZ_TR_CLASS) != "FAN":
                 continue
 
+            # Normalise any existing raw string commands on the FAN to
+            # dict templates
+            fan_commands = entry.get(SZ_TR_COMMANDS)
+            if isinstance(fan_commands, dict):
+                from .remote import _is_command_dict, _parse_packet_to_template
+
+                for cmd_name, cmd_val in list(fan_commands.items()):
+                    if cmd_name.startswith("_"):
+                        continue
+                    if isinstance(cmd_val, str) and not _is_command_dict(
+                        cmd_val
+                    ):
+                        try:
+                            fan_commands[cmd_name] = _parse_packet_to_template(
+                                cmd_val
+                            )
+                            changed = True
+                            _LOGGER.info(
+                                "Phase 3b: converted raw command '%s' on "
+                                "FAN %s to dict template",
+                                cmd_name,
+                                fan_id,
+                            )
+                        except (ValueError, IndexError) as err:
+                            _LOGGER.debug(
+                                "Phase 3b: kept raw command '%s' on FAN %s: %s",
+                                cmd_name,
+                                fan_id,
+                                err,
+                            )
+
             # Get bound REMs
             bound = entry.get(SZ_TR_BOUND, [])
             if isinstance(bound, str):
@@ -1429,7 +1460,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             elif isinstance(bound, list):
                 bound_rems = bound
             else:
-                continue
+                bound_rems = []
 
             # Collect commands from bound REMs (skip _comment etc.)
             rem_commands: dict[str, str] = {}
@@ -1444,46 +1475,46 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             if cmd_name not in rem_commands:
                                 rem_commands[cmd_name] = str(cmd_val)
 
-            if not rem_commands:
-                continue
+            if rem_commands:
+                if not isinstance(fan_commands, dict):
+                    fan_commands = {}
 
-            # Parse packet strings to dict templates and merge into FAN
-            fan_commands = entry.get(SZ_TR_COMMANDS, {})
-            if not isinstance(fan_commands, dict):
-                fan_commands = {}
+                from .remote import _parse_packet_to_template
 
-            from .remote import _parse_packet_to_template
+                for cmd_name, packet_str in rem_commands.items():
+                    if cmd_name in fan_commands:
+                        # FAN already has this command — skip (authoritative)
+                        continue
+                    try:
+                        fan_commands[cmd_name] = _parse_packet_to_template(
+                            packet_str
+                        )
+                        changed = True
+                        _LOGGER.info(
+                            "Phase 3b migration: copied command '%s' from "
+                            "REM to FAN %s as dict template",
+                            cmd_name,
+                            fan_id,
+                        )
+                    except (ValueError, IndexError) as err:
+                        _LOGGER.warning(
+                            "Phase 3b migration: failed to parse packet "
+                            "'%s' for command '%s' on FAN %s: %s",
+                            packet_str,
+                            cmd_name,
+                            fan_id,
+                            err,
+                        )
 
-            for cmd_name, packet_str in rem_commands.items():
-                if cmd_name in fan_commands:
-                    # FAN already has this command — skip (authoritative)
-                    continue
-                try:
-                    fan_commands[cmd_name] = _parse_packet_to_template(
-                        packet_str
-                    )
-                    changed = True
-                    _LOGGER.info(
-                        "Phase 3b migration: copied command '%s' from REM to "
-                        "FAN %s as dict template",
-                        cmd_name,
-                        fan_id,
-                    )
-                except (ValueError, IndexError) as err:
-                    _LOGGER.warning(
-                        "Phase 3b migration: failed to parse packet '%s' for "
-                        "command '%s' on FAN %s: %s",
-                        packet_str,
-                        cmd_name,
-                        fan_id,
-                        err,
-                    )
-
-            if changed:
+            if changed and isinstance(fan_commands, dict):
                 entry[SZ_TR_COMMANDS] = fan_commands
 
             # Auto-inject _comment hint on FAN if it has commands without one
-            if fan_commands and "_comment" not in fan_commands:
+            if (
+                isinstance(fan_commands, dict)
+                and fan_commands
+                and "_comment" not in fan_commands
+            ):
                 fan_commands["_comment"] = (
                     "Commands on FAN (Phase 3b) — target entity for "
                     "automations"

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -615,10 +615,11 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
                 cmd_value, self._device, self.coordinator
             )
         else:
-            # REM entity with packet string (Phase 3a backward compat)
+            # Packet string: REM entity (Phase 3a) or FAN raw string fallback
             packet_str = str(cmd_value)
             if (
-                not self._device.is_faked
+                not isinstance(self._device, HvacVentilator)
+                and not self._device.is_faked
             ):  # have to check here, as not using device method
                 raise HomeAssistantError(
                     f"{self._device.id} is not configured for faking"

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -1684,6 +1684,44 @@ async def test_set_fan_mode_fan_commands_wins_over_rem_and_native(
     mock_device.set_fan_mode.assert_not_called()
 
 
+async def test_set_fan_mode_with_fan_raw_string_commands_defensive_guard(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    """FAN's _commands with raw packet string sends packet directly.
+
+    Defensive guard for issue #995: when a user defines raw packet strings
+    directly under FAN._commands, async_set_fan_mode should parse and send
+    them rather than falling through to native set_fan_mode scheme validation.
+    """
+    # Arrange
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:022222"
+    mock_device.get_bound_rem.return_value = "29:091138"
+    mock_device._gateway = MagicMock()
+    mock_device._gateway.async_send_cmd = AsyncMock()
+    mock_device.set_fan_mode = AsyncMock()
+
+    # FAN has raw packet string directly under _commands (issue #995 scenario)
+    mock_coordinator._remotes = {
+        "32:022222": {
+            "laag": " I --- 29:123150 29:099029 --:------ 22F1 003 000206"
+        },
+    }
+    mock_coordinator.options = {}
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.async_write_ha_state = MagicMock()
+
+    # Act
+    await hvac.async_set_fan_mode("laag")
+
+    # Assert
+    mock_device._gateway.async_send_cmd.assert_awaited_once()
+    cmd = mock_device._gateway.async_send_cmd.call_args.args[0]
+    assert "000206" in str(cmd)
+    mock_device.set_fan_mode.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Phase 3a: fan_modes property tests
 # ---------------------------------------------------------------------------

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -5728,6 +5728,22 @@ class TestMigrateRemCommandsToFan:
         fan_cmds = result["30:160000"].get(SZ_TR_COMMANDS, {})
         assert "bad" not in fan_cmds
 
+    def test_fan_string_commands_normalized_to_dicts(self) -> None:
+        """FAN with raw string commands has them converted to dict templates."""
+        schema: dict[str, Any] = {
+            "30:160000": {
+                "_class": "FAN",
+                "_commands": {
+                    "laag": "I --- 32:153001 30:160000 --:------ 22F1 003 000206",
+                },
+            },
+        }
+        result = RamsesCoordinator._migrate_rem_commands_to_fan(schema)
+        fan_entry = result["30:160000"]
+        assert SZ_TR_COMMANDS in fan_entry
+        cmd = fan_entry[SZ_TR_COMMANDS]["laag"]
+        assert cmd == {"verb": "I", "code": "22F1", "payload": "000206"}
+
 
 class TestCheckRfContradictions:
     """Tests for _check_rf_contradictions (issue 1000).

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -1516,6 +1516,28 @@ async def test_fan_send_command_rem_string_fallback(
     assert "22F1" in str(cmd)
 
 
+async def test_fan_send_command_raw_string_defensive_guard(
+    fan_remote_entity: RamsesRemote,
+    fan_coordinator: MagicMock,
+    mock_fan_device: MagicMock,
+) -> None:
+    """FAN entity send_command sends raw packet string even when is_faked is False."""
+    # Arrange: FAN has raw string command directly, and device is NOT faked
+    mock_fan_device.is_faked = False
+    fan_remote_entity._commands["laag"] = (
+        "I --- 29:123150 30:160000 --:------ 22F1 003 000206"
+    )
+
+    # Act
+    await fan_remote_entity.async_send_command("laag")
+
+    # Assert
+    fan_coordinator.client.async_send_cmd.assert_called_once()
+    cmd = fan_coordinator.client.async_send_cmd.call_args.args[0]
+    assert "22F1" in str(cmd)
+    assert "000206" in str(cmd)
+
+
 async def test_fan_add_command_parses_to_dict(
     fan_remote_entity: RamsesRemote,
     fan_coordinator: MagicMock,


### PR DESCRIPTION
### The Problem:
When users configure or copy raw RF packet strings directly under `FAN._commands` (instead of `{verb, code, payload}` dict templates), `fan_modes` exposes those custom modes in the Home Assistant UI dropdown. However, selecting a custom mode causes `_is_command_dict()` to return `False`, skipping custom command interception and falling through to native device scheme validation (`self._device.set_fan_mode()`), which crashes with `fan_mode is not valid for scheme 'orcon': <mode>`. Additionally, sending a string command on a FAN remote entity fails with `<fan_id> is not configured for faking`.

### The Fix:
- **`climate.py`**: Added a defensive fallback in `RamsesHvac.async_set_fan_mode()` to detect string commands under `FAN._commands`, parse them via `parse_packet_string()`, and send them directly via `async_send_cmd()` without falling through to scheme validation.
- **`remote.py`**: Updated `RamsesRemote.async_send_command()` faking check so that `HvacVentilator` entities can send raw string packets without requiring `is_faked == True` on the FAN device.
- **`coordinator.py`**: Updated `RamsesCoordinator._migrate_rem_commands_to_fan()` to automatically normalise existing raw string commands on `FAN` entities to structured dict templates.

### Testing Performed:
- Added `test_set_fan_mode_with_fan_raw_string_commands_defensive_guard` to `tests/tests_new/test_climate.py`.
- Added `test_fan_send_command_raw_string_defensive_guard` to `tests/tests_new/test_remote.py`.
- Added `test_fan_string_commands_normalized_to_dicts` to `tests/tests_new/test_coordinator.py`.
- Executed `.venv/bin/ruff format --check .` (75 files formatted).
- Executed `.venv/bin/ruff check --select D custom_components/ramses_cc/climate.py custom_components/ramses_cc/remote.py custom_components/ramses_cc/coordinator.py` (All checks passed).
- Executed `.venv/bin/mypy` (68 source files checked, 0 errors).
- Executed full test suite `.venv/bin/python -u -m pytest -n auto` (1363 passed, 10 skipped, 3 snapshots passed in 20.07s).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.