### PR TITLE
chore: unify YAML bool values to lowercase (true/false)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,13 @@ repos:
       types: [python]
       exclude: .pre-commit-config.yaml  # avoid false +ve
 
+    - id: yaml_bool_lowercase
+      name: check YAML bools are lowercase (true/false, not True/False)
+      entry: ': (True|False)\b'
+      language: pygrep
+      files: \.(yaml|yml)$
+      exclude: .pre-commit-config.yaml  # avoid false +ve
+
     # - id: private imports
     #   name: check for private imports
     #   entry: 'from .* import _.*'

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -731,7 +731,7 @@
 
         "put_room_temp": {
             "name": "Pas Ruimtetemperatuur aan",
-            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone-thermostaat. De thermostaat moet als `_faked-True` in het `Systeemschema` staan, en als zone-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
+            "description": "Stel een nieuwe ruimtetemperatuur in (niet het instelpunt) voor een evohome zone-thermostaat. De thermostaat moet als `_faked: true` in het `Systeemschema` staan, en als zone-sensor zijn gekoppeld aan een Verwarming/Warmtapwater-controller.",
             "fields": {
                 "temperature": {
                     "name": "Temperatuur",

--- a/tests/tests_new/fixtures/remotes/configuration.yaml
+++ b/tests/tests_new/fixtures/remotes/configuration.yaml
@@ -11,7 +11,7 @@ ramses_cc:
 
     29:179540:
       class: "REM"
-      faked: True
+      faked: true
       commands:
         auto: " I --- 29:179540 32:157747 --:------ 22F1 003 000404"
         away: " I --- 29:179540 32:157747 --:------ 22F1 003 000004"


### PR DESCRIPTION
## Summary

- Fix two remaining instances of Python-style `True`/`False` in YAML and translations to align with YAML 1.2 convention (lowercase `true`/`false`)
- `configuration.yaml` test fixture: `faked: True` → `faked: true`
- `nl.json` translation: `_faked-True` → `_faked: true` (also fixes hyphen to colon, matching `en.json`)
- Add pre-commit hook (`yaml_bool_lowercase`) to prevent regression

Closes https://github.com/ramses-rf/ramses_cc/issues/1079

#### Test plan
- [x] pre-commit hooks pass (including new `yaml_bool_lowercase`)
- [x] `check-yaml` passes on all YAML files
- [x] No functional changes — YAML 1.1 accepts both `True` and `true` as booleans