### PR TITLE
feat: warn on weak/missing device traffic (issue 1047)

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2397,20 +2397,19 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             coordinator.discovery_manager.get_weak_signal_devices()
         )
 
-        # Deduplicate: a device could be lost, orphaned, and weak — only
-        # show it once, prioritising LOST (most severe), then orphaned,
-        # then weak_signal (least severe).
+        # Deduplicate: a device with weak_signal is being heard (has
+        # RSSI data), so it cannot be lost — exclude it from the lost
+        # list.  Orphaned + weak can coexist (orphaned = not in schema,
+        # weak = poor signal), so show both sections independently.
+        weak_ids = {e.device.device_id for e in weak_signal_devices}
+        lost_devices = [
+            e for e in lost_devices if e.device.device_id not in weak_ids
+        ]
         lost_ids = {e.device.device_id for e in lost_devices}
-        orphaned_ids = {e.device.device_id for e in orphaned_devices}
         orphaned_only = [
             e for e in orphaned_devices if e.device.device_id not in lost_ids
         ]
-        weak_only = [
-            e
-            for e in weak_signal_devices
-            if e.device.device_id not in lost_ids
-            and e.device.device_id not in orphaned_ids
-        ]
+        weak_only = list(weak_signal_devices)
 
         if not orphaned_only and not lost_devices and not weak_only:
             if user_input is not None:

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2353,11 +2353,15 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
     async def async_step_review_device_health(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Review devices that haven't been seen recently.
+        """Review devices with health issues.
 
-        Shows orphaned devices (in schema but not seen by scan for >threshold)
-        and lost devices (ACCEPTED, not seen for >threshold).  The user can
-        keep (dismiss the flag) or remove (full cleanup via remove_device
+        Shows:
+        - Lost devices (ACCEPTED, not seen for >threshold) — keep or remove
+        - Orphaned devices (in schema but not seen recently) — keep or remove
+        - Weak signal devices (poor RSSI or stale) — dismiss or suppress
+
+        The user can keep (dismiss the flag), suppress future warnings
+        (for weak signal), or remove (full cleanup via remove_device
         service) each device individually.
         """
         self.get_options()
@@ -2382,24 +2386,39 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 config_schema_check
             )
             coordinator.discovery_manager.check_for_lost_devices()
+            coordinator.discovery_manager.check_communication_quality(
+                config_schema_check,
+                devices=(coordinator._devices if coordinator.client else None),
+            )
 
         orphaned_devices = coordinator.discovery_manager.get_orphaned_devices()
         lost_devices = coordinator.discovery_manager.get_lost_devices()
+        weak_signal_devices = (
+            coordinator.discovery_manager.get_weak_signal_devices()
+        )
 
-        # Deduplicate: a device could be both orphaned and lost — only
-        # show it once, prioritising LOST (more severe).
+        # Deduplicate: a device could be lost, orphaned, and weak — only
+        # show it once, prioritising LOST (most severe), then orphaned,
+        # then weak_signal (least severe).
         lost_ids = {e.device.device_id for e in lost_devices}
+        orphaned_ids = {e.device.device_id for e in orphaned_devices}
         orphaned_only = [
             e for e in orphaned_devices if e.device.device_id not in lost_ids
         ]
+        weak_only = [
+            e
+            for e in weak_signal_devices
+            if e.device.device_id not in lost_ids
+            and e.device.device_id not in orphaned_ids
+        ]
 
-        if not orphaned_only and not lost_devices:
+        if not orphaned_only and not lost_devices and not weak_only:
             if user_input is not None:
                 return self._async_save()
             return self.async_show_form(
                 step_id="review_device_health",
                 description_placeholders={
-                    "message": "No orphaned or lost devices."
+                    "message": "No orphaned, lost, or weak-signal devices."
                 },
                 last_step=True,
             )
@@ -2475,6 +2494,38 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         dev_entry["_suppress_not_seen"] = 7
                         config_schema[device_id] = dev_entry
 
