### PR TITLE
refactor(fan): use coordinator callbacks instead of event bus for fan parameters

### DIFF
--- a/custom_components/ramses_cc/fan_handler.py
+++ b/custom_components/ramses_cc/fan_handler.py
@@ -9,6 +9,7 @@ from datetime import timedelta as td
 from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.const import Platform
+from homeassistant.core import callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
@@ -36,6 +37,7 @@ class RamsesFanHandler:
         self.coordinator = coordinator
         self.hass = coordinator.hass
         self._fan_bound_to_remote: dict[str, DeviceIdT] = {}
+        self._param_listeners: dict[str, list[Callable[[str, Any], None]]] = {}
 
     def find_param_entity(
         self, device_id: str, param_id: str
@@ -104,6 +106,55 @@ class RamsesFanHandler:
                 )
 
         return None
+
+    @callback
+    def async_subscribe_param_updates(
+        self,
+        device_id: str,
+        listener: Callable[[str, Any], None],
+    ) -> Callable[[], None]:
+        """Subscribe a listener callback for 2411 parameter updates.
+
+        Registers a callback function that will be invoked whenever a
+        2411 parameter is updated for the specified device. Returns an
+        unsubscription callback suitable for passing to
+        `async_on_remove`.
+
+        :param device_id: The ID of the target device.
+        :type device_id: str
+        :param listener: The callback function receiving (param_id,
+            value).
+        :type listener: Callable[[str, Any], None]
+        :returns: A zero-argument callable that unregisters the listener.
+        :rtype: Callable[[], None]
+        """
+        if device_id not in self._param_listeners:
+            self._param_listeners[device_id] = []
+
+        self._param_listeners[device_id].append(listener)
+        _LOGGER.debug(
+            "Subscribed listener %s for 2411 param updates on device %s "
+            "(total: %d)",
+            listener,
+            device_id,
+            len(self._param_listeners[device_id]),
+        )
+
+        @callback
+        def async_unsubscribe() -> None:
+            """Unregister the parameter update listener."""
+            listeners = self._param_listeners.get(device_id)
+            if listeners and listener in listeners:
+                listeners.remove(listener)
+                _LOGGER.debug(
+                    "Unsubscribed listener for device %s (remaining: %d)",
+                    device_id,
+                    len(listeners),
+                )
+                if not listeners:
+                    self._param_listeners.pop(device_id, None)
+
+        return async_unsubscribe
 
     def create_parameter_entities(self, device: RamsesRFEntity) -> None:
         """Signal number platform to create parameter entities for a device.
@@ -312,22 +363,27 @@ class RamsesFanHandler:
                     dev_id: str,
                 ) -> Callable[[str, Any], None]:
                     def param_callback(param_id: str, value: Any) -> None:
+                        listeners = list(self._param_listeners.get(dev_id, []))
                         _LOGGER.debug(
                             "Parameter %s updated for device %s: %s "
-                            "(firing event)",
+                            "(dispatching to %d listener(s))",
                             param_id,
                             dev_id,
                             value,
+                            len(listeners),
                         )
-                        # Fire the event for Home Assistant entities
-                        self.hass.bus.async_fire(
-                            f"{DOMAIN}.fan_param_updated",
-                            {
-                                "device_id": dev_id,
-                                "param_id": param_id,
-                                "value": value,
-                            },
-                        )
+                        for listener in listeners:
+                            try:
+                                listener(param_id, value)
+                            except Exception as err:
+                                _LOGGER.error(
+                                    "Error executing parameter update callback "
+                                    "for device %s (param %s): %s",
+                                    dev_id,
+                                    param_id,
+                                    err,
+                                    exc_info=True,
+                                )
 
                     return param_callback
 

--- a/custom_components/ramses_cc/number.py
+++ b/custom_components/ramses_cc/number.py
@@ -60,7 +60,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
 )
 from homeassistant.const import EntityCategory
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
@@ -786,28 +786,31 @@ class RamsesNumberParam(RamsesNumberBase):
         """
         await super().async_added_to_hass()
 
