### PR TITLE
Wave 0, PR 4: Annotate HA @callback [untyped-decorator] source errors

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -714,82 +714,82 @@ async def async_unload_entry(
     return True
 
 
-@callback
-def async_register_domain_services(
+@callback  # type: ignore[untyped-decorator]
+def async_register_domain_services(  # type: ignore[misc]
     hass: HomeAssistant, entry: ConfigEntry, _coordinator: RamsesCoordinator
 ) -> None:
     """Set up and register handlers for the domain-wide services."""
 
-    @verify_domain_control(DOMAIN)
-    async def async_bind_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_bind_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_bind_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_force_update(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_force_update(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_force_update(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_sync_topology(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_sync_topology(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_sync_topology(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_send_packet(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_send_packet(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_send_packet(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_probe_hvac_binding(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_probe_hvac_binding(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_probe_hvac_binding(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_discover_known_devices(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_discover_known_devices(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_discover_known_devices(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_get_discovered_devices(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_get_discovered_devices(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_get_discovered_devices(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_accept_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_accept_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_accept_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_discard_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_discard_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_discard_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_remove_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_remove_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_remove_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_enable_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_enable_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_enable_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_disable_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_disable_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_disable_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_add_faked_rem(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_add_faked_rem(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_add_faked_rem(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_remove_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_remove_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_remove_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_set_fan_param(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_set_fan_param(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_set_fan_param(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_get_fan_param(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_get_fan_param(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_get_fan_param(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_update_fan_params(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_update_fan_params(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator._async_run_fan_param_sequence(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_set_polling_interval(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_set_polling_interval(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_set_polling_interval(call)
 
     # register the handlers

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -113,7 +113,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
+class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):  # type: ignore[misc]
     """Representation of a Ramses binary sensor."""
 
     entity_description: RamsesBinarySensorEntityDescription
@@ -362,7 +362,8 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesBinarySensorEntityDescription(
-    RamsesEntityDescription, BinarySensorEntityDescription
+    RamsesEntityDescription,
+    BinarySensorEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -90,8 +90,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform = entity_platform.async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         """Add new devices to the platform.

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -164,7 +164,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesController(RamsesEntity, ClimateEntity):
+class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses controller."""
 
     _device: Evohome
@@ -516,7 +516,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesZone(RamsesEntity, ClimateEntity):
+class RamsesZone(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses zone."""
 
     _device: Zone
@@ -1082,7 +1082,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesHvac(RamsesEntity, ClimateEntity):
+class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Base for a Honeywell HVAC unit (Fan, HRU, MVHR, PIV, etc)."""
 
     _device: HvacVentilator
@@ -1511,7 +1511,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesClimateEntityDescription(
-    RamsesEntityDescription, ClimateEntityDescription
+    RamsesEntityDescription,
+    ClimateEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -151,8 +151,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(devices: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(devices: Any) -> None:  # type: ignore[misc]
         entities = [
             description.ramses_cc_class(coordinator, device, description)
             for device in devices
@@ -417,8 +417,8 @@ class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
 
     # the following methods are integration-specific service calls
 
-    @callback
-    async def async_get_system_faults(self, num_entries: int) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_system_faults(self, num_entries: int) -> None:  # type: ignore[misc]
         """Get the nth latest fault log entries from the Controller.
 
         :param num_entries: Number of entries to fetch.
@@ -1449,8 +1449,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
 
     # the 2411 fan_param services, copied to numbers and to remote.py
 
-    @callback
-    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'get_fan_param' service call.
 
         :param kwargs: Service arguments.
@@ -1476,8 +1476,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
                 f"Failed to get fan param: {err}"
             ) from err
 
-    @callback
-    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'set_fan_param' service call.
 
         :param kwargs: Service arguments.

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1428,7 +1428,7 @@ class BaseRamsesFlow:
         )
 
 
-class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
+class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg,misc]
     """Config flow for Ramses."""
 
     VERSION = 3
@@ -1543,7 +1543,7 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         return RamsesOptionsFlowHandler(config_entry)
 
 
-class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
+class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):  # type: ignore[misc]
     """Options config flow handler for Ramses."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -263,8 +263,8 @@ class BaseRamsesFlow:
             self.hass.loop.create_future()
         )
 
-        @callback
-        def _msg_callback(msg: Any) -> None:
+        @callback  # type: ignore[untyped-decorator]
+        def _msg_callback(msg: Any) -> None:  # type: ignore[misc]
             """Handle incoming MQTT discovery messages.
 
             :param msg: The incoming MQTT message.
@@ -1533,8 +1533,8 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         return self._async_save()
 
     @staticmethod
-    @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+    @callback  # type: ignore[untyped-decorator]
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:  # type: ignore[misc]
         """Options callback for Ramses.
 
         :param config_entry: The loaded configuration entry.

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -665,8 +665,8 @@ class RamsesCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
         # coroutine runs, and the coroutine has internal await points
         # that yield to the event loop before _cqrs_ingestion_engine
         # executes.
-        @callback
-        def _on_packet(dto: PacketDTO) -> None:
+        @callback  # type: ignore[untyped-decorator]
+        def _on_packet(dto: PacketDTO) -> None:  # type: ignore[misc]
             """Emit SIGNAL_UPDATE after ramses_rf has ingested the packet."""
 
             async def _signal_after_ingestion() -> None:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -199,7 +199,7 @@ def _normalize_class_slug(value: str) -> str:
 _T_Entity = TypeVar("_T_Entity", bound=RamsesRFEntity)
 
 
-class RamsesCoordinator(DataUpdateCoordinator):
+class RamsesCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
     """Central coordinator for the RAMSES integration."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class RamsesEntityDescription(EntityDescription):
+class RamsesEntityDescription(EntityDescription):  # type: ignore[misc]
     """Class describing Ramses entities."""
 
     has_entity_name: bool = True
@@ -39,7 +39,7 @@ class RamsesEntityDescription(EntityDescription):
     ramses_cc_extra_attributes: dict[str, str] | None = None
 
 
-class RamsesEntity(CoordinatorEntity):
+class RamsesEntity(CoordinatorEntity):  # type: ignore[misc]
     """Base for any RAMSES II-compatible entity (e.g. Climate, Sensor).
 
     This class handles the connection between the Home Assistant entity

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -123,8 +123,8 @@ class RamsesEvent(EventEntity):  # type: ignore[misc]
             _LOGGER.warning(warn_text)
             raise HomeAssistantError(warn_text)
 
-    @callback
-    def _async_handle_event(self, event: str) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _async_handle_event(self, event: str) -> None:  # type: ignore[misc]
         """Handle the RAMSES event."""
         _LOGGER.debug("handle_event %s, data: %s", self._type, self._data)
         self._trigger_event(
@@ -180,8 +180,8 @@ class RamsesLearnEvent(RamsesEvent):
         self._attr_unique_id = "learn_event"
         self._attr_translation_key = "learn_event"
 
-        @callback
-        def async_process_msg(
+        @callback  # type: ignore[untyped-decorator]
+        def async_process_msg(  # type: ignore[misc]
             dto: PacketDTO, *args: Any, **kwargs: Any
         ) -> None:
             """Process a message from the event bus and pass it on."""
@@ -233,8 +233,8 @@ class RamsesRegexEvent(RamsesEvent):
         self._attr_unique_id = "regex_event"
         self._attr_translation_key = "regex_event"
 
-        @callback
-        def async_process_msg(
+        @callback  # type: ignore[untyped-decorator]
+        def async_process_msg(  # type: ignore[misc]
             dto: PacketDTO, *args: Any, **kwargs: Any
         ) -> None:
             """Process a message from the event bus and pass it on."""

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
     )
 
 
-class RamsesEvent(EventEntity):
+class RamsesEvent(EventEntity):  # type: ignore[misc]
     """Representation of a RAMSES RF event."""
 
     _attr_event_types = [

--- a/custom_components/ramses_cc/exceptions.py
+++ b/custom_components/ramses_cc/exceptions.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from homeassistant.exceptions import HomeAssistantError
 
 
-class RamsesError(HomeAssistantError):
+class RamsesError(HomeAssistantError):  # type: ignore[misc]
     """Base exception class for all RAMSES CC integration errors."""
 
 

--- a/custom_components/ramses_cc/mqtt_bridge.py
+++ b/custom_components/ramses_cc/mqtt_bridge.py
@@ -167,8 +167,8 @@ class RamsesMqttBridge:
                 exc_info=True,
             )
 
-    @callback
-    def _handle_rx_message(self, msg: ReceiveMessage) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _handle_rx_message(self, msg: ReceiveMessage) -> None:  # type: ignore[misc]
         """Process incoming radio packets."""
         if self._transport is None:
             _LOGGER.warning(
@@ -222,8 +222,8 @@ class RamsesMqttBridge:
                 exc_info=True,
             )
 
-    @callback
-    def _handle_cmd_message(self, msg: ReceiveMessage) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _handle_cmd_message(self, msg: ReceiveMessage) -> None:  # type: ignore[misc]
         """Process incoming MQTT messages and inject into ramses_rf."""
         if self._transport is None:
             _LOGGER.warning(
@@ -328,8 +328,8 @@ class RamsesMqttBridge:
         )
         _LOGGER.debug("MqttBridge: CMD -> %s, on topic: %s", payload, topic)
 
-    @callback
-    def _handle_connection_status(self, connected: bool) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _handle_connection_status(self, connected: bool) -> None:  # type: ignore[misc]
         """Handle MQTT broker connection/disconnection."""
         status_str = "online" if connected else "offline"
         _LOGGER.debug(

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -380,7 +380,7 @@ async def async_setup_entry(
         add_devices(entities)
 
 
-class RamsesNumberBase(RamsesEntity, NumberEntity):
+class RamsesNumberBase(RamsesEntity, NumberEntity):  # type: ignore[misc]
     """Base class for all RAMSES number entities.
 
     This abstract base class provides common functionality for all RAMSES
@@ -1129,7 +1129,8 @@ class RamsesNumberParam(RamsesNumberBase):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesNumberEntityDescription(
-    RamsesEntityDescription, NumberEntityDescription
+    RamsesEntityDescription,
+    NumberEntityDescription,  # type: ignore[misc]
 ):
     """Description for RAMSES number entities.
 

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -155,8 +155,8 @@ async def async_setup_entry(
 
     _LOGGER.debug("Setting up number platform")
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity
         | RamsesNumberBase
         | Sequence[RamsesRFEntity | RamsesNumberBase],
@@ -795,8 +795,8 @@ class RamsesNumberParam(RamsesNumberBase):
 
         await self._request_parameter_value()
 
-    @callback
-    def _async_param_updated(
+    @callback  # type: ignore[untyped-decorator]
+    def _async_param_updated(  # type: ignore[misc]
         self, event: Event | dict[str, Any] | object
     ) -> None:
         """Handle parameter updates from the device.

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -231,8 +231,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         # 1. Safely wrap a single device into a list, or keep it as a sequence
@@ -459,8 +459,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
         # Event to signal when the command is received, TODO not thread safe!
         learning_session = asyncio.Event()
 
-        @callback
-        async def _async_on_change(event: Event) -> None:
+        @callback  # type: ignore[untyped-decorator]
+        async def _async_on_change(event: Event) -> None:  # type: ignore[misc]
             """Save the new command to storage.
 
             For REM entities: listens to ``src == self._device.id``,
@@ -742,8 +742,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
 
     # 2411 fan_param services, adapted from climate.py (no REM update_all)
 
-    @callback
-    async def async_get_fan_rem_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_fan_rem_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'get_fan_param' service call.
 
         :param kwargs: Arbitrary keyword arguments.
@@ -766,8 +766,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
         else:
             _LOGGER.warning("REM %s not bound to a FAN", self._device.id)
 
-    @callback
-    async def async_set_fan_rem_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_set_fan_rem_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'set_fan_param' service call.
 
         :param kwargs: Arbitrary keyword arguments.

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -254,7 +254,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesRemote(RamsesEntity, RemoteEntity):
+class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
     """Representation of a RAMSES RF remote.
 
     Phase 3b: This entity is created on both REMs (``HvacRemote``) and
@@ -798,7 +798,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesRemoteEntityDescription(
-    RamsesEntityDescription, RemoteEntityDescription
+    RamsesEntityDescription,
+    RemoteEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses remote entities."""
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -136,7 +136,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesSensor(RamsesEntity, SensorEntity):
+class RamsesSensor(RamsesEntity, SensorEntity):  # type: ignore[misc]
     """Representation of a generic sensor."""
 
     entity_description: RamsesSensorEntityDescription
@@ -293,7 +293,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesSensorEntityDescription(
-    RamsesEntityDescription, SensorEntityDescription
+    RamsesEntityDescription,
+    SensorEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -116,8 +116,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         # 1. Safely wrap a single device into a list, or keep it as a sequence
@@ -214,8 +214,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):  # type: ignore[misc]
 
     # the following methods are integration-specific service calls
 
-    @callback
-    def async_put_co2_level(self, co2_level: int) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def async_put_co2_level(self, co2_level: int) -> None:  # type: ignore[misc]
         """Cast the CO2 level (if faked).
 
         :param co2_level: The CO2 concentration in parts per million (ppm).
@@ -252,8 +252,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):  # type: ignore[misc]
         await device.set_temperature(temperature)
         self.async_write_ha_state()
 
-    @callback
-    def async_put_indoor_humidity(self, indoor_humidity: float) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def async_put_indoor_humidity(self, indoor_humidity: float) -> None:  # type: ignore[misc]
         """Cast the indoor humidity level (if faked).
 
         :param indoor_humidity: The humidity percentage (0-100).

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -234,8 +234,8 @@ class RamsesServiceHandler:
         self._call_later_handles: list[Any] = []
         self._pending_timers: list[asyncio.Task[Any]] = []
 
-    @callback
-    def _schedule_refresh(self, _: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _schedule_refresh(self, _: Any) -> None:  # type: ignore[misc]
         """Schedule a coordinator refresh.
 
         :param _: Unused argument (required for callback signature).

--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -29,7 +29,7 @@ _MAX_BACKUPS: Final[int] = 5
 _BACKUP_DIR: Final[str] = "ramses_cc_backups"
 
 
-class RamsesCcStore(Store[dict[str, Any]]):
+class RamsesCcStore(Store[dict[str, Any]]):  # type: ignore[misc]
     """HA Store subclass with a migration hook for ramses_cc .storage.
 
     STORAGE_VERSION stays at 1 — the store format hasn't changed.

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
+class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):  # type: ignore[misc]
     """Representation of a Ramses DHW controller.
 
     This class provides control over RAMSES domestic hot water (DHW) zones,
@@ -500,7 +500,8 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesWaterHeaterEntityDescription(
-    RamsesEntityDescription, WaterHeaterEntityDescription
+    RamsesEntityDescription,
+    WaterHeaterEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses water heater entities."""
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -69,8 +69,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         # 1. Safely wrap a single device into a list, or keep it as a sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ directory = "coverage_html"
 
   # These shouldn't be too much additional work, but may be tricky to
   # get passing if you use a lot of untyped libraries
-  # disallow_subclassing_any = true                                                    # excl. for HA
+  disallow_subclassing_any = true                                                      # was: excl. for HA (Wave 0, PR 3)
   # disallow_untyped_decorators = true                                                 # excl. for HA
   disallow_any_generics = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,9 @@ directory = "coverage_html"
   # These shouldn't be too much additional work, but may be tricky to
   # get passing if you use a lot of untyped libraries
   disallow_subclassing_any = true                                                      # was: excl. for HA (Wave 0, PR 3)
-  # disallow_untyped_decorators = true                                                 # excl. for HA
+  disallow_untyped_decorators = true                                                    # was: excl. for HA (Wave 0, PR 4)
   disallow_any_generics = true
+  disallow_any_decorated = true                                                       # Wave 0, PR 4
 
   # These next few are various gradations of forcing use of type annotations
   disallow_untyped_calls = true


### PR DESCRIPTION
## Summary

Add `# type: ignore[untyped-decorator]` to decorator lines and
`# type: ignore[misc]` to def lines for all HA `@callback`-decorated
functions. Enable `disallow_any_decorated = true` in `pyproject.toml`.

HA's `@callback` decorator is typed as `Any` due to
`follow_imports = "skip"`, producing both `[untyped-decorator]` on the
decorator line and `[misc]` "Function is untyped after decorator
transformation" on the def line. Both are suppressed.

### Files changed (13)
- `__init__.py` (20 websocket handlers), `climate.py`, `config_flow.py`
- `coordinator.py`, `event.py`, `mqtt_bridge.py`, `number.py`
- `remote.py`, `sensor.py`, `services.py`, `water_heater.py`
- `binary_sensor.py`, `pyproject.toml`

## Stacking note

**This PR is stacked on PR 3 (issue 967, PR 3).** It requires
`disallow_subclassing_any = true` from PR 3 to be in effect. Rebase
onto master after PR 3 is merged.

## Verification

- `mypy` (project): 0 source errors (139 test errors — deferred to PR 5)
- `mypy . --strict`: 0 source errors (164 test errors — deferred to PR 5)
- `ruff check`: clean
- `pytest`: 1400 passed, 1 pre-existing failure (probatio)

Refs: issue 967

#### Test plan
- [x] `mypy` (project) — 0 source errors
- [x] `mypy . --strict` — 0 source errors
- [x] `ruff check` — clean
- [x] `pytest` — no new failures