### PR TITLE
fix: replace clear_async_attr_cache with reset_async_attr_cooldown (issue 1040)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2769,9 +2769,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
         """Force an immediate update of all device states.
 
         Clears the resolve_async_attr cooldown cache on all entities so
-        that freshly-received packet data (e.g. a 2349 setpoint update)
-        is visible immediately rather than waiting for the 30-second
-        cooldown to expire.
+        that freshly-received packet data is visible immediately rather
+        than waiting for the 1-second cooldown to expire.
 
         :param _: Unused service call argument.
         """

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -18,7 +18,10 @@ from ramses_rf.devices import Fakeable
 from ramses_rf.entity import Entity as RamsesRFEntity
 
 from .const import DOMAIN, SIGNAL_UPDATE
-from .helpers import clear_async_attr_cache, resolve_async_attr
+from .helpers import (
+    reset_async_attr_cooldown,
+    resolve_async_attr,
+)
 
 if TYPE_CHECKING:
     from .coordinator import RamsesCoordinator
@@ -178,12 +181,15 @@ class RamsesEntity(CoordinatorEntity):
 
         Prevents event loop saturation from concurrent updates.
 
-        Clears the async attribute cache so that freshly-received packet
-        data is visible immediately, bypassing the 30-second cooldown in
-        resolve_async_attr.  Without this, async state readers (e.g.
-        BdrSwitch.active, TrvActuator.heat_demand) return stale cached
-        values for up to 30 seconds after a packet updates the underlying
-        state (issue 1042).
+        Resets the resolve_async_attr cooldown so that the next property
+        access can dispatch a fresh ``_resolve()`` to read the updated
+        state (issue 1042).  Unlike ``clear_async_attr_cache``, this
+        preserves the cached value and does NOT cancel in-flight tasks,
+        so it doesn't cause the recorder death spiral (issue 1040):
+        - The cached value is returned → HA detects no state change →
+          recorder write skipped
+        - When ``_resolve()`` completes with a different value, a second
+          state write triggers a recorder write (only for real changes)
         """
         if self._update_lock.locked():
             self._dropped_updates += 1
@@ -200,5 +206,5 @@ class RamsesEntity(CoordinatorEntity):
             return
 
         async with self._update_lock:
-            clear_async_attr_cache(self)
+            reset_async_attr_cooldown(self)
             self.async_write_ha_state()

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -168,14 +168,24 @@ def resolve_async_attr[T](
             state = _AsyncAttrState()
             state_map[state_key] = state
 
-        # Cooldown: don't re-dispatch the async getter within 30 seconds of
-        # the last dispatch.  This prevents command floods when the getter
+        # Cooldown: don't re-dispatch the async getter within a short window
+        # of the last dispatch.  This prevents command floods when the getter
         # has side-effects (e.g. dispatching RQ commands) and the result is
         # still None (unhydrated state).
         # However, if the cached value is None (unhydrated), we skip the
         # cooldown so that the first real data (e.g. a 30C9 temperature
-        # broadcast) is picked up immediately rather than waiting 30s.
-        COOLDOWN_SECS = 30
+        # broadcast) is picked up immediately rather than waiting.
+        #
+        # The cooldown was 30s (issue 1042), but that caused stale sensor
+        # readings for up to 30s after a packet updated the underlying
+        # state.  It is now 1s, and ``reset_async_attr_cooldown`` is called
+        # on every inbound packet (in ``_async_update_and_write_state``) to
+        # reset the cooldown timestamp.  This allows the next property
+        # access to dispatch a fresh ``_resolve()`` that reads the updated
+        # state, while preserving the cached value so HA doesn't detect
+        # spurious state changes (which caused the recorder death spiral,
+        # issue 1040).
+        COOLDOWN_SECS = 1
         now = time.monotonic()
         cached_val = state.cached if state.cached is not _UNSET else default
         within_cooldown = (
@@ -241,8 +251,8 @@ def clear_async_attr_cache(entity: Any) -> None:
     """Clear all resolve_async_attr cooldown/cache state for an entity.
 
     This forces the next property access to re-dispatch the async getter,
-    bypassing the 30-second cooldown.  Used by force_update so that
-    freshly-received packet data is visible immediately.
+    bypassing the cooldown.  Used by force_update so that freshly-received
+    packet data is visible immediately.
 
     If a resolution task is still in flight (e.g. waiting on a real RQ/RP
     round-trip that can take up to 20s), it is cancelled here rather than
@@ -270,6 +280,41 @@ def clear_async_attr_cache(entity: Any) -> None:
     # Then clear cooldown/cache/resolving-flag state so the next property
     # access re-dispatches a fresh getter.
     state_map.clear()
+
+
+def reset_async_attr_cooldown(entity: Any) -> None:
+    """Reset the cooldown timestamp for all async attrs on an entity.
+
+    Unlike ``clear_async_attr_cache``, this preserves the cached value
+    and does NOT cancel in-flight resolution tasks.  It only resets
+    ``last_dispatch`` to 0 so that the next property access can dispatch
+    a fresh ``_resolve()`` if the current one has completed.
+
+    This is called on every inbound packet (via
+    ``_async_update_and_write_state``) to ensure that freshly-received
+    packet data is visible immediately (issue 1042), while avoiding the
+    death spiral that ``clear_async_attr_cache`` caused (issue 1040):
+
+    - **Cached value preserved**: the next ``async_write_ha_state()``
+      returns the previous value, so HA detects no state change and
+      skips the recorder write.  Only when ``_resolve()`` completes with
+      a different value does a second state write trigger a recorder
+      write.
+    - **In-flight tasks not cancelled**: if a ``_resolve()`` is already
+      running (e.g. waiting on an RQ/RP round-trip), it is allowed to
+      complete.  The ``resolving`` flag prevents a duplicate dispatch.
+    - **Cooldown reset**: once the in-flight ``_resolve()`` completes,
+      the next property access (from the next packet's state write)
+      will dispatch a fresh ``_resolve()`` that reads the updated state.
+    """
+    state_map: dict[tuple[int, str], _AsyncAttrState] | None = getattr(
+        entity, "_async_attr_state", None
+    )
+    if not state_map:
+        return
+
+    for state in state_map.values():
+        state.last_dispatch = 0.0
 
 
 def parse_packet_string(packet_str: str) -> CommandDTO | None:


### PR DESCRIPTION
## Summary

- Replace `clear_async_attr_cache(self)` in `_async_update_and_write_state` with `reset_async_attr_cooldown(self)` — a lighter-weight function that only resets the cooldown timestamp without clearing the cached value or cancelling in-flight tasks
- Reduce `COOLDOWN_SECS` from 30 to 1 (the 30s cooldown was designed for `system_mode()` which has since been refactored to a pure read)

### Root cause of issue 1040

The `clear_async_attr_cache` call (added in rc-5 to fix issue 1042) cleared the cache on **every inbound packet**, forcing all async properties to re-resolve. This caused spurious state changes and excessive recorder writes, creating a death spiral: more recorder writes → slower SQLite → slower event loop → dropped updates → "blocky" sensor graphs.

### How the fix works

`reset_async_attr_cooldown` resets `last_dispatch` to 0, allowing the next property access to dispatch a fresh `_resolve()`. But unlike `clear_async_attr_cache`:
- **Cached value preserved** → HA detects no state change → recorder write skipped (only real changes trigger writes)
- **In-flight tasks not cancelled** → no duplicate dispatches
- **Cooldown reset** → fresh `_resolve()` reads the updated state after the current one completes

| | 30s cooldown (original) | clear_async_attr_cache (rc-5) | reset_async_attr_cooldown (this PR) |
|---|---|---|---|
| #1042 (stale 30s) | BROKEN | fixed | fixed (<100ms) |
| #1040 (death spiral) | OK | BROKEN | OK |
| Edge case (2 pkts < 1s) | BROKEN | fixed | fixed |
| Recorder writes per packet | 0 (cached) | 25+ (all re-resolved) | 0-1 (only real changes) |

#### Test plan

- [x] ramses_cc unit tests: 1376 passed, 0 failed
- [x] R89 (issue 1042 regression): BDR active updates in 0.0s (budget: 15s)
- [x] R90 (issue 1040 new): 117 31DA packets in 60s burst, final temp picked up in 0.0s, 0 dropped updates
- [x] Edge case test: two 3EF0 packets 0.3s apart — second value picked up within 0.8s