### PR TITLE
fix: dispatch SIGNAL_UPDATE for BDR on `0008` `FC` packets (issue 1042)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -667,6 +667,26 @@ class RamsesCoordinator(DataUpdateCoordinator):
                         self.hass, f"{SIGNAL_UPDATE}_{dto.addr2}"
                     )
 
+                # 0008 FC packets from the CTL update the BDR's
+                # demand_state.relay_demand via the CQRS ingestion
+                # pipeline, but the BDR is neither src nor dst of the
+                # packet.  Dispatch SIGNAL_UPDATE for the BDR so its
+                # entities (e.g. active binary_sensor) refresh.
+                # See: issue 1042.
+                if dto.code == "0008" and dto.payload[:2] == "FC":
+                    try:
+                        registry = self.client.device_registry
+                        tcs = registry.system_by_id.get(src_id)
+                        if tcs is not None:
+                            bdr = getattr(tcs, "appliance_control", None)
+                            if bdr is not None and bdr.id != src_id:
+                                async_dispatcher_send(
+                                    self.hass,
+                                    f"{SIGNAL_UPDATE}_{bdr.id}",
+                                )
+                    except Exception:  # noqa: BLE001
+                        pass
+
             self.hass.async_create_task(_signal_after_ingestion())
 
         if self.client:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -667,18 +667,26 @@ class RamsesCoordinator(DataUpdateCoordinator):
                         self.hass, f"{SIGNAL_UPDATE}_{dto.addr2}"
                     )
 
-                # 0008 FC packets from the CTL update the BDR's
+                # 0008 FC/FA/F9 packets from the CTL update a BDR's
                 # demand_state.relay_demand via the CQRS ingestion
                 # pipeline, but the BDR is neither src nor dst of the
                 # packet.  Dispatch SIGNAL_UPDATE for the BDR so its
                 # entities (e.g. active binary_sensor) refresh.
                 # See: issue 1042.
-                if dto.code == "0008" and dto.payload[:2] == "FC":
+                if dto.code == "0008" and self.client is not None:
+                    domain = dto.payload[:2]
                     try:
                         registry = self.client.device_registry
                         tcs = registry.system_by_id.get(src_id)
                         if tcs is not None:
-                            bdr = getattr(tcs, "appliance_control", None)
+                            if domain == "FC":
+                                bdr = getattr(tcs, "appliance_control", None)
+                            elif domain == "FA":
+                                bdr = getattr(tcs, "hotwater_valve", None)
+                            elif domain == "F9":
+                                bdr = getattr(tcs, "heating_valve", None)
+                            else:
+                                bdr = None
                             if bdr is not None and bdr.id != src_id:
                                 async_dispatcher_send(
                                     self.hass,


### PR DESCRIPTION
## Summary

0008 FC packets from the CTL update the BDR's `demand_state.relay_demand` via the CQRS ingestion pipeline (ramses_rf PR 1113), but the BDR is neither the source nor the destination of the packet. The coordinator's `_on_packet` callback only dispatched `SIGNAL_UPDATE` for `dto.addr1` (CTL) and `dto.addr2` (broadcast), so the BDR's entities never refreshed.

This PR adds a special case: when a 0008 FC packet is received, also dispatch `SIGNAL_UPDATE` for the TCS's `appliance_control` (BDR) so its `active` binary_sensor reflects the CTL's relay demand in real-time.

### Before
- CTL sends 0008 FC with 0% → BDR's `demand_state.relay_demand` updated to 0.0, but BDR's `active` entity stays `on` (no refresh signal)

### After
- CTL sends 0008 FC with 0% → BDR's `demand_state.relay_demand` updated to 0.0, `SIGNAL_UPDATE` dispatched for BDR, `active` entity shows `off`

**Depends on:** ramses_rf PR 1113 (https://github.com/ramses-rf/ramses_rf/pull/1113)

#### Test plan
- [x] ramses_cc: 1272 passed, 10 skipped
- [x] ha_sim_test R89: all 4 checks pass (including 0008 FC fallback)