### PR TITLE
fix: enable passive scan by default on v2→v3 migration

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -398,6 +398,27 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Remove deprecated disabled_devices key (replaced by _disabled trait)
         new_options.pop("disabled_devices", None)
 
+        # Enable passive scan by default for upgrading users.
+        # Pre-0.57 (v2) users had enforce_known_list=False in many cases,
+        # so devices that were not in the known_list were still allowed
+        # through.  The v3 migration makes enforce_known_list always-on,
+        # which would filter out those devices.  Enabling passive scan
+        # lets the user re-discover them via the discovery flow and add
+        # them to the schema.  The user can disable it later from the
+        # advanced features options once they've reviewed everything.
+        advanced = dict(new_options.get(CONF_ADVANCED_FEATURES, {}))
+        if not advanced.get(CONF_PASSIVE_SCAN):
+            advanced[CONF_PASSIVE_SCAN] = True
+            new_options[CONF_ADVANCED_FEATURES] = advanced
+            _LOGGER.info(
+                "Phase 4 migration: enabled passive scan for config "
+                "entry %s (enforce_known_list is now always-on, "
+                "passive scan helps re-discover devices that were "
+                "previously allowed through without being in the "
+                "known_list)",
+                entry.entry_id,
+            )
+
         hass.config_entries.async_update_entry(
             entry, options=new_options, version=3
         )

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -3148,6 +3148,11 @@ async def test_migrate_entry_v2_to_v3(hass: HomeAssistant) -> None:
     assert "32:150000" in schema
     assert schema["32:150000"][SZ_TR_CLASS] == "FAN"
 
