### PR TITLE
fix: clear async attr cache on packet arrival for real-time state updates (issue 1042)

### DIFF
--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -18,7 +18,7 @@ from ramses_rf.devices import Fakeable
 from ramses_rf.entity import Entity as RamsesRFEntity
 
 from .const import DOMAIN, SIGNAL_UPDATE
-from .helpers import resolve_async_attr
+from .helpers import clear_async_attr_cache, resolve_async_attr
 
 if TYPE_CHECKING:
     from .coordinator import RamsesCoordinator
@@ -177,6 +177,13 @@ class RamsesEntity(CoordinatorEntity):
         """Safely write HA state using an async lock.
 
         Prevents event loop saturation from concurrent updates.
+
+        Clears the async attribute cache so that freshly-received packet
+        data is visible immediately, bypassing the 30-second cooldown in
+        resolve_async_attr.  Without this, async state readers (e.g.
+        BdrSwitch.active, TrvActuator.heat_demand) return stale cached
+        values for up to 30 seconds after a packet updates the underlying
+        state (issue 1042).
         """
         if self._update_lock.locked():
             self._dropped_updates += 1
@@ -193,4 +200,5 @@ class RamsesEntity(CoordinatorEntity):
             return
 
         async with self._update_lock:
+            clear_async_attr_cache(self)
             self.async_write_ha_state()


### PR DESCRIPTION
## Summary

- Call `clear_async_attr_cache(self)` in `_async_update_and_write_state` before `async_write_ha_state()` so that freshly-received packet data is visible immediately, bypassing the 30-second cooldown in `resolve_async_attr`.

## Root Cause

When a packet arrived and the coordinator sent `SIGNAL_UPDATE` to an entity, `_async_update_and_write_state` called `async_write_ha_state()` without clearing the `resolve_async_attr` cache. This meant async state readers (e.g. `BdrSwitch.active`, `TrvActuator.heat_demand`, `OtbGateway.rel_modulation_level`) returned stale cached values for up to 30 seconds after the underlying state was updated by the ingestion pipeline.

The 30-second cooldown in `resolve_async_attr` exists to prevent command floods from UI re-renders (e.g. `system_mode()` dispatches a 2E04 RQ when unhydrated). But it also prevented fresh data from being fetched when a packet arrived — the entity showed the old relay state until the cooldown expired.

## The Fix

Call the existing `clear_async_attr_cache(self)` helper (already used by `force_update`) in `_async_update_and_write_state` before `async_write_ha_state()`. This:
- Invalidates the cache so the next property access dispatches the async getter fresh
- Bypasses the cooldown for this one state write cycle
- Still protects against UI re-render floods (the cooldown is re-established after the getter completes)
- Fixes all 75+ async state readers in ramses_rf, not just `BdrSwitch.active`

## Why not convert async methods to properties?

ramses_rf has 75+ "falsely async" state-reader methods (e.g. `heat_demand`, `relay_demand`, `temperature`, `co2_level`, `fan_mode`, `bypass_position`, etc.) that just read state attributes without side-effects. Converting them all to properties would be a massive change with high regression risk. This fix addresses the root cause in ramses_cc instead — one line, benefits all entities.

## Context

- Issue: https://github.com/ramses-rf/ramses_cc/issues/1042
- Originally reported by @bmhughes in issue 1041 comments
- `clear_async_attr_cache` was already implemented for `force_update` — this PR reuses it for packet-driven updates

## Test plan

- [x] ramses_cc unit tests: 1376 passed, 10 skipped
- [ ] ha_sim_test with BDR 3EF1 relay state verification
- [ ] Manual verification on `hass` instance with real BDR relays