### PR TITLE
fix: restore fire-and-forget for get_fan_param (issue 1040)

### DIFF
--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -646,8 +646,17 @@ class RamsesServiceHandler:
             # directly passes a CommandDTO (positional addr1/addr2/addr3) to
             # a code path that expects cmd.src.id, raising AttributeError.
             # See ramses_cc issue 851.
+            #
+            # wait_for_reply=False restores the original fire-and-forget
+            # behaviour (issue 1040): the RQ is sent and the call returns
+            # immediately after the TX echo, without blocking for up to 3s
+            # per param waiting for an RP that may never come.  The RP, when
+            # it arrives, is still processed by the ingestion pipeline and
+            # updates the parameter entity via _handle_2411_message.
             _LOGGER.debug("Sending get_fan_param intent: %s", intent)
-            await self._coordinator.client.dispatcher.send(intent)
+            await self._coordinator.client.dispatcher.send(
+                intent, wait_for_reply=False
+            )
 
             # Clear pending state after timeout (non-blocking)
             self._schedule_clear_pending(entity, 30)
@@ -864,6 +873,9 @@ class RamsesServiceHandler:
             )
             # Use the CQRS CommandDispatcher (translates intent → CommandDTO).
             # See get_fan_param above / issue 851.
+            # Unlike get_fan_param, set_fan_param keeps wait_for_reply=True
+            # (the default) because writes should wait for the RP to confirm
+            # the parameter was accepted by the device.
             _LOGGER.debug("Sending set_fan_param intent: %s", intent)
             await self._coordinator.client.dispatcher.send(intent)
             await asyncio.sleep(0.2)

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -2260,6 +2260,10 @@ async def test_coordinator_get_fan_param(
     # CommandDTO with addr1=src, addr2=dst, verb=RQ, code=2411
     assert intent.dst.id == FAN_ID
     assert intent.action.name == "GET_FAN_PARAM"
+    # get_fan_param is fire-and-forget (issue 1040): wait_for_reply=False
+    # so the call returns after the TX echo without blocking for the RP.
+    kwargs = mock_client.dispatcher.send.call_args.kwargs
+    assert kwargs.get("wait_for_reply") is False
 
 
 async def test_coordinator_set_fan_param(
@@ -2322,6 +2326,9 @@ async def test_update_fan_params_sequence(
     calls = mock_client.dispatcher.send.call_args_list
     assert calls[0][0][0].action.name == "GET_FAN_PARAM"
     assert calls[1][0][0].action.name == "GET_FAN_PARAM"
+    # Both calls should be fire-and-forget (issue 1040)
+    assert calls[0].kwargs.get("wait_for_reply") is False
+    assert calls[1].kwargs.get("wait_for_reply") is False
 
 
 async def test_set_fan_param_no_bound_remote(
@@ -2428,6 +2435,9 @@ async def test_get_fan_param_uses_hgi_fallback(
     assert mock_client.dispatcher.send.called
     intent = mock_client.dispatcher.send.call_args[0][0]
     assert intent.src.id == "18:999999"
+    # get_fan_param is fire-and-forget (issue 1040)
+    kwargs = mock_client.dispatcher.send.call_args.kwargs
+    assert kwargs.get("wait_for_reply") is False
 
 
 async def test_target_to_device_id_internals_coverage(


### PR DESCRIPTION
## Summary

- Restore fire-and-forget behaviour for `get_fan_param` by passing `wait_for_reply=False` to `dispatcher.send()`
- Keep `set_fan_param` waiting for reply (writes need RP confirmation)
- Add test assertions for `wait_for_reply=False` on `get_fan_param` tests

## Context

Commit b6fde61 (for issue 851) switched `get_fan_param` from `async_send_cmd` (fire-and-forget) to `dispatcher.send(intent)`, which defaults to `wait_for_reply=True`. This caused each 2411 RQ to block for up to 3 seconds waiting for an RP that may never come — 11 of 20 params time out, blocking the sweep for ~42 seconds per FAN device.

With 3 FAN devices, each coordinator restart blocked for ~2 minutes on 2411 polling alone, contributing to the event loop saturation and blocky sensor graphs reported in issue 1040.

The RP, when it arrives, is still processed by the ingestion pipeline and updates the parameter entity via `_handle_2411_message` — the reply future is not needed for parameter updates.

This complements the death spiral fix (PR 1050, `reset_async_attr_cooldown`) which is already on master.

Fixes https://github.com/wimpie70/ramses_cc/issues/1040

#### Test plan

- [x] `pytest tests/tests_new/test_services.py` — 170 passed
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [ ] Verify on live HA that 2411 RQ sweep completes in ~10s instead of ~42s per device
- [ ] Verify parameter entities still update when RPs arrive