### PR TITLE
fix: deprecate legacy known_list from `configuration.yaml` on first upgrade (issue 1055)

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -81,6 +81,7 @@ from .const import (
     CONF_MQTT_TOPIC,
     CONF_MQTT_USE_HA,
     CONF_PASSIVE_SCAN,
+    CONF_RAMSES_RF,
     CONF_SEND_PACKET,
     DOMAIN,
     STORAGE_KEY,
@@ -158,6 +159,131 @@ CONFIG_SCHEMA = vol.All(
 PLATFORMS = [Platform.EVENT]
 
 
+async def _async_cleanup_yaml_known_list(
+    hass: HomeAssistant, domain_config: dict[str, Any]
+) -> None:
+    """Warn about legacy known_list/block_list in configuration.yaml (issue 1055).
+
+    Phase 4 migrated known_list and block_list into the config entry
+    schema (block_list is now derived from _owner/_skipped traits at
+    runtime).  The YAML file was never cleaned up.  This does NOT modify
+    configuration.yaml (to preserve user comments and formatting).
+    Instead it:
+
+    1. Backs up the known_list/block_list to ``ramses_cc_backups/`` as a
+       YAML file
+    2. Creates a persistent notification telling the user to remove the
+       ``known_list``, ``block_list`` and ``enforce_known_list`` keys
+       manually
+
+    The backup ensures no data is lost — the user can copy/paste values
+    from the backup into the schema editor if needed.
+    """
+    known_list = domain_config.get("known_list")
+    block_list = domain_config.get("block_list")
+    ramses_rf = domain_config.get(CONF_RAMSES_RF, {})
+    has_enforce = (
+        isinstance(ramses_rf, dict) and "enforce_known_list" in ramses_rf
+    )
+
+    if not known_list and not block_list and not has_enforce:
+        return
+
+    # 1. Back up known_list and/or block_list to ramses_cc_backups/
+    backup_data: dict[str, Any] = {}
+    if known_list and isinstance(known_list, dict):
+        backup_data["known_list"] = known_list
+    if block_list and isinstance(block_list, dict):
+        backup_data["block_list"] = block_list
+
+    backup_path: str | None = None
+    if backup_data:
+        import json
+        import os
+        import time
+
+        import yaml  # type: ignore[import-untyped, unused-ignore]
+
+        def _write_backup() -> str:
+            backup_dir = hass.config.path("ramses_cc_backups")
+            os.makedirs(backup_dir, exist_ok=True)
+            timestamp_str = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+            path = os.path.join(
+                backup_dir,
+                f"backup_{timestamp_str}_yaml_known_list.yaml",
+            )
+            # Convert HA-internal dict types (NodeDictClass, etc.) to
+            # plain dicts so the YAML dump is clean and portable.
+            clean_data = json.loads(json.dumps(backup_data))
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    f"# ramses_cc known_list/block_list backup"
+                    f" (from configuration.yaml)\n"
+                    f"# timestamp: {timestamp_str}\n"
+                    f"# These were migrated to the config flow schema\n"
+                    f"# in Phase 4.  You can copy/paste values from here\n"
+                    f"# into the schema editor if needed.\n\n"
+                )
+                yaml.dump(
+                    clean_data,
+                    f,
+                    default_flow_style=False,
+                    sort_keys=True,
+                    allow_unicode=True,
+                )
+            return path
+
+        backup_path = await hass.async_add_executor_job(_write_backup)
+        _LOGGER.info(
+            "Backed up known_list/block_list from configuration.yaml to %s",
+            backup_path,
+        )
+
+    # 2. Persistent notification telling the user to clean up
+    from homeassistant.components.persistent_notification import (
+        async_create as async_create_notification,
+    )
+
+    lines = [
+        "The `known_list` and `block_list` configuration has been migrated",
+        "to the config flow schema (Phase 4).  `block_list` is now derived",
+        "from `_owner`/`_skipped` traits at runtime.  Please remove the",
+        "following keys from `configuration.yaml` under `ramses_cc:`:",
+        "",
+    ]
+    if known_list:
+        lines.append("- `known_list` (backed up to `ramses_cc_backups/`)")
+    if block_list:
+        lines.append(
+            "- `block_list` (now derived from schema `_owner`/`_skipped`)"
+        )
+    if has_enforce:
+        lines.append("- `enforce_known_list` (now always-on)")
+    lines += [
+        "",
+        "The integration will continue to work, but these keys are no",
+        "longer used and will generate warnings on every restart.",
+    ]
+    if backup_path:
+        lines += [
+            "",
+            f"A backup was saved to: `{backup_path}`",
+        ]
+
+    async_create_notification(
+        hass,
+        message="\n".join(lines),
+        title="RAMSES CC: Remove legacy known_list from configuration.yaml",
+        notification_id=f"{DOMAIN}_yaml_known_list_cleanup",
+    )
+    _LOGGER.warning(
+        "Legacy known_list/block_list/enforce_known_list found in "
+        "configuration.yaml. A backup has been saved and a persistent "
+        "notification created. Please remove these keys from "
+        "configuration.yaml manually."
+    )
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Ramses integration."""
     # If required, do a one-off import of entry from config yaml
@@ -169,6 +295,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 data=config[DOMAIN],
             )
         )
+
+    # Phase 4 cleanup: warn about legacy known_list in configuration.yaml.
+    # The known_list was migrated to the config entry schema (v2→v3
+    # migration for existing entries, or async_step_import for first-time
+    # YAML setups).  After that, the YAML known_list is redundant.
+    # This backs it up and creates a persistent notification telling the
+    # user to remove it manually (issue 1055).  configuration.yaml is NOT
+    # modified, to preserve user comments and formatting.
+    if DOMAIN in config and isinstance(config[DOMAIN], dict):
+        await _async_cleanup_yaml_known_list(hass, config[DOMAIN])
 
     # register all platform services during async_setup, since 2025.10, see
     # https://developers.home-assistant.io/blog/2025/09/25/entity-services-api-changes

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1479,7 +1479,11 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         self.options.pop(SZ_RESTORE_CACHE, None)
 
         # Phase 4: migrate known_list traits into schema (same logic as
-        # async_migrate_entry v2→v3).  YAML configs may still use known_list.
+        # async_migrate_entry v2→v3).  This import flow only runs once
+        # (when no config entry exists yet), so it is the only chance to
+        # transfer known_list traits from YAML into the config entry
+        # schema.  After this, the YAML known_list is redundant —
+        # async_setup warns and backs it up (issue 1055).
         known_list = self.options.pop("known_list", None)
         # block_list is added by SCH_DOMAIN_CONFIG validation with a default
         # empty dict — pop it so it doesn't end up in the schema.

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -877,3 +877,103 @@ async def test_no_fresh_start_preserves_storage(
 
     # .storage should NOT have been removed
     mock_store.async_remove.assert_not_called()
+
+
+# ── YAML known_list cleanup (issue 1055) ──────────────────────────────
+
+
+async def test_yaml_known_list_cleanup_backs_up_and_notifies(
+    hass: HomeAssistant, tmp_path: Any
+) -> None:
+    """async_setup backs up known_list/block_list and creates a notification.
+
+    Issue 1055: known_list and block_list were migrated to the config
+    entry schema in Phase 4, but the YAML file was never cleaned up.
+    This verifies that async_setup backs them up and notifies the user
+    to remove them manually (configuration.yaml is NOT modified, to
+    preserve user comments and formatting).
+    """
+    import yaml  # type: ignore[import-untyped, unused-ignore]
+
+    domain_config = {
+        "ramses_rf": {"enforce_known_list": True},
+        "known_list": {
+            "01:234567": {"class": "FAN"},
+            "37:153226": {"class": "FAN", "alias": "Ventura"},
+        },
+        "block_list": {
+            "04:999999": {},
+        },
+    }
+
+    with (
+        patch.object(
+            hass.config,
+            "path",
+            side_effect=lambda x: str(tmp_path / x if "/" not in x else x),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_entries",
+            return_value=[MagicMock()],
+        ),
+        patch(
+            "homeassistant.components.persistent_notification.async_create",
+        ) as mock_notify,
+    ):
+        from custom_components.ramses_cc import async_setup
+
+        await async_setup(hass, {"ramses_cc": domain_config})
+
+    # Verify backup was created with both known_list and block_list
+    backup_dir = tmp_path / "ramses_cc_backups"
+    backups = list(backup_dir.glob("backup_*_yaml_known_list.yaml"))
+    assert len(backups) == 1
+    backup_data = yaml.safe_load(backups[0].read_text(encoding="utf-8"))
+    assert "known_list" in backup_data
+    assert backup_data["known_list"]["37:153226"]["alias"] == "Ventura"
+    assert "block_list" in backup_data
+    assert "04:999999" in backup_data["block_list"]
+
+    # Verify persistent notification was created
+    mock_notify.assert_called_once()
+    call_kwargs = mock_notify.call_args.kwargs
+    assert "known_list" in call_kwargs["message"]
+    assert "block_list" in call_kwargs["message"]
+    assert "enforce_known_list" in call_kwargs["message"]
+    assert (
+        call_kwargs["notification_id"] == "ramses_cc_yaml_known_list_cleanup"
+    )
+
+
+async def test_yaml_known_list_cleanup_noop_without_known_list(
+    hass: HomeAssistant, tmp_path: Any
+) -> None:
+    """async_setup does nothing if no known_list or enforce_known_list."""
+    domain_config = {"ramses_rf": {}}
+
+    with (
+        patch.object(
+            hass.config,
+            "path",
+            side_effect=lambda x: str(tmp_path / x if "/" not in x else x),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_entries",
+            return_value=[MagicMock()],
+        ),
+        patch(
+            "homeassistant.components.persistent_notification.async_create",
+        ) as mock_notify,
+    ):
+        from custom_components.ramses_cc import async_setup
+
+        await async_setup(hass, {"ramses_cc": domain_config})
+
+    # No backup, no notification
+    backup_dir = tmp_path / "ramses_cc_backups"
+    assert not backup_dir.exists() or not list(
+        backup_dir.glob("backup_*_yaml_known_list.yaml")
+    )
+    mock_notify.assert_not_called()


### PR DESCRIPTION
## Summary

- `async_setup` now detects legacy `known_list`, `block_list`, and `enforce_known_list` in `configuration.yaml`
- Backs up `known_list` and `block_list` to `ramses_cc_backups/` as a YAML file
- Creates a **persistent notification** telling the user to remove the keys manually
- **Does NOT modify `configuration.yaml`** — preserves user comments and formatting

## Context

Phase 4 migrated `known_list` from `configuration.yaml` into the config entry schema (v2→v3 migration in `async_migrate_entry`), but the YAML file was never cleaned up. `block_list` is now derived from `_owner`/`_skipped` traits at runtime. `enforce_known_list` is always-on. Users who had these keys in `configuration.yaml` still have them sitting there, causing HA to log warnings on every restart.

## Approach

Per @silverailscolo's feedback, this PR takes a conservative approach — it does **not** rewrite `configuration.yaml` (which would destroy comments and formatting). Instead:

1. **Backup**: `known_list` and `block_list` are saved to `ramses_cc_backups/backup_<timestamp>_yaml_known_list.yaml` so no data is lost. HA-internal dict types (NodeDictClass) are converted to plain dicts via `json.loads(json.dumps(...))` for clean, portable YAML.
2. **Persistent notification**: A HA persistent notification is created listing all keys to remove
3. **Warning log**: A `WARNING`-level log message is emitted

The user removes the keys manually at their convenience. The backup file allows them to copy/paste values into the schema editor if needed.

Other YAML options (`serial_port`, `ramses_rf`, `scan_interval`, `advanced_features`, `packet_log`, TCS schema structure) are left untouched — only the three legacy keys are flagged.

The first-time import flow (`async_step_import`) still migrates `known_list` traits into the schema for users upgrading from YAML-only setups (no config entry exists yet). This is the only chance to transfer those traits.

Fixes https://github.com/ramses-rf/ramses_cc/issues/1055

#### Test plan

- [x] `pytest tests/tests_new/test_init.py` — 25 passed
- [x] `ruff check` + `ruff format` — clean
- [x] `test_yaml_known_list_cleanup_backs_up_and_notifies` — verifies backup file contains both `known_list` and `block_list`, and persistent notification mentions all three keys
- [x] `test_yaml_known_list_cleanup_noop_without_known_list` — verifies nothing happens when no legacy keys are present
- [x] Manual: verified on ha-sim — persistent notification appears, backup file created with clean YAML (both `known_list` and `block_list`), integration loads normally, `configuration.yaml` not modified