### PR TITLE
fix: preserve foreign HGI entries across schema wipe

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2693,7 +2693,40 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             ):
                 new_options = dict(self.config_entry.options)
                 if user_input["clear_schema"]:
-                    new_options.pop(CONF_SCHEMA, None)
+                    # Preserve foreign-owned device entries (_owner: not-me)
+                    # when the schema is cleared.  These represent the user's
+                    # explicit decision to decline a foreign device (e.g. a
+                    # neighbour's HGI).  Without this, the device is
+                    # re-discovered as NEW after the wipe, forcing the user
+                    # to re-decline it (issue 1020).
+                    from .coordinator import RamsesCoordinator
+
+                    old_schema = new_options.get(CONF_SCHEMA, {})
+                    foreign_ids = (
+                        RamsesCoordinator._extract_foreign_device_ids(
+                            old_schema
+                        )
+                    )
+                    if foreign_ids:
+                        root_owner = old_schema.get(SZ_OWNER, "me")
+                        preserved: dict[str, Any] = {SZ_OWNER: root_owner}
+                        for dev_id in foreign_ids:
+                            entry = old_schema.get(dev_id)
+                            if isinstance(entry, dict):
+                                preserved[dev_id] = {
+                                    SZ_TR_OWNER: entry.get(
+                                        SZ_TR_OWNER, "not-me"
+                                    )
+                                }
+                        new_options[CONF_SCHEMA] = preserved
+                        _LOGGER.info(
+                            "Clear cache: preserved %d foreign-owned "
+                            "device entry/entries across schema wipe: %s",
+                            len(foreign_ids),
+                            sorted(foreign_ids),
+                        )
+                    else:
+                        new_options.pop(CONF_SCHEMA, None)
                 new_options[CONF_FRESH_START] = True
                 self.hass.config_entries.async_update_entry(
                     self.config_entry, options=new_options

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -461,8 +461,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
             migration_done = bool(advanced.get(CONF_SSOT_MIGRATED, False))
 
             # Check if schema is effectively empty (no real device entries,
-            # only extension keys like _disabled, _skipped, orphans lists)
-            schema_has_devices = bool(schema_device_ids)
+            # only extension keys like _disabled, _skipped, orphans lists).
+            # Foreign-owned devices (_owner: not-me) are preserved across
+            # schema wipes (issue 1020) but do not count as "real" devices
+            # for the fresh-start check — the user wiped their own devices
+            # and expects discovery metadata to be cleared so they are
+            # re-discovered as NEW.
+            foreign_ids = self._extract_foreign_device_ids(config_schema)
+            schema_has_devices = bool(schema_device_ids - foreign_ids)
 
             if not schema_has_devices:
                 # Schema is empty — either a fresh SSOT start or the user

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -432,6 +432,147 @@ async def test_options_flow_reload_logic(hass: HomeAssistant) -> None:
         assert update_kwargs.get("options", {}).get(CONF_FRESH_START) is True
 
 
+async def test_clear_schema_preserves_foreign_hgi_entries(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing the schema preserves foreign-owned (_owner: not-me) entries.
+
+    Issue 1020: when the user clears the schema (fresh start), foreign HGI
+    entries with ``_owner: not-me`` were wiped along with everything else.
+    The user's decline decision was lost, and the foreign HGI was
+    re-discovered as NEW after the wipe, forcing the user to re-decline it.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "01:111111": {SZ_TR_OWNER: "me", SZ_TR_CLASS: "CTL"},
+                "18:072981": {SZ_TR_OWNER: "not-me", SZ_TR_CLASS: "HGI"},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    try:
+        config_entry.mock_state(hass, ConfigEntryState.LOADED)
+    except AttributeError:
+        object.__setattr__(config_entry, "_state", ConfigEntryState.LOADED)
+        config_entry.__dict__["state"] = ConfigEntryState.LOADED
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "clear_cache"}
+    )
+
+    with (
+        patch.object(hass.config_entries, "async_unload"),
+        patch.object(hass.config_entries, "async_setup"),
+        patch.object(hass.config_entries, "async_update_entry") as mock_update,
+        patch(
+            "custom_components.ramses_cc.config_flow.dr.async_entries_for_config_entry",
+            return_value=[],
+        ),
+        patch("custom_components.ramses_cc.config_flow.Store") as mock_store,
+    ):
+        mock_instance = MagicMock()
+        mock_store.return_value = mock_instance
+        mock_instance.async_load = AsyncMock(
+            return_value={
+                "client_state": {"schema": {}, "packets": {}},
+            }
+        )
+        mock_instance.async_save = AsyncMock()
+
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"clear_schema": True, "clear_packets": False},
+        )
+
+        # The foreign HGI entry should be preserved in the new schema
+        mock_update.assert_called_once()
+        new_options = mock_update.call_args.kwargs.get("options", {})
+        new_schema = new_options.get(CONF_SCHEMA, {})
+        assert "18:072981" in new_schema, (
+            "Foreign HGI entry should be preserved across schema wipe"
+        )
+        assert new_schema["18:072981"].get(SZ_TR_OWNER) == "not-me"
+        # The user's own devices should be gone
+        assert "01:111111" not in new_schema
+        # Root _owner should be preserved
+        assert new_schema.get(SZ_OWNER) == "me"
+
+
+async def test_clear_schema_no_foreign_entries_pops_schema(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing the schema with no foreign entries pops CONF_SCHEMA entirely."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "01:111111": {SZ_TR_OWNER: "me", SZ_TR_CLASS: "CTL"},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    try:
+        config_entry.mock_state(hass, ConfigEntryState.LOADED)
+    except AttributeError:
+        object.__setattr__(config_entry, "_state", ConfigEntryState.LOADED)
+        config_entry.__dict__["state"] = ConfigEntryState.LOADED
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "clear_cache"}
+    )
+
+    with (
+        patch.object(hass.config_entries, "async_unload"),
+        patch.object(hass.config_entries, "async_setup"),
+        patch.object(hass.config_entries, "async_update_entry") as mock_update,
+        patch(
+            "custom_components.ramses_cc.config_flow.dr.async_entries_for_config_entry",
+            return_value=[],
+        ),
+        patch("custom_components.ramses_cc.config_flow.Store") as mock_store,
+    ):
+        mock_instance = MagicMock()
+        mock_store.return_value = mock_instance
+        mock_instance.async_load = AsyncMock(
+            return_value={
+                "client_state": {"schema": {}, "packets": {}},
+            }
+        )
+        mock_instance.async_save = AsyncMock()
+
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"clear_schema": True, "clear_packets": False},
+        )
+
+        mock_update.assert_called_once()
+        new_options = mock_update.call_args.kwargs.get("options", {})
+        # No foreign entries → CONF_SCHEMA should be popped entirely
+        assert CONF_SCHEMA not in new_options
+
+
 async def test_options_flow_defaults_and_branches(hass: HomeAssistant) -> None:
     """Test various options flow branches including defaults & finish steps."""
     config_entry = MockConfigEntry(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -4469,6 +4469,68 @@ async def test_passive_scan_no_migration_when_schema_has_device(
     await asyncio.sleep(0)
 
 
+async def test_passive_scan_schema_with_only_foreign_treats_as_empty(
+    hass: HomeAssistant,
+) -> None:
+    """Schema with only foreign devices is treated as empty for fresh-start.
+
+    Issue 1020: foreign-owned (_owner: not-me) entries are preserved across
+    schema wipes, but they should not prevent the fresh-start discovery
+    metadata clearing.  The user wiped their own devices and expects them
+    to be re-discovered as NEW.
+    """
+    from custom_components.ramses_cc.const import (
+        CONF_ADVANCED_FEATURES,
+        CONF_PASSIVE_SCAN,
+        SZ_OWNER,
+        SZ_TR_OWNER,
+    )
+    from custom_components.ramses_cc.discovery import SZ_DISCOVERY
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="test_foreign_only",
+        options={
+            "ramses_rf": {},
+            "serial_port": {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:072981": {SZ_TR_OWNER: "not-me"},
+            },
+            CONF_ADVANCED_FEATURES: {CONF_PASSIVE_SCAN: True},
+        },
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = RamsesCoordinator(hass, entry)
+    coordinator.store = MagicMock()
+    coordinator.store.async_load = AsyncMock(
+        return_value={
+            SZ_DISCOVERY: {"devices": {"01:111111": {"status": "accepted"}}}
+        }
+    )
+    coordinator.store.async_save_backup = AsyncMock()
+
+    mock_client = MagicMock(spec=Gateway)
+    mock_client.start = AsyncMock()
+    coordinator._create_client = MagicMock(return_value=mock_client)
+
+    await coordinator.async_setup()
+    await asyncio.sleep(0)
+
+    # The schema has only a foreign device — the fresh-start check should
+    # treat it as empty and clear discovery metadata.  The foreign entry
+    # itself should remain in the schema (preserved by clear_cache).
+    schema = coordinator.options.get(CONF_SCHEMA, {})
+    assert "18:072981" in schema  # foreign entry preserved
+    assert schema["18:072981"].get(SZ_TR_OWNER) == "not-me"
+
+    # _skip_discovery_restore should be True (fresh-start triggered
+    # because the schema is treated as empty despite having a foreign entry)
+    assert coordinator._skip_discovery_restore is True
+    await asyncio.sleep(0)
+
+
 async def test_passive_scan_no_migration_when_scan_disabled(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Summary

- When the user clears the schema (fresh start via Clear Cache), foreign-owned device entries (`_owner: not-me`) were wiped along with everything else. The user's decline decision was lost, and the foreign HGI was re-discovered as NEW after the wipe, forcing the user to re-decline it.
- This preserves foreign-owned entries when the schema is cleared, and adjusts the coordinator's fresh-start check to exclude foreign devices from the "schema has devices" determination.

### Changes

**`config_flow.py` (async_step_clear_cache):** Before popping `CONF_SCHEMA`, extract foreign device IDs via `_extract_foreign_device_ids` and preserve them as trait-only entries (`_owner: not-me`) in a minimal schema dict with the root `_owner`. If there are no foreign entries, `CONF_SCHEMA` is popped entirely as before.

**`coordinator.py` (fresh-start check):** Exclude foreign device IDs from the `schema_has_devices` check. A schema with only foreign entries is treated as empty for the fresh-start logic — discovery metadata is cleared so the user's own devices are re-discovered as NEW. The foreign entries themselves remain in the schema and are not re-flagged as NEW (the discovery manager already filters foreign devices from the NEW list).

### Why this works

- The discovery manager already filters foreign devices from the NEW device list (line 588-591 in `discovery.py`), so preserved foreign entries won't re-trigger discovery notifications
- The `_derive_known_list_from_schema` method already excludes foreign devices from the known_list and adds them to the block_list, so ramses_rf won't create entities for them
- The schema editor path is unaffected — the user makes explicit per-device decisions there

#### Test plan

- [x] `test_clear_schema_preserves_foreign_hgi_entries` — verifies foreign HGI entry survives schema wipe with `_owner: not-me` intact
- [x] `test_clear_schema_no_foreign_entries_pops_schema` — verifies `CONF_SCHEMA` is popped entirely when no foreign entries exist
- [x] `test_passive_scan_schema_with_only_foreign_treats_as_empty` — verifies coordinator treats foreign-only schema as empty for fresh-start
- [x] All 1262 ramses_cc tests pass (10 skipped, 1 pre-existing snapshot failure unrelated to this change)
- [x] ruff check + format pass

Issue 1020: https://github.com/ramses-rf/ramses_cc/issues/1020