### PR TITLE
fix(discovery): handle integer _suppress_not_seen in check_for_lost_devices

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -2370,13 +2370,52 @@ class DiscoveryManager:
                 continue
 
             # Respect _suppress_not_seen from schema (issue 988)
+            # Accepted values: True (suppress forever) or N int (suppress
+            # for N days from last_seen, then re-notify).  This mirrors
+            # the logic in check_orphaned_devices.
             if schema is not None:
                 schema_entry = schema.get(device_id)
-                if (
-                    isinstance(schema_entry, dict)
-                    and schema_entry.get("_suppress_not_seen") is True
-                ):
-                    continue
+                if isinstance(schema_entry, dict):
+                    suppress_val = schema_entry.get("_suppress_not_seen")
+                    suppress_forever = suppress_val is True
+                    suppress_days: int | None = None
+                    if isinstance(
+                        suppress_val, (int, float)
+                    ) and not isinstance(suppress_val, bool):
+                        suppress_days = int(suppress_val)
+
+                    if suppress_forever or suppress_days is not None:
+                        # For int mode, check if suppress period has expired
+                        if suppress_days is not None:
+                            engine_dev_check = next(
+                                (
+                                    d
+                                    for d in self._scan.get_devices()
+                                    if d.device_id == device_id
+                                ),
+                                None,
+                            )
+                            if engine_dev_check and engine_dev_check.last_seen:
+                                try:
+                                    ls = dt.fromisoformat(
+                                        engine_dev_check.last_seen
+                                    )
+                                    if ls.tzinfo is None:
+                                        ls = ls.replace(
+                                            tzinfo=dt_util.get_default_time_zone()
+                                        )
+                                    suppress_threshold = now - td(
+                                        days=suppress_days
+                                    )
+                                    if ls < suppress_threshold:
+                                        # Suppress expired — allow lost check
+                                        pass
+                                    else:
+                                        continue
+                                except (ValueError, TypeError):
+                                    pass
+                        else:
+                            continue
 
             engine_dev = next(
                 (


### PR DESCRIPTION
## Summary

- `check_for_lost_devices` only checked `_suppress_not_seen is True` (identity with `True`), but the 'keep' action in `review_device_health` sets `_suppress_not_seen = 7` (integer, suppress for 7 days)
- Integer values were ignored, causing devices to be immediately re-flagged as lost after the config entry reload triggered by the 'keep' submission
- This mirrors the logic already present in `check_orphaned_devices`, which handles both `True` (suppress forever) and `N` int (suppress for N days from `last_seen`, then re-notify)

## Root cause

The 'keep' action for lost devices in `async_step_review_device_health` sets:
```python
dev_entry["_suppress_not_seen"] = 7  # integer, not True
```

But `check_for_lost_devices` checked:
```python
if schema_entry.get("_suppress_not_seen") is True:  # only matches True, not 7
    continue
```

So the suppress was ignored and the device was re-flagged as lost on the next reload.

## Fix

Updated `check_for_lost_devices` to handle both `True` and integer values, with expired-suppress detection for the integer mode — same logic as `check_orphaned_devices`.

## Test plan

- [x] R50 ha_sim_test passes (device health tracking — orphaned/lost devices)
- [x] `pytest tests/tests_new/test_ha_compat.py` passes
- [x] No unexpected ERROR/WARNING logs in ha_sim_test