### PR TITLE
fix: drop staleness check from communication quality health check

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -1313,13 +1313,20 @@ class DiscoveryManager:
         schema: dict[str, Any],
         devices: list[Any] | None = None,
     ) -> int:
-        """Check device communication quality (RSSI + staleness).
+        """Check device communication quality (RSSI only).
 
         For each ramses_rf device that has a ``communication_quality``
         property, evaluates the snapshot.  If the RSSI quality is
-        ``"weak"`` or ``"very_weak"``, or the device is stale, sets
-        ``weak_signal`` on the device's metadata so the review_device_health
-        step can surface it.
+        ``"weak"`` or ``"very_weak"``, sets ``weak_signal`` on the
+        device's metadata so the review_device_health step can surface
+        it.
+
+        Staleness (time since last transmission) is **not** checked
+        here.  Battery devices (TRVs, sensors, DHW) transmit every
+        10-30 minutes by design, so a flat staleness threshold would
+        falsely flag them.  "Device gone silent" is handled by:
+        - ``is_available`` (entity state in HA UI)
+        - ``check_for_orphaned_devices`` (7-day persistent notification)
 
         A WARNING is logged at most once per hour per device (throttled
         via ``last_weak_signal_log``) to avoid spamming the HA log.
@@ -1378,19 +1385,18 @@ class DiscoveryManager:
                         quality.best_rssi,
                     )
 
-            # Determine if the device is weak or stale.
+            # Determine if the device has weak signal (RSSI only).
+            # Staleness is not checked — see docstring above.
             is_weak = quality.rssi_quality in ("weak", "very_weak")
-            is_stale = quality.is_stale
             _LOGGER.debug(
                 "check_communication_quality: %s rssi=%s quality=%s "
-                "stale=%s is_weak=%s",
+                "is_weak=%s",
                 device_id,
                 quality.best_rssi,
                 quality.rssi_quality,
-                is_stale,
                 is_weak,
             )
-            if not is_weak and not is_stale:
+            if not is_weak:
                 # Quality is good — clear any previous flag.
                 existing = self._metadata.get(device_id)
                 if existing and (
@@ -1414,19 +1420,9 @@ class DiscoveryManager:
                 continue
 
             # Build a human-readable description.
-            parts: list[str] = []
-            if is_weak:
-                parts.append(
-                    f"RSSI {quality.best_rssi} dBm ({quality.rssi_quality})"
-                )
-            if is_stale:
-                secs = quality.staleness_seconds
-                if secs is not None:
-                    mins = int(secs // 60)
-                    parts.append(f"stale ({mins}m since last tx)")
-                else:
-                    parts.append("stale (no recent tx)")
-            description = ", ".join(parts)
+            description = (
+                f"RSSI {quality.best_rssi} dBm ({quality.rssi_quality})"
+            )
 
             # Check if the user has suppressed warnings for this device.
             schema_entry = schema.get(device_id)

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -2238,6 +2238,21 @@ class TestCheckCommunicationQuality:
         device.communication_quality = quality
         return device
 
+    def test_stale_alone_does_not_set_flag(self) -> None:
+        """Staleness alone (good RSSI) does not flag a device (issue 1062).
+
+        Battery devices transmit every 10-30 minutes by design — a flat
+        staleness threshold would falsely flag them.  Only RSSI quality
+        is checked; "device gone silent" is handled by is_available and
+        check_for_orphaned_devices.
+        """
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        device = self._make_device("04:056053", "normal", is_stale=True)
+        schema = {"04:056053": {"_class": "TRV"}}
+        count = manager.check_communication_quality(schema, [device])
+        assert count == 0
+
     def test_weak_rssi_sets_flag(self) -> None:
         scan = make_mock_scan([])
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
@@ -2269,15 +2284,6 @@ class TestCheckCommunicationQuality:
         good_device = self._make_device("04:056053", "normal")
         manager.check_communication_quality(schema, [good_device])
         assert manager._metadata["04:056053"].weak_signal is None
-
-    def test_stale_sets_flag(self) -> None:
-        scan = make_mock_scan([])
-        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
-        device = self._make_device("04:056053", "normal", is_stale=True)
-        schema = {"04:056053": {"_class": "TRV"}}
-        count = manager.check_communication_quality(schema, [device])
-        assert count == 1
-        assert "stale" in manager._metadata["04:056053"].weak_signal
 
     def test_suppress_weak_signal(self) -> None:
         scan = make_mock_scan([])


### PR DESCRIPTION
## Summary

- Dropped the `is_stale` check from `check_communication_quality` — RSSI quality only
- The 5-minute staleness threshold was falsely flagging battery devices (TRVs, sensors, DHW) that transmit every 10-30 minutes by design

## Context

The health check was flagging devices as `weak_signal` if either:
- RSSI quality was weak/very_weak, OR
- The device was "stale" (no transmission in 5 minutes)

Evohome battery devices transmit every 10-30 minutes to conserve battery, so they were almost always flagged as stale. The staleness check is redundant with two existing mechanisms:

1. **`is_available`** — marks the HA entity as unavailable after the device-class-aware heartbeat timeout (1h default, 12h for TRV/sensor, 24h for DHW/BDR)
2. **`check_for_orphaned_devices`** — creates a persistent notification after 7 days of silence (with `_suppress_not_seen` per-device suppression)

The health check now uses RSSI quality only. "Device gone silent" is handled by the existing availability and orphaned-device checks, which have appropriate per-device-class thresholds and suppression mechanisms.

Fixes https://github.com/ramses-rf/ramses_cc/issues/1062

#### Test plan

- [x] `pytest tests/tests_new/` — 1294 passed, 10 skipped
- [x] `ruff check` + `ruff format` — clean
- [x] `test_stale_alone_does_not_set_flag` — verifies that a device with good RSSI but stale (10 min silence) is NOT flagged
- [x] `test_weak_rssi_sets_flag` — still flags devices with weak RSSI
- [x] `test_normal_rssi_clears_flag` — clears flag when RSSI recovers
- [x] `test_suppress_weak_signal` — suppression still works