+            for entry in weak_only:
+                device_id = entry.device.device_id
+                action = user_input.get(f"weak_{device_id}", "keep")
+                if action == "suppress":
+                    # Suppress future weak-signal warnings for this device
+                    # by setting _suppress_weak_signal in the schema.
+                    meta = coordinator.discovery_manager._metadata.get(
+                        device_id
+                    )
+                    if meta:
+                        meta.weak_signal = None
+                    dev_entry = config_schema.get(device_id)
+                    if isinstance(dev_entry, dict):
+                        dev_entry["_suppress_weak_signal"] = True
+                        config_schema[device_id] = dev_entry
+                    _LOGGER.info(
+                        "review_device_health: suppressed weak-signal "
+                        "warnings for %s",
+                        device_id,
+                    )
+                elif action == "keep":
+                    # Dismiss the flag — the device is known to be weak
+                    # but the user doesn't want to suppress future
+                    # warnings entirely.  weak_signal_dismissed prevents
+                    # re-flagging until quality recovers and degrades again.
+                    meta = coordinator.discovery_manager._metadata.get(
+                        device_id
+                    )
+                    if meta:
+                        meta.weak_signal = None
+                        meta.weak_signal_dismissed = True
+
             # Save discovery metadata to .storage via coordinator's save
             # cycle (export_state is called in async_save_client_state)
             await coordinator.async_save_client_state()
@@ -2526,8 +2577,24 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     f"| {last_seen} | {note} |"
                 )
 
+        if weak_only:
+            if lines:
+                lines.append("\n")
+            lines.append(
+                f"**{len(weak_only)} weak signal device(s)** "
+                "(poor RSSI or stale — check RF range/batteries):\n"
+            )
+            lines.append("| Device | Type | Issue |")
+            lines.append("|--------|------|-------|")
+            for entry in weak_only:
+                d = entry.device
+                note = entry.metadata.weak_signal or ""
+                lines.append(
+                    f"| `{d.device_id}` | {d.likely_type or '?'} | {note} |"
+                )
+
         if not lines:
-            lines.append("No orphaned or lost devices.")
+            lines.append("No orphaned, lost, or weak-signal devices.")
         summary = "\n".join(lines)
 
         # Build form with per-device Keep/Remove selectors
