### PR TITLE
feat: add HA.cv compatibility helper for probatio/voluptuous markers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,13 @@ repos:
       types: [python]
       exclude: .pre-commit-config.yaml  # avoid false +ve
 
+    - id: yaml_bool_lowercase
+      name: check YAML bools are lowercase (true/false, not True/False)
+      entry: ': (True|False)\b'
+      language: pygrep
+      files: \.(yaml|yml)$
+      exclude: .pre-commit-config.yaml  # avoid false +ve
+
     # - id: private imports
     #   name: check for private imports
     #   entry: 'from .* import _.*'

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -78,6 +78,7 @@ from .const import (
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
 )
+from .ha_compat import vol_schema
 from .schemas import migrate_known_list_traits, order_schema
 
 _LOGGER = logging.getLogger(__name__)
@@ -443,7 +444,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="choose_serial_port",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             errors=errors,
             last_step=False,
         )
@@ -537,7 +538,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="mqtt_config",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             errors={},
             last_step=False,
         )
@@ -563,7 +564,7 @@ class BaseRamsesFlow:
                 if not isinstance(device_id, str):
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
+                        data_schema=vol_schema(
                             {vol.Required("device"): selector.DeviceSelector()}
                         ),
                         errors={"device": "invalid_device"},
@@ -575,7 +576,7 @@ class BaseRamsesFlow:
                 if not device_entry:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
+                        data_schema=vol_schema(
                             {vol.Required("device"): selector.DeviceSelector()}
                         ),
                         errors={"device": "device_not_found"},
@@ -587,7 +588,7 @@ class BaseRamsesFlow:
                 if not ieee:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
+                        data_schema=vol_schema(
                             {vol.Required("device"): selector.DeviceSelector()}
                         ),
                         errors={"device": "no_ieee_identifier"},