+    # Passive scan must be enabled for upgrading users
+    assert (
+        entry.options.get("advanced_features", {}).get("passive_scan") is True
+    )
+
 
 async def test_migrate_entry_v2_to_v3_saves_backup(
     hass: HomeAssistant,
@@ -3213,6 +3218,10 @@ async def test_migrate_entry_v2_to_v3_no_known_list(
     assert entry.version == 3
     # Schema unchanged — no known_list to merge
     assert entry.options[CONF_SCHEMA] == {"01:150000": {"_class": "CTL"}}
+    # Passive scan still enabled even with no known_list
+    assert (
+        entry.options.get("advanced_features", {}).get("passive_scan") is True
+    )
 
 
 async def test_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
@@ -3242,6 +3251,11 @@ async def test_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
 
     # v2→v3: known_list class merged into schema
     assert entry.options[CONF_SCHEMA]["01:150000"][SZ_TR_CLASS] == "CTL"
+
+    # v2→v3: passive scan enabled for upgrading users
+    assert (
+        entry.options.get("advanced_features", {}).get("passive_scan") is True
+    )
 
 
 # ───────────────────────────────────────────────────────────────────────
@@ -3620,6 +3634,11 @@ async def test_chained_config_entry_migration_v1_to_v3(
     assert "use_database" not in config_entry.options.get("ramses_rf", {})
     assert "known_list" not in config_entry.options
     assert config_entry.options["schema"]["04:123456"] == {"_class": "TRV"}
+    # Passive scan enabled for upgrading users
+    assert (
+        config_entry.options.get("advanced_features", {}).get("passive_scan")
+        is True
+    )
 
 
 async def test_options_flow_unloaded_entry_fallback(

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -580,7 +580,7 @@ async def test_async_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
             },
             version=2,
         )
-        # Second call: v2→v3 (no known_list to merge, just version bump)
+        # Second call: v2→v3 (no known_list to merge, passive scan enabled)
         assert mock_update.call_args_list[1] == call(
             entry,
             options={
@@ -589,6 +589,7 @@ async def test_async_migrate_entry_v1_to_v3(hass: HomeAssistant) -> None:
                 },
                 "ramses_rf": {},
                 "other_setting": "kept",
+                "advanced_features": {"passive_scan": True},
             },
             version=3,
         )
@@ -638,6 +639,11 @@ async def test_async_migrate_entry_v2_to_v3(hass: HomeAssistant) -> None:
         # Device only in known_list gets a new schema entry
         assert "04:654321" in schema
         assert schema["04:654321"].get("_faked") is True
+        # Passive scan must be enabled for upgrading users
+        assert (
+            migrated_options.get("advanced_features", {}).get("passive_scan")
+            is True
+        )
 
 
 def test_healed_serial_port_options_from_mqtt_hints() -> None:

--- a/tests/tests_old/test_init_config.py
+++ b/tests/tests_old/test_init_config.py
@@ -21,6 +21,10 @@ from custom_components.ramses_cc import (
     RamsesCoordinator,
 )
 from custom_components.ramses_cc.config_flow import SZ_RESTORE_CACHE
+from custom_components.ramses_cc.const import (
+    CONF_ADVANCED_FEATURES,
+    CONF_PASSIVE_SCAN,
+)
 from ramses_rf.gateway import Gateway
 
 from ..virtual_rf import VirtualRf
@@ -31,6 +35,11 @@ _CALL_LATER_DELAY: Final = 0  # from: custom_components.ramses_cc.services.py
 NUM_SVCS_AFTER = (
     39  # proxy for success, platform services included since 0.51.8
 )
+# Passive scan services (registered when advanced_features.passive_scan
+# is enabled, e.g. after v2→v3 migration).  7 services:
+# get_discovered_devices, accept/discard/remove/enable/disable_discovered_device,
+# add_faked_rem.
+_NUM_PASSIVE_SCAN_SVCS = 7
 
 
 TEST_CONFIGS = {
@@ -126,9 +135,14 @@ async def _test_common(
         len(hass.states.async_entity_ids(Platform.BINARY_SENSOR)) >= 1
     )  # binary_sensor.18_000730_status
 
-    assert (
-        len(hass.services.async_services_for_domain(DOMAIN)) == NUM_SVCS_AFTER
+    # Service count: base services + passive scan services if enabled.
+    # The v2→v3 migration enables passive scan for upgrading users, so
+    # entries that went through migration have 7 extra discovery services.
+    passive_scan = entry.options.get(CONF_ADVANCED_FEATURES, {}).get(
+        CONF_PASSIVE_SCAN, False
     )
+    expected = NUM_SVCS_AFTER + (_NUM_PASSIVE_SCAN_SVCS if passive_scan else 0)
+    assert len(hass.services.async_services_for_domain(DOMAIN)) == expected
 
 
 @patch(

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -29,7 +29,12 @@ from custom_components.ramses_cc import (
     SVC_SEND_PACKET,
 )
 from custom_components.ramses_cc.climate import RamsesController, RamsesZone
-from custom_components.ramses_cc.const import SystemMode, ZoneMode
+from custom_components.ramses_cc.const import (
+    CONF_ADVANCED_FEATURES,
+    CONF_PASSIVE_SCAN,
+    SystemMode,
+    ZoneMode,
+)
 from custom_components.ramses_cc.coordinator import RamsesCoordinator
 from custom_components.ramses_cc.schemas import (
     SCH_DELETE_COMMAND,
@@ -92,6 +97,9 @@ NUM_DEVS_AFTER = 16  # Same — all devices already in known_list
 NUM_SVCS_AFTER = (
     41  # proxy for success, platform services included since 0.51.8
 )
+# Passive scan services (registered when advanced_features.passive_scan
+# is enabled, e.g. after v2→v3 migration).  7 services.
+_NUM_PASSIVE_SCAN_SVCS = 7
 NUM_ENTS_AFTER = 72  # proxy for success (Phase 4: more devices in known_list)
 NUM_ENTS_AFTER_ALT = (
     NUM_ENTS_AFTER - 9
@@ -295,8 +303,16 @@ async def _cast_packets_to_rf(hass: HomeAssistant, rf: VirtualRf) -> None:
     except AssertionError:
         assert len(gwy.device_registry.devices) == NUM_DEVS_AFTER - 4
 
+    # Service count: base + passive scan services if enabled.
+    # The v2→v3 migration enables passive scan for upgrading users.
+    passive_scan = entry.options.get(CONF_ADVANCED_FEATURES, {}).get(
+        CONF_PASSIVE_SCAN, False
+    )
+    expected_svcs = NUM_SVCS_AFTER + (
+        _NUM_PASSIVE_SCAN_SVCS if passive_scan else 0
+    )
     assert (
-        len(hass.services.async_services_for_domain(DOMAIN)) == NUM_SVCS_AFTER
+        len(hass.services.async_services_for_domain(DOMAIN)) == expected_svcs
     )
     # 2025.10.0: some services registered earlier during async_setup, not in platform
 


### PR DESCRIPTION
## Summary

- The v2→v3 config entry migration now enables `passive_scan` by default in `advanced_features`.
- Pre-0.57 (v2) users typically had `enforce_known_list=False`, so devices not in the known_list were still allowed through. The v3 migration makes `enforce_known_list` always-on, which would silently filter out those devices.
- Enabling passive scan during migration lets the user re-discover those devices via the discovery flow and add them to the schema. The user can disable it from advanced features once they've reviewed everything.

#### Test plan

- [x] `ruff check` — clean
- [x] `pytest tests/tests_new/test_init.py tests/tests_new/test_config_flow.py` — 97 passed, 2 skipped
- [x] Updated `test_async_migrate_entry_v1_to_v3` — asserts `passive_scan: True`
- [x] Updated `test_async_migrate_entry_v2_to_v3` — asserts `passive_scan: True`
- [x] Updated `test_migrate_entry_v2_to_v3` — asserts `passive_scan: True`
- [x] Updated `test_migrate_entry_v2_to_v3_no_known_list` — asserts `passive_scan: True` even without known_list
- [x] Updated `test_migrate_entry_v1_to_v3` — asserts `passive_scan: True`
- [x] Updated `test_chained_config_entry_migration_v1_to_v3` — asserts `passive_scan: True`