-        # Listen for parameter update events
-        self.async_on_remove(
-            self.hass.bus.async_listen(
-                "ramses_cc.fan_param_updated", self._async_param_updated
+        # Listen for parameter update events from coordinator fan handler
+        if (
+            hasattr(self.coordinator, "fan_handler")
+            and self.coordinator.fan_handler is not None
+        ):
+            self.async_on_remove(
+                self.coordinator.fan_handler.async_subscribe_param_updates(
+                    self._device.id, self._async_param_updated
+                )
             )
-        )
 
         await self._request_parameter_value()
 
     @callback
-    def _async_param_updated(
-        self, event: Event | dict[str, Any] | object
-    ) -> None:
-        """Handle parameter updates from the device.
+    def _async_param_updated(self, param_id: str, value: Any) -> None:
+        """Handle parameter updates from the fan handler.
 
-        This callback is triggered when a fan parameter update event is
-        received. It processes the update and updates the entity's state if
+        Processes the parameter update and updates the entity state if
         the parameter matches this entity's parameter ID.
 
-        :param event: The event data containing the parameter update
-        :type event: dict[str, Any]
-        :return: None
+        :param param_id: The ID of the parameter that was updated.
+        :type param_id: str
+        :param value: The new value of the parameter.
+        :type value: Any
+        :returns: None
         :rtype: None
         """
         # Get the parameter ID we're interested in
@@ -815,37 +818,22 @@ class RamsesNumberParam(RamsesNumberBase):
         if not our_param_id:
             return
 
-        if isinstance(event, dict):
-            event_data = event
-        elif isinstance(event, Event):
-            event_data = event.data
-        else:
-            event_data = getattr(event, "data", {})
-
         # Only process if this is our parameter
         # Normalize param IDs by uppercasing and stripping leading zeros
         # (ramses_rf's _handle_2411_message strips leading zeros, but the
         # entity description keeps the original format, e.g. "01" vs "1")
-        event_param = (
-            str(event_data.get("param_id", "")).upper().lstrip("0") or "0"
-        )
+        event_param = str(param_id).upper().lstrip("0") or "0"
         our_param_norm = str(our_param_id).upper().lstrip("0") or "0"
-        if (
-            str(event_data.get("device_id", "")).lower()
-            == str(self._device.id).lower()
-            and event_param == our_param_norm
-        ):
-            new_value = event_data.get("value")
-
-            param_id = str(our_param_id).upper()
-            self._param_native_value[param_id] = new_value
+        if event_param == our_param_norm:
+            norm_param_id = str(our_param_id).upper()
+            self._param_native_value[norm_param_id] = value
             _LOGGER.debug(
                 "Parameter %s updated for device %s: %s (stored: %s, "
                 "dict: %s)",
                 our_param_id,
                 self._device.id,
-                new_value,
-                self._param_native_value.get(param_id),
+                value,
+                self._param_native_value.get(norm_param_id),
                 self._param_native_value,
             )
 

--- a/tests/tests_new/test_fan_handler.py
+++ b/tests/tests_new/test_fan_handler.py
@@ -63,27 +63,30 @@ async def test_coordinator_fan_setup(
     mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
 ) -> None:
     """Test fan_handler.async_setup_fan_device logic."""
+    # Arrange
     mock_fan_device.set_initialized_callback = MagicMock()
     mock_fan_device.set_param_update_callback = MagicMock()
 
+    # Act
     await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
 
+    # Assert
     assert mock_fan_device.set_initialized_callback.called
     assert mock_fan_device.set_param_update_callback.called
 
+    # Arrange
     callback_fn = mock_fan_device.set_param_update_callback.call_args[0][0]
-    event_callback = MagicMock()
-    mock_coordinator.hass.bus.async_listen(
-        "ramses_cc.fan_param_updated", event_callback
+    listener_cb = MagicMock()
+    mock_coordinator.fan_handler.async_subscribe_param_updates(
+        FAN_ID, listener_cb
     )
 
+    # Act
     callback_fn(PARAM_ID_HEX, 19.5)
-    await mock_coordinator.hass.async_block_till_done()
 
-    assert event_callback.called
-    event = event_callback.call_args[0][0]
-    assert event.data["device_id"] == FAN_ID
-    assert event.data["value"] == 19.5
+    # Assert
+    assert listener_cb.called
+    listener_cb.assert_called_once_with(PARAM_ID_HEX, 19.5)
 
 
 async def test_setup_fan_bound_invalid_type(
@@ -870,4 +873,144 @@ async def test_setup_fan_bound_single_str_normalized_to_list(
     )
     assert (
         mock_coordinator.fan_handler._fan_bound_to_remote[bound_id] == FAN_ID
+    )
+
+
+async def test_fan_handler_subscribe_and_unsubscribe(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test subscribing and unsubscribing parameter update listeners."""
+    # Arrange
+    handler = mock_coordinator.fan_handler
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+
+    # Act - Subscribe
+    unsub_1 = handler.async_subscribe_param_updates(FAN_ID, listener_1)
+    unsub_2 = handler.async_subscribe_param_updates(FAN_ID, listener_2)
+
+    # Assert
+    assert len(handler._param_listeners[FAN_ID]) == 2
+
+    # Act - Unsubscribe first listener
+    unsub_1()
+
+    # Assert
+    assert len(handler._param_listeners[FAN_ID]) == 1
+    assert listener_1 not in handler._param_listeners[FAN_ID]
+    assert listener_2 in handler._param_listeners[FAN_ID]
+
+    # Act - Unsubscribe second listener (should prune device entry)
+    unsub_2()
+
+    # Assert
+    assert FAN_ID not in handler._param_listeners
+
+    # Act & Assert - Calling unsubscribe again is safe and idempotent
+    unsub_1()
+    unsub_2()
+    assert FAN_ID not in handler._param_listeners
+
+
+async def test_fan_handler_multiple_param_listeners_dispatch(
+    mock_coordinator: RamsesCoordinator, mock_fan_device: MagicMock
+) -> None:
+    """Test multiple listeners receive parameter updates and hass.bus is untouched."""
+    # Arrange
+    mock_fan_device.set_initialized_callback = MagicMock()
+    mock_fan_device.set_param_update_callback = MagicMock()
+    await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
+    callback_fn = mock_fan_device.set_param_update_callback.call_args[0][0]
+
+    listener_1 = MagicMock()
+    listener_2 = MagicMock()
+    mock_coordinator.fan_handler.async_subscribe_param_updates(
+        FAN_ID, listener_1
+    )
+    mock_coordinator.fan_handler.async_subscribe_param_updates(
+        FAN_ID, listener_2
+    )
+
+    bus_listener = MagicMock()
+    mock_coordinator.hass.bus.async_listen(
+        "ramses_cc.fan_param_updated", bus_listener
+    )
+
+    # Act
+    callback_fn("01", 0.5)
+
+    # Assert
+    listener_1.assert_called_once_with("01", 0.5)
+    listener_2.assert_called_once_with("01", 0.5)
+    assert not bus_listener.called
+
+
+async def test_fan_handler_multi_device_isolation(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test that parameter updates for device A do not notify device B listeners."""
+    # Arrange
+    fan_a_id = "30:111111"
+    fan_b_id = "30:222222"
+
+    mock_fan_a = MagicMock()
+    mock_fan_a.id = fan_a_id
+    mock_fan_a._SLUG = "FAN"
+    mock_fan_a.set_initialized_callback = MagicMock()
+    mock_fan_a.set_param_update_callback = MagicMock()
+
+    await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_a)
+    callback_fan_a = mock_fan_a.set_param_update_callback.call_args[0][0]
+
+    listener_fan_a = MagicMock()
+    listener_fan_b = MagicMock()
+
+    mock_coordinator.fan_handler.async_subscribe_param_updates(
+        fan_a_id, listener_fan_a
+    )
+    mock_coordinator.fan_handler.async_subscribe_param_updates(
+        fan_b_id, listener_fan_b
+    )
+
+    # Act
+    callback_fan_a("3D", 1)
+
+    # Assert
+    listener_fan_a.assert_called_once_with("3D", 1)
+    assert not listener_fan_b.called
+
+
+async def test_fan_handler_listener_exception_resilience(
+    mock_coordinator: RamsesCoordinator,
+    mock_fan_device: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a failing listener does not break dispatch to other listeners."""
+    # Arrange
+    mock_fan_device.set_initialized_callback = MagicMock()
+    mock_fan_device.set_param_update_callback = MagicMock()
+    await mock_coordinator.fan_handler.async_setup_fan_device(mock_fan_device)
+    callback_fn = mock_fan_device.set_param_update_callback.call_args[0][0]
+
+    failing_listener = MagicMock(
+        side_effect=RuntimeError("Entity update failed")
+    )
+    healthy_listener = MagicMock()
+
+    mock_coordinator.fan_handler.async_subscribe_param_updates(
+        FAN_ID, failing_listener
+    )
+    mock_coordinator.fan_handler.async_subscribe_param_updates(
+        FAN_ID, healthy_listener
+    )
+
+    # Act
+    with caplog.at_level(logging.ERROR):
+        callback_fn("75", 21.0)
+
+    # Assert
+    assert failing_listener.called
+    healthy_listener.assert_called_once_with("75", 21.0)
+    assert (
+        "Error executing parameter update callback for device" in caplog.text
     )

--- a/tests/tests_new/test_number.py
+++ b/tests/tests_new/test_number.py
@@ -405,28 +405,32 @@ async def test_init_parameter_52(
 
 
 async def test_events_handling(number_entity: RamsesNumberParam) -> None:
-    """Test event handling."""
-    await number_entity.async_added_to_hass()
-    assert cast(MagicMock, number_entity.hass.bus.async_listen).called
-    callback = cast(MagicMock, number_entity.hass.bus.async_listen).call_args[
-        0
-    ][1]
+    """Test parameter update callback handling."""
+    # Arrange
+    number_entity.async_on_remove = MagicMock()
+    subscribe_mock = (
+        number_entity.coordinator.fan_handler.async_subscribe_param_updates
+    )
+    subscribe_mock.return_value = MagicMock()
 
-    event = MagicMock()
-    event.data = {
-        "device_id": number_entity._device.id,
-        "param_id": "01",
-        "value": 0.5,
-    }
-    callback(event)
+    # Act
+    await number_entity.async_added_to_hass()
+
+    # Assert
+    assert subscribe_mock.called
+    assert subscribe_mock.call_args[0][0] == number_entity._device.id
+    callback = subscribe_mock.call_args[0][1]
+
+    # Act - matching parameter
+    callback("01", 0.5)
+
+    # Assert
     assert number_entity._param_native_value["01"] == 0.5
 
-    event.data = {
-        "device_id": "99:999999",
-        "param_id": "01",
-        "value": 0.9,
-    }
-    callback(event)
+    # Act - different parameter ID (e.g. "02")
+    callback("02", 0.9)
+
+    # Assert - should not update "01"
     assert number_entity._param_native_value["01"] == 0.5
 
 
@@ -434,19 +438,22 @@ async def test_events_handling_no_param_id(
     number_entity: RamsesNumberParam,
 ) -> None:
     """Test event handling return when no param id."""
-    # Remove attr from description
+    # Arrange
     new_desc = dataclasses.replace(
         number_entity.entity_description, ramses_rf_attr=""
     )
     number_entity.entity_description = new_desc
+    subscribe_mock = (
+        number_entity.coordinator.fan_handler.async_subscribe_param_updates
+    )
+    subscribe_mock.return_value = MagicMock()
 
+    # Act
     await number_entity.async_added_to_hass()
-    callback = cast(MagicMock, number_entity.hass.bus.async_listen).call_args[
-        0
-    ][1]
+    callback = subscribe_mock.call_args[0][1]
 
-    # Should return early and not raise
-    callback(MagicMock())
+    # Act & Assert - Should return early and not raise
+    callback("01", 0.5)
 
 
 async def test_request_parameter_value(
@@ -966,11 +973,8 @@ async def test_number_entity_initial_state_and_update(
     assert entity.native_value is None
     assert entity.available is False  # No value yet
 
-    # 4. Test Update from Event (simulating incoming packet)
-    event_data = {"device_id": FAN_ID, "param_id": "75", "value": 20.5}
-
-    # Calls _async_param_updated directly
-    entity._async_param_updated(event_data)
+    # 4. Test Update from fan handler (simulating incoming packet)
+    entity._async_param_updated("75", 20.5)
 
     assert entity.native_value == 20.5
     assert entity.available is True


### PR DESCRIPTION
### The Problem:
`custom_components/ramses_cc/fan_handler.py` synchronised 2411 fan parameter updates with `RamsesNumberParam` entities by firing events on the global Home Assistant event bus (`hass.bus.async_fire("ramses_cc.fan_param_updated", ...)`). This introduced unnecessary event bus overhead and violated standard Home Assistant architectural patterns for internal state coordination.

### The Fix:
- Implemented `RamsesFanHandler.async_subscribe_param_updates(device_id, listener)` returning an unsubscription callback.
- Refactored `RamsesNumberParam.async_added_to_hass` to subscribe directly to `fan_handler` updates and register the teardown callable via `self.async_on_remove(...)`.
- Simplified `RamsesNumberParam._async_param_updated` to accept `(param_id, value)` directly.
- Removed `hass.bus.async_fire` for `ramses_cc.fan_param_updated`.
- Added unit tests covering multiple listener dispatch, unsubscribe lifecycle, multi-device isolation, and callback exception resilience.

Fixes #978

### Testing Performed:
- `tests/tests_new/test_fan_handler.py`: Verified multi-listener dispatch, isolation, and unsubscription.
- `tests/tests_new/test_number.py`: Verified direct callback processing and parameter filtering.
- `.venv/bin/prek run -a`: All hooks passed.
- `.venv/bin/ruff check --select D`: Docstrings verified.
- `.venv/bin/pytest -n auto`: All 1,405 tests passed (10 skipped, 3 snapshots passed).

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.