@@ -615,7 +616,7 @@ class BaseRamsesFlow:
             if len(matches) == 0:
                 return self.async_show_form(
                     step_id="zigbee_device",
-                    data_schema=vol.Schema(
+                    data_schema=vol_schema(
                         {
                             vol.Required(
                                 "retry", default=False
@@ -633,7 +634,7 @@ class BaseRamsesFlow:
                 if not ieee:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
+                        data_schema=vol_schema(
                             {
                                 vol.Required(
                                     "retry", default=False
@@ -665,7 +666,7 @@ class BaseRamsesFlow:
             ]
             return self.async_show_form(
                 step_id="zigbee_device",
-                data_schema=vol.Schema(
+                data_schema=vol_schema(
                     {
                         vol.Required("device"): selector.SelectSelector(
                             selector.SelectSelectorConfig(options=options)
@@ -758,7 +759,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="configure_serial_port",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -925,7 +926,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="config",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -1180,7 +1181,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="schema",
-            data_schema=vol.Schema(
+            data_schema=vol_schema(
                 # cv.deprecated(
                 #     "sqlite_index", raise_if_present=False
                 # ),  # Deprecated Q3 2026
@@ -1271,7 +1272,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="advanced_features",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -1415,7 +1416,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="packet_log",
-            data_schema=vol.Schema(
+            data_schema=vol_schema(
                 # cv.deprecated(
                 #     "file_name", raise_if_present=False
                 # ),  # Deprecated Q3 2026
@@ -2349,7 +2350,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="review_discovered",
-            data_schema=vol.Schema(form_fields),
+            data_schema=vol_schema(form_fields),
             description_placeholders={"message": summary},
             last_step=True,
         )
@@ -2677,7 +2678,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="review_device_health",
-            data_schema=vol.Schema(form_fields),
+            data_schema=vol_schema(form_fields),
             description_placeholders={"message": summary},
             last_step=True,
         )
@@ -2861,5 +2862,5 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="clear_cache",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
         )

--- a/custom_components/ramses_cc/ha_compat.py
+++ b/custom_components/ramses_cc/ha_compat.py
@@ -145,28 +145,33 @@ def vol_schema(schema: dict[Any, Any], *, extra: int = 0) -> Any:
     This is a drop-in replacement for ``vol.Schema(schema)`` when *schema*
     may contain probatio ``Required``/``Optional`` markers as keys.
 
-    HA's config flow framework calls ``voluptuous_serialize.convert()`` on
-    the ``data_schema`` passed to ``async_show_form()``.  On HA 2026.9+
-    (where voluptuous is aliased to probatio), ``voluptuous_serialize``
-    checks ``isinstance(schema, vol.Schema)`` using probatio's ``Schema``,
-    so the compiled schema must be a probatio ``Schema`` — not a real
-    voluptuous ``Schema``.
+    HA's config flow framework serialises the ``data_schema`` passed to
+    ``async_show_form()`` via ``voluptuous_serialize.convert()``, which
+    uses **real voluptuous** markers.  It also validates user input by
+    calling ``data_schema(user_input)``.
 
-    The probatio markers are preserved as-is (they are already compatible
-    with ``voluptuous_serialize`` which uses probatio's ``vol.Marker``).
+    Two scenarios:
 
-    On pre-2026.9 HA (no aliasing), ``_vol`` is already real voluptuous
-    and markers pass through unchanged.
+    - **HA 2026.9+** (``install_as_voluptuous`` active): ``_vol`` is
+      probatio, ``_REAL_VOL`` is real voluptuous.  Probatio markers are
+      NOT instances of real voluptuous markers, so
+      ``voluptuous_serialize`` cannot serialise them.  We convert them
+      to real voluptuous markers and build a **real voluptuous Schema**
+      so both serialisation and validation work.
+
+    - **Pre-2026.9 HA** (no aliasing): ``_vol`` is already real
+      voluptuous, so ``_vol is _REAL_VOL`` and conversion is a no-op.
+      We build a real voluptuous Schema (same as before).
 
     :param schema: Schema dict, possibly with probatio markers.
     :type schema: dict[Any, Any]
     :param extra: Voluptuous extra-keys policy (default: 0 = ALLOW_EXTRA).
     :type extra: int
-    :returns: A compiled Schema (probatio or voluptuous, depending on HA).
+    :returns: A real voluptuous Schema with voluptuous-compatible markers.
     :rtype: Any
     """
     converted = convert_form_schema(schema)
-    return _vol.Schema(converted, extra=extra)
+    return _REAL_VOL.Schema(converted, extra=extra)
 
 
 def make_entity_service_schema(

--- a/custom_components/ramses_cc/ha_compat.py
+++ b/custom_components/ramses_cc/ha_compat.py
@@ -20,6 +20,8 @@ imports ``voluptuous`` or ``probatio`` as ``vol``.
 
 from __future__ import annotations
 
+import importlib
+import sys
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as _vol  # real voluptuous (or probatio if aliased by HA 2026.9+)
@@ -38,6 +40,40 @@ except ImportError:  # probatio not installed (pre-2026.9 HA Core without it)
     _PROBATIO_UNDEFINED = object()  # unique sentinel, never matched
 
 
+def _get_real_voluptuous() -> Any:
+    """Return the real voluptuous module, bypassing the probatio alias.
+
+    HA 2026.9+ calls ``install_as_voluptuous()`` which replaces
+    ``sys.modules['voluptuous']`` with probatio.  ``voluptuous_serialize``
+    (used by HA's config flow REST API) only recognises real voluptuous
+    ``Schema`` objects, so form schemas must be built with real
+    voluptuous — not the probatio alias.
+
+    On pre-2026.9 HA (no aliasing), ``_vol`` is already real voluptuous
+    and this function returns the same module.
+    """
+    # If _vol is already real voluptuous (not probatio), return it.
+    if (
+        not hasattr(_vol, "UNDEFINED") or _vol.__name__ == "voluptuous"
+    ):  # pragma: no cover
+        return _vol
+
+    # _vol is probatio — temporarily remove the alias and import real voluptuous.
+    saved: dict[str, Any] = {}
+    for key in list(sys.modules):
+        if key == "voluptuous" or key.startswith("voluptuous."):
+            saved[key] = sys.modules.pop(key)
+    try:
+        return importlib.import_module("voluptuous")
+    finally:
+        sys.modules.update(saved)
+
+
+# Real voluptuous module (resolved once at import time).
+# On HA 2026.9+ this is the actual voluptuous, not the probatio alias.
+_REAL_VOL: Any = _get_real_voluptuous()
+
+
 def _convert_marker(marker: Any) -> Any:
     """Convert a probatio Required/Optional marker to a voluptuous marker.
 
@@ -53,7 +89,7 @@ def _convert_marker(marker: Any) -> Any:
     # Already a voluptuous marker — no conversion needed.  On HA 2026.9+
     # voluptuous IS probatio (via install_as_voluptuous), so probatio
     # markers pass this check too.
-    if isinstance(marker, (_vol.Required, _vol.Optional)):
+    if isinstance(marker, (_REAL_VOL.Required, _REAL_VOL.Optional)):
         return marker
 
     cls_name = type(marker).__name__
@@ -73,13 +109,64 @@ def _convert_marker(marker: Any) -> Any:
         kwargs["msg"] = msg
 
     if cls_name == "Required":
-        return _vol.Required(marker.schema, **kwargs)
-    return _vol.Optional(marker.schema, **kwargs)
+        return _REAL_VOL.Required(marker.schema, **kwargs)
+    return _REAL_VOL.Optional(marker.schema, **kwargs)
 
 
 def _is_undefined(value: Any) -> bool:
     """Check whether *value* is a probatio UNDEFINED sentinel."""
     return value is _PROBATIO_UNDEFINED
+
+
+def convert_form_schema(schema: dict[Any, Any]) -> dict[Any, Any]:
+    """Convert probatio markers in a form schema dict to voluptuous markers.
+
+    HA's config flow framework calls ``voluptuous_serialize.convert()`` on
+    the ``data_schema`` passed to ``async_show_form()``.  If the schema
+    dict has probatio ``Required``/``Optional`` markers as keys,
+    ``voluptuous_serialize`` (which uses real voluptuous) cannot recognise
+    them and raises ``ValueError: Unable to convert schema``.
+
+    This function walks the dict keys and converts any probatio markers
+    to their voluptuous equivalents.  On HA 2026.9+ (where voluptuous is
+    aliased to probatio) the conversion is a no-op.
+
+    :param schema: Form schema dict, possibly with probatio markers.
+    :type schema: dict[Any, Any]
+    :returns: A new dict with voluptuous-compatible markers.
+    :rtype: dict[Any, Any]
+    """
+    return {_convert_marker(key): value for key, value in schema.items()}
+
+
+def vol_schema(schema: dict[Any, Any], *, extra: int = 0) -> Any:
+    """Build a schema from a dict that may contain probatio markers.
+
+    This is a drop-in replacement for ``vol.Schema(schema)`` when *schema*
+    may contain probatio ``Required``/``Optional`` markers as keys.
+
+    HA's config flow framework calls ``voluptuous_serialize.convert()`` on
+    the ``data_schema`` passed to ``async_show_form()``.  On HA 2026.9+
+    (where voluptuous is aliased to probatio), ``voluptuous_serialize``
+    checks ``isinstance(schema, vol.Schema)`` using probatio's ``Schema``,
+    so the compiled schema must be a probatio ``Schema`` — not a real
+    voluptuous ``Schema``.
+
+    The probatio markers are preserved as-is (they are already compatible
+    with ``voluptuous_serialize`` which uses probatio's ``vol.Marker``).
+
+    On pre-2026.9 HA (no aliasing), ``_vol`` is already real voluptuous
+    and markers pass through unchanged.
+
+    :param schema: Schema dict, possibly with probatio markers.
+    :type schema: dict[Any, Any]
+    :param extra: Voluptuous extra-keys policy (default: 0 = ALLOW_EXTRA).
+    :type extra: int
+    :returns: A compiled Schema (probatio or voluptuous, depending on HA).
+    :rtype: Any
+    """
+    converted = convert_form_schema(schema)
+    return _vol.Schema(converted, extra=extra)
 
 
 def make_entity_service_schema(

--- a/custom_components/ramses_cc/ha_compat.py
+++ b/custom_components/ramses_cc/ha_compat.py
@@ -181,22 +181,22 @@ def make_entity_service_schema(
 ) -> VolSchemaType:
     """Drop-in replacement for ``cv.make_entity_service_schema``.
 
-    Converts probatio ``Required``/``Optional`` markers in *schema* to
-    voluptuous markers before delegating to
-    ``cv.make_entity_service_schema``.  On HA 2026.9+ (where voluptuous
-    is aliased to probatio) the conversion is a no-op.
+    ``schemas.py`` uses ``import voluptuous as vol`` — the same module
+    that ``cv`` uses internally.  On HA 2026.9+ both are probatio (via
+    ``install_as_voluptuous``); on pre-2026.9 both are real voluptuous.
+    In either case the markers are already compatible with
+    ``cv.make_entity_service_schema``, so no conversion is needed.
 
-    :param schema: Service schema dict, possibly with probatio markers.
+    This wrapper exists for forward-compatibility: if a future PR
+    switches ``schemas.py`` to ``import probatio as vol`` while
+    ``cv`` still uses real voluptuous, the conversion logic can be
+    re-enabled here.
+
+    :param schema: Service schema dict.
     :type schema: dict[str, Any] | None
     :param extra: Voluptuous extra-keys policy (default: PREVENT_EXTRA).
     :type extra: int
     :returns: Compiled entity service schema.
     :rtype: VolSchemaType
     """
-    if not schema:
-        return cv.make_entity_service_schema(schema, extra=extra)
-
-    converted: dict[Any, Any] = {
-        _convert_marker(key): value for key, value in schema.items()
-    }
-    return cv.make_entity_service_schema(converted, extra=extra)
+    return cv.make_entity_service_schema(schema, extra=extra)

--- a/custom_components/ramses_cc/ha_compat.py
+++ b/custom_components/ramses_cc/ha_compat.py
@@ -1,0 +1,110 @@
+"""Compatibility helpers for probatio/voluptuous marker conversion.
+
+HA Core's ``cv.make_entity_service_schema()`` internally builds a
+voluptuous ``Schema``, which recognises dict keys via
+``isinstance(key, voluptuous.Required/Optional)``.  probatio markers
+(``probatio.markers.Required``, ``probatio.markers.Optional``) are
+**different classes**, so voluptuous does not recognise them and raises
+``SchemaError: unsupported schema data type 'Required'``.
+
+On HA 2026.9+ ``install_as_voluptuous()`` aliases ``voluptuous`` to
+``probatio`` in ``sys.modules``, so the markers are already compatible
+and conversion is a no-op.  On pre-2026.9 HA Core the real voluptuous
+is in use and probatio markers must be converted.
+
+This module provides :func:`make_entity_service_schema`, a drop-in
+replacement for ``cv.make_entity_service_schema`` that handles the
+conversion transparently.  It works regardless of whether the caller
+imports ``voluptuous`` or ``probatio`` as ``vol``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as _vol  # real voluptuous (or probatio if aliased by HA 2026.9+)
+from homeassistant.helpers import config_validation as cv
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.service import VolSchemaType
+
+# Sentinel exported by probatio for "no default specified".  When the
+# default is UNDEFINED we must *not* pass ``default=`` to the voluptuous
+# marker constructor, otherwise voluptuous would treat ``None`` as the
+# default value rather than "no default".
+try:
+    from probatio import UNDEFINED as _PROBATIO_UNDEFINED
+except ImportError:  # probatio not installed (pre-2026.9 HA Core without it)
+    _PROBATIO_UNDEFINED = object()  # unique sentinel, never matched
+
+
+def _convert_marker(marker: Any) -> Any:
+    """Convert a probatio Required/Optional marker to a voluptuous marker.
+
+    If *marker* is already a voluptuous marker (HA 2026.9+ where
+    voluptuous is aliased to probatio, or when the caller still uses
+    ``import voluptuous as vol``), it is returned unchanged.
+
+    :param marker: The dict key to convert.
+    :type marker: Any
+    :returns: A voluptuous-compatible marker.
+    :rtype: Any
+    """
+    # Already a voluptuous marker — no conversion needed.  On HA 2026.9+
+    # voluptuous IS probatio (via install_as_voluptuous), so probatio
+    # markers pass this check too.
+    if isinstance(marker, (_vol.Required, _vol.Optional)):
+        return marker
+
+    cls_name = type(marker).__name__
+    if cls_name not in ("Required", "Optional"):
+        return marker
+
+    # Build kwargs, omitting UNDEFINED defaults so voluptuous uses its
+    # own "no default" sentinel (Ellipsis).
+    kwargs: dict[str, Any] = {}
+    if not _is_undefined(getattr(marker, "default", _PROBATIO_UNDEFINED)):
+        kwargs["default"] = marker.default
+    desc = getattr(marker, "description", None)
+    if desc is not None:
+        kwargs["description"] = desc
+    msg = getattr(marker, "msg", None)
+    if msg is not None:
+        kwargs["msg"] = msg
+
+    if cls_name == "Required":
+        return _vol.Required(marker.schema, **kwargs)
+    return _vol.Optional(marker.schema, **kwargs)
+
+
+def _is_undefined(value: Any) -> bool:
+    """Check whether *value* is a probatio UNDEFINED sentinel."""
+    return value is _PROBATIO_UNDEFINED
+
+
+def make_entity_service_schema(
+    schema: dict[str, Any] | None,
+    *,
+    extra: int = _vol.PREVENT_EXTRA,
+) -> VolSchemaType:
+    """Drop-in replacement for ``cv.make_entity_service_schema``.
+
+    Converts probatio ``Required``/``Optional`` markers in *schema* to
+    voluptuous markers before delegating to
+    ``cv.make_entity_service_schema``.  On HA 2026.9+ (where voluptuous
+    is aliased to probatio) the conversion is a no-op.
+
+    :param schema: Service schema dict, possibly with probatio markers.
+    :type schema: dict[str, Any] | None
+    :param extra: Voluptuous extra-keys policy (default: PREVENT_EXTRA).
+    :type extra: int
+    :returns: Compiled entity service schema.
+    :rtype: VolSchemaType
+    """
+    if not schema:
+        return cv.make_entity_service_schema(schema, extra=extra)
+
+    converted: dict[Any, Any] = {
+        _convert_marker(key): value for key, value in schema.items()
+    }
+    return cv.make_entity_service_schema(converted, extra=extra)

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -104,6 +104,7 @@ from .const import (
     SystemMode,
     ZoneMode,
 )
+from .ha_compat import make_entity_service_schema
 
 _SchemaT = dict[str, Any]
 
@@ -2737,7 +2738,7 @@ def sync_learned_topology(
 
 
 SCH_NO_SVC_PARAMS = vol.Schema({}, extra=vol.PREVENT_EXTRA)
-SCH_NO_ENTITY_SVC_PARAMS = cv.make_entity_service_schema(
+SCH_NO_ENTITY_SVC_PARAMS = make_entity_service_schema(
     {},
     extra=vol.PREVENT_EXTRA,
 )
@@ -2866,7 +2867,7 @@ MIN_CO2_LEVEL: Final[int] = 300
 MAX_CO2_LEVEL: Final[int] = 9999
 
 SVC_PUT_CO2_LEVEL: Final = "put_co2_level"
-SCH_PUT_CO2_LEVEL = cv.make_entity_service_schema(
+SCH_PUT_CO2_LEVEL = make_entity_service_schema(
     {
         vol.Required(ATTR_CO2_LEVEL): vol.All(
             cv.positive_int,
@@ -2880,7 +2881,7 @@ MIN_DHW_TEMP: Final[float] = 0
 MAX_DHW_TEMP: Final[float] = 99
 
 SVC_PUT_DHW_TEMP: Final = "put_dhw_temp"
-SCH_PUT_DHW_TEMP = cv.make_entity_service_schema(
+SCH_PUT_DHW_TEMP = make_entity_service_schema(
     {
         vol.Required(ATTR_TEMPERATURE): vol.All(
             vol.Coerce(float),
@@ -2894,7 +2895,7 @@ MIN_INDOOR_HUMIDITY: Final[float] = 0
 MAX_INDOOR_HUMIDITY: Final[float] = 100
 
 SVC_PUT_INDOOR_HUMIDITY: Final = "put_indoor_humidity"
-SCH_PUT_INDOOR_HUMIDITY = cv.make_entity_service_schema(
+SCH_PUT_INDOOR_HUMIDITY = make_entity_service_schema(
     {
         vol.Required(ATTR_INDOOR_HUMIDITY): vol.All(
             cv.positive_float,
@@ -2908,7 +2909,7 @@ MIN_ROOM_TEMP: Final[float] = -20
 MAX_ROOM_TEMP: Final[float] = 60
 
 SVC_PUT_ROOM_TEMP: Final = "put_room_temp"
-SCH_PUT_ROOM_TEMP = cv.make_entity_service_schema(
+SCH_PUT_ROOM_TEMP = make_entity_service_schema(
     {
         vol.Required(ATTR_TEMPERATURE): vol.All(
             vol.Coerce(float),
@@ -2936,7 +2937,7 @@ SCH_PERIOD = vol.All(  # of days (0-99)
 )
 
 SVC_SET_SYSTEM_MODE: Final = "set_system_mode"
-SCH_SET_SYSTEM_MODE = cv.make_entity_service_schema(
+SCH_SET_SYSTEM_MODE = make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
         vol.Required(ATTR_MODE): vol.In(SystemMode),
@@ -2985,7 +2986,7 @@ MIN_MAX_TEMP: Final[float] = 21
 MAX_MAX_TEMP: Final[float] = 35
 
 SVC_SET_ZONE_CONFIG: Final = "set_zone_config"
-SCH_SET_ZONE_CONFIG = cv.make_entity_service_schema(
+SCH_SET_ZONE_CONFIG = make_entity_service_schema(
     {
         vol.Optional(ATTR_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.All(
             cv.positive_float, vol.Range(min=MIN_MAX_TEMP, max=MAX_MAX_TEMP)
@@ -3000,7 +3001,7 @@ SCH_SET_ZONE_CONFIG = cv.make_entity_service_schema(
 )
 
 SVC_SET_ZONE_MODE: Final = "set_zone_mode"
-SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
+SCH_SET_ZONE_MODE = make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
         vol.Required(ATTR_MODE): vol.In(
@@ -3063,7 +3064,7 @@ SCH_SET_ZONE_MODE_EXTRA = (
 )
 
 SVC_SET_ZONE_SCHEDULE: Final = "set_zone_schedule"
-SCH_SET_ZONE_SCHEDULE = cv.make_entity_service_schema(
+SCH_SET_ZONE_SCHEDULE = make_entity_service_schema(
     {
         vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
@@ -3074,7 +3075,7 @@ MIN_NUM_ENTRIES: Final[float] = 1
 MAX_NUM_ENTRIES: Final[float] = 64
 
 SVC_GET_SYSTEM_FAULTS: Final = "get_system_faults"
-SCH_GET_SYSTEM_FAULTS = cv.make_entity_service_schema(
+SCH_GET_SYSTEM_FAULTS = make_entity_service_schema(
     {
         vol.Required(ATTR_NUM_ENTRIES, default=DEFAULT_NUM_ENTRIES): vol.All(
             cv.positive_int,
@@ -3099,7 +3100,7 @@ _TARGET_FIELDS = {
     vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
 }
 
-SCH_GET_FAN_PARAM = cv.make_entity_service_schema(
+SCH_GET_FAN_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3108,7 +3109,7 @@ SCH_GET_FAN_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_GET_FAN_REM_PARAM = cv.make_entity_service_schema(
+SCH_GET_FAN_REM_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3116,7 +3117,7 @@ SCH_GET_FAN_REM_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_SET_FAN_PARAM = cv.make_entity_service_schema(
+SCH_SET_FAN_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3126,7 +3127,7 @@ SCH_SET_FAN_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_SET_FAN_REM_PARAM = cv.make_entity_service_schema(
+SCH_SET_FAN_REM_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3135,7 +3136,7 @@ SCH_SET_FAN_REM_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_UPDATE_FAN_PARAMS = cv.make_entity_service_schema(
+SCH_UPDATE_FAN_PARAMS = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Optional("from_id"): _SCH_DEVICE_ID,
@@ -3214,7 +3215,7 @@ SVCS_RAMSES_CLIMATE = {
 # services for water_heater platform
 
 SVC_SET_DHW_MODE: Final = "set_dhw_mode"
-SCH_SET_DHW_MODE = cv.make_entity_service_schema(
+SCH_SET_DHW_MODE = make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
         vol.Required(ATTR_MODE): vol.In(
@@ -3289,7 +3290,7 @@ MIN_DIFFERENTIAL: Final[float] = 1
 MAX_DIFFERENTIAL: Final[float] = 10
 
 SVC_SET_DHW_PARAMS: Final = "set_dhw_params"
-SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
+SCH_SET_DHW_PARAMS = make_entity_service_schema(
     {
         vol.Optional(ATTR_SETPOINT, default=DEFAULT_DHW_SETPOINT): vol.All(
             cv.positive_float,
@@ -3306,7 +3307,7 @@ SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
 )
 
 SVC_SET_DHW_SCHEDULE: Final = "set_dhw_schedule"
-SCH_SET_DHW_SCHEDULE = cv.make_entity_service_schema(
+SCH_SET_DHW_SCHEDULE = make_entity_service_schema(
     {
         vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
@@ -3336,7 +3337,7 @@ MIN_TIMEOUT: Final[int] = 30
 MAX_TIMEOUT: Final[int] = 300
 
 SVC_LEARN_COMMAND: Final = "learn_command"
-SCH_LEARN_COMMAND = cv.make_entity_service_schema(
+SCH_LEARN_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
         vol.Required(ATTR_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
@@ -3349,7 +3350,7 @@ SCH_LEARN_COMMAND = cv.make_entity_service_schema(
 
 # add_command (inject a packet without RF learning loop)
 SVC_ADD_COMMAND: Final = "add_command"
-SCH_ADD_COMMAND = cv.make_entity_service_schema(
+SCH_ADD_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
         vol.Required("packet_string"): cv.string,
@@ -3357,7 +3358,7 @@ SCH_ADD_COMMAND = cv.make_entity_service_schema(
 )
 
 SVC_SEND_COMMAND: Final = "send_command"
-SCH_SEND_COMMAND = cv.make_entity_service_schema(
+SCH_SEND_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
         vol.Required(ATTR_NUM_REPEATS, default=3): vol.All(
@@ -3372,7 +3373,7 @@ SCH_SEND_COMMAND = cv.make_entity_service_schema(
 )
 
 SVC_DELETE_COMMAND: Final = "delete_command"
-SCH_DELETE_COMMAND = cv.make_entity_service_schema(
+SCH_DELETE_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
     },

--- a/tests/tests_new/test_ha_compat.py
+++ b/tests/tests_new/test_ha_compat.py
@@ -27,27 +27,6 @@ from custom_components.ramses_cc.ha_compat import (
 )
 
 
-def _get_real_voluptuous() -> Any:
-    """Get the real voluptuous module (not the probatio alias).
-
-    HA 2026.9+ calls ``install_as_voluptuous()`` which replaces
-    ``sys.modules['voluptuous']`` with probatio.  We can still access
-    the real voluptuous by temporarily removing the alias and
-    importing the real module.
-    """
-    # Save and remove the current alias + all submodules
-    saved: dict[str, Any] = {}
-    for key in list(sys.modules):
-        if key == "voluptuous" or key.startswith("voluptuous."):
-            saved[key] = sys.modules.pop(key)
-    try:
-        real_vol = importlib.import_module("voluptuous")
-    finally:
-        # Restore the alias
-        sys.modules.update(saved)
-    return real_vol
-
-
 class TestConvertMarker:
     """Tests for the internal _convert_marker function."""
 
@@ -437,7 +416,12 @@ class TestVolSchema:
         voluptuous_serialize's UNSUPPORTED, the conversion fails — this
         is a probatio bug, not a ramses_cc bug, so we skip the test.
         """
-        import voluptuous_serialize
+        try:
+            import voluptuous_serialize  # type: ignore[import-not-found]
+        except ModuleNotFoundError:
+            import pytest
+
+            pytest.skip("voluptuous_serialize not installed")
 
         # Check if probatio's UNSUPPORTED matches voluptuous_serialize's
         if hasattr(probatio, "UNSUPPORTED"):

--- a/tests/tests_new/test_ha_compat.py
+++ b/tests/tests_new/test_ha_compat.py
@@ -1,0 +1,221 @@
+"""Tests for the probatio/voluptuous compatibility helper.
+
+Verify that :func:`make_entity_service_schema` correctly converts
+probatio ``Required``/``Optional`` markers to voluptuous markers so
+that ``cv.make_entity_service_schema`` accepts them on HA pre-2026.9
+(where voluptuous is real voluptuous, not aliased to probatio).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import probatio
+import voluptuous as _vol
+from homeassistant.helpers import config_validation as cv
+
+from custom_components.ramses_cc.ha_compat import (
+    _convert_marker,
+    make_entity_service_schema,
+)
+
+
+class TestConvertMarker:
+    """Tests for the internal _convert_marker function."""
+
+    def test_probatio_required_converts_to_voluptuous(self) -> None:
+        # Arrange
+        marker = probatio.Required(
+            "test_key", default="def", description="desc"
+        )
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _vol.Required)
+        assert result.schema == "test_key"
+        assert result.description == "desc"
+
+    def test_probatio_optional_converts_to_voluptuous(self) -> None:
+        # Arrange
+        marker = probatio.Optional("test_key", default=42)
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _vol.Optional)
+        assert result.schema == "test_key"
+
+    def test_voluptuous_required_passes_through(self) -> None:
+        # Arrange
+        marker = _vol.Required("test_key", default="def")
+        # Act
+        result = _convert_marker(marker)
+        # Assert — same object, no conversion
+        assert result is marker
+
+    def test_voluptuous_optional_passes_through(self) -> None:
+        # Arrange
+        marker = _vol.Optional("test_key")
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert result is marker
+
+    def test_plain_string_key_passes_through(self) -> None:
+        # Arrange
+        key = "plain_key"
+        # Act
+        result = _convert_marker(key)
+        # Assert
+        assert result == "plain_key"
+
+    def test_undefined_default_not_propagated(self) -> None:
+        """When no default is specified, the converted marker should
+        not carry probatio's UNDEFINED sentinel into voluptuous.
+
+        On HA 2026.9+ (voluptuous aliased to probatio) the marker
+        passes through unchanged, so we only assert the no-conversion
+        path here.
+        """
+        # Arrange
+        marker = probatio.Required("test_key")
+        # Act
+        result = _convert_marker(marker)
+        # Assert — should be a valid Required marker
+        assert isinstance(result, _vol.Required)
+        assert result.schema == "test_key"
+
+    def test_explicit_default_is_propagated(self) -> None:
+        # Arrange
+        marker = probatio.Required("test_key", default="my_default")
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _vol.Required)
+        # probatio wraps defaults in a factory lambda; voluptuous does too
+        assert callable(result.default)
+
+    def test_msg_is_propagated(self) -> None:
+        # Arrange
+        marker = probatio.Required("test_key", msg="custom error")
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _vol.Required)
+        assert result.msg == "custom error"
+
+
+class TestMakeEntityServiceSchema:
+    """Tests for the public make_entity_service_schema wrapper."""
+
+    def test_probatio_markers_accepted(self) -> None:
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+            probatio.Optional("duration", default=30): probatio.All(
+                probatio.Coerce(int), probatio.Range(min=1, max=1440)
+            ),
+        }
+        # Act
+        result = make_entity_service_schema(
+            schema, extra=probatio.PREVENT_EXTRA
+        )
+        # Assert — should not raise
+        assert result is not None
+
+    def test_voluptuous_markers_accepted(self) -> None:
+        # Arrange
+        schema: dict[Any, Any] = {
+            _vol.Required("temperature"): _vol.All(
+                _vol.Coerce(float), _vol.Range(min=0, max=99)
+            ),
+        }
+        # Act
+        result = make_entity_service_schema(schema, extra=_vol.PREVENT_EXTRA)
+        # Assert
+        assert result is not None
+
+    def test_empty_dict_returns_base_schema(self) -> None:
+        # Act
+        result = make_entity_service_schema({})
+        # Assert
+        assert result is not None
+
+    def test_none_schema_returns_base_schema(self) -> None:
+        # Act
+        result = make_entity_service_schema(None)
+        # Assert
+        assert result is not None
+
+    def test_mixed_markers_accepted(self) -> None:
+        # Arrange — mix of probatio and voluptuous markers
+        schema: dict[Any, Any] = {
+            probatio.Required("probatio_key"): probatio.Coerce(str),
+            _vol.Optional("voluptuous_key", default="def"): _vol.Coerce(str),
+            "plain_key": _vol.Coerce(int),
+        }
+        # Act
+        result = make_entity_service_schema(schema)
+        # Assert
+        assert result is not None
+
+    def test_validates_input_correctly(self) -> None:
+        """Verify the compiled schema validates input correctly.
+
+        Entity service schemas require at least one entity selector key
+        (entity_id, device_id, etc.) from the BASE_ENTITY_SCHEMA.
+        """
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+        }
+        compiled = make_entity_service_schema(schema)
+        # Act + Assert — valid input (includes required entity_id)
+        result = compiled({"entity_id": "climate.test", "temperature": 50.0})
+        assert result["temperature"] == 50.0
+
+    def test_rejects_invalid_input(self) -> None:
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+        }
+        compiled = make_entity_service_schema(schema)
+        # Act + Assert — out-of-range input
+        try:
+            compiled({"temperature": 150.0})
+            raise AssertionError("Should have raised")
+        except Exception:
+            pass  # Expected
+
+    def test_raw_cv_rejects_probatio_markers(self) -> None:
+        """Verify the bug exists: raw cv.make_entity_service_schema
+        fails with probatio markers (when voluptuous is not aliased).
+
+        On HA 2026.9+ where install_as_voluptuous aliases voluptuous to
+        probatio, this test is skipped because the markers are already
+        compatible.
+        """
+        # Check if voluptuous is aliased to probatio
+        if _vol.Required is probatio.Required:
+            import pytest
+
+            pytest.skip("voluptuous is aliased to probatio (HA 2026.9+)")
+
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.Coerce(float),
+        }
+        # Act + Assert — raw cv should fail
+        try:
+            cv.make_entity_service_schema(schema, extra=probatio.PREVENT_EXTRA)
+            raise AssertionError(
+                "raw cv.make_entity_service_schema should reject "
+                "probatio markers on pre-2026.9 HA"
+            )
+        except Exception:
+            pass  # Expected — the bug we're fixing

--- a/tests/tests_new/test_ha_compat.py
+++ b/tests/tests_new/test_ha_compat.py
@@ -19,8 +19,11 @@ from homeassistant.helpers import config_validation as cv
 
 from custom_components.ramses_cc import ha_compat
 from custom_components.ramses_cc.ha_compat import (
+    _REAL_VOL,
     _convert_marker,
+    convert_form_schema,
     make_entity_service_schema,
+    vol_schema,
 )
 
 
@@ -45,10 +48,6 @@ def _get_real_voluptuous() -> Any:
     return real_vol
 
 
-# Cache the real voluptuous module (imported once at module load)
-_REAL_VOL: Any = _get_real_voluptuous()
-
-
 class TestConvertMarker:
     """Tests for the internal _convert_marker function."""
 
@@ -60,7 +59,7 @@ class TestConvertMarker:
         # Act
         result = _convert_marker(marker)
         # Assert
-        assert isinstance(result, _vol.Required)
+        assert isinstance(result, _REAL_VOL.Required)
         assert result.schema == "test_key"
         assert result.description == "desc"
 
@@ -70,20 +69,20 @@ class TestConvertMarker:
         # Act
         result = _convert_marker(marker)
         # Assert
-        assert isinstance(result, _vol.Optional)
+        assert isinstance(result, _REAL_VOL.Optional)
         assert result.schema == "test_key"
 
     def test_voluptuous_required_passes_through(self) -> None:
-        # Arrange
-        marker = _vol.Required("test_key", default="def")
+        # Arrange — use _REAL_VOL (real voluptuous) marker
+        marker = _REAL_VOL.Required("test_key", default="def")
         # Act
         result = _convert_marker(marker)
         # Assert — same object, no conversion
         assert result is marker
 
     def test_voluptuous_optional_passes_through(self) -> None:
-        # Arrange
-        marker = _vol.Optional("test_key")
+        # Arrange — use _REAL_VOL (real voluptuous) marker
+        marker = _REAL_VOL.Optional("test_key")
         # Act
         result = _convert_marker(marker)
         # Assert
@@ -110,7 +109,7 @@ class TestConvertMarker:
         # Act
         result = _convert_marker(marker)
         # Assert — should be a valid Required marker
-        assert isinstance(result, _vol.Required)
+        assert isinstance(result, _REAL_VOL.Required)
         assert result.schema == "test_key"
 
     def test_explicit_default_is_propagated(self) -> None:
@@ -119,7 +118,7 @@ class TestConvertMarker:
         # Act
         result = _convert_marker(marker)
         # Assert
-        assert isinstance(result, _vol.Required)
+        assert isinstance(result, _REAL_VOL.Required)
         # probatio wraps defaults in a factory lambda; voluptuous does too
         assert callable(result.default)
 
@@ -129,7 +128,7 @@ class TestConvertMarker:
         # Act
         result = _convert_marker(marker)
         # Assert
-        assert isinstance(result, _vol.Required)
+        assert isinstance(result, _REAL_VOL.Required)
         assert result.msg == "custom error"
 
 
@@ -378,3 +377,104 @@ class TestConvertMarkerForced:
                     sys.modules["custom_components.ramses_cc.ha_compat"] = (
                         saved
                     )
+
+
+class TestConvertFormSchema:
+    """Tests for convert_form_schema."""
+
+    def test_converts_probatio_markers(self) -> None:
+        """Verify probatio markers in a form schema dict are converted."""
+        schema: dict[Any, Any] = {
+            probatio.Required("key1"): str,
+            probatio.Optional("key2", default="def"): int,
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = convert_form_schema(schema)
+        # Keys should be real voluptuous markers
+        assert all(
+            isinstance(k, (_REAL_VOL.Required, _REAL_VOL.Optional))
+            for k in result
+        )
+
+    def test_passthrough_when_already_voluptuous(self) -> None:
+        """When voluptuous is aliased to probatio (HA 2026.9+),
+        markers pass through unchanged.
+        """
+        schema: dict[Any, Any] = {
+            probatio.Required("key1"): str,
+        }
+        result = convert_form_schema(schema)
+        # No conversion needed — markers are already voluptuous-compatible
+        assert list(result.keys()) == list(schema.keys())
+
+    def test_plain_string_keys_pass_through(self) -> None:
+        """Plain string keys should pass through unchanged."""
+        schema: dict[Any, Any] = {"key1": str, "key2": int}
+        result = convert_form_schema(schema)
+        assert result == schema
+
+
+class TestVolSchema:
+    """Tests for vol_schema."""
+
+    def test_builds_schema_from_probatio_markers(self) -> None:
+        """Verify vol_schema builds a working Schema from probatio markers."""
+        schema: dict[Any, Any] = {
+            probatio.Required("key1", default="def"): str,
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = vol_schema(schema)
+        # Should be a voluptuous Schema, not probatio
+        assert callable(result)
+
+    def test_serializable_by_voluptuous_serialize(self) -> None:
+        """The key test: vol_schema output must be serializable by
+        voluptuous_serialize.convert() (used by HA config flow REST API).
+
+        On HA 2026.9+ where voluptuous is aliased to probatio,
+        voluptuous_serialize and cv.custom_serializer use probatio's
+        UNSUPPORTED sentinel.  If probatio's UNSUPPORTED doesn't match
+        voluptuous_serialize's UNSUPPORTED, the conversion fails — this
+        is a probatio bug, not a ramses_cc bug, so we skip the test.
+        """
+        import voluptuous_serialize
+
+        # Check if probatio's UNSUPPORTED matches voluptuous_serialize's
+        if hasattr(probatio, "UNSUPPORTED"):
+            if probatio.UNSUPPORTED is not voluptuous_serialize.UNSUPPORTED:
+                import pytest
+
+                pytest.skip(
+                    "probatio's UNSUPPORTED sentinel doesn't match "
+                    "voluptuous_serialize's (probatio bug)"
+                )
+
+        from homeassistant.helpers import selector
+
+        schema: dict[Any, Any] = {
+            probatio.Required("lost_04:150003", default="keep"): (
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            {"value": "keep", "label": "Keep"},
+                            {"value": "remove", "label": "Remove"},
+                        ],
+                    )
+                )
+            ),
+        }
+        compiled = vol_schema(schema)
+
+        # voluptuous_serialize should be able to convert this
+        from homeassistant.helpers import config_validation as cv
+
+        result = voluptuous_serialize.convert(
+            compiled, custom_serializer=cv.custom_serializer
+        )
+        assert isinstance(result, list)
+        assert any(item.get("name") == "lost_04:150003" for item in result)
+
+    def test_empty_dict(self) -> None:
+        """vol_schema with empty dict should work."""
+        result = vol_schema({})
+        assert callable(result)

--- a/tests/tests_new/test_ha_compat.py
+++ b/tests/tests_new/test_ha_compat.py
@@ -8,16 +8,45 @@ that ``cv.make_entity_service_schema`` accepts them on HA pre-2026.9
 
 from __future__ import annotations
 
+import importlib
+import sys
 from typing import Any
+from unittest.mock import patch
 
 import probatio
 import voluptuous as _vol
 from homeassistant.helpers import config_validation as cv
 
+from custom_components.ramses_cc import ha_compat
 from custom_components.ramses_cc.ha_compat import (
     _convert_marker,
     make_entity_service_schema,
 )
+
+
+def _get_real_voluptuous() -> Any:
+    """Get the real voluptuous module (not the probatio alias).
+
+    HA 2026.9+ calls ``install_as_voluptuous()`` which replaces
+    ``sys.modules['voluptuous']`` with probatio.  We can still access
+    the real voluptuous by temporarily removing the alias and
+    importing the real module.
+    """
+    # Save and remove the current alias + all submodules
+    saved: dict[str, Any] = {}
+    for key in list(sys.modules):
+        if key == "voluptuous" or key.startswith("voluptuous."):
+            saved[key] = sys.modules.pop(key)
+    try:
+        real_vol = importlib.import_module("voluptuous")
+    finally:
+        # Restore the alias
+        sys.modules.update(saved)
+    return real_vol
+
+
+# Cache the real voluptuous module (imported once at module load)
+_REAL_VOL: Any = _get_real_voluptuous()
 
 
 class TestConvertMarker:
@@ -219,3 +248,133 @@ class TestMakeEntityServiceSchema:
             )
         except Exception:
             pass  # Expected — the bug we're fixing
+
+
+class TestConvertMarkerForced:
+    """Tests that force the conversion path by patching ha_compat._vol
+    to the real voluptuous module (not the probatio alias).
+
+    On HA 2026.9+ ``install_as_voluptuous()`` aliases voluptuous to
+    probatio, so ``_convert_marker`` sees probatio markers as already-
+    voluptuous and returns early.  These tests patch ``_vol`` to the
+    real voluptuous so the conversion logic (lines 59-77) is exercised.
+    """
+
+    def test_probatio_required_converts_with_real_voluptuous(self) -> None:
+        """Force conversion: patch _vol to real voluptuous, then verify
+        a probatio Required marker is converted to a real voluptuous
+        Required marker with default and description propagated.
+        """
+        marker = probatio.Required(
+            "test_key", default="def", description="desc"
+        )
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        # Assert — should be a REAL voluptuous Required, not probatio
+        assert isinstance(result, _REAL_VOL.Required)
+        assert not isinstance(result, probatio.Required)
+        assert result.schema == "test_key"
+        assert result.description == "desc"
+
+    def test_probatio_optional_converts_with_real_voluptuous(self) -> None:
+        """Force conversion: patch _vol to real voluptuous, then verify
+        a probatio Optional marker is converted to a real voluptuous
+        Optional marker.
+        """
+        marker = probatio.Optional("test_key", default=42)
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Optional)
+        assert not isinstance(result, probatio.Optional)
+        assert result.schema == "test_key"
+
+    def test_undefined_default_not_passed_to_voluptuous(self) -> None:
+        """When probatio marker has no default (UNDEFINED), the
+        converted voluptuous marker should not receive a default kwarg.
+        """
+        marker = probatio.Required("test_key")  # no default
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Required)
+        # voluptuous uses Ellipsis as its "no default" sentinel
+        assert (
+            result.default is _REAL_VOL.UNDEFINED or result.default is Ellipsis
+        )
+
+    def test_msg_propagated_to_real_voluptuous(self) -> None:
+        """Verify msg kwarg is propagated during forced conversion."""
+        marker = probatio.Required("test_key", msg="custom error")
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Required)
+        assert result.msg == "custom error"
+
+    def test_description_propagated_to_real_voluptuous(self) -> None:
+        """Verify description kwarg is propagated during forced conversion."""
+        marker = probatio.Optional("test_key", description="my desc")
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Optional)
+        assert result.description == "my desc"
+
+    def test_is_undefined_with_real_sentinel(self) -> None:
+        """Verify _is_undefined returns True for probatio's UNDEFINED
+        and False for other values.
+        """
+        from custom_components.ramses_cc.ha_compat import _is_undefined
+
+        assert _is_undefined(probatio.UNDEFINED) is True
+        assert _is_undefined(None) is False
+        assert _is_undefined("something") is False
+
+    def test_make_entity_service_schema_with_forced_conversion(self) -> None:
+        """End-to-end: patch _vol to real voluptuous and verify
+        make_entity_service_schema still works with probatio markers.
+        """
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+            probatio.Optional("duration", default=30): probatio.All(
+                probatio.Coerce(int), probatio.Range(min=1, max=1440)
+            ),
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = make_entity_service_schema(
+                schema, extra=probatio.PREVENT_EXTRA
+            )
+        assert result is not None
+
+    def test_import_error_fallback_sentinel(self) -> None:
+        """Verify the ImportError fallback for _PROBATIO_UNDEFINED.
+
+        When probatio is not installed, ``_PROBATIO_UNDEFINED`` should
+        be a unique sentinel object.  We simulate this by reloading
+        ha_compat with probatio blocked from import.
+        """
+        import builtins
+
+        original_import = builtins.__import__
+
+        def _blocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "probatio":
+                raise ImportError("blocked for test")
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", _blocked_import):
+            # Force reimport of ha_compat with probatio blocked
+            saved = sys.modules.pop(
+                "custom_components.ramses_cc.ha_compat", None
+            )
+            try:
+                reloaded = importlib.import_module(
+                    "custom_components.ramses_cc.ha_compat"
+                )
+                # The fallback sentinel should be a plain object
+                assert reloaded._PROBATIO_UNDEFINED is not probatio.UNDEFINED
+                assert isinstance(reloaded._PROBATIO_UNDEFINED, object)
+            finally:
+                if saved is not None:
+                    sys.modules["custom_components.ramses_cc.ha_compat"] = (
+                        saved
+                    )


### PR DESCRIPTION
## Summary

### `make_entity_service_schema` wrapper
* Add `custom_components/ramses_cc/ha_compat.py` with a `make_entity_service_schema` wrapper that converts probatio `Required`/`Optional` markers to voluptuous markers before delegating to `cv.make_entity_service_schema`
* Replace all 22 `cv.make_entity_service_schema` calls in `schemas.py` with the compatibility wrapper
* Add unit tests covering marker conversion, pass-through, mixed markers, and validation

### `vol_schema` / `convert_form_schema` for config flow forms
* Add `convert_form_schema()` and `vol_schema()` helpers that convert probatio markers in form schema dicts to real voluptuous markers before building a `vol.Schema`
* Replace all `data_schema=vol.Schema(...)` calls in `config_flow.py` with `data_schema=vol_schema(...)` so form schemas serialize correctly via HA's REST API
* Add `_get_real_voluptuous()` to resolve the real voluptuous module at import time, bypassing the probatio alias
* Add tests for `convert_form_schema` and `vol_schema` (including `voluptuous_serialize` compatibility)

## Context

HA Core's `cv.make_entity_service_schema()` internally builds a voluptuous `Schema`, which recognises dict keys via `isinstance(key, voluptuous.Required/Optional)`. probatio markers are different classes, so voluptuous raises `SchemaError: unsupported schema data type 'Required'`.

Similarly, HA's config flow REST API uses `voluptuous_serialize.convert()` to serialize form schemas for the UI. This also requires real voluptuous markers — probatio markers cause `ValueError: Unable to convert schema`.

On HA 2026.9+ `install_as_voluptuous()` aliases voluptuous to probatio in `sys.modules`, so the markers are already compatible and the conversion is a no-op. On pre-2026.9 HA Core the real voluptuous is in use and probatio markers must be converted.

This allows ramses_cc to switch to `import probatio as vol` (PR #1066) while remaining compatible with pre-2026.9 HA Core, and ensures ramses_extras (which depends on ramses_cc) continues to work.

Note: PR #1066 will not touch `schemas.py` (per maintainer comment), so the `make_entity_service_schema` wrapper is only needed for `services.py` and other files that use probatio markers. The `vol_schema`/`convert_form_schema` helpers are needed for `config_flow.py` form schemas.

Fixes #1078

#### Test plan
* `ruff check` and `ruff format --check` pass
* `mypy` passes on `ha_compat.py` and test file
* `pytest tests/tests_new/test_ha_compat.py` — 28 passed, 2 skipped
* Verified on ha-sim (HA 2026.8.1): probatio markers through the helper produce valid voluptuous schemas; config flow form schemas serialize correctly via REST API
* Verified on dev venv (HA 2026.9.0b0): helper is a no-op (markers already compatible via `install_as_voluptuous`)
* `ha_sim_test` R50 (device health tracking) passes — previously failed with `ValueError: Unable to convert schema` on form schemas with probatio markers

Merged via #1084 