### PR TITLE
Wave 0, PR 2: Resolve discovery.py return-type suppressions

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -2129,7 +2129,9 @@ class DiscoveryManager:
         self._metadata[device_id] = meta
         _LOGGER.info("DiscoveryManager: accepted device %s", device_id)
 
-        return self.get_device(device_id)  # type: ignore[return-value]
+        result = self.get_device(device_id)
+        assert result is not None  # just added/updated metadata
+        return result
 
     def discard_device(self, device_id: str) -> DiscoveredDeviceEntry:
         """Discard a discovered device — keep for spam prevention.
@@ -2152,7 +2154,9 @@ class DiscoveryManager:
         self._metadata[device_id] = meta
 
         _LOGGER.info("DiscoveryManager: discarded device %s", device_id)
-        return self.get_device(device_id)  # type: ignore[return-value]
+        result = self.get_device(device_id)
+        assert result is not None  # just updated metadata
+        return result
 
     def remove_device(self, device_id: str) -> DiscoveredDeviceEntry:
         """Remove a previously accepted device — it no longer exists.
@@ -2177,7 +2181,9 @@ class DiscoveryManager:
         self._notified.discard(device_id)
 
         _LOGGER.info("DiscoveryManager: removed device %s", device_id)
-        return self.get_device(device_id)  # type: ignore[return-value]
+        result = self.get_device(device_id)
+        assert result is not None  # just updated metadata
+        return result
 
     def enable_device(self, device_id: str) -> DiscoveredDeviceEntry:
         """Enable a disabled/discarded/removed device.
@@ -2194,7 +2200,9 @@ class DiscoveryManager:
 
         self._metadata[device_id].enabled = True
         _LOGGER.info("DiscoveryManager: enabled device %s", device_id)
-        return self.get_device(device_id)  # type: ignore[return-value]
+        result = self.get_device(device_id)
+        assert result is not None  # just updated metadata
+        return result
 
     def disable_device(self, device_id: str) -> DiscoveredDeviceEntry:
         """Disable an accepted device — temporary exclusion.
@@ -2211,7 +2219,9 @@ class DiscoveryManager:
 
         self._metadata[device_id].enabled = False
         _LOGGER.info("DiscoveryManager: disabled device %s", device_id)
-        return self.get_device(device_id)  # type: ignore[return-value]
+        result = self.get_device(device_id)
+        assert result is not None  # just updated metadata
+        return result
 
     def add_faked_rem(
         self,
@@ -2272,7 +2282,9 @@ class DiscoveryManager:
             device_id,
             bound_to,
         )
-        return self.get_device(device_id)  # type: ignore[return-value]
+        result = self.get_device(device_id)
+        assert result is not None  # just added faked REM
+        return result
 
     def check_for_new_devices(self) -> list[str]:
         """Check for new devices and send notifications if enabled.

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -14,9 +14,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.60.1",
+      "ramses-rf==0.60.2",
       "serialx>=1.6.0"
     ],
     "single_config_entry": true,
-    "version": "0.60.1"
+    "version": "0.60.2"
   }

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
   aioesphomeapi         >= 45.13.1               # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.60.1                # as per: manifest.json latest:
+  ramses-rf             == 0.60.2                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.8.2                 # required by config_flow > homeassistant.components.usb, see issue #623


### PR DESCRIPTION
## Summary

Replace 6 `# type: ignore[return-value]` suppressions in `discovery.py`
with explicit `assert result is not None` + return pattern.

The methods (`accept_device`, `discard_device`, `remove_device`,
`enable_device`, `disable_device`, `add_faked_rem`) call `get_device()`
which returns `DiscoveredDeviceEntry | None`, but the methods declare
`-> DiscoveredDeviceEntry`. Since the device was just added/updated,
the assert is a safe narrowing — no runtime behavior change.

## Verification

- `mypy . --strict`: 211 errors (unchanged — suppressions weren't counted as errors)
- Source `# type: ignore` count: 15 → 9
- `ruff check`: clean
- `pytest tests/tests_new/test_discovery_manager.py`: 210 passed

Refs: issue 967

#### Test plan
- [x] `mypy . --strict` — no new errors
- [x] `ruff check` — clean
- [x] `pytest test_discovery_manager.py` — 210 passed