### PR TITLE
Wave 0, PR 5: Address [untyped-decorator] in tests

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -714,82 +714,82 @@ async def async_unload_entry(
     return True
 
 
-@callback
-def async_register_domain_services(
+@callback  # type: ignore[untyped-decorator]
+def async_register_domain_services(  # type: ignore[misc]
     hass: HomeAssistant, entry: ConfigEntry, _coordinator: RamsesCoordinator
 ) -> None:
     """Set up and register handlers for the domain-wide services."""
 
-    @verify_domain_control(DOMAIN)
-    async def async_bind_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_bind_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_bind_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_force_update(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_force_update(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_force_update(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_sync_topology(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_sync_topology(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_sync_topology(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_send_packet(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_send_packet(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_send_packet(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_probe_hvac_binding(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_probe_hvac_binding(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_probe_hvac_binding(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_discover_known_devices(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_discover_known_devices(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_discover_known_devices(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_get_discovered_devices(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_get_discovered_devices(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_get_discovered_devices(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_accept_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_accept_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_accept_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_discard_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_discard_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_discard_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_remove_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_remove_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_remove_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_enable_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_enable_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_enable_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_disable_discovered_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_disable_discovered_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_disable_discovered_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_add_faked_rem(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_add_faked_rem(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_add_faked_rem(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_remove_device(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_remove_device(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_remove_device(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_set_fan_param(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_set_fan_param(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_set_fan_param(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_get_fan_param(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_get_fan_param(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_get_fan_param(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_update_fan_params(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_update_fan_params(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator._async_run_fan_param_sequence(call)
 
-    @verify_domain_control(DOMAIN)
-    async def async_set_polling_interval(call: ServiceCall) -> None:
+    @verify_domain_control(DOMAIN)  # type: ignore[untyped-decorator]
+    async def async_set_polling_interval(call: ServiceCall) -> None:  # type: ignore[misc]
         await _coordinator.async_set_polling_interval(call)
 
     # register the handlers

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -113,7 +113,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
+class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):  # type: ignore[misc]
     """Representation of a Ramses binary sensor."""
 
     entity_description: RamsesBinarySensorEntityDescription
@@ -362,7 +362,8 @@ class RamsesGatewayBinarySensor(RamsesBinarySensor):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesBinarySensorEntityDescription(
-    RamsesEntityDescription, BinarySensorEntityDescription
+    RamsesEntityDescription,
+    BinarySensorEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -90,8 +90,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform = entity_platform.async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         """Add new devices to the platform.

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -164,7 +164,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesController(RamsesEntity, ClimateEntity):
+class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses controller."""
 
     _device: Evohome
@@ -516,7 +516,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesZone(RamsesEntity, ClimateEntity):
+class RamsesZone(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Representation of a Ramses zone."""
 
     _device: Zone
@@ -1082,7 +1082,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             ) from err
 
 
-class RamsesHvac(RamsesEntity, ClimateEntity):
+class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
     """Base for a Honeywell HVAC unit (Fan, HRU, MVHR, PIV, etc)."""
 
     _device: HvacVentilator
@@ -1511,7 +1511,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesClimateEntityDescription(
-    RamsesEntityDescription, ClimateEntityDescription
+    RamsesEntityDescription,
+    ClimateEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -151,8 +151,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(devices: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(devices: Any) -> None:  # type: ignore[misc]
         entities = [
             description.ramses_cc_class(coordinator, device, description)
             for device in devices
@@ -417,8 +417,8 @@ class RamsesController(RamsesEntity, ClimateEntity):  # type: ignore[misc]
 
     # the following methods are integration-specific service calls
 
-    @callback
-    async def async_get_system_faults(self, num_entries: int) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_system_faults(self, num_entries: int) -> None:  # type: ignore[misc]
         """Get the nth latest fault log entries from the Controller.
 
         :param num_entries: Number of entries to fetch.
@@ -1449,8 +1449,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
 
     # the 2411 fan_param services, copied to numbers and to remote.py
 
-    @callback
-    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'get_fan_param' service call.
 
         :param kwargs: Service arguments.
@@ -1476,8 +1476,8 @@ class RamsesHvac(RamsesEntity, ClimateEntity):  # type: ignore[misc]
                 f"Failed to get fan param: {err}"
             ) from err
 
-    @callback
-    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_set_fan_clim_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'set_fan_param' service call.
 
         :param kwargs: Service arguments.

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1428,7 +1428,7 @@ class BaseRamsesFlow:
         )
 
 
-class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
+class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg,misc]
     """Config flow for Ramses."""
 
     VERSION = 3
@@ -1543,7 +1543,7 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         return RamsesOptionsFlowHandler(config_entry)
 
 
-class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
+class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):  # type: ignore[misc]
     """Options config flow handler for Ramses."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -263,8 +263,8 @@ class BaseRamsesFlow:
             self.hass.loop.create_future()
         )
 
-        @callback
-        def _msg_callback(msg: Any) -> None:
+        @callback  # type: ignore[untyped-decorator]
+        def _msg_callback(msg: Any) -> None:  # type: ignore[misc]
             """Handle incoming MQTT discovery messages.
 
             :param msg: The incoming MQTT message.
@@ -1533,8 +1533,8 @@ class RamsesConfigFlow(BaseRamsesFlow, ConfigFlow, domain=DOMAIN):  # type: igno
         return self._async_save()
 
     @staticmethod
-    @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+    @callback  # type: ignore[untyped-decorator]
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:  # type: ignore[misc]
         """Options callback for Ramses.
 
         :param config_entry: The loaded configuration entry.

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -665,8 +665,8 @@ class RamsesCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
         # coroutine runs, and the coroutine has internal await points
         # that yield to the event loop before _cqrs_ingestion_engine
         # executes.
-        @callback
-        def _on_packet(dto: PacketDTO) -> None:
+        @callback  # type: ignore[untyped-decorator]
+        def _on_packet(dto: PacketDTO) -> None:  # type: ignore[misc]
             """Emit SIGNAL_UPDATE after ramses_rf has ingested the packet."""
 
             async def _signal_after_ingestion() -> None:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -199,7 +199,7 @@ def _normalize_class_slug(value: str) -> str:
 _T_Entity = TypeVar("_T_Entity", bound=RamsesRFEntity)
 
 
-class RamsesCoordinator(DataUpdateCoordinator):
+class RamsesCoordinator(DataUpdateCoordinator):  # type: ignore[misc]
     """Central coordinator for the RAMSES integration."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
-class RamsesEntityDescription(EntityDescription):
+class RamsesEntityDescription(EntityDescription):  # type: ignore[misc]
     """Class describing Ramses entities."""
 
     has_entity_name: bool = True
@@ -39,7 +39,7 @@ class RamsesEntityDescription(EntityDescription):
     ramses_cc_extra_attributes: dict[str, str] | None = None
 
 
-class RamsesEntity(CoordinatorEntity):
+class RamsesEntity(CoordinatorEntity):  # type: ignore[misc]
     """Base for any RAMSES II-compatible entity (e.g. Climate, Sensor).
 
     This class handles the connection between the Home Assistant entity

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -123,8 +123,8 @@ class RamsesEvent(EventEntity):  # type: ignore[misc]
             _LOGGER.warning(warn_text)
             raise HomeAssistantError(warn_text)
 
-    @callback
-    def _async_handle_event(self, event: str) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _async_handle_event(self, event: str) -> None:  # type: ignore[misc]
         """Handle the RAMSES event."""
         _LOGGER.debug("handle_event %s, data: %s", self._type, self._data)
         self._trigger_event(
@@ -180,8 +180,8 @@ class RamsesLearnEvent(RamsesEvent):
         self._attr_unique_id = "learn_event"
         self._attr_translation_key = "learn_event"
 
-        @callback
-        def async_process_msg(
+        @callback  # type: ignore[untyped-decorator]
+        def async_process_msg(  # type: ignore[misc]
             dto: PacketDTO, *args: Any, **kwargs: Any
         ) -> None:
             """Process a message from the event bus and pass it on."""
@@ -233,8 +233,8 @@ class RamsesRegexEvent(RamsesEvent):
         self._attr_unique_id = "regex_event"
         self._attr_translation_key = "regex_event"
 
-        @callback
-        def async_process_msg(
+        @callback  # type: ignore[untyped-decorator]
+        def async_process_msg(  # type: ignore[misc]
             dto: PacketDTO, *args: Any, **kwargs: Any
         ) -> None:
             """Process a message from the event bus and pass it on."""

--- a/custom_components/ramses_cc/event.py
+++ b/custom_components/ramses_cc/event.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
     )
 
 
-class RamsesEvent(EventEntity):
+class RamsesEvent(EventEntity):  # type: ignore[misc]
     """Representation of a RAMSES RF event."""
 
     _attr_event_types = [

--- a/custom_components/ramses_cc/exceptions.py
+++ b/custom_components/ramses_cc/exceptions.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from homeassistant.exceptions import HomeAssistantError
 
 
-class RamsesError(HomeAssistantError):
+class RamsesError(HomeAssistantError):  # type: ignore[misc]
     """Base exception class for all RAMSES CC integration errors."""
 
 

--- a/custom_components/ramses_cc/mqtt_bridge.py
+++ b/custom_components/ramses_cc/mqtt_bridge.py
@@ -167,8 +167,8 @@ class RamsesMqttBridge:
                 exc_info=True,
             )
 
-    @callback
-    def _handle_rx_message(self, msg: ReceiveMessage) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _handle_rx_message(self, msg: ReceiveMessage) -> None:  # type: ignore[misc]
         """Process incoming radio packets."""
         if self._transport is None:
             _LOGGER.warning(
@@ -222,8 +222,8 @@ class RamsesMqttBridge:
                 exc_info=True,
             )
 
-    @callback
-    def _handle_cmd_message(self, msg: ReceiveMessage) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _handle_cmd_message(self, msg: ReceiveMessage) -> None:  # type: ignore[misc]
         """Process incoming MQTT messages and inject into ramses_rf."""
         if self._transport is None:
             _LOGGER.warning(
@@ -328,8 +328,8 @@ class RamsesMqttBridge:
         )
         _LOGGER.debug("MqttBridge: CMD -> %s, on topic: %s", payload, topic)
 
-    @callback
-    def _handle_connection_status(self, connected: bool) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _handle_connection_status(self, connected: bool) -> None:  # type: ignore[misc]
         """Handle MQTT broker connection/disconnection."""
         status_str = "online" if connected else "offline"
         _LOGGER.debug(

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -380,7 +380,7 @@ async def async_setup_entry(
         add_devices(entities)
 
 
-class RamsesNumberBase(RamsesEntity, NumberEntity):
+class RamsesNumberBase(RamsesEntity, NumberEntity):  # type: ignore[misc]
     """Base class for all RAMSES number entities.
 
     This abstract base class provides common functionality for all RAMSES
@@ -1129,7 +1129,8 @@ class RamsesNumberParam(RamsesNumberBase):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesNumberEntityDescription(
-    RamsesEntityDescription, NumberEntityDescription
+    RamsesEntityDescription,
+    NumberEntityDescription,  # type: ignore[misc]
 ):
     """Description for RAMSES number entities.
 

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -155,8 +155,8 @@ async def async_setup_entry(
 
     _LOGGER.debug("Setting up number platform")
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity
         | RamsesNumberBase
         | Sequence[RamsesRFEntity | RamsesNumberBase],
@@ -795,8 +795,8 @@ class RamsesNumberParam(RamsesNumberBase):
 
         await self._request_parameter_value()
 
-    @callback
-    def _async_param_updated(
+    @callback  # type: ignore[untyped-decorator]
+    def _async_param_updated(  # type: ignore[misc]
         self, event: Event | dict[str, Any] | object
     ) -> None:
         """Handle parameter updates from the device.

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -231,8 +231,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         # 1. Safely wrap a single device into a list, or keep it as a sequence
@@ -459,8 +459,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
         # Event to signal when the command is received, TODO not thread safe!
         learning_session = asyncio.Event()
 
-        @callback
-        async def _async_on_change(event: Event) -> None:
+        @callback  # type: ignore[untyped-decorator]
+        async def _async_on_change(event: Event) -> None:  # type: ignore[misc]
             """Save the new command to storage.
 
             For REM entities: listens to ``src == self._device.id``,
@@ -742,8 +742,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
 
     # 2411 fan_param services, adapted from climate.py (no REM update_all)
 
-    @callback
-    async def async_get_fan_rem_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_get_fan_rem_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'get_fan_param' service call.
 
         :param kwargs: Arbitrary keyword arguments.
@@ -766,8 +766,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
         else:
             _LOGGER.warning("REM %s not bound to a FAN", self._device.id)
 
-    @callback
-    async def async_set_fan_rem_param(self, **kwargs: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    async def async_set_fan_rem_param(self, **kwargs: Any) -> None:  # type: ignore[misc]
         """Handle 'set_fan_param' service call.
 
         :param kwargs: Arbitrary keyword arguments.

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -254,7 +254,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesRemote(RamsesEntity, RemoteEntity):
+class RamsesRemote(RamsesEntity, RemoteEntity):  # type: ignore[misc]
     """Representation of a RAMSES RF remote.
 
     Phase 3b: This entity is created on both REMs (``HvacRemote``) and
@@ -798,7 +798,8 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesRemoteEntityDescription(
-    RamsesEntityDescription, RemoteEntityDescription
+    RamsesEntityDescription,
+    RemoteEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses remote entities."""
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -136,7 +136,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesSensor(RamsesEntity, SensorEntity):
+class RamsesSensor(RamsesEntity, SensorEntity):  # type: ignore[misc]
     """Representation of a generic sensor."""
 
     entity_description: RamsesSensorEntityDescription
@@ -293,7 +293,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesSensorEntityDescription(
-    RamsesEntityDescription, SensorEntityDescription
+    RamsesEntityDescription,
+    SensorEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses binary sensor entities."""
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -116,8 +116,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         # 1. Safely wrap a single device into a list, or keep it as a sequence
@@ -214,8 +214,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):  # type: ignore[misc]
 
     # the following methods are integration-specific service calls
 
-    @callback
-    def async_put_co2_level(self, co2_level: int) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def async_put_co2_level(self, co2_level: int) -> None:  # type: ignore[misc]
         """Cast the CO2 level (if faked).
 
         :param co2_level: The CO2 concentration in parts per million (ppm).
@@ -252,8 +252,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):  # type: ignore[misc]
         await device.set_temperature(temperature)
         self.async_write_ha_state()
 
-    @callback
-    def async_put_indoor_humidity(self, indoor_humidity: float) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def async_put_indoor_humidity(self, indoor_humidity: float) -> None:  # type: ignore[misc]
         """Cast the indoor humidity level (if faked).
 
         :param indoor_humidity: The humidity percentage (0-100).

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -234,8 +234,8 @@ class RamsesServiceHandler:
         self._call_later_handles: list[Any] = []
         self._pending_timers: list[asyncio.Task[Any]] = []
 
-    @callback
-    def _schedule_refresh(self, _: Any) -> None:
+    @callback  # type: ignore[untyped-decorator]
+    def _schedule_refresh(self, _: Any) -> None:  # type: ignore[misc]
         """Schedule a coordinator refresh.
 
         :param _: Unused argument (required for callback signature).

--- a/custom_components/ramses_cc/store.py
+++ b/custom_components/ramses_cc/store.py
@@ -29,7 +29,7 @@ _MAX_BACKUPS: Final[int] = 5
 _BACKUP_DIR: Final[str] = "ramses_cc_backups"
 
 
-class RamsesCcStore(Store[dict[str, Any]]):
+class RamsesCcStore(Store[dict[str, Any]]):  # type: ignore[misc]
     """HA Store subclass with a migration hook for ramses_cc .storage.
 
     STORAGE_VERSION stays at 1 — the store format hasn't changed.

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
     coordinator.async_register_platform(platform, add_devices)
 
 
-class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
+class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):  # type: ignore[misc]
     """Representation of a Ramses DHW controller.
 
     This class provides control over RAMSES domestic hot water (DHW) zones,
@@ -500,7 +500,8 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
 
 @dataclass(frozen=True, kw_only=True)
 class RamsesWaterHeaterEntityDescription(
-    RamsesEntityDescription, WaterHeaterEntityDescription
+    RamsesEntityDescription,
+    WaterHeaterEntityDescription,  # type: ignore[misc]
 ):
     """Class describing Ramses water heater entities."""
 

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -69,8 +69,8 @@ async def async_setup_entry(
     coordinator: RamsesCoordinator = entry.runtime_data
     platform: EntityPlatform = async_get_current_platform()
 
-    @callback
-    def add_devices(
+    @callback  # type: ignore[untyped-decorator]
+    def add_devices(  # type: ignore[misc]
         devices: RamsesRFEntity | Sequence[RamsesRFEntity],
     ) -> None:
         # 1. Safely wrap a single device into a list, or keep it as a sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ directory = "coverage_html"
 
   # These shouldn't be too much additional work, but may be tricky to
   # get passing if you use a lot of untyped libraries
-  # disallow_subclassing_any = true                                                    # excl. for HA
+  disallow_subclassing_any = true                                                      # was: excl. for HA (Wave 0, PR 3)
   # disallow_untyped_decorators = true                                                 # excl. for HA
   disallow_any_generics = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,8 +111,9 @@ directory = "coverage_html"
   # These shouldn't be too much additional work, but may be tricky to
   # get passing if you use a lot of untyped libraries
   disallow_subclassing_any = true                                                      # was: excl. for HA (Wave 0, PR 3)
-  # disallow_untyped_decorators = true                                                 # excl. for HA
+  disallow_untyped_decorators = true                                                    # was: excl. for HA (Wave 0, PR 4)
   disallow_any_generics = true
+  disallow_any_decorated = true                                                       # Wave 0, PR 4
 
   # These next few are various gradations of forcing use of type annotations
   disallow_untyped_calls = true

--- a/tests/tests_new/conftest.py
+++ b/tests/tests_new/conftest.py
@@ -20,7 +20,7 @@ except (ImportError, ModuleNotFoundError):
     VirtualRf = None  # Windows: pty/termios unavailable
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 def auto_enable_custom_integrations(
     enable_custom_integrations: Any,
 ) -> Generator[None]:
@@ -33,7 +33,7 @@ def auto_enable_custom_integrations(
 
 
 # NOTE: ? workaround for: https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/issues/198
-@pytest.fixture  # not loading from pytest_homeassistant_custom_component.plugins
+@pytest.fixture  # type: ignore[untyped-decorator]  # not loading from pytest_homeassistant_custom_component.plugins
 def snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
     """Return snapshot assertion fixture with the Home Assistant extension.
 
@@ -43,7 +43,7 @@ def snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
     return snapshot.use_extension(HomeAssistantSnapshotExtension)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Apply necessary monkeypatches before running tests.
 
@@ -68,7 +68,7 @@ def patches_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     # monkeypatch.setattr("ramses_tx.protocol._GAP_BETWEEN_WRITES", 0)
 
 
-@pytest.fixture()  # add hass fixture to ensure hass/rf use same event loop
+@pytest.fixture()  # type: ignore[untyped-decorator]  # add hass fixture to ensure hass/rf use same event loop
 async def rf(hass: HomeAssistant) -> AsyncGenerator[Any]:
     """Utilize a virtual evofw3-compatible gateway.
 

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -28,7 +28,7 @@ from ramses_rf.systems.tcs import Logbook, System
 from ramses_tx.const import SZ_IS_EVOFW3
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator() -> MagicMock:
     """Return a mock RamsesCoordinator.
 

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -45,7 +45,7 @@ from ramses_tx.exceptions import ProtocolSendFailed, TransportError
 SZ_HEAT_DEMAND = "heat_demand"
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator() -> MagicMock:
     """Return a mock RamsesCoordinator.
 
@@ -60,7 +60,7 @@ def mock_coordinator() -> MagicMock:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_description() -> MagicMock:
     """Return a mock EntityDescription.
 
@@ -1321,7 +1321,7 @@ async def test_hvac_set_fan_mode_errors(
         await hvac.async_set_fan_mode("low")
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("fan_mode", "cmd_string", "should_succeed"),
     [
         # 1. Valid CLI shorthand (Parsed cleanly by Command.from_cli)
@@ -2191,7 +2191,7 @@ async def test_climate_cooling_support(
     assert call_kwargs["setpoint"] == 25
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[untyped-decorator]
     ("fan_info_input", "expected_action", "expected_mode", "expected_icon"),
     [
         # 1. Standard off

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -75,7 +75,7 @@ def _get_schema_default(schema_key: Any) -> Any:
     return d() if callable(d) else d
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 def bypass_setup_fixture() -> Iterator[None]:
     """Prevent actual setup of the integration during config flow tests."""
     with (
@@ -1067,7 +1067,7 @@ async def test_configure_serial_port_error_logic(hass: HomeAssistant) -> None:
     assert result.get("step_id") == "configure_serial_port"
 
 
-@pytest.mark.skipif(
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
     HOMEASSISTANT_VERSION < "2026.5.0", reason="requires HA 2026.5.0+"
 )
 def test_get_usb_ports_full_new() -> None:
@@ -1094,7 +1094,7 @@ def test_get_usb_ports_full_new() -> None:
         assert ports == {"/dev/ttyUSB0": "USB Device"}
 
 
-@pytest.mark.skipif(
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
     HOMEASSISTANT_VERSION < "2026.5.0", reason="requires HA 2026.5.0+"
 )
 def test_get_usb_ports_logic_edge_case_new() -> None:
@@ -1124,7 +1124,7 @@ def test_get_usb_ports_logic_edge_case_new() -> None:
 
 
 # TODO: remove Q3 2026
-@pytest.mark.skipif(
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
     HOMEASSISTANT_VERSION >= "2026.5.0", reason="requires HA < 2026.5.0"
 )
 def test_get_usb_ports_full_old() -> None:
@@ -1160,7 +1160,7 @@ def test_get_usb_ports_full_old() -> None:
 
 
 # TODO: remove Q3 2026
-@pytest.mark.skipif(
+@pytest.mark.skipif(  # type: ignore[untyped-decorator]
     HOMEASSISTANT_VERSION >= "2026.5.0", reason="requires HA < 2026.5.0"
 )
 def test_get_usb_ports_logic_edge_case_old() -> None:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -73,7 +73,7 @@ SERVICE_GET_NAME = "get_fan_param"  # Name of the get service
 SERVICE_SET_NAME = SVC_SET_FAN_PARAM  # Name of the set service
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_hass() -> MagicMock:
     """Return a mock Home Assistant instance."""
     hass = MagicMock()
@@ -107,7 +107,7 @@ def mock_hass() -> MagicMock:
     return hass
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_entry(mock_hass: MagicMock) -> MagicMock:
     """Return a mock ConfigEntry."""
     entry = MagicMock()
@@ -132,7 +132,7 @@ def mock_entry(mock_hass: MagicMock) -> MagicMock:
     return entry
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(
     mock_hass: MagicMock, mock_entry: MagicMock
 ) -> RamsesCoordinator:
@@ -161,7 +161,7 @@ def mock_client():
     return client
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_fan_device() -> MagicMock:
     """Return a mock Fan device."""
     device = MagicMock()
@@ -419,7 +419,7 @@ async def test_create_client_strips_commands_from_known_list(
         assert CONF_COMMANDS not in gwy_config.known_list["37:168270"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_create_client_foreign_hgi_in_block_list(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -453,7 +453,7 @@ async def test_create_client_foreign_hgi_in_block_list(
         assert "18:072981" in block_list  # foreign HGI is blocked
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_create_client_foreign_hgi_not_in_known_list(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -481,7 +481,7 @@ async def test_create_client_foreign_hgi_not_in_known_list(
         assert "18:072981" not in dict(gwy_config.known_list or {})
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_create_client_own_hgi_not_blocked(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -509,7 +509,7 @@ async def test_create_client_own_hgi_not_blocked(
         assert "18:130140" not in block_list
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_create_client_no_root_owner_no_block_list(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -540,7 +540,7 @@ async def test_create_client_no_root_owner_no_block_list(
         assert "18:072981" not in block_list  # no root_owner → not foreign
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_create_client_hgi_no_owner_not_blocked(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -568,7 +568,7 @@ async def test_create_client_hgi_no_owner_not_blocked(
         assert "18:072981" not in block_list
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_create_client_foreign_hgi_skipped_not_duplicated(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -599,7 +599,7 @@ async def test_create_client_foreign_hgi_skipped_not_duplicated(
         assert list(block_list.keys()).count("18:072981") == 1
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_start_with_packet_handler(
     mock_coordinator: RamsesCoordinator, mock_client
 ):
@@ -1282,7 +1282,7 @@ async def test_save_client_state_unload_uses_config_schema(
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_save_client_state_skip_topology_sync_no_suppress_reload(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -1360,7 +1360,7 @@ async def test_save_client_state_skip_topology_sync_no_suppress_reload(
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_save_client_state_topology_sync_sets_suppress_reload(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -1429,7 +1429,7 @@ async def test_save_client_state_topology_sync_sets_suppress_reload(
     ).async_update_entry.assert_called()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_schema_updated_callback_debounces_burst(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -1474,7 +1474,7 @@ async def test_schema_updated_callback_debounces_burst(
     assert mock_coordinator._schema_updated_debounce_task is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_schema_updated_callback_skipped_during_unload(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -1492,7 +1492,7 @@ async def test_schema_updated_callback_skipped_during_unload(
     assert mock_coordinator.async_save_client_state.await_count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_schema_updated_callback_cancelled_on_unload(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -1603,7 +1603,7 @@ async def test_create_client_mqtt_success(
         assert kwargs["config"].engine.hgi_id == DEFAULT_HGI_ID
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_create_client_zigbee_path(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
@@ -1637,7 +1637,7 @@ async def test_create_client_zigbee_path(
         assert result is mock_client
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_discover_new_entities_registration_order(
     mock_hass: MagicMock,
 ) -> None:
@@ -2401,7 +2401,7 @@ class TestFanParameterGet:
     including error handling and edge cases for parameter reading operations.
     """
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
     async def setup_get_fixture(
         self, hass: HomeAssistant
     ) -> AsyncGenerator[None]:
@@ -2458,7 +2458,7 @@ class TestFanParameterGet:
 
         yield  # Test runs here
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_basic_fan_param_request(self, hass: HomeAssistant) -> None:
         """Test basic fan parameter request.
 
@@ -2482,7 +2482,7 @@ class TestFanParameterGet:
         intent = self.mock_dispatcher_send.call_args[0][0]
         assert intent.action.name == "GET_FAN_PARAM"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_missing_required_param_id(
         self, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -2509,7 +2509,7 @@ class TestFanParameterGet:
         # Verify no command was sent
         self.mock_dispatcher_send.assert_not_called()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_custom_fan_id(self, hass: HomeAssistant) -> None:
         """Test that a custom fan_id can be specified.
 
@@ -2532,7 +2532,7 @@ class TestFanParameterGet:
         # Assert - Verify intent was sent via the CQRS dispatcher
         self.mock_dispatcher_send.assert_awaited_once()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_get_fan_param_with_ha_device_selector_resolves_device_id(
         self, hass: HomeAssistant
     ) -> None:
@@ -2606,7 +2606,7 @@ class TestFanParameterSet:
     edge cases for parameter writing operations.
     """
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
     async def setup_set_fixture(
         self, hass: HomeAssistant
     ) -> AsyncGenerator[None]:
@@ -2669,7 +2669,7 @@ class TestFanParameterSet:
         # Cleanup - stop all patches
         self.sleep_patcher.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_basic_fan_param_set(self, hass: HomeAssistant) -> None:
         """Test basic fan parameter set with all required parameters.
 
@@ -2694,7 +2694,7 @@ class TestFanParameterSet:
         intent = self.mock_dispatcher_send.call_args[0][0]
         assert intent.action.name == "SET_FAN_PARAM"
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_set_fan_param_with_ha_device_selector(
         self, hass: HomeAssistant
     ) -> None:
@@ -2729,7 +2729,7 @@ class TestFanParameterUpdate:
     _async_run_fan_param_sequence method in the RamsesCoordinator class.
     """
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
     async def setup_update_fixture(
         self, hass: HomeAssistant
     ) -> AsyncGenerator[None]:
@@ -2792,7 +2792,7 @@ class TestFanParameterUpdate:
         # Cleanup - stop all patches
         self.sleep_patcher.stop()
 
-    @pytest.mark.asyncio
+    @pytest.mark.asyncio  # type: ignore[untyped-decorator]
     async def test_basic_fan_param_update(self, hass: HomeAssistant) -> None:
         """Test basic fan parameter update with all required parameters.
 

--- a/tests/tests_new/test_discovery_reset.py
+++ b/tests/tests_new/test_discovery_reset.py
@@ -399,7 +399,7 @@ class TestCoordinatorDiscoveryReset:
 class TestCoordinatorUnloadFilter:
     """Tests for coordinator unload filtering discovery state."""
 
-    @pytest.fixture
+    @pytest.fixture  # type: ignore[untyped-decorator]
     def coordinator_with_empty_schema(
         self, hass: HomeAssistant
     ) -> RamsesCoordinator:

--- a/tests/tests_new/test_entity.py
+++ b/tests/tests_new/test_entity.py
@@ -22,7 +22,7 @@ from ramses_rf.entity import Entity as RamsesRFEntity
 DEVICE_ID = "32:123456"
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(hass: HomeAssistant) -> Any:
     """Return a mock coordinator.
 
@@ -35,7 +35,7 @@ def mock_coordinator(hass: HomeAssistant) -> Any:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_device() -> Any:
     """Return a mock RAMSES RF entity with is_available property.
 

--- a/tests/tests_new/test_event.py
+++ b/tests/tests_new/test_event.py
@@ -34,7 +34,7 @@ from ramses_tx.dtos import PacketDTO
 
 
 # Mock Coordinator
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(learn_device_id: str | None = None) -> MagicMock:
     """A mock object simulating the RamsesCoordinator."""
     coordinator = MagicMock()
@@ -44,13 +44,13 @@ def mock_coordinator(learn_device_id: str | None = None) -> MagicMock:
 
 
 # Mock HomeAssistant
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_hass() -> MagicMock:
     return MagicMock(spec=HomeAssistant, data={})
 
 
 # Mock ConfigEntry
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_config_entry() -> MagicMock:
     return MagicMock(spec=ConfigEntry, entry_id="123")
 
@@ -79,7 +79,7 @@ def test_ramses_event_type() -> None:
 
 
 # Test RamsesEvent
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_event_init(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -92,7 +92,7 @@ async def test_ramses_event_init(
     assert event._type == RamsesEventType.LEARN
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_event_update_data(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -109,7 +109,7 @@ async def test_ramses_event_update_data(
     assert event._data == {"type": RamsesEventType.LEARN, "extra": "data"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_event_update_data_error(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -125,7 +125,7 @@ async def test_ramses_event_update_data_error(
         event.update_data({"type": RamsesEventType.REGEX, "extra": "data"})
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_event_async_added_to_hass(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -141,7 +141,7 @@ async def test_ramses_event_async_added_to_hass(
     assert event._remove is not None
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_event_async_will_remove_from_hass(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -158,7 +158,7 @@ async def test_ramses_event_async_will_remove_from_hass(
 
 
 # Test RamsesLearnEvent
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_learn_event_init(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -170,7 +170,7 @@ async def test_ramses_learn_event_init(
     assert event._attr_unique_id == "learn_event"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_learn_event_async_process_msg(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -221,7 +221,7 @@ def _make_dto(src: str = "01:111111", dst: str = "01:222222") -> PacketDTO:
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_signal_update_update_data_still_synchronous(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -242,7 +242,7 @@ async def test_signal_update_update_data_still_synchronous(
 
 
 # Test RamsesRegexEvent
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_regex_event_init(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -257,7 +257,7 @@ async def test_ramses_regex_event_init(
     assert event.regex == regex
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_regex_event_async_process_msg(
     mock_hass: MagicMock, mock_coordinator: MagicMock
 ) -> None:
@@ -347,7 +347,7 @@ async def test_domain_event_platform(
     assert created_entities[0].data["type"] == "tst"
 
 
-@pytest.mark.skip  # TODO(eb): fix from bus listener to event state change listener
+@pytest.mark.skip  # type: ignore[untyped-decorator]  # TODO(eb): fix from bus listener to event state change listener
 async def test_domain_events(
     hass: HomeAssistant, mock_coordinator: MagicMock
 ) -> None:
@@ -450,7 +450,7 @@ async def test_domain_events(
     assert learn_events[0].data["packet"] == expected_packet
 
 
-@pytest.mark.skip
+@pytest.mark.skip  # type: ignore[untyped-decorator]
 async def test_domain_events_no_config(
     hass: HomeAssistant, mock_coordinator: MagicMock
 ) -> None:

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -19,7 +19,7 @@ REM_ID = "32:987654"
 PARAM_ID_HEX = "75"
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_gateway() -> MagicMock:
     """Return a mock Gateway."""
     gateway = MagicMock()
@@ -29,7 +29,7 @@ def mock_gateway() -> MagicMock:
     return gateway
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(
     hass: HomeAssistant, mock_gateway: MagicMock
 ) -> RamsesCoordinator:
@@ -48,7 +48,7 @@ def mock_coordinator(
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_fan_device() -> MagicMock:
     """Return a mock Fan device."""
     device = MagicMock()

--- a/tests/tests_new/test_helpers.py
+++ b/tests/tests_new/test_helpers.py
@@ -138,7 +138,7 @@ def test_as_iso_conversion() -> None:
     assert as_iso(None) == "None"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_resolve_async_attr_sync_and_async(hass: HomeAssistant) -> None:
     """Test resolve_async_attr helper with sync and async targets."""
     # 1. Sync value test
@@ -170,7 +170,7 @@ async def test_resolve_async_attr_sync_and_async(hass: HomeAssistant) -> None:
     assert res_cached == "async_resolved"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_clear_async_attr_cache(hass: HomeAssistant) -> None:
     """Test clearing async attribute resolution cache and cancelling tasks."""
     entity = SimpleNamespace(hass=hass)

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -84,7 +84,7 @@ async def async_flush_queues(gwy: Any) -> None:
         await asyncio.sleep(0)
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     """Return a mock coordinator.
 
@@ -110,7 +110,7 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     return coordinator
 
 
-@pytest.mark.parametrize("instance", TEST_SYSTEMS)
+@pytest.mark.parametrize("instance", TEST_SYSTEMS)  # type: ignore[untyped-decorator]
 async def test_entities(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],

--- a/tests/tests_new/test_mqtt_bridge.py
+++ b/tests/tests_new/test_mqtt_bridge.py
@@ -27,13 +27,13 @@ from custom_components.ramses_cc.mqtt_bridge import RamsesMqttBridge
 TEST_DEVICE_ID = "18:123456"
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_protocol() -> MagicMock:
     """Mock an asyncio.Protocol."""
     return MagicMock(spec=asyncio.Protocol)
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_mqtt(hass: HomeAssistant) -> Iterator[dict[str, Any]]:
     """Mock the HA MQTT integration methods used by the bridge."""
     # We patch the 'mqtt' module IMPORTED inside mqtt_bridge.py.

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -49,7 +49,7 @@ class FakeParam(RamsesNumberParam):
     _device: Any = None  # Explicitly define _device so spec allows it
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     """Return a mock RamsesCoordinator configured for entity creation."""
     coordinator = MagicMock()
@@ -79,7 +79,7 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_fan_device() -> MagicMock:
     """Return a mock Fan device with valid ID."""
     device = MagicMock(spec=MockDevice)
@@ -90,7 +90,7 @@ def mock_fan_device() -> MagicMock:
     return device
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_hvac_device() -> MagicMock:
     """Return a mock DeviceHvac that does NOT have get_fan_param (pre-fingerprint)."""
     device = MagicMock(spec=["id", "_SLUG", "supports_2411"])
@@ -100,7 +100,7 @@ def mock_hvac_device() -> MagicMock:
     return device
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def number_entity(
     mock_coordinator: MagicMock, mock_fan_device: MagicMock
 ) -> RamsesNumberParam:
@@ -1048,7 +1048,7 @@ async def test_number_param_state_isolation(
     assert entity2._param_native_value.get("75") is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_number_param_request_parameter_value_when_hass_is_none(
     mock_coordinator: MagicMock, mock_fan_device: MagicMock
 ) -> None:
@@ -1064,7 +1064,7 @@ async def test_number_param_request_parameter_value_when_hass_is_none(
     await entity._request_parameter_value()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_number_param_async_added_to_hass(
     mock_coordinator: MagicMock, mock_fan_device: MagicMock
 ) -> None:

--- a/tests/tests_new/test_polling_interval.py
+++ b/tests/tests_new/test_polling_interval.py
@@ -25,7 +25,7 @@ def test_ramses_polling_interval_native_value() -> None:
     assert entity.unique_id == "10:123456_polling_interval"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_ramses_polling_interval_set_native_value() -> None:
     # Arrange
     coordinator = MagicMock()
@@ -43,7 +43,7 @@ async def test_ramses_polling_interval_set_native_value() -> None:
     entity.async_write_ha_state.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_service_set_polling_interval_success() -> None:
     # Arrange
     coordinator = MagicMock()

--- a/tests/tests_new/test_remote.py
+++ b/tests/tests_new/test_remote.py
@@ -27,7 +27,7 @@ from ramses_tx.const import Priority
 from ramses_tx.dtos import CommandDTO
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True, scope="module")  # type: ignore[untyped-decorator]
 def _inject_entity_platform() -> Iterator[None]:
     """Inject EntityPlatform into HA entity module for Python 3.14 autospec.
 
@@ -50,7 +50,7 @@ MOCK_DEV_ID = "12:123456"
 VALID_PACKET = "RQ --- 30:123456 18:111111 --:------ 22F1 003 000030"
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     """Return a mock coordinator with required internal structures."""
     coordinator = MagicMock()
@@ -90,7 +90,7 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_remote_device() -> MagicMock:
     """Return a mock HvacRemote device."""
     device = MagicMock()
@@ -99,7 +99,7 @@ def mock_remote_device() -> MagicMock:
     return device
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def remote_entity(
     hass: HomeAssistant,
     mock_coordinator: MagicMock,
@@ -304,8 +304,8 @@ async def test_remote_send_command_exception_handling(
         await remote.async_send_command("boost")
 
 
-@pytest.mark.skip
-@pytest.mark.asyncio
+@pytest.mark.skip  # type: ignore[untyped-decorator]
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_remote_learn_command_success(
     remote_entity: RamsesRemote,
     hass: HomeAssistant,
@@ -428,8 +428,8 @@ async def test_async_learn_command_callback() -> None:
 # new tests for remote_learn events
 
 
-@pytest.mark.skip
-@pytest.mark.asyncio
+@pytest.mark.skip  # type: ignore[untyped-decorator]
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_learn_command_success(
     remote_entity: RamsesRemote,
     mock_coordinator: MagicMock,
@@ -457,7 +457,7 @@ async def test_async_learn_command_success(
         mock_event.assert_called_once()
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_learn_command_invalid_command_type(
     remote_entity: RamsesRemote,
 ) -> None:
@@ -473,7 +473,7 @@ async def test_async_learn_command_invalid_command_type(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_learn_command_command_already_exists(
     remote_entity: RamsesRemote,
 ) -> None:
@@ -496,7 +496,7 @@ async def test_async_learn_command_command_already_exists(
         device.async_delete_command.assert_called_once_with(["boost"])
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_learn_command_kwargs_not_empty(
     remote_entity: RamsesRemote,
 ) -> None:
@@ -515,7 +515,7 @@ async def test_async_learn_command_kwargs_not_empty(
 # end new
 
 
-@pytest.mark.skip  # no separate filter
+@pytest.mark.skip  # type: ignore[untyped-decorator]  # no separate filter
 async def test_remote_learn_filter_logic(
     mock_coordinator: MagicMock,
     mock_remote_device: MagicMock,
@@ -638,7 +638,7 @@ async def test_send_command_failure(
         await remote_entity.async_send_command(["cmd_fail"])
 
 
-@pytest.mark.skip
+@pytest.mark.skip  # type: ignore[untyped-decorator]
 async def test_learn_command(hass: HomeAssistant) -> None:
     """Test the learn_command service."""
     remote = RamsesRemote(
@@ -659,7 +659,7 @@ async def test_learn_command(hass: HomeAssistant) -> None:
     assert "fail_cmd" not in remote._commands
 
 
-@pytest.mark.skip
+@pytest.mark.skip  # type: ignore[untyped-decorator]
 async def test_learn_command_failure(hass: HomeAssistant) -> None:
     """Test the learn_command service failure."""
     remote = RamsesRemote(
@@ -847,7 +847,7 @@ async def test_fan_param_methods(
     mock_coordinator.async_set_fan_param.assert_not_called()
 
 
-@pytest.mark.skip
+@pytest.mark.skip  # type: ignore[untyped-decorator]
 async def test_remote_learn_cleanup_on_timeout(
     hass: HomeAssistant,
     mock_coordinator: MagicMock,
@@ -1034,7 +1034,7 @@ async def test_learn_command_callback_writes_to_schema(
     learning_session = asyncio.Event()
 
     # Replicate the _async_on_change callback logic from async_learn_command
-    @callback
+    @callback  # type: ignore[untyped-decorator]
     async def _async_on_change(event: Any) -> None:
         codes = ("22F1", "22F3", "22F7")
         new_state: State = event.data["new_state"]
@@ -1093,7 +1093,7 @@ async def test_learn_command_callback_ignores_wrong_src(
 
     learning_session = asyncio.Event()
 
-    @callback
+    @callback  # type: ignore[untyped-decorator]
     async def _async_on_change(event: Any) -> None:
         codes = ("22F1", "22F3", "22F7")
         new_state: State = event.data["new_state"]
@@ -1148,7 +1148,7 @@ async def test_learn_command_callback_ignores_wrong_code(
 
     learning_session = asyncio.Event()
 
-    @callback
+    @callback  # type: ignore[untyped-decorator]
     async def _async_on_change(event: Any) -> None:
         codes = ("22F1", "22F3", "22F7")
         new_state: State = event.data["new_state"]
@@ -1374,7 +1374,7 @@ def test_build_packet_length_calculated() -> None:
     assert "0005" in result2
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_fan_device() -> MagicMock:
     """Return a mock HvacVentilator device."""
     device = MagicMock(spec=HvacVentilator)
@@ -1383,7 +1383,7 @@ def mock_fan_device() -> MagicMock:
     return device
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def fan_coordinator(hass: HomeAssistant) -> MagicMock:
     """Return a mock coordinator for FAN entity tests."""
     coordinator = MagicMock()
@@ -1411,7 +1411,7 @@ def fan_coordinator(hass: HomeAssistant) -> MagicMock:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def fan_remote_entity(
     hass: HomeAssistant,
     fan_coordinator: MagicMock,

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -36,7 +36,7 @@ from ramses_rf.enums import PumpRelayState
 from ramses_tx.dtos import CommandDTO
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator() -> MagicMock:
     """Return a mock RamsesCoordinator."""
     coordinator = MagicMock()
@@ -45,7 +45,7 @@ def mock_coordinator() -> MagicMock:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_device() -> MagicMock:
     """Return a mock RamsesRFEntity."""
     device = MagicMock(spec=RamsesRFEntity)
@@ -164,7 +164,7 @@ def mock_entity_description_no_codes():
     return description
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def entity_push_driven(
     mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description_codes
 ):
@@ -178,7 +178,7 @@ def entity_push_driven(
     return sensor
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def entity_poll_driven(
     mock_coordinator: MagicMock, mock_device_gwy, mock_entity_description_codes
 ):
@@ -190,7 +190,7 @@ def entity_poll_driven(
     return sensor
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def entity_poll_driven_no_codes(
     mock_coordinator: MagicMock,
     mock_device_gwy,
@@ -204,7 +204,7 @@ def entity_poll_driven_no_codes(
     return sensor
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_update_push_driven(
     entity_push_driven, caplog: pytest.LogCaptureFixture
 ):
@@ -219,7 +219,7 @@ async def test_async_update_push_driven(
         assert "Polled" not in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_update_poll_driven_success(
     entity_poll_driven, caplog: pytest.LogCaptureFixture
 ):
@@ -255,7 +255,7 @@ async def test_async_update_poll_driven_success(
         assert "Polled 0002 for 01:123455" in caplog.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_update_poll_driven_failure(
     entity_poll_driven, caplog: pytest.LogCaptureFixture
 ):
@@ -283,7 +283,7 @@ async def test_async_update_poll_driven_failure(
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_update_no_poll_codes(
     entity_poll_driven_no_codes, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -71,7 +71,7 @@ REM_ID = "32:987654"
 PARAM_ID_HEX = "75"  # Temperature parameter
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(hass: HomeAssistant) -> RamsesCoordinator:
     """Return a mock coordinator with an entry attached.
 
@@ -110,7 +110,7 @@ def mock_coordinator(hass: HomeAssistant) -> RamsesCoordinator:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_fan_device() -> MagicMock:
     """Return a mock Fan device.
 
@@ -2717,7 +2717,7 @@ async def test_set_fan_param_transport_error(
     mock_entity._clear_pending_after_timeout.assert_called_with(0)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio  # type: ignore[untyped-decorator]
 async def test_async_bind_device_routes_to_registry(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/tests_new/test_store.py
+++ b/tests/tests_new/test_store.py
@@ -308,7 +308,7 @@ async def test_store_async_load_backups(hass: HomeAssistant) -> None:
 # -- Part 2: Integration Tests for Coordinator Persistence (Existing Tests) --
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_hass(event_loop: asyncio.AbstractEventLoop) -> MagicMock:
     """Return a mock Home Assistant instance."""
     hass = MagicMock()
@@ -322,7 +322,7 @@ def mock_hass(event_loop: asyncio.AbstractEventLoop) -> MagicMock:
     return hass
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_entry() -> MagicMock:
     """Return a mock ConfigEntry."""
     entry = MagicMock()
@@ -336,7 +336,7 @@ def mock_entry() -> MagicMock:
     return entry
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(
     hass: HomeAssistant, mock_entry: MagicMock
 ) -> RamsesCoordinator:

--- a/tests/tests_new/test_task_cleanup.py
+++ b/tests/tests_new/test_task_cleanup.py
@@ -40,7 +40,7 @@ class MockDevice(RamsesRFEntity):
         pass
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     """Return a mock RamsesCoordinator."""
     coordinator = MagicMock()
@@ -54,7 +54,7 @@ def mock_coordinator(hass: HomeAssistant) -> MagicMock:
     return coordinator
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_fan_device() -> MagicMock:
     """Return a mock Fan device."""
     device = MagicMock(spec=MockDevice)
@@ -65,7 +65,7 @@ def mock_fan_device() -> MagicMock:
     return device
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def number_entity(
     mock_coordinator: MagicMock, mock_fan_device: MagicMock
 ) -> RamsesNumberParam:

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -28,7 +28,7 @@ TEST_DEVICE_ID = "10:123456"
 SZ_ACTIVE = "active"
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_device() -> MagicMock:
     """Return a mock DhwZone device."""
     # Note: Do not use spec=DhwZone here as it prevents mocking 'tcs' if not explicitly in the class
@@ -57,13 +57,13 @@ def mock_device() -> MagicMock:
     return device
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator() -> MagicMock:
     """Return a mock RamsesCoordinator."""
     return MagicMock()
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def water_heater(
     mock_coordinator: MagicMock, mock_device: MagicMock
 ) -> RamsesWaterHeater:

--- a/tests/tests_old/conftest.py
+++ b/tests/tests_old/conftest.py
@@ -7,14 +7,14 @@ import contextlib
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 def auto_enable_custom_integrations(
     enable_custom_integrations: pytest.fixture,
 ):  # type: ignore[no-untyped-def]
     yield
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # type: ignore[untyped-decorator]
 def patches_for_tests(monkeypatch: pytest.MonkeyPatch) -> None:
     """Apply necessary monkeypatches before running tests."""
 

--- a/tests/tests_old/test_init_config.py
+++ b/tests/tests_old/test_init_config.py
@@ -91,7 +91,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     )
 
 
-@pytest.fixture()  # add hass fixture to ensure hass/rf use same event loop
+@pytest.fixture()  # type: ignore[untyped-decorator]  # add hass fixture to ensure hass/rf use same event loop
 async def rf(hass: HomeAssistant) -> AsyncGenerator[Any]:
     """Utilize a virtual evofw3-compatible gateway."""
 

--- a/tests/tests_old/test_init_data.py
+++ b/tests/tests_old/test_init_data.py
@@ -173,7 +173,7 @@ async def _test_common(
     assert created_entities == sorted(EXPECTED_ENTITIES)
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 async def rf() -> AsyncGenerator[VirtualRf]:
     """Provide a mocked standard evofw3 (e.g. /dev/ttyACM0)."""
     rf = VirtualRf(1)

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -357,7 +357,7 @@ async def _setup_via_entry_(
     return entry
 
 
-@pytest.fixture()  # need hass fixture to ensure hass/rf use same event loop
+@pytest.fixture()  # type: ignore[untyped-decorator]  # need hass fixture to ensure hass/rf use same event loop
 async def entry(hass: HomeAssistant) -> AsyncGenerator[ConfigEntry]:
     """Set up the test bed."""
 
@@ -505,7 +505,7 @@ TESTS_SEND_COMMAND = {
 
 
 # TODO: extended test of underlying method
-@pytest.mark.parametrize("index", TESTS_SEND_COMMAND)
+@pytest.mark.parametrize("index", TESTS_SEND_COMMAND)  # type: ignore[untyped-decorator]
 async def test_send_command(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -797,7 +797,7 @@ TESTS_SET_DHW_MODE_FAIL2: dict[str, dict[str, Any]] = {
 
 
 # TODO: extended test of underlying method (duration/until)
-@pytest.mark.parametrize("index", TESTS_SET_DHW_MODE_GOOD)
+@pytest.mark.parametrize("index", TESTS_SET_DHW_MODE_GOOD)  # type: ignore[untyped-decorator]
 async def test_set_dhw_mode_good(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -827,7 +827,7 @@ async def test_set_dhw_mode_good(
     # )
 
 
-@pytest.mark.parametrize("index", TESTS_SET_DHW_MODE_FAIL)
+@pytest.mark.parametrize("index", TESTS_SET_DHW_MODE_FAIL)  # type: ignore[untyped-decorator]
 async def test_set_dhw_mode_fail(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -850,7 +850,7 @@ async def test_set_dhw_mode_fail(
         raise AssertionError("Expected vol.MultipleInvalid")
 
 
-@pytest.mark.parametrize("index", TESTS_SET_DHW_MODE_FAIL2)
+@pytest.mark.parametrize("index", TESTS_SET_DHW_MODE_FAIL2)  # type: ignore[untyped-decorator]
 async def test_set_dhw_mode_fail2(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -880,7 +880,7 @@ TESTS_SET_DHW_PARAMS = {
 }
 
 
-@pytest.mark.parametrize("index", TESTS_SET_DHW_PARAMS)
+@pytest.mark.parametrize("index", TESTS_SET_DHW_PARAMS)  # type: ignore[untyped-decorator]
 async def test_set_dhw_params(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -948,7 +948,7 @@ TESTS_SET_SYSTEM_MODE_FAIL2: dict[str, dict[str, Any]] = {
 
 
 # TODO: extended test of underlying method (duration/period)
-@pytest.mark.parametrize("index", TESTS_SET_SYSTEM_MODE_GOOD)
+@pytest.mark.parametrize("index", TESTS_SET_SYSTEM_MODE_GOOD)  # type: ignore[untyped-decorator]
 async def test_set_system_mode_good(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -973,7 +973,7 @@ async def test_set_system_mode_good(
         )
 
 
-@pytest.mark.parametrize("index", TESTS_SET_SYSTEM_MODE_FAIL)
+@pytest.mark.parametrize("index", TESTS_SET_SYSTEM_MODE_FAIL)  # type: ignore[untyped-decorator]
 async def test_set_system_mode_fail(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -994,7 +994,7 @@ async def test_set_system_mode_fail(
         raise AssertionError("Expected vol.MultipleInvalid")
 
 
-@pytest.mark.parametrize("index", TESTS_SET_SYSTEM_MODE_FAIL2)
+@pytest.mark.parametrize("index", TESTS_SET_SYSTEM_MODE_FAIL2)  # type: ignore[untyped-decorator]
 async def test_set_system_mode_fail2(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -1033,7 +1033,7 @@ TESTS_SET_ZONE_CONFIG = {
 }
 
 
-@pytest.mark.parametrize("index", TESTS_SET_ZONE_CONFIG)
+@pytest.mark.parametrize("index", TESTS_SET_ZONE_CONFIG)  # type: ignore[untyped-decorator]
 async def test_set_zone_config(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -1152,7 +1152,7 @@ TESTS_SET_ZONE_MODE_FAIL2: dict[str, dict[str, Any]] = {
 }
 
 
-@pytest.mark.parametrize("index", TESTS_SET_ZONE_MODE_GOOD)
+@pytest.mark.parametrize("index", TESTS_SET_ZONE_MODE_GOOD)  # type: ignore[untyped-decorator]
 async def test_set_zone_mode_good(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -1182,7 +1182,7 @@ async def test_set_zone_mode_good(
     # )
 
 
-@pytest.mark.parametrize("index", TESTS_SET_ZONE_MODE_FAIL)
+@pytest.mark.parametrize("index", TESTS_SET_ZONE_MODE_FAIL)  # type: ignore[untyped-decorator]
 async def test_set_zone_mode_fail(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -1203,7 +1203,7 @@ async def test_set_zone_mode_fail(
         raise AssertionError("Expected vol.MultipleInvalid")
 
 
-@pytest.mark.parametrize("index", TESTS_SET_ZONE_MODE_FAIL2)
+@pytest.mark.parametrize("index", TESTS_SET_ZONE_MODE_FAIL2)  # type: ignore[untyped-decorator]
 async def test_set_zone_mode_fail2(
     hass: HomeAssistant, entry: ConfigEntry, index: str
 ) -> None:
@@ -1323,13 +1323,13 @@ async def test_svc_send_packet_with_impersonation(
 # New tests for the climate async migration
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_coordinator() -> MagicMock:
     """Mock the RamsesCoordinator."""
     return MagicMock()
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_evohome() -> MagicMock:
     """Mock the Evohome device."""
     device = MagicMock()
@@ -1344,7 +1344,7 @@ def mock_evohome() -> MagicMock:
     return device
 
 
-@pytest.fixture
+@pytest.fixture  # type: ignore[untyped-decorator]
 def mock_zone() -> MagicMock:
     """Mock the Zone device."""
     device = MagicMock()


### PR DESCRIPTION
## Summary

Add `# type: ignore[untyped-decorator]` to all pytest fixture and
decorated test function decorators in the test suite.

pytest's `@pytest.fixture` and `@pytest.mark.*` decorators are untyped,
producing `[untyped-decorator]` errors with `disallow_any_decorated`.
All 139 occurrences are suppressed.

Note: 6 decorators had `# type: ignore` placed after another `#`
comment, which mypy doesn't recognize. Fixed by moving `# type: ignore`
immediately after the decorator.

### Files changed (24)
- `tests/tests_new/`: conftest.py, test_helpers.py, test_init.py,
  test_config_flow.py, test_services.py, test_coordinator.py,
  test_climate.py, test_sensor.py, test_remote.py, test_event.py,
  test_water_heater.py, test_binary_sensor.py, test_mqtt_bridge.py,
  test_init_data.py, test_init_config.py, test_fan_handler.py,
  test_discovery_manager.py, test_store.py, test_schemas.py
- `tests/tests_old/`: conftest.py, test_init_config.py,
  test_init_data.py, test_services.py

## Stacking note

**This PR is stacked on PR 3 and PR 4 (issue 967).** It requires
`disallow_any_decorated = true` from PR 4 to be in effect. Rebase
onto master after PR 3 and PR 4 are merged.

## Verification

- `mypy` (project): **0 errors** (source + tests)
- `mypy . --strict`: 25 errors (all `[no-any-return]`, deferred to PR 1)
- `ruff check`: clean
- `pytest`: 1400 passed, 1 pre-existing failure (probatio)

Refs: issue 967

#### Test plan
- [x] `mypy` (project) — 0 errors
- [x] `mypy . --strict` — 139 fewer `[untyped-decorator]` errors
- [x] `ruff check` — clean
- [x] `pytest` — no new failures