@@ -2575,6 +2642,32 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     options=[
                         {"value": "keep", "label": "Keep (dismiss flag)"},
                         {"value": "remove", "label": "Remove device"},
+                    ],
+                )
+            )
+
+        for entry in weak_only:
+            d = entry.device
+            device_id = d.device_id
+            note = entry.metadata.weak_signal or ""
+            field_label = f"{device_id} | {d.likely_type or '?'} | {note}"
+            form_fields[
+                vol.Required(
+                    f"weak_{device_id}",
+                    default="keep",
+                    description={"label": field_label},
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        {
+                            "value": "keep",
+                            "label": "Dismiss (re-warn if it degrades again)",
+                        },
+                        {
+                            "value": "suppress",
+                            "label": "Suppress (no future warnings)",
+                        },
                     ],
                 )
             )

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -794,7 +794,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # (schema is authoritative — this only logs warnings + notification)
         if isinstance(schema, dict):
             self.discovery_manager.check_all_mismatches(
-                schema, zones=self._zones
+                schema,
+                zones=self._zones,
+                devices=self._devices if self.client else None,
             )
         self.discovery_manager.check_for_new_devices()
         self.discovery_manager.check_for_lost_devices(
@@ -2811,7 +2813,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
             schema = self.entry.options.get(CONF_SCHEMA, {})
             if isinstance(schema, dict):
                 self.discovery_manager.check_all_mismatches(
-                    schema, zones=self._zones
+                    schema,
+                    zones=self._zones,
+                    devices=self._devices if self.client else None,
                 )
 
     async def async_send_packet(self, call: ServiceCall) -> None:

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -110,6 +110,17 @@ class DeviceMetadata:
     # custom display name.  No dismiss option: the schema _name should
     # be updated to match the controller (issue 947).
     name_mismatch: str | None = None
+    # Set when a device's communication quality is poor (weak RSSI or
+    # stale).  Cleared when quality recovers.  See check_communication_quality.
+    weak_signal: str | None = None
+    # Set when the user explicitly chose "Keep (dismiss)" in the
+    # review_device_health step for a weak-signal device.  Prevents
+    # check_communication_quality from re-flagging the same device.
+    weak_signal_dismissed: bool = False
+    # ISO timestamp of the last WARNING log for a weak-signal device.
+    # Used to throttle logs to once per hour per device so the HA log
+    # is not spammed.  Cleared when quality recovers.
+    last_weak_signal_log: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict for JSON storage."""
@@ -128,6 +139,9 @@ class DeviceMetadata:
             "orphaned": self.orphaned,
             "last_orphaned_log": self.last_orphaned_log,
             "name_mismatch": self.name_mismatch,
+            "weak_signal": self.weak_signal,
+            "weak_signal_dismissed": self.weak_signal_dismissed,
+            "last_weak_signal_log": self.last_weak_signal_log,
         }
 
     @classmethod
@@ -154,6 +168,9 @@ class DeviceMetadata:
             orphaned=data.get("orphaned"),
             last_orphaned_log=data.get("last_orphaned_log"),
             name_mismatch=data.get("name_mismatch"),
+            weak_signal=data.get("weak_signal"),
+            weak_signal_dismissed=data.get("weak_signal_dismissed", False),
+            last_weak_signal_log=data.get("last_weak_signal_log"),
         )
 
 
@@ -1284,22 +1301,195 @@ class DiscoveryManager:
                 result.append(entry)
         return result
 
+    # ── Communication quality (issue 1047) ───────────────────────
+
+    # Log throttle: minimum seconds between WARNING logs for the same
+    # device's weak-signal condition.  Prevents HA log spam when a
+    # device is borderline and oscillates around the threshold.
+    _WEAK_SIGNAL_LOG_INTERVAL: Final[int] = 3600  # 1 hour
+
+    def check_communication_quality(
+        self,
+        schema: dict[str, Any],
+        devices: list[Any] | None = None,
+    ) -> int:
+        """Check device communication quality (RSSI + staleness).
+
+        For each ramses_rf device that has a ``communication_quality``
+        property, evaluates the snapshot.  If the RSSI quality is
+        ``"weak"`` or ``"very_weak"``, or the device is stale, sets
+        ``weak_signal`` on the device's metadata so the review_device_health
+        step can surface it.
+
+        A WARNING is logged at most once per hour per device (throttled
+        via ``last_weak_signal_log``) to avoid spamming the HA log.
+
+        The user can suppress future warnings for a device by setting
+        ``_suppress_weak_signal: True`` in the schema entry (e.g. for
+        a device that is known to be far from the HGI and works fine).
+
+        :param schema: The current config entry schema (with _ traits).
+        :param devices: The coordinator's list of ramses_rf device
+            objects.  If ``None``, the check is skipped.
+        :return: Number of weak-signal flags set.
+        """
+        if devices is None:
+            return 0
+
+        now = dt_util.now()
+        log_threshold = now - td(seconds=self._WEAK_SIGNAL_LOG_INTERVAL)
+        flagged: list[str] = []
+
+        for device in devices:
+            device_id = str(device.id)
+            # Skip HGI gateway — it is the receiver, not a remote device.
+            if device_id.startswith("18:"):
+                continue
+            # Skip foreign-owner devices.
+            if device_id in self._foreign_device_ids:
+                continue
+
+            quality = getattr(device, "communication_quality", None)
+            if quality is None:
+                continue  # no RSSI tracker (e.g. tests without a gateway)
+
+            # Determine if the device is weak or stale.
+            is_weak = quality.rssi_quality in ("weak", "very_weak")
+            is_stale = quality.is_stale
+            if not is_weak and not is_stale:
+                # Quality is good — clear any previous flag.
+                existing = self._metadata.get(device_id)
+                if existing and (
+                    existing.weak_signal
+                    or existing.last_weak_signal_log
+                    or existing.weak_signal_dismissed
+                ):
+                    existing.weak_signal = None
+                    existing.last_weak_signal_log = None
+                    # Clear dismissed so the user gets a fresh warning
+                    # if the device degrades again after recovering.
+                    existing.weak_signal_dismissed = False
+                    self._metadata[device_id] = existing
+                    _LOGGER.debug(
+                        "DiscoveryManager: communication quality "
+                        "recovered for %s (rssi=%s, quality=%s)",
+                        device_id,
+                        quality.best_rssi,
+                        quality.rssi_quality,
+                    )
+                continue
+
+            # Build a human-readable description.
+            parts: list[str] = []
+            if is_weak:
+                parts.append(
+                    f"RSSI {quality.best_rssi} dBm ({quality.rssi_quality})"
+                )
+            if is_stale:
+                secs = quality.staleness_seconds
+                if secs is not None:
+                    mins = int(secs // 60)
+                    parts.append(f"stale ({mins}m since last tx)")
+                else:
+                    parts.append("stale (no recent tx)")
+            description = ", ".join(parts)
+
+            # Check if the user has suppressed warnings for this device.
+            schema_entry = schema.get(device_id)
+            if isinstance(schema_entry, dict):
+                if schema_entry.get("_suppress_weak_signal") is True:
+                    # Suppressed — clear flag, no notification.
+                    existing = self._metadata.get(device_id)
+                    if existing and existing.weak_signal:
+                        existing.weak_signal = None
+                        self._metadata[device_id] = existing
+                    continue
+
+            # Check if the user has dismissed this via review_device_health.
+            existing = self._metadata.get(device_id)
+            if existing and existing.weak_signal_dismissed:
+                continue  # user decided — don't re-flag
+
+            # Set the flag.
+            meta = existing or DeviceMetadata()
+            meta.weak_signal = description
+            self._metadata[device_id] = meta
+            flagged.append(device_id)
+
+            # Throttle the WARNING log to once per hour per device.
+            should_log = True
+            if meta.last_weak_signal_log:
+                try:
+                    last_log = dt.fromisoformat(meta.last_weak_signal_log)
+                    if last_log.tzinfo is None:
+                        last_log = last_log.replace(
+                            tzinfo=dt_util.get_default_time_zone()
+                        )
+                    if last_log > log_threshold:
+                        should_log = False
+                except (ValueError, TypeError):
+                    pass  # invalid timestamp → log again
+
+            if should_log:
+                meta.last_weak_signal_log = now.isoformat()
+                self._metadata[device_id] = meta
+                _LOGGER.warning(
+                    "DiscoveryManager: weak signal for %s — %s. "
+                    "Check RF range/batteries, or set "
+                    "_suppress_weak_signal: True in the schema "
+                    "to dismiss.",
+                    device_id,
+                    description,
+                )
+
+        if flagged:
+            _LOGGER.info(
+                "DiscoveryManager: %d device(s) have weak signal: %s",
+                len(flagged),
+                ", ".join(flagged),
+            )
+
+        return len(flagged)
+
+    def get_weak_signal_devices(self) -> list[DiscoveredDeviceEntry]:
+        """Get devices that have a weak_signal flag set.
+
+        These are devices whose communication quality (RSSI or
+        staleness) is poor.  The ``review_device_health`` config flow
+        step shows them so the user can dismiss the flag or suppress
+        future warnings.
+
+        :return: List of device entries with weak_signal set.
+        """
+        result: list[DiscoveredDeviceEntry] = []
+        for entry in self.get_devices():
+            if entry.metadata.weak_signal:
+                result.append(entry)
+        return result
+
     def check_all_mismatches(
-        self, schema: dict[str, Any], zones: list[Any] | None = None
+        self,
+        schema: dict[str, Any],
+        zones: list[Any] | None = None,
+        devices: list[Any] | None = None,
     ) -> dict[str, int]:
         """Run all mismatch checks & send persistent notification if needed.
 
-        Convenience method that calls all five checks:
+        Convenience method that calls all six checks:
         - check_class_mismatches
         - check_bound_mismatches
         - check_missing_class
         - check_orphaned_devices
         - check_name_mismatches (requires *zones*)
+        - check_communication_quality (requires *devices*)
 
         :param schema: The current config entry schema (with _ traits).
         :param zones: The coordinator's list of ramses_rf Zone objects.
             Passed to :meth:`check_name_mismatches`.  If ``None``, the
             name mismatch check is skipped.
+        :param devices: The coordinator's list of ramses_rf device
+            objects.  Passed to :meth:`check_communication_quality`.
+            If ``None``, the communication quality check is skipped.
         :return: Dict with counts per check type.
         """
         counts = {
@@ -1308,6 +1498,7 @@ class DiscoveryManager:
             "missing_class": self.check_missing_class(schema),
             "orphaned": self.check_orphaned_devices(schema),
             "name_mismatch": self.check_name_mismatches(schema, zones),
+            "weak_signal": self.check_communication_quality(schema, devices),
         }
         # Also count rf-flagged mismatches (from _check_rf_contradictions)
         # that check_class_mismatches may have missed (scan engine doesn't
@@ -1395,13 +1586,25 @@ class DiscoveryManager:
                 )
             lines.append("")
 
+        weak = self.get_weak_signal_devices()
+        if counts.get("weak_signal") and weak:
+            lines.append(
+                f"**{counts['weak_signal']} weak signal device(s):**\n"
+            )
+            for entry in weak:
+                lines.append(
+                    f"- `{entry.device.device_id}` — "
+                    f"{entry.metadata.weak_signal}"
+                )
+            lines.append("")
+
         if not lines:
             return
 
         lines.append(
-            "[Review discovered devices]"
+            "[Review device health]"
             "(/config/integrations/integration/ramses_cc)"
-            " — open **Configure → Review discovered devices** to resolve."
+            " — open **Configure → Review device health** to resolve."
         )
 
         async_create_notification(

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -1334,12 +1334,18 @@ class DiscoveryManager:
         :return: Number of weak-signal flags set.
         """
         if devices is None:
+            _LOGGER.debug(
+                "check_communication_quality: devices is None, skipping"
+            )
             return 0
 
         now = dt_util.now()
         log_threshold = now - td(seconds=self._WEAK_SIGNAL_LOG_INTERVAL)
         flagged: list[str] = []
 
+        _LOGGER.debug(
+            "check_communication_quality: checking %d device(s)", len(devices)
+        )
         for device in devices:
             device_id = str(device.id)
             # Skip HGI gateway — it is the receiver, not a remote device.
@@ -1351,11 +1357,39 @@ class DiscoveryManager:
 
             quality = getattr(device, "communication_quality", None)
             if quality is None:
+                _LOGGER.debug(
+                    "check_communication_quality: %s has no "
+                    "communication_quality (getattr returned None)",
+                    device_id,
+                )
                 continue  # no RSSI tracker (e.g. tests without a gateway)
+
+            # If we have RSSI data, the device is being heard — clear
+            # any stale LOST status (a weak device is not lost).
+            if quality.best_rssi is not None:
+                existing = self._metadata.get(device_id)
+                if existing and existing.status == DiscoveryStatus.LOST:
+                    existing.status = DiscoveryStatus.ACCEPTED
+                    self._metadata[device_id] = existing
+                    _LOGGER.info(
+                        "DiscoveryManager: %s was LOST but is now "
+                        "being heard (rssi=%s), cleared LOST status",
+                        device_id,
+                        quality.best_rssi,
+                    )
 
             # Determine if the device is weak or stale.
             is_weak = quality.rssi_quality in ("weak", "very_weak")
             is_stale = quality.is_stale
+            _LOGGER.debug(
+                "check_communication_quality: %s rssi=%s quality=%s "
+                "stale=%s is_weak=%s",
+                device_id,
+                quality.best_rssi,
+                quality.rssi_quality,
+                is_stale,
+                is_weak,
+            )
             if not is_weak and not is_stale:
                 # Quality is good — clear any previous flag.
                 existing = self._metadata.get(device_id)

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -152,6 +152,7 @@ class RamsesEntity(CoordinatorEntity):
                     ("bound_mismatch", meta.bound_mismatch),
                     ("missing_class", meta.missing_class),
                     ("orphaned", meta.orphaned),
+                    ("weak_signal", meta.weak_signal),
                 ):
                     if isinstance(flag_val, str) and flag_val:
                         attrs[flag_key] = flag_val

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -3345,7 +3345,9 @@ async def test_review_device_health_no_devices(hass: HomeAssistant) -> None:
     )
     assert result.get("type") == FlowResultType.FORM
     placeholders = result.get("description_placeholders", {})
