### PR TITLE
Revert "fix: dispatch SIGNAL_UPDATE for BDR on `0008` `FC` packets (1045)"

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -667,34 +667,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
                         self.hass, f"{SIGNAL_UPDATE}_{dto.addr2}"
                     )
 
-                # 0008 FC/FA/F9 packets from the CTL update a BDR's
-                # demand_state.relay_demand via the CQRS ingestion
-                # pipeline, but the BDR is neither src nor dst of the
-                # packet.  Dispatch SIGNAL_UPDATE for the BDR so its
-                # entities (e.g. active binary_sensor) refresh.
-                # See: issue 1042.
-                if dto.code == "0008" and self.client is not None:
-                    domain = dto.payload[:2]
-                    try:
-                        registry = self.client.device_registry
-                        tcs = registry.system_by_id.get(src_id)
-                        if tcs is not None:
-                            if domain == "FC":
-                                bdr = getattr(tcs, "appliance_control", None)
-                            elif domain == "FA":
-                                bdr = getattr(tcs, "hotwater_valve", None)
-                            elif domain == "F9":
-                                bdr = getattr(tcs, "heating_valve", None)
-                            else:
-                                bdr = None
-                            if bdr is not None and bdr.id != src_id:
-                                async_dispatcher_send(
-                                    self.hass,
-                                    f"{SIGNAL_UPDATE}_{bdr.id}",
-                                )
-                    except Exception:  # noqa: BLE001
-                        pass
-
             self.hass.async_create_task(_signal_after_ingestion())
 
         if self.client:


### PR DESCRIPTION
Reverts ramses-rf/ramses_cc#1045 as discussed