### PR TITLE
fix: prevent phantom zones in dual-CTL setups

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1422,6 +1422,20 @@ def sync_learned_topology(
     # zone_index but may not have bound_to (since dst is --:------ for
     # broadcasts). In that case, infer CTL from main_tcs or only TCS key.
     main_tcs_id = config_schema.get(SZ_MAIN_TCS)
+    # Count CTL controllers (01: or 23: with a zones dict) to detect
+    # multi-TCS setups.  Issue 1027: in a dual-CTL setup, the main_tcs
+    # fallback must not be used for comment-based zone placement — it
+    # would assign the second CTL's TRVs to the first CTL, creating
+    # phantom zones on the wrong controller.
+    ctl_keys_with_zones: list[str] = [
+        k
+        for k in config_schema
+        if isinstance(k, str)
+        and k[:3] in ("01:", "23:")
+        and isinstance(config_schema.get(k), dict)
+        and isinstance(config_schema[k].get(SZ_ZONES), dict)
+    ]
+    is_multi_tcs = len(ctl_keys_with_zones) > 1
     # Fallback: find the CTL key (01: or 23: prefix) if main_tcs is not set.
     # When multiple 01: keys exist (CTL + sensors), prefer the one with
     # a "zones" dict — zone sensors don't have zones, only the CTL does.
@@ -1490,9 +1504,17 @@ def sync_learned_topology(
             # Skip invalid zone indices (ramses_rf only allows 00-0B)
             if zone_index and not _VALID_ZONE_INDEX_RE.match(zone_index):
                 continue
-            # If no bound_to in comment but zone_index is present, infer CTL
-            if not comment_tcs_id and zone_index and main_tcs_id:
-                comment_tcs_id = main_tcs_id
+            # If no bound_to in comment but zone_index is present, infer CTL.
+            # Issue 1027: in a multi-TCS setup, never infer from main_tcs —
+            # a TRV broadcasting zone 04 on CTL-B would be wrongly placed on
+            # CTL-A (main_tcs), creating phantom zones on the wrong
+            # controller.  Instead, try the learned schema first, and only
+            # fall back to main_tcs in single-CTL setups.
+            if not comment_tcs_id and zone_index:
+                if device_id in learned_device_zones:
+                    comment_tcs_id = learned_device_zones[device_id][0]
+                elif main_tcs_id and not is_multi_tcs:
+                    comment_tcs_id = main_tcs_id
             if comment_tcs_id and zone_index:
                 comment_device_zones[device_id] = (comment_tcs_id, zone_index)
 

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2225,6 +2225,110 @@ def test_sync_learned_topology_comment_zone_only_infers_single_ctl() -> None:
     assert "04:111111" in result["01:123456"][SZ_ZONES]["03"]["actuators"]
 
 
+def test_sync_learned_topology_multi_tcs_zone_isolation() -> None:
+    """Multi-TCS: TRV comment with zone but no bound_to must not infer CTL.
+
+    Issue 1027: a dual-CTL setup where CTL-A has 4 zones and CTL-B has 7
+    zones.  TRVs on CTL-B broadcasting zone codes (30C9) without a
+    bound_to in the comment must NOT be placed on CTL-A via main_tcs
+    fallback — that creates phantom zones 04/05/06 on CTL-A shadowing
+    CTL-B's zones.
+    """
+    config: dict[str, Any] = {
+        "01:161591": {
+            SZ_ZONES: {
+                "00": {"actuators": ["04:147093"]},
+                "01": {"actuators": ["04:144637"]},
+                "02": {"actuators": ["04:147099"]},
+                "03": {"actuators": ["04:147095"]},
+            },
+        },
+        "01:258891": {
+            SZ_ZONES: {
+                "00": {"actuators": ["04:012975", "04:012979"]},
+                "01": {"actuators": ["04:107753", "04:147097"]},
+                "02": {"actuators": ["04:012981"]},
+                "03": {"actuators": ["04:078977"]},
+                "04": {"actuators": ["04:078971"]},
+                "05": {"actuators": ["04:078973"]},
+                "06": {"actuators": ["04:012977"]},
+            },
+        },
+        SZ_DEVICE_COMMENTS: {
+            # CTL-B TRVs in zones 04/05/06 — no bound_to in comment
+            "04:078971": "Likely TRV. zone 04. codes: 30C9, 3150.",
+            "04:078973": "Likely TRV. zone 05. codes: 30C9, 3150.",
+            "04:012977": "Likely TRV. zone 06. codes: 30C9, 3150.",
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:161591": {
+            SZ_ZONES: {
+                "00": {"actuators": ["04:147093"]},
+                "01": {"actuators": ["04:144637"]},
+                "02": {"actuators": ["04:147099"]},
+                "03": {"actuators": ["04:147095"]},
+            },
+        },
+        "01:258891": {
+            SZ_ZONES: {
+                "00": {"actuators": ["04:012975", "04:012979"]},
+                "01": {"actuators": ["04:107753", "04:147097"]},
+                "02": {"actuators": ["04:012981"]},
+                "03": {"actuators": ["04:078977"]},
+                "04": {"actuators": ["04:078971"]},
+                "05": {"actuators": ["04:078973"]},
+                "06": {"actuators": ["04:012977"]},
+            },
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    target = result if result is not None else config
+    # CTL-A must still have exactly 4 zones (00-03)
+    assert set(target["01:161591"][SZ_ZONES].keys()) == {
+        "00",
+        "01",
+        "02",
+        "03",
+    }
+    # CTL-A must NOT have phantom zones 04, 05, 06
+    assert "04" not in target["01:161591"][SZ_ZONES]
+    assert "05" not in target["01:161591"][SZ_ZONES]
+    assert "06" not in target["01:161591"][SZ_ZONES]
+
+
+def test_sync_learned_topology_multi_tcs_zone_uses_learned_tcs() -> None:
+    """Multi-TCS: comment without bound_to uses learned schema for TCS.
+
+    When a TRV's comment has zone_index but no bound_to, and the learned
+    schema places the TRV under a specific CTL, that CTL should be used
+    rather than skipping the device entirely.
+    """
+    config: dict[str, Any] = {
+        "01:161591": {SZ_ZONES: {"00": {"actuators": ["04:147093"]}}},
+        "01:258891": {SZ_ZONES: {"00": {"actuators": ["04:012975"]}}},
+        SZ_DEVICE_COMMENTS: {
+            "04:078971": "Likely TRV. zone 04. codes: 30C9, 3150.",
+        },
+    }
+    learned: dict[str, Any] = {
+        "01:161591": {SZ_ZONES: {"00": {"actuators": ["04:147093"]}}},
+        "01:258891": {
+            SZ_ZONES: {
+                "00": {"actuators": ["04:012975"]},
+                "04": {"actuators": ["04:078971"]},
+            },
+        },
+    }
+    result = sync_learned_topology(config, learned)
+    target = result if result is not None else config
+    # 04:078971 must be in CTL-B's zone 04, not CTL-A
+    assert "04:078971" in target["01:258891"][SZ_ZONES]["04"].get(
+        "actuators", []
+    )
+    assert "04" not in target["01:161591"].get(SZ_ZONES, {})
+
+
 def test_sync_learned_topology_comment_skips_invalid_zone_index() -> None:
     """Zone indices > 0B are rejected by ramses_rf schema (max 12 zones).
 


### PR DESCRIPTION
## Summary

- In a multi-TCS (dual controller) setup, the `main_tcs` fallback for comment-based zone placement assigned the second CTL's TRVs to the first CTL, creating phantom zones on the wrong controller
- Now the learned schema is checked first for the correct TCS assignment, and the `main_tcs` fallback is only used in single-CTL setups
- Mirrors the existing DHW isolation fix (issue 971) which already required concrete `bound to` bindings for DHW sensor placement in multi-TCS setups

Fixes https://github.com/ramses-rf/ramses_cc/issues/1027

#### Test plan

- [x] `test_sync_learned_topology_multi_tcs_zone_isolation` — verifies CTL-A does not get phantom zones 04/05/06 from CTL-B's TRVs
- [x] `test_sync_learned_topology_multi_tcs_zone_uses_learned_tcs` — verifies the learned schema TCS is used when comment has no `bound to`
- [x] Existing single-CTL inference tests still pass
- [x] Full test suite passes (1259 passed, 10 skipped)