-    assert "No orphaned or lost" in placeholders.get("message", "")
+    assert "No orphaned, lost, or weak-signal" in placeholders.get(
+        "message", ""
+    )
 
 
 async def test_review_device_health_shows_form_with_lost(

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -2368,6 +2368,53 @@ class TestCheckCommunicationQuality:
         count = manager.check_communication_quality(schema, [weak_device])
         assert count == 1
 
+    def test_weak_device_clears_lost_status(self) -> None:
+        """A device with RSSI data is being heard — clear LOST status.
+
+        If we're receiving weak signals, the device is not lost.
+        """
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Pre-set LOST status
+        manager._metadata["04:056053"] = DeviceMetadata(
+            status=DiscoveryStatus.LOST, enabled=True
+        )
+        device = self._make_device("04:056053", "weak")
+        schema = {"04:056053": {"_class": "TRV"}}
+        manager.check_communication_quality(schema, [device])
+        assert (
+            manager._metadata["04:056053"].status == DiscoveryStatus.ACCEPTED
+        )
+
+    def test_good_device_clears_lost_status(self) -> None:
+        """A device with strong RSSI is also being heard — clear LOST."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager._metadata["04:056053"] = DeviceMetadata(
+            status=DiscoveryStatus.LOST, enabled=True
+        )
+        device = self._make_device("04:056053", "normal")
+        schema = {"04:056053": {"_class": "TRV"}}
+        manager.check_communication_quality(schema, [device])
+        assert (
+            manager._metadata["04:056053"].status == DiscoveryStatus.ACCEPTED
+        )
+
+    def test_no_rssi_does_not_clear_lost(self) -> None:
+        """A device with no RSSI data (quality=None) stays LOST."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager._metadata["04:056053"] = DeviceMetadata(
+            status=DiscoveryStatus.LOST, enabled=True
+        )
+        # Device with communication_quality=None (no RSSI tracker)
+        device = MagicMock()
+        device.id = "04:056053"
+        device.communication_quality = None
+        schema = {"04:056053": {"_class": "TRV"}}
+        manager.check_communication_quality(schema, [device])
+        assert manager._metadata["04:056053"].status == DiscoveryStatus.LOST
+
 
 class TestSyncWithSchema:
     """Tests for DiscoveryManager.sync_with_schema.

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -2173,6 +2173,7 @@ class TestCheckAllMismatches:
             "missing_class": 0,
             "orphaned": 0,
             "name_mismatch": 0,
+            "weak_signal": 0,
         }
 
     def test_multiple_mismatch_types(self) -> None:
@@ -2218,6 +2219,154 @@ class TestCheckAllMismatches:
         ) as mock_dismiss:
             manager.check_all_mismatches(schema)
             mock_dismiss.assert_called_once()
+
+
+class TestCheckCommunicationQuality:
+    """Tests for DiscoveryManager.check_communication_quality (issue 1047)."""
+
+    def _make_device(
+        self, device_id: str, rssi_quality: str, is_stale: bool = False
+    ) -> MagicMock:
+        """Create a mock ramses_rf device with communication_quality."""
+        quality = MagicMock()
+        quality.rssi_quality = rssi_quality
+        quality.is_stale = is_stale
+        quality.best_rssi = -98 if rssi_quality == "weak" else -72
+        quality.staleness_seconds = 600 if is_stale else None
+        device = MagicMock()
+        device.id = device_id
+        device.communication_quality = quality
+        return device
+
+    def test_weak_rssi_sets_flag(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        device = self._make_device("04:056053", "weak")
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_communication_quality(schema, [device])
+        assert count == 1
+        meta = manager._metadata["04:056053"]
+        assert meta.weak_signal is not None
+        assert "RSSI" in meta.weak_signal
+
+    def test_very_weak_rssi_sets_flag(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        device = self._make_device("04:056053", "very_weak")
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_communication_quality(schema, [device])
+        assert count == 1
+
+    def test_normal_rssi_clears_flag(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # First set the flag
+        weak_device = self._make_device("04:056053", "weak")
+        schema = {"04:056053": {"_class": "TRV"}}
+        manager.check_communication_quality(schema, [weak_device])
+        assert manager._metadata["04:056053"].weak_signal is not None
+        # Now quality recovers
+        good_device = self._make_device("04:056053", "normal")
+        manager.check_communication_quality(schema, [good_device])
+        assert manager._metadata["04:056053"].weak_signal is None
+
+    def test_stale_sets_flag(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        device = self._make_device("04:056053", "normal", is_stale=True)
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_communication_quality(schema, [device])
+        assert count == 1
+        assert "stale" in manager._metadata["04:056053"].weak_signal
+
+    def test_suppress_weak_signal(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        device = self._make_device("04:056053", "weak")
+        schema = {
+            "04:056053": {"_class": "TRV", "_suppress_weak_signal": True}
+        }
+        count = manager.check_communication_quality(schema, [device])
+        assert count == 0
+
+    def test_dismissed_prevents_re_flagging(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Pre-set dismissed flag
+        manager._metadata["04:056053"] = DeviceMetadata(
+            weak_signal_dismissed=True
+        )
+        device = self._make_device("04:056053", "weak")
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_communication_quality(schema, [device])
+        assert count == 0
+
+    def test_hgi_skipped(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        device = self._make_device("18:001234", "weak")
+        schema = {"18:001234": {}}
+        count = manager.check_communication_quality(schema, [device])
+        assert count == 0
+
+    def test_no_devices_skips_check(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        count = manager.check_communication_quality({}, devices=None)
+        assert count == 0
+
+    def test_log_throttle_one_per_hour(self) -> None:
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        device = self._make_device("04:056053", "weak")
+        schema = {"04:056053": {"_class": "TRV"}}
+
+        with patch(
+            "custom_components.ramses_cc.discovery._LOGGER"
+        ) as mock_logger:
+            # First call — should log WARNING
+            manager.check_communication_quality(schema, [device])
+            assert mock_logger.warning.call_count >= 1
+
+            # Second call within 1 hour — should NOT log WARNING
+            mock_logger.warning.reset_mock()
+            manager.check_communication_quality(schema, [device])
+            assert mock_logger.warning.call_count == 0
+
+    def test_metadata_serialization_roundtrip(self) -> None:
+        meta = DeviceMetadata(
+            weak_signal="RSSI -98 dBm (weak)",
+            weak_signal_dismissed=False,
+            last_weak_signal_log="2026-08-25T12:00:00",
+        )
+        d = meta.to_dict()
+        assert d["weak_signal"] == "RSSI -98 dBm (weak)"
+        assert d["weak_signal_dismissed"] is False
+        assert d["last_weak_signal_log"] == "2026-08-25T12:00:00"
+
+        restored = DeviceMetadata.from_dict(d)
+        assert restored.weak_signal == "RSSI -98 dBm (weak)"
+        assert restored.weak_signal_dismissed is False
+        assert restored.last_weak_signal_log == "2026-08-25T12:00:00"
+
+    def test_recovery_clears_dismissed(self) -> None:
+        """Dismissed flag is cleared on recovery so re-degradation re-warns."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Pre-set dismissed flag
+        manager._metadata["04:056053"] = DeviceMetadata(
+            weak_signal_dismissed=True
+        )
+        # Quality recovers
+        good_device = self._make_device("04:056053", "normal")
+        schema = {"04:056053": {"_class": "TRV"}}
+        manager.check_communication_quality(schema, [good_device])
+        assert manager._metadata["04:056053"].weak_signal_dismissed is False
+
+        # Now device degrades again — should be flagged
+        weak_device = self._make_device("04:056053", "weak")
+        count = manager.check_communication_quality(schema, [weak_device])
+        assert count == 1
 
 
 class TestSyncWithSchema:


### PR DESCRIPTION
## Summary

Surfaces ramses_rf's `CommunicationQuality` (PR 1123) to the user through three mechanisms, all running in the existing 5-minute discovery checkpoint:

1. **WARNING log** (throttled to 1/hour per device) when RSSI quality is `weak`/`very_weak` or the device is stale
2. **Persistent notification** + `review_device_health` config flow step showing weak-signal devices with Dismiss/Suppress options
3. **`weak_signal` diagnostic attribute** on entity `extra_state_attributes`

### Suppression

- `_suppress_weak_signal: True` in schema → permanent suppression (no flag, no notification, no log)
- "Dismiss" in `review_device_health` → clears flag, re-warns if the device degrades again after recovering (dismissed flag is cleared on quality recovery)

### Backward compatibility

Silently skips the check if ramses_rf doesn't expose `communication_quality` (older versions without PR 1123). Uses `getattr(device, "communication_quality", None)` — returns `None`, check is skipped.

`_suppress_weak_signal` is a `_`-prefixed schema key, stripped by `strip_traits` before ramses_rf sees it. Same pattern as the existing `_suppress_not_seen`.

### Changes

| File | Change |
|---|---|
| `discovery.py` | `DeviceMetadata` + 3 new fields, `check_communication_quality()`, `get_weak_signal_devices()`, wired into `check_all_mismatches` + notification |
| `coordinator.py` | Pass `devices=self._devices` to `check_all_mismatches` in checkpoint + sync_topology |
| `entity.py` | Surface `weak_signal` in `extra_state_attributes` |
| `config_flow.py` | `review_device_health` step shows weak-signal devices with Dismiss/Suppress options |
| `test_discovery_manager.py` | 11 new tests for `check_communication_quality` |
| `test_config_flow.py` | Updated "no devices" message assertion |

Depends on ramses_rf PR 1123 (merged) for `RssiTracker` + `CommunicationQuality`.

#### Test plan

- [x] 1387 unit tests passed, 0 failed
- [x] ruff: all checks passed
- [x] mypy: no issues found
- [x] 11 new tests cover: weak/very_weak RSSI, stale, recovery clears flag + dismissed, suppress, HGI skip, no devices skip, log throttle, serialization roundtrip