### PR TITLE
fix: preserve learned representative TRV zone sensors

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1590,19 +1590,6 @@ def sync_learned_topology(
             if isinstance(orig_config_zones, dict):
                 orig_config_zone_keys = set(orig_config_zones.keys())
 
-            # Track original user-authored sensors per zone.  The
-            # issue-813 TRV-demotion logic below must NOT null a sensor
-            # the user explicitly set in the config flow (e.g. a TRV's
-            # built-in sensor that is also listed in actuators).  See
-            # ramses-rf/ramses_cc#887.
-            orig_config_sensors: dict[str, str] = {}
-            if isinstance(orig_config_zones, dict):
-                for z_index, z_val in orig_config_zones.items():
-                    if isinstance(z_val, dict) and isinstance(
-                        z_val.get(SZ_SENSOR), str
-                    ):
-                        orig_config_sensors[z_index] = z_val[SZ_SENSOR]
-
             # 1a. Sync appliance_control
             learned_sys = learned_entry.get(SZ_SYSTEM, {})
             if isinstance(learned_sys, dict):
@@ -1680,95 +1667,47 @@ def sync_learned_topology(
             # the thermostat to sensor (see issue 813).
             config_zones = config_entry.get(SZ_ZONES)
             if isinstance(config_zones, dict):
-                for zone_index, zone in config_zones.items():
+                for _zone_index, zone in config_zones.items():
                     if not isinstance(zone, dict):
                         continue
-                    # If a TRV (04:) is the sensor, it should be in actuators
-                    # instead.  A TRV's primary role is as an actuator (heat
-                    # demand / valve position).  If a dedicated thermostat
-                    # (01:, 22:, 34:) is also in actuators, promote it to
-                    # sensor.  Otherwise, just move the TRV to actuators and
-                    # leave sensor=None (see issue 813: single-TRV zones had
-                    # the TRV as sensor instead of actuator).
+                    # A representative TRV is both the zone sensor and an
+                    # actuator.  If a dedicated thermostat is also present,
+                    # prefer it as sensor while keeping every TRV in actuators.
                     sensor = zone.get(SZ_SENSOR)
                     actuators = zone.get("actuators")
-                    if (
-                        isinstance(sensor, str)
-                        and sensor.startswith("04:")
-                        and isinstance(actuators, list)
-                    ):
-                        thermostat = next(
-                            (
-                                a
-                                for a in actuators
-                                if isinstance(a, str)
-                                and a[:3] in ("01:", "22:", "34:")
-                            ),
-                            None,
-                        )
-                        if thermostat:
-                            # Move TRV to actuators, thermostat to sensor
-                            if sensor not in actuators:
-                                actuators.append(sensor)
-                            actuators.remove(thermostat)
-                            actuators.sort()
-                            zone[SZ_SENSOR] = thermostat
+                    if isinstance(sensor, str) and sensor.startswith("04:"):
+                        if not isinstance(actuators, list):
+                            zone["actuators"] = [sensor]
                             changed = True
                             _LOGGER.debug(
-                                "sync_learned_topology: swapped TRV %s from "
-                                "sensor to actuators, promoted %s to sensor "
-                                "(dedicated thermostat takes priority)",
+                                "sync_learned_topology: added representative "
+                                "TRV %s to actuators",
                                 sensor,
-                                thermostat,
                             )
-                        elif zone_index not in orig_config_sensors:
-                            # No thermostat to swap — just move TRV to
-                            # actuators.  Skipped when the user explicitly
-                            # set the sensor (ramses-rf/ramses_cc#887).
+                        else:
+                            thermostat = next(
+                                (
+                                    a
+                                    for a in actuators
+                                    if isinstance(a, str)
+                                    and a[:3] in ("01:", "22:", "34:")
+                                ),
+                                None,
+                            )
                             if sensor not in actuators:
                                 actuators.append(sensor)
                                 actuators.sort()
-                            zone[SZ_SENSOR] = None
-                            changed = True
-                            _LOGGER.debug(
-                                "sync_learned_topology: moved TRV %s from "
-                                "sensor to actuators (no dedicated thermostat "
-                                "to promote)",
-                                sensor,
-                            )
-                    elif (
-                        isinstance(sensor, str)
-                        and sensor.startswith("04:")
-                        and not isinstance(actuators, list)
-                    ):
-                        # TRV is sensor, no actuators list at all — create one
-                        zone["actuators"] = [sensor]
-                        zone[SZ_SENSOR] = None
-                        changed = True
-                        _LOGGER.debug(
-                            "sync_learned_topology: moved TRV %s from "
-                            "sensor to new actuators list",
-                            sensor,
-                        )
-                    # Clear 04: (TRV) from sensor if also in actuators
-                    # (dup).  Skipped when the user explicitly set the
-                    # sensor (ramses-rf/ramses_cc#887).
-                    sensor = zone.get(SZ_SENSOR)
-                    actuators = zone.get("actuators")
-                    if (
-                        isinstance(sensor, str)
-                        and sensor.startswith("04:")
-                        and isinstance(actuators, list)
-                        and sensor in actuators
-                        and zone_index not in orig_config_sensors
-                    ):
-                        zone[SZ_SENSOR] = None
-                        changed = True
-                        _LOGGER.debug(
-                            "sync_learned_topology: cleared TRV %s from "
-                            "sensor (duplicate of actuator entry)",
-                            sensor,
-                        )
+                                changed = True
+                            if thermostat:
+                                actuators.remove(thermostat)
+                                zone[SZ_SENSOR] = thermostat
+                                changed = True
+                                _LOGGER.debug(
+                                    "sync_learned_topology: replaced TRV %s "
+                                    "as sensor with dedicated thermostat %s",
+                                    sensor,
+                                    thermostat,
+                                )
                     # Move sensor-type devices from actuators to sensor
                     actuators = zone.get("actuators")
                     if not isinstance(actuators, list):

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2386,13 +2386,8 @@ def test_sync_learned_topology_comment_moves_device_between_zones() -> None:
     assert "04:444444" in zones["04"].get("actuators", [])
 
 
-def test_sync_learned_topology_clears_trv_from_sensor() -> None:
-    """TRVs (04:) placed as both sensor and actuator must have sensor cleared.
-
-    ramses_rf's 000C handler sometimes places a TRV as both the zone sensor
-    and an actuator.  A TRV is never a zone sensor — it measures valve
-    position, not room temperature.  Clear the sensor field in that case.
-    """
+def test_sync_learned_topology_preserves_learned_trv_sensor() -> None:
+    """A learned representative TRV remains both sensor and actuator."""
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:123456",
         "01:123456": {},
@@ -2413,11 +2408,11 @@ def test_sync_learned_topology_clears_trv_from_sensor() -> None:
     result = sync_learned_topology(config, learned)
     assert result is not None
     zone = result["01:123456"][SZ_ZONES]["02"]
-    # 04:111111 should be cleared from sensor (it's a TRV)
-    assert zone.get(SZ_SENSOR) is None
-    # It should still be in actuators
+    assert zone[SZ_SENSOR] == "04:111111"
     assert "04:111111" in zone["actuators"]
     assert "04:222222" in zone["actuators"]
+    result = sync_learned_topology(result, learned) or result
+    assert result["01:123456"][SZ_ZONES]["02"][SZ_SENSOR] == "04:111111"
 
 
 def test_sync_learned_topology_skips_ctl_comment_zone() -> None:
@@ -3080,16 +3075,8 @@ def test_sync_learned_topology_trv_sensor_rnd_actuator_swapped() -> None:
     assert sorted(zone["actuators"]) == ["04:056679", "04:219929"]
 
 
-def test_sync_learned_topology_single_trv_as_sensor_moved_to_actuators() -> (
-    None
-):
-    """A single TRV (04:) placed as zone sensor with no thermostat should be
-    moved to actuators, sensor set to None (issue 813).
-
-    ramses_rf's active discovery sometimes places a TRV as the zone sensor
-    when it's the only device in the zone.  The TRV's primary role is as an
-    actuator — move it to actuators and leave sensor=None.
-    """
+def test_sync_learned_topology_single_trv_keeps_both_roles() -> None:
+    """A single representative TRV remains both sensor and actuator."""
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:216136",
         "01:216136": {
@@ -3116,8 +3103,7 @@ def test_sync_learned_topology_single_trv_as_sensor_moved_to_actuators() -> (
     result = sync_learned_topology(config, learned)
     assert result is not None
     zone = result["01:216136"][SZ_ZONES]["06"]
-    # TRV should be in actuators, not sensor
-    assert zone.get(SZ_SENSOR) is None
+    assert zone[SZ_SENSOR] == "04:056675"
     assert "04:056675" in zone["actuators"]
 
 


### PR DESCRIPTION
## Summary

- preserve a representative TRV as the zone `sensor` when `ramses_rf` also lists it under `actuators`
- ensure a representative TRV remains an actuator, while still promoting a dedicated `01:`, `22:`, or `34:` thermostat when present
- replace tests that encoded the incorrect assumption that a TRV could never be a zone sensor

## Findings

The live schema attached to https://github.com/ramses-rf/ramses_rf/pull/1096#issuecomment-5360149554 showed that `ramses_rf` initially discovered the representative TRVs correctly. During `sync_learned_topology()`, `ramses_cc` copied those learned sensors and then cleared every `04:` sensor unless it had already been authored in the config entry.

This conflicted with established behavior:

- https://github.com/ramses-rf/ramses_cc/issues/887 documents a TRV legitimately appearing in both `sensor` and `actuators`
- https://github.com/ramses-rf/ramses_rf/pull/1070 uses the designated `zone.sensor` to prevent non-authoritative TRVs from overwriting `current_temperature`
- https://github.com/ramses-rf/ramses_rf/pull/1096 restores discovery of that representative TRV and expects the same device in both roles

The sensor and actuator fields represent independent roles. Keeping the representative TRV in both fields fixes https://github.com/ramses-rf/ramses_cc/issues/1013 without reverting the temperature-source guard from https://github.com/ramses-rf/ramses_cc/issues/976 or the dedicated-thermostat correction associated with https://github.com/ramses-rf/ramses_cc/issues/813.

## Test plan

- [x] `pytest -q` — 1364 passed, 10 skipped
- [x] `mypy custom_components tests`
- [x] `prek run -a`
- [x] `ramses_rf` issue-976 / PR-1096 focused tests — 6 passed
- [x] HA simulator R36, R75, and new R83 — 20 passed
- [x] R83 verifies discovery, topology sync, reload persistence, and authoritative temperature routing
- [x] Full parallel HA simulator run exercised all 69 recipes; issue-1013 coverage passed after hardening its startup retry. R23 and R78 parallel failures passed in isolation; R68 retains its pre-existing active-probe simulator limitation.

## End-to-end coverage

The companion simulator PR is https://github.com/wimpie70/ramses_extras/pull/180.