### PR TITLE
Wave 0, PR 1: Fix [no-any-return] in property accessors

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -90,8 +90,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform = entity_platform.async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         """Add new devices to the platform.
@@ -113,7 +113,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
+class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):  # type: ignore[misc]
     """Representation of a Ramses binary sensor."""
 
     entity_description: RamsesBinarySensorEntityDescription
@@ -161,7 +161,8 @@ class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
         :rtype: str | None
         """
         if self.is_on:
-            return self.entity_description.icon
+            icon: str | None = self.entity_description.icon
+            return icon
         return self.entity_description.icon_off
 
 
@@ -362,7 +363,8 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesBinarySensorEntityDescription(
-    RamsesEntityDescription, BinarySensorEntityDescription
+    RamsesEntityDescription,
+    BinarySensorEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -90,8 +90,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform = entity_platform.async_get_current_platform()
 
-    @callback  # type: ignore[untyped-decorator]
-    def add_devices(  # type: ignore[misc]
+    @callback
+    def add_devices(
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         """Add new devices to the platform.
@@ -113,7 +113,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):  # type: ignore[misc]
+class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
     """Representation of a Ramses binary sensor."""
 
     entity_description: RamsesBinarySensorEntityDescription
@@ -364,7 +364,7 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
 @dataclass(frozen=True, kw_only=True)
 class RamsesBinarySensorEntityDescription(
     RamsesEntityDescription,
-    BinarySensorEntityDescription,  # type: ignore[misc]
+    BinarySensorEntityDescription,
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -6,7 +6,7 @@ import json
 import logging
 from dataclasses import dataclass, replace as dc_replace
 from datetime import datetime as dt, timedelta as td
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import voluptuous as vol
 from homeassistant.components.climate import (
@@ -84,6 +84,9 @@ from .typing import RamsesConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
+# PRESET_NONE is imported from HA as Any (follow_imports=skip); narrow it
+_PRESET_NONE: Final[str] = PRESET_NONE
+
 MODE_TCS_TO_HA: Final[dict[str, HVACMode]] = {
     SystemMode.AUTO: HVACMode.HEAT,  # NOTE: don't use AUTO
     SystemMode.HEAT_OFF: HVACMode.OFF,
@@ -151,8 +154,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(devices: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(devices: Any) -> None:  # type: ignore[misc]
         entities = [
             description.ramses_cc_class(coordinator, device, description)
             for device in devices
@@ -164,7 +167,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesController(RamsesEntity, ClimateEntity):
+class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses controller."""
 
     _device: Evohome
@@ -328,14 +331,16 @@ class RamsesController(RamsesEntity, ClimateEntity):
         system_mode = resolve_async_attr(self, self._device, "system_mode")
         if system_mode is not None:
             if system_mode[SZ_SYSTEM_MODE] == SystemMode.HEAT_OFF:
-                return HVACMode.OFF
+                return cast(str | None, HVACMode.OFF)
             if system_mode[SZ_SYSTEM_MODE] == SystemMode.AWAY:
-                return HVACMode.AUTO  # users can't adjust setpoints away
+                return cast(
+                    str | None, HVACMode.AUTO
+                )  # users can't adjust setpoints away
 
         thermal_mode = resolve_async_attr(self, self._device, "thermal_mode")
         if thermal_mode == ThermalMode.COOL:
-            return HVACMode.COOL
-        return HVACMode.HEAT
+            return cast(str | None, HVACMode.COOL)
+        return cast(str | None, HVACMode.HEAT)
 
     @property
     def preset_mode(self) -> str | None:
@@ -346,7 +351,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         system_mode = resolve_async_attr(self, self._device, "system_mode")
         if system_mode is None:
             # Fallback instead of returning None (unable to determine)
-            return PRESET_NONE
+            return _PRESET_NONE
         return PRESET_TCS_TO_HA.get(system_mode[SZ_SYSTEM_MODE])
 
     @property
@@ -417,8 +422,8 @@ class RamsesController(RamsesEntity, ClimateEntity):
 
     # the following methods are integration-specific service calls
 
-    @callback
-    async def async_get_system_faults(self, num_entries: int) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_system_faults(self, num_entries: int) -> None:  # type: ignore[misc]
         """Get the nth latest fault log entries from the Controller.
 
         :param num_entries: Number of entries to fetch.
@@ -516,7 +521,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesZone(RamsesEntity, ClimateEntity):
+class RamsesZone(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses zone."""
 
     _device: Zone
@@ -651,9 +656,9 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         system_mode = resolve_async_attr(self, self._device.tcs, "system_mode")
         if system_mode is not None:
             if system_mode[SZ_SYSTEM_MODE] == SystemMode.AWAY:
-                return HVACMode.AUTO
+                return cast(str | None, HVACMode.AUTO)
             if system_mode[SZ_SYSTEM_MODE] == SystemMode.HEAT_OFF:
-                return HVACMode.OFF
+                return cast(str | None, HVACMode.OFF)
 
         mode = resolve_async_attr(self, self._device, "mode")
         if mode is None or mode.get(SZ_SETPOINT) is None:
@@ -668,12 +673,12 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             else 5.0
         )
         if mode[SZ_SETPOINT] <= min_temp:
-            return HVACMode.OFF
+            return cast(str | None, HVACMode.OFF)
 
         thermal_mode = resolve_async_attr(self, self._device, "thermal_mode")
         if thermal_mode == ThermalMode.COOL:
-            return HVACMode.COOL
-        return HVACMode.HEAT
+            return cast(str | None, HVACMode.COOL)
+        return cast(str | None, HVACMode.HEAT)
 
     @property
     def max_temp(self) -> float:
@@ -726,7 +731,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         if mode[SZ_MODE] == ZoneMode.SCHEDULE:
             if system_mode is not None:
                 return PRESET_TCS_TO_HA.get(system_mode[SZ_SYSTEM_MODE])
-            return PRESET_NONE
+            return _PRESET_NONE
 
         return PRESET_ZONE_TO_HA.get(mode[SZ_MODE])
 
@@ -1082,7 +1087,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesHvac(RamsesEntity, ClimateEntity):
+class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Base for a Honeywell HVAC unit (Fan, HRU, MVHR, PIV, etc)."""
 
     _device: HvacVentilator
@@ -1262,7 +1267,7 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
         :return: The preset mode.
         """
-        return PRESET_NONE
+        return cast(str | None, PRESET_NONE)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode for the HVAC device.
@@ -1449,8 +1454,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
     # the 2411 fan_param services, copied to numbers and to remote.py
 
-    @callback
-    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'get_fan_param' service call.
 
         :param kwargs: Service arguments.
@@ -1476,8 +1481,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                 f"Failed to get fan param: {err}"
             ) from err
 
-    @callback
-    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'set_fan_param' service call.
 
         :param kwargs: Service arguments.
@@ -1511,7 +1516,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesClimateEntityDescription(
-    RamsesEntityDescription, ClimateEntityDescription
+    RamsesEntityDescription,
+    ClimateEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -154,8 +154,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback  # type: ignore[untyped-decorator]
-    def add_devices(devices: Any) -> None:  # type: ignore[misc]
+    @callback
+    def add_devices(devices: Any) -> None:
         entities = [
             description.ramses_cc_class(coordinator, device, description)
             for device in devices
@@ -167,7 +167,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
+class RamsesController(RamsesEntity, ClimateEntity):
     """Representation of a Ramses controller."""
 
     _device: Evohome
@@ -422,8 +422,8 @@ class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
 
     # the following methods are integration-specific service calls
 
-    @callback  # type: ignore[untyped-decorator]
-    async def async_get_system_faults(self, num_entries: int) -> None:  # type: ignore[misc]
+    @callback
+    async def async_get_system_faults(self, num_entries: int) -> None:
         """Get the nth latest fault log entries from the Controller.
 
         :param num_entries: Number of entries to fetch.
@@ -521,7 +521,7 @@ class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
             ) from err
 
 
-class RamsesZone(RamsesEntity, ClimateEntity):  # type: ignore[misc]
+class RamsesZone(RamsesEntity, ClimateEntity):
     """Representation of a Ramses zone."""
 
     _device: Zone
@@ -1087,7 +1087,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):  # type: ignore[misc]
             ) from err
 
 
-class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
+class RamsesHvac(RamsesEntity, ClimateEntity):
     """Base for a Honeywell HVAC unit (Fan, HRU, MVHR, PIV, etc)."""
 
     _device: HvacVentilator
@@ -1454,8 +1454,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
 
     # the 2411 fan_param services, copied to numbers and to remote.py
 
-    @callback  # type: ignore[untyped-decorator]
-    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
+    @callback
+    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:
         """Handle 'get_fan_param' service call.
 
         :param kwargs: Service arguments.
@@ -1481,8 +1481,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
                 f"Failed to get fan param: {err}"
             ) from err
 
-    @callback  # type: ignore[untyped-decorator]
-    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
+    @callback
+    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:
         """Handle 'set_fan_param' service call.
 
         :param kwargs: Service arguments.
@@ -1517,7 +1517,7 @@ class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
 @dataclass(frozen=True, kw_only=True)
 class RamsesClimateEntityDescription(
     RamsesEntityDescription,
-    ClimateEntityDescription,  # type: ignore[misc]
+    ClimateEntityDescription,
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -6,7 +6,7 @@ import re
 from abc import abstractmethod
 from collections.abc import Callable
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlparse
 
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
@@ -160,7 +160,9 @@ async def async_get_usb_ports(hass: HomeAssistant) -> dict[str, str]:
     :param hass: The Home Assistant instance.
     :return: A dictionary mapping device paths to descriptions.
     """
-    return await hass.async_add_executor_job(get_usb_ports)
+    return cast(
+        dict[str, str], await hass.async_add_executor_job(get_usb_ports)
+    )
 
 
 def _extract_ieee_from_device(device_entry: dr.DeviceEntry) -> str | None:

--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Callable
 from datetime import timedelta as td
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.const import Platform
 from homeassistant.helpers import entity_registry as er
@@ -99,7 +99,9 @@ class RamsesFanHandler:
                 hasattr(platform, "entities")
                 and entity_id in platform.entities
             ):
-                return platform.entities[entity_id]
+                return cast(
+                    "RamsesEntity | None", platform.entities[entity_id]
+                )
 
         return None
 

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -9,7 +9,7 @@ import time
 from contextlib import suppress
 from dataclasses import asdict, dataclass
 from datetime import datetime as dt
-from typing import Any, Final
+from typing import Any, Final, cast
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -85,7 +85,7 @@ def ramses_device_id_to_ha_device_id(
     if not device_entry:
         return None
 
-    return device_entry.id
+    return cast(str | None, device_entry.id)
 
 
 def fields_to_aware(dt_or_none: dt | str | None) -> dt | None:
@@ -115,7 +115,7 @@ def fields_to_aware(dt_or_none: dt | str | None) -> dt | None:
         return final_dt
 
     # If it is naive, assume it is Local Time (Wall Clock) and make it aware
-    return dt_util.as_local(final_dt)
+    return cast(dt | None, dt_util.as_local(final_dt))
 
 
 def as_iso(val: Any) -> str:

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -14,9 +14,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.60.1",
+      "ramses-rf==0.60.2",
       "serialx>=1.6.0"
     ],
     "single_config_entry": true,
-    "version": "0.60.1"
+    "version": "0.60.2"
   }

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -6,7 +6,7 @@ import logging
 import re
 from copy import deepcopy
 from datetime import timedelta as td
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.const import CONF_SCAN_INTERVAL
@@ -760,7 +760,7 @@ def merge_schemas(
     # cannot resurrect devices the user removed.  Only applies in SSOT
     # mode (passive scan).  In legacy mode, the cache is kept as-is.
     if not schema_is_ssot:
-        return result
+        return cast(_SchemaT | None, result)
 
     if not config_device_ids:
         # Config has no devices at all — check if the result has any
@@ -776,7 +776,7 @@ def merge_schemas(
                         has_devices = True
                         break
         if not has_devices:
-            return result
+            return cast(_SchemaT | None, result)
         # Config is fully wiped of devices — drop all cached device keys
         # and orphan lists, keep only non-device keys (known_list, etc.)
         _LOGGER.info(

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import timedelta as td
 from types import UnionType
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -209,8 +209,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):
             self.entity_description.ramses_cc_icon_off
             and not self.native_value
         ):
-            return self.entity_description.ramses_cc_icon_off
-        return super().icon
+            return cast(str | None, self.entity_description.ramses_cc_icon_off)
+        return cast(str | None, super().icon)
 
     # the following methods are integration-specific service calls
 

--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 import os
 import time
-from typing import Any, Final
+from typing import Any, Final, cast
 
 import yaml  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.core import HomeAssistant
@@ -225,7 +225,7 @@ class RamsesStore:
             reason, filepath, filename.
         """
         existing = await self._store.async_load() or {}
-        return existing.get(_BACKUP_KEY, [])
+        return cast(list[dict[str, Any]], existing.get(_BACKUP_KEY, []))
 
     async def async_load_backup_file(
         self, filepath: str
@@ -236,8 +236,11 @@ class RamsesStore:
         :return: The backup dict with schema + known_list, or None on failure.
         """
         try:
-            return await self._hass.async_add_executor_job(
-                _read_yaml_file, filepath
+            return cast(
+                dict[str, Any] | None,
+                await self._hass.async_add_executor_job(
+                    _read_yaml_file, filepath
+                ),
             )
         except (OSError, yaml.YAMLError) as err:
             _LOGGER.error("Failed to read backup file %s: %s", filepath, err)
@@ -275,7 +278,7 @@ def _write_yaml_file(filepath: str, data: dict[str, Any]) -> None:
 def _read_yaml_file(filepath: str) -> dict[str, Any]:
     """Read a YAML file."""
     with open(filepath, encoding="utf-8") as f:
-        return yaml.load(f, Loader=yaml.SafeLoader)
+        return cast(dict[str, Any], yaml.load(f, Loader=yaml.SafeLoader))
 
 
 def _safe_remove(filepath: str) -> None:

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
   aioesphomeapi         >= 45.13.1               # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.60.1                # as per: manifest.json latest:
+  ramses-rf             == 0.60.2                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.8.2                 # required by config_flow > homeassistant.components.usb, see issue #623


### PR DESCRIPTION
## Summary

Add explicit `cast()` at the ramses_cc/ramses_rf boundary for properties
returning `Any` from HA constants (`HVACMode`, `PRESET_NONE`, etc.) and
ramses_rf functions (`deep_merge`, `resolve_async_attr` results).

Eliminates all 23 `[no-any-return]` errors from source files:

- `climate.py`: 12 errors (HVACMode/PRESET casts)
- `store.py`: 3 errors (yaml.load, async_load casts)
- `helpers.py`: 2 errors (device_entry.id, dt_util.as_local casts)
- `schemas.py`: 2 errors (deep_merge result casts)
- `binary_sensor.py`: 1 error (entity_description.icon cast)
- `sensor.py`: 1 error (entity_description.icon cast)
- `fan_handler.py`: 1 error (platform.entities cast)
- `config_flow.py`: 1 error (async_add_executor_job cast)

Zero runtime changes — `cast()` is a no-op at runtime.

## Verification

- `mypy . --strict`: 230 → 211 errors (89 → 66 source errors)
- `ruff check`: clean
- `pytest`: 1398 passed, 1 pre-existing failure (probatio schema)

Refs: issue 967

#### Test plan
- [x] `mypy . --strict` — 23 fewer errors
- [x] `ruff check` — clean
- [x] `pytest` — no new failures