### PR TITLE
fix(schemas): preserve _name in zone entries for issue 919

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -377,7 +377,7 @@ def _strip_and_orchestrate(schema: dict[str, Any]) -> dict[str, Any]:
             # but ramses_rf's zone creation uses keep_hints=True to
             # retain _name — it needs to be present in the schema.
             orig_zones = (
-                schema.get(k, {}).get("zones")  # type: ignore[union-attr]
+                schema.get(k, {}).get("zones")
                 if isinstance(schema.get(k), dict)
                 else None
             )
@@ -388,7 +388,7 @@ def _strip_and_orchestrate(schema: dict[str, Any]) -> dict[str, Any]:
             ):
                 for z_idx, z_entry in v["zones"].items():
                     if isinstance(z_entry, dict):
-                        orig_name = orig_zones.get(z_idx, {}).get("_name")  # type: ignore[union-attr]
+                        orig_name = orig_zones.get(z_idx, {}).get("_name")
                         if orig_name is not None:
                             z_entry["_name"] = orig_name
         # Non-heat device at root level without remotes/sensors — move

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -371,6 +371,26 @@ def _strip_and_orchestrate(schema: dict[str, Any]) -> dict[str, Any]:
         # _derive_known_list_from_schema via strip_and_map_traits.
         if isinstance(v, dict):
             v = _strip_traits_rf(v)
+            # Preserve _name in zone entries for ramses_rf's issue 919
+            # fix (Zone._update_schema hydrates zone_state.name from
+            # _name).  strip_traits removes all _ keys recursively,
+            # but ramses_rf's zone creation uses keep_hints=True to
+            # retain _name — it needs to be present in the schema.
+            orig_zones = (
+                schema.get(k, {}).get("zones")  # type: ignore[union-attr]
+                if isinstance(schema.get(k), dict)
+                else None
+            )
+            if (
+                isinstance(orig_zones, dict)
+                and isinstance(v, dict)
+                and isinstance(v.get("zones"), dict)
+            ):
+                for z_idx, z_entry in v["zones"].items():
+                    if isinstance(z_entry, dict):
+                        orig_name = orig_zones.get(z_idx, {}).get("_name")  # type: ignore[union-attr]
+                        if orig_name is not None:
+                            z_entry["_name"] = orig_name
         # Non-heat device at root level without remotes/sensors — move
         # to orphans_hvac instead of keeping as an invalid VCS entry.
         # ramses_rf's SCH_GLOBAL_SCHEMAS treats root-level non-CTL


### PR DESCRIPTION
## Summary
- `_strip_and_orchestrate` delegates to ramses_rf's `strip_traits` which recursively removes all `_-prefixed` keys, including `_name` from zone entries
- This defeats the issue 919 fix in ramses_rf's `Zone._update_schema` (which hydrates `zone_state.name` from `_name` so zone names survive MessageStore pruning after 24h)
- Re-add `_name` from the original schema after `strip_traits`, so it's present in the schema passed to ramses_rf's Gateway

Works together with ramses_rf PR 1143 (https://github.com/ramses-rf/ramses_rf/pull/1143) which re-adds `_name` after `SCH_GLOBAL_SCHEMAS` validation in the Gateway constructor.

#### Before fix
- `Zone._update_schema` receives `_name=None` (stripped by `_strip_and_orchestrate`)
- Zone device registry name falls back to `01:150000_03` instead of `Lounge`
- Zone names lost after 24h MessageStore pruning

#### After fix
- `Zone._update_schema` receives `_name='Lounge'` (preserved through stripping)
- Zone device registry name is `Lounge` (survives restart/MessageStore pruning)
- ha_sim_test R63 "after restart" check now passes

#### Test plan
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] ha_sim_test R63: "after restart" check passes (zone name survives)