### PR TITLE
fix: pass `foreign_device_ids` in r`eview_discovered` to stop discovery loop (#1018)

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1630,7 +1630,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             schema_device_ids = RamsesCoordinator._extract_schema_device_ids(
                 config_schema_for_sync
             )
-            coordinator.discovery_manager.sync_with_schema(schema_device_ids)
+            foreign_device_ids = RamsesCoordinator._extract_foreign_device_ids(
+                config_schema_for_sync
+            )
+            coordinator.discovery_manager.sync_with_schema(
+                schema_device_ids, foreign_device_ids
+            )
 
         # Run an immediate check so devices found by the scan since the
         # last periodic checkpoint are visible without waiting up to 5 min.

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -3506,3 +3506,48 @@ async def test_options_flow_unloaded_entry_fallback(
     assert result.get("type") == FlowResultType.FORM
     placeholders = result.get("description_placeholders", {})
     assert "not enabled" in placeholders.get("message", "")
+
+
+async def test_review_discovered_foreign_device_sync_with_schema(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_discovered passes foreign_device_ids to sync_with_schema."""
+    # Arrange
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:072981": {SZ_TR_CLASS: "HGI", SZ_TR_OWNER: "not-me"},
+                "01:216136": {},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_devices.return_value = []
+    mock_coord.discovery_manager.get_mismatched_devices.return_value = []
+    mock_coord.discovery_manager.get_missing_class_devices.return_value = []
+    mock_coord.discovery_manager.get_name_mismatch_devices.return_value = []
+    config_entry.runtime_data = mock_coord
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    # Act
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+
+    # Assert
+    mock_coord.discovery_manager.sync_with_schema.assert_called_once_with(
+        {"01:216136", "18:072981"}, {"18:072981"}
+    )


### PR DESCRIPTION
### The Problem #1018 :
When navigating to the `review_discovered` step in the options flow (`config_flow.py`), `sync_with_schema` was invoked with only `schema_device_ids`, omitting `foreign_device_ids`. This reset `DiscoveryManager._foreign_device_ids` to empty. When `check_for_new_devices()` immediately followed, foreign devices with `REMOVED` status were re-promoted to `NEW` status, re-prompting the user on every review session (reported in #984).

### The Fix:
- Extracted `foreign_device_ids` using `RamsesCoordinator._extract_foreign_device_ids(config_schema_for_sync)` and passed it to `coordinator.discovery_manager.sync_with_schema(schema_device_ids, foreign_device_ids)` in `async_step_review_discovered`.
- Added unit test `test_review_discovered_foreign_device_sync_with_schema` to verify `foreign_device_ids` are passed.

### Testing Performed:
- `prek run -a` passed.
- `mypy custom_components tests` passed (0 errors in 68 source files).
- `pytest -n auto` full test suite passed (1364 passed, 10 skipped).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.