### PR TITLE
Wave 0, PR 3: Annotate HA entity subclass [misc] errors

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -113,7 +113,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
+class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):  # type: ignore[misc]
     """Representation of a Ramses binary sensor."""
 
     entity_description: RamsesBinarySensorEntityDescription
@@ -362,7 +362,8 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesBinarySensorEntityDescription(
-    RamsesEntityDescription, BinarySensorEntityDescription
+    RamsesEntityDescription,
+    BinarySensorEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -164,7 +164,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesController(RamsesEntity, ClimateEntity):
+class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses controller."""
 
     _device: Evohome
@@ -516,7 +516,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesZone(RamsesEntity, ClimateEntity):
+class RamsesZone(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses zone."""
 
     _device: Zone
@@ -1082,7 +1082,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesHvac(RamsesEntity, ClimateEntity):
+class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Base for a Honeywell HVAC unit (Fan, HRU, MVHR, PIV, etc)."""
 
     _device: HvacVentilator
@@ -1511,7 +1511,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesClimateEntityDescription(
-    RamsesEntityDescription, ClimateEntityDescription
+    RamsesEntityDescription,
+    ClimateEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1428,7 +1428,7 @@ class BaseRamsesFlow:
         )
 
 
-class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
+class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg,misc]
     """Config flow for Ramses."""
 
     VERSION = 3
@@ -1543,7 +1543,7 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         return RamsesOptionsFlowHandler(config_entry)
 
 
-class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
+class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):  # type: ignore[misc]
     """Options config flow handler for Ramses."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -199,7 +199,7 @@ def _normalize_class_slug(value: str) -> str:
 _T_Entity = TypeVar("_T_Entity", bound=RamsesRFEntity)
 
 
-class RamsesCoordinator(DataUpdateCoordinator):
+class RamsesCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
     """Central coordinator for the RAMSES integration."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class RamsesEntityDescription(EntityDescription):
+class RamsesEntityDescription(EntityDescription):  # type: ignore[misc]
     """Class describing Ramses entities."""
 
     has_entity_name: bool = True
@@ -39,7 +39,7 @@ class RamsesEntityDescription(EntityDescription):
     ramses_cc_extra_attributes: dict[str, str] | None = None
 
 
-class RamsesEntity(CoordinatorEntity):
+class RamsesEntity(CoordinatorEntity):  # type: ignore[misc]
     """Base for any RAMSES II-compatible entity (e.g. Climate, Sensor).
 
     This class handles the connection between the Home Assistant entity

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
     )
 
 
-class RamsesEvent(EventEntity):
+class RamsesEvent(EventEntity):  # type: ignore[misc]
     """Representation of a RAMSES RF event."""
 
     _attr_event_types = [

--- a/custom_components/ramses_cc/exceptions.py
+++ b/custom_components/ramses_cc/exceptions.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from homeassistant.exceptions import HomeAssistantError
 
 
-class RamsesError(HomeAssistantError):
+class RamsesError(HomeAssistantError):  # type: ignore[misc]
     """Base exception class for all RAMSES CC integration errors."""
 
 

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -380,7 +380,7 @@ async def async_setup_entry(
         add_devices(entities)
 
 
-class RamsesNumberBase(RamsesEntity, NumberEntity):
+class RamsesNumberBase(RamsesEntity, NumberEntity):  # type: ignore[misc]
     """Base class for all RAMSES number entities.
 
     This abstract base class provides common functionality for all RAMSES
@@ -1129,7 +1129,8 @@ class RamsesNumberParam(RamsesNumberBase):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesNumberEntityDescription(
-    RamsesEntityDescription, NumberEntityDescription
+    RamsesEntityDescription,
+    NumberEntityDescription,  # type: ignore[misc]
 ):
     """Description for RAMSES number entities.
 

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -254,7 +254,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesRemote(RamsesEntity, RemoteEntity):
+class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
     """Representation of a RAMSES RF remote.
 
     Phase 3b: This entity is created on both REMs (``HvacRemote``) and
@@ -798,7 +798,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesRemoteEntityDescription(
-    RamsesEntityDescription, RemoteEntityDescription
+    RamsesEntityDescription,
+    RemoteEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses remote entities."""
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -136,7 +136,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesSensor(RamsesEntity, SensorEntity):
+class RamsesSensor(RamsesEntity, SensorEntity):  # type: ignore[misc]
     """Representation of a generic sensor."""
 
     entity_description: RamsesSensorEntityDescription
@@ -293,7 +293,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesSensorEntityDescription(
-    RamsesEntityDescription, SensorEntityDescription
+    RamsesEntityDescription,
+    SensorEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -29,7 +29,7 @@ _MAX_BACKUPS: Final[int] = 5
 _BACKUP_DIR: Final[str] = "ramses_cc_backups"
 
 
-class RamsesCcStore(Store[dict[str, Any]]):
+class RamsesCcStore(Store[dict[str, Any]]):  # type: ignore[misc]
     """HA Store subclass with a migration hook for ramses_cc .storage.
 
     STORAGE_VERSION stays at 1 — the store format hasn't changed.

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
+class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):  # type: ignore[misc]
     """Representation of a Ramses DHW controller.
 
     This class provides control over RAMSES domestic hot water (DHW) zones,
@@ -500,7 +500,8 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesWaterHeaterEntityDescription(
-    RamsesEntityDescription, WaterHeaterEntityDescription
+    RamsesEntityDescription,
+    WaterHeaterEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses water heater entities."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ directory = "coverage_html"
 
   # These shouldn't be too much additional work, but may be tricky to
   # get passing if you use a lot of untyped libraries
-  # disallow_subclassing_any = true                                                    # excl. for HA
+  disallow_subclassing_any = true                                                      # was: excl. for HA (Wave 0, PR 3)
   # disallow_untyped_decorators = true                                                 # excl. for HA
   disallow_any_generics = true
 


### PR DESCRIPTION
# DONT MERGE YET. FIRST READ COMMENTS ON #1072 

## Summary

Add `# type: ignore[misc]` to all HA entity base class subclasses and
enable `disallow_subclassing_any = true` in `pyproject.toml`.

HA's base classes (`ClimateEntity`, `SensorEntity`, `NumberEntity`, etc.)
are typed as `Any` due to `follow_imports = "skip"`, causing mypy to
report `[misc]` errors for subclassing `Any`. The suppressions are
necessary until HA ships proper type stubs or `follow_imports` is set
to `"normal"` (issue 967, deferred).

### Files changed (13)
- `exceptions.py`, `entity.py`, `store.py`, `coordinator.py`, `remote.py`
- `number.py`, `water_heater.py`, `sensor.py`, `event.py`, `config_flow.py`
- `climate.py`, `binary_sensor.py`
- `pyproject.toml` (enable `disallow_subclassing_any`)

## Verification

- `mypy . --strict`: 230 → 208 errors (89 → 44 source errors, all `[untyped-decorator]`)
- `mypy` (project config): 0 errors
- `ruff check`: clean
- `pytest`: 1400 passed, 1 pre-existing failure (probatio `Optional + Required`)

Refs: issue 967

#### Test plan
- [x] `mypy` (project) — 0 errors
- [x] `mypy . --strict` — 22 fewer `[misc]` errors
- [x] `ruff check` — clean
- [x] `pytest` — no new failures