### PR TITLE
feat(ha_compat): add vol_schema helper for probatio config flow forms (stacked on 1066)

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -49,7 +49,7 @@ if ENABLE_DEV_HOOK and os.path.isdir(DEV_LIB_PATH):  # pragma: no cover
     )
 # ------------------------
 
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant import config_entries
 from homeassistant.components.climate.const import (
     DOMAIN as CLIMATE_ENTITY_DOMAIN,

--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -49,7 +49,7 @@ if ENABLE_DEV_HOOK and os.path.isdir(DEV_LIB_PATH):  # pragma: no cover
     )
 # ------------------------
 
-import probatio as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as prob
 from homeassistant import config_entries
 from homeassistant.components.climate.const import (
     DOMAIN as CLIMATE_ENTITY_DOMAIN,
@@ -151,9 +151,9 @@ def _get_ramses_tx_exceptions() -> ModuleType:
     return _RAMSES_TX_EXC
 
 
-CONFIG_SCHEMA = vol.All(
+CONFIG_SCHEMA = prob.All(
     cv.deprecated(DOMAIN, raise_if_present=False),
-    vol.Schema({DOMAIN: SCH_DOMAIN_CONFIG}, extra=vol.ALLOW_EXTRA),
+    prob.Schema({DOMAIN: SCH_DOMAIN_CONFIG}, extra=prob.ALLOW_EXTRA),
 )
 
 PLATFORMS = [Platform.EVENT]

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, replace as dc_replace
 from datetime import datetime as dt, timedelta as td
 from typing import Any, Final, cast
 
-import voluptuous as vol
+import probatio as vol
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,

--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, replace as dc_replace
 from datetime import datetime as dt, timedelta as td
 from typing import Any, Final, cast
 
-import probatio as vol
+import probatio as prob
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,
@@ -390,7 +390,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
 
         try:
             await self.async_set_system_mode(target_mode)
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="validation_error",
@@ -413,7 +413,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
 
         try:
             await self.async_set_system_mode(target_mode)
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="validation_error",
@@ -484,7 +484,7 @@ class RamsesController(RamsesEntity, ClimateEntity):
         # strict, non-entity schema check
         try:
             SCH_SET_SYSTEM_MODE_EXTRA(entry)  # result not used
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="validation_error",
@@ -781,7 +781,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             raise HomeAssistantError(
                 f"Failed to set hvac mode: {err}"
             ) from err
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="validation_error",
@@ -807,7 +807,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             try:
                 await self._device.tcs.set_mode(target_mode)
                 self.async_write_ha_state()
-            except vol.Invalid as err:
+            except prob.Invalid as err:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="validation_error",
@@ -828,7 +828,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
                     td(hours=1) if preset_mode == PRESET_TEMPORARY else None
                 ),
             )
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="validation_error",
@@ -869,7 +869,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             await self.async_set_zone_mode(
                 mode=mode, setpoint=temperature, duration=duration, until=until
             )
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="validation_error",
@@ -985,7 +985,7 @@ class RamsesZone(RamsesEntity, ClimateEntity):
         # strict, non-entity schema check
         try:
             checked_entry = SCH_SET_ZONE_MODE_EXTRA(entry)
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="validation_error",

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlparse
 
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.components import mqtt, usb
 from homeassistant.config_entries import (
     ConfigEntry,

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -78,6 +78,7 @@ from .const import (
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
 )
+from .ha_compat import vol_schema
 from .schemas import migrate_known_list_traits, order_schema
 
 _LOGGER = logging.getLogger(__name__)
@@ -461,7 +462,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="choose_serial_port",
-            data_schema=prob.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             errors=errors,
             last_step=False,
         )
@@ -555,7 +556,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="mqtt_config",
-            data_schema=prob.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             errors={},
             last_step=False,
         )
@@ -581,7 +582,7 @@ class BaseRamsesFlow:
                 if not isinstance(device_id, str):
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=prob.Schema(
+                        data_schema=vol_schema(
                             {
                                 prob.Required(
                                     "device"
@@ -597,7 +598,7 @@ class BaseRamsesFlow:
                 if not device_entry:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=prob.Schema(
+                        data_schema=vol_schema(
                             {
                                 prob.Required(
                                     "device"
@@ -613,7 +614,7 @@ class BaseRamsesFlow:
                 if not ieee:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=prob.Schema(
+                        data_schema=vol_schema(
                             {
                                 prob.Required(
                                     "device"
@@ -645,7 +646,7 @@ class BaseRamsesFlow:
             if len(matches) == 0:
                 return self.async_show_form(
                     step_id="zigbee_device",
-                    data_schema=prob.Schema(
+                    data_schema=vol_schema(
                         {
                             prob.Required(
                                 "retry", default=False
@@ -663,7 +664,7 @@ class BaseRamsesFlow:
                 if not ieee:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=prob.Schema(
+                        data_schema=vol_schema(
                             {
                                 prob.Required(
                                     "retry", default=False
@@ -695,7 +696,7 @@ class BaseRamsesFlow:
             ]
             return self.async_show_form(
                 step_id="zigbee_device",
-                data_schema=prob.Schema(
+                data_schema=vol_schema(
                     {
                         prob.Required("device"): selector.SelectSelector(
                             selector.SelectSelectorConfig(options=options)
@@ -788,7 +789,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="configure_serial_port",
-            data_schema=prob.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -824,7 +825,7 @@ class BaseRamsesFlow:
                 if k in self.options[CONF_RAMSES_RF]
             }
             try:
-                prob.Schema(
+                vol_schema(
                     SCH_GATEWAY_DICT | SCH_ENGINE_DICT,
                     extra=prob.PREVENT_EXTRA,
                 )(gateway_config)
@@ -956,7 +957,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="config",
-            data_schema=prob.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -1211,7 +1212,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="schema",
-            data_schema=prob.Schema(
+            data_schema=vol_schema(
                 # cv.deprecated(
                 #     "sqlite_index", raise_if_present=False
                 # ),  # Deprecated Q3 2026
@@ -1302,7 +1303,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="advanced_features",
-            data_schema=prob.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -1446,7 +1447,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="packet_log",
-            data_schema=prob.Schema(
+            data_schema=vol_schema(
                 # cv.deprecated(
                 #     "file_name", raise_if_present=False
                 # ),  # Deprecated Q3 2026
@@ -2380,7 +2381,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="review_discovered",
-            data_schema=prob.Schema(form_fields),
+            data_schema=vol_schema(form_fields),
             description_placeholders={"message": summary},
             last_step=True,
         )
@@ -2708,7 +2709,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="review_device_health",
-            data_schema=prob.Schema(form_fields),
+            data_schema=vol_schema(form_fields),
             description_placeholders={"message": summary},
             last_step=True,
         )
@@ -2892,5 +2893,5 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="clear_cache",
-            data_schema=prob.Schema(data_schema),
+            data_schema=vol_schema(data_schema),
         )

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlparse
 
-import probatio as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as prob
 from homeassistant.components import mqtt, usb
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -422,14 +422,14 @@ class BaseRamsesFlow:
         if self.options.get(CONF_MQTT_USE_HA):
             default_port = CONF_HA_MQTT_PATH
         elif port_name is None:
-            default_port = vol.UNDEFINED
+            default_port = prob.UNDEFINED
         elif port_name in ports:
             default_port = port_name
         else:
             default_port = CONF_MANUAL_PATH
 
         data_schema = {
-            vol.Required(
+            prob.Required(
                 SZ_PORT_NAME,
                 default=default_port,
             ): selector.SelectSelector(
@@ -445,7 +445,7 @@ class BaseRamsesFlow:
 
         # used in test_configure_serial_port_missing_port_name
         _optional_schema = {
-            vol.Optional(
+            prob.Optional(
                 SZ_PORT_NAME,
                 default=default_port,
             ): selector.SelectSelector(
@@ -461,7 +461,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="choose_serial_port",
-            data_schema=vol.Schema(data_schema),
+            data_schema=prob.Schema(data_schema),
             errors=errors,
             last_step=False,
         )
@@ -524,14 +524,14 @@ class BaseRamsesFlow:
 
         # Define the Form Schema with 'suggested_value'
         data_schema = {
-            vol.Required(
+            prob.Required(
                 "host", description={"suggested_value": suggested_host}
             ): selector.TextSelector(),
-            vol.Required(
+            prob.Required(
                 "port",
                 default=1883,
                 description={"suggested_value": suggested_port},
-            ): vol.All(
+            ): prob.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=1,
@@ -541,10 +541,10 @@ class BaseRamsesFlow:
                 ),
                 cv.positive_int,
             ),
-            vol.Optional(
+            prob.Optional(
                 "username", description={"suggested_value": suggested_user}
             ): selector.TextSelector(),
-            vol.Optional(
+            prob.Optional(
                 "password", description={"suggested_value": suggested_pass}
             ): selector.TextSelector(
                 selector.TextSelectorConfig(
@@ -555,7 +555,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="mqtt_config",
-            data_schema=vol.Schema(data_schema),
+            data_schema=prob.Schema(data_schema),
             errors={},
             last_step=False,
         )
@@ -581,8 +581,12 @@ class BaseRamsesFlow:
                 if not isinstance(device_id, str):
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
-                            {vol.Required("device"): selector.DeviceSelector()}
+                        data_schema=prob.Schema(
+                            {
+                                prob.Required(
+                                    "device"
+                                ): selector.DeviceSelector()
+                            }
                         ),
                         errors={"device": "invalid_device"},
                         last_step=False,
@@ -593,8 +597,12 @@ class BaseRamsesFlow:
                 if not device_entry:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
-                            {vol.Required("device"): selector.DeviceSelector()}
+                        data_schema=prob.Schema(
+                            {
+                                prob.Required(
+                                    "device"
+                                ): selector.DeviceSelector()
+                            }
                         ),
                         errors={"device": "device_not_found"},
                         last_step=False,
@@ -605,8 +613,12 @@ class BaseRamsesFlow:
                 if not ieee:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
-                            {vol.Required("device"): selector.DeviceSelector()}
+                        data_schema=prob.Schema(
+                            {
+                                prob.Required(
+                                    "device"
+                                ): selector.DeviceSelector()
+                            }
                         ),
                         errors={"device": "no_ieee_identifier"},
                         last_step=False,
@@ -633,9 +645,9 @@ class BaseRamsesFlow:
             if len(matches) == 0:
                 return self.async_show_form(
                     step_id="zigbee_device",
-                    data_schema=vol.Schema(
+                    data_schema=prob.Schema(
                         {
-                            vol.Required(
+                            prob.Required(
                                 "retry", default=False
                             ): selector.BooleanSelector()
                         }
@@ -651,9 +663,9 @@ class BaseRamsesFlow:
                 if not ieee:
                     return self.async_show_form(
                         step_id="zigbee_device",
-                        data_schema=vol.Schema(
+                        data_schema=prob.Schema(
                             {
-                                vol.Required(
+                                prob.Required(
                                     "retry", default=False
                                 ): selector.BooleanSelector()
                             }
@@ -683,9 +695,9 @@ class BaseRamsesFlow:
             ]
             return self.async_show_form(
                 step_id="zigbee_device",
-                data_schema=vol.Schema(
+                data_schema=prob.Schema(
                     {
-                        vol.Required("device"): selector.SelectSelector(
+                        prob.Required("device"): selector.SelectSelector(
                             selector.SelectSelectorConfig(options=options)
                         )
                     }
@@ -716,7 +728,7 @@ class BaseRamsesFlow:
             config = user_input.get(SZ_SERIAL_PORT, {})
             try:
                 SCH_SERIAL_PORT_CONFIG(config)
-            except vol.Invalid as err:
+            except prob.Invalid as err:
                 errors[SZ_SERIAL_PORT] = "invalid_port_config"
                 description_placeholders["error_detail"] = err.msg
 
@@ -755,10 +767,10 @@ class BaseRamsesFlow:
                 },
             }
 
-        data_schema: dict[vol.Marker, Any] = {}
+        data_schema: dict[prob.Marker, Any] = {}
         if self._manual_serial_port:
             data_schema |= {
-                vol.Required(
+                prob.Required(
                     SZ_PORT_NAME,
                     description={
                         "suggested_value": suggested_values.get(SZ_PORT_NAME)
@@ -766,7 +778,7 @@ class BaseRamsesFlow:
                 ): selector.TextSelector(),
             }
         data_schema |= {
-            vol.Optional(
+            prob.Optional(
                 SZ_SERIAL_PORT,
                 description={
                     "suggested_value": suggested_values.get(SZ_SERIAL_PORT)
@@ -776,7 +788,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="configure_serial_port",
-            data_schema=vol.Schema(data_schema),
+            data_schema=prob.Schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -812,10 +824,11 @@ class BaseRamsesFlow:
                 if k in self.options[CONF_RAMSES_RF]
             }
             try:
-                vol.Schema(
-                    SCH_GATEWAY_DICT | SCH_ENGINE_DICT, extra=vol.PREVENT_EXTRA
+                prob.Schema(
+                    SCH_GATEWAY_DICT | SCH_ENGINE_DICT,
+                    extra=prob.PREVENT_EXTRA,
                 )(gateway_config)
-            except vol.Invalid as err:
+            except prob.Invalid as err:
                 errors[CONF_RAMSES_RF] = "invalid_gateway_config"
                 description_placeholders["error_detail"] = err.msg
 
@@ -869,7 +882,7 @@ class BaseRamsesFlow:
             }
 
         data_schema = {
-            vol.Required(
+            prob.Required(
                 CONF_SCAN_INTERVAL,
                 default=60,
                 description={
@@ -877,7 +890,7 @@ class BaseRamsesFlow:
                         CONF_SCAN_INTERVAL, 60
                     )
                 },
-            ): vol.All(
+            ): prob.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=0,
@@ -888,7 +901,7 @@ class BaseRamsesFlow:
                 ),
                 cv.positive_int,
             ),
-            vol.Required(
+            prob.Required(
                 CONF_GATEWAY_TIMEOUT,
                 default=10,
                 description={
@@ -896,7 +909,7 @@ class BaseRamsesFlow:
                         CONF_GATEWAY_TIMEOUT, 10
                     )
                 },
-            ): vol.All(
+            ): prob.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=1,
@@ -907,7 +920,7 @@ class BaseRamsesFlow:
                 ),
                 cv.positive_int,
             ),
-            vol.Optional(
+            prob.Optional(
                 CONF_RAMSES_RF,
                 description={
                     "suggested_value": suggested_values.get(CONF_RAMSES_RF)
@@ -918,7 +931,7 @@ class BaseRamsesFlow:
         # If using MQTT, expose the HGI ID field and Topic
         if self.options.get(CONF_MQTT_USE_HA):
             data_schema[
-                vol.Optional(
+                prob.Optional(
                     CONF_MQTT_TOPIC,
                     default=DEFAULT_MQTT_TOPIC,
                     description={
@@ -930,7 +943,7 @@ class BaseRamsesFlow:
             ] = selector.TextSelector()
 
             data_schema[
-                vol.Optional(
+                prob.Optional(
                     CONF_MQTT_HGI_ID,
                     default=DEFAULT_HGI_ID,
                     description={
@@ -943,7 +956,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="config",
-            data_schema=vol.Schema(data_schema),
+            data_schema=prob.Schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -986,7 +999,7 @@ class BaseRamsesFlow:
 
             try:
                 SCH_GLOBAL_SCHEMAS(raw_schema)
-            except vol.Invalid as err:
+            except prob.Invalid as err:
                 errors[CONF_SCHEMA] = "invalid_schema"
                 description_placeholders["error_detail"] = err.msg
 
@@ -1169,13 +1182,13 @@ class BaseRamsesFlow:
             }
 
         data_schema = {
-            vol.Optional(
+            prob.Optional(
                 CONF_SCHEMA,
                 description={
                     "suggested_value": suggested_values.get(CONF_SCHEMA)
                 },
             ): selector.ObjectSelector(),
-            vol.Required(
+            prob.Required(
                 "owner_name",
                 default=suggested_values.get("owner_name", "me"),
                 description={
@@ -1183,7 +1196,7 @@ class BaseRamsesFlow:
                     "go to block_list)",
                 },
             ): selector.TextSelector(),
-            vol.Optional(
+            prob.Optional(
                 SZ_LOG_ALL_MQTT,
                 default=False,
                 description={
@@ -1198,12 +1211,12 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="schema",
-            data_schema=vol.Schema(
+            data_schema=prob.Schema(
                 # cv.deprecated(
                 #     "sqlite_index", raise_if_present=False
                 # ),  # Deprecated Q3 2026
                 data_schema,
-                extra=vol.ALLOW_EXTRA,
+                extra=prob.ALLOW_EXTRA,
             ),  # extra = migration from v1
             description_placeholders=description_placeholders,
             errors=errors,
@@ -1240,14 +1253,14 @@ class BaseRamsesFlow:
             suggested_values = self.options.get(CONF_ADVANCED_FEATURES, {})
 
         data_schema = {
-            vol.Optional(
+            prob.Optional(
                 CONF_SEND_PACKET,
                 default=False,
                 description={
                     "suggested_value": suggested_values.get(CONF_SEND_PACKET)
                 },
             ): selector.BooleanSelector(),
-            vol.Optional(
+            prob.Optional(
                 CONF_MESSAGE_EVENTS,
                 description={
                     "suggested_value": suggested_values.get(
@@ -1255,21 +1268,21 @@ class BaseRamsesFlow:
                     )
                 },
             ): selector.TextSelector(),
-            vol.Optional(
+            prob.Optional(
                 CONF_PASSIVE_SCAN,
                 default=True,
                 description={
                     "suggested_value": suggested_values.get(CONF_PASSIVE_SCAN)
                 },
             ): selector.BooleanSelector(),
-            vol.Optional(
+            prob.Optional(
                 CONF_AUTO_NOTIFY,
                 default=True,
                 description={
                     "suggested_value": suggested_values.get(CONF_AUTO_NOTIFY)
                 },
             ): selector.BooleanSelector(),
-            vol.Optional(
+            prob.Optional(
                 CONF_LOST_THRESHOLD,
                 default=7,
                 description={
@@ -1289,7 +1302,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="advanced_features",
-            data_schema=vol.Schema(data_schema),
+            data_schema=prob.Schema(data_schema),
             description_placeholders=description_placeholders,
             errors=errors,
             last_step=not self._initial_setup,
@@ -1314,7 +1327,7 @@ class BaseRamsesFlow:
         suggested_values = self.options.get(SZ_PACKET_LOG, {})
 
         data_schema = {
-            vol.Optional(
+            prob.Optional(
                 SZ_PACKET_LOG_PATH,
                 default="/config/ramses_rf_logs/",
                 description={
@@ -1323,7 +1336,7 @@ class BaseRamsesFlow:
                     )
                 },
             ): selector.TextSelector(),
-            vol.Optional(
+            prob.Optional(
                 SZ_PACKET_LOG_PREFIX,
                 default="packet_log",
                 description={
@@ -1332,7 +1345,7 @@ class BaseRamsesFlow:
                     )
                 },
             ): selector.TextSelector(),
-            vol.Optional(
+            prob.Optional(
                 SZ_PACKET_LOG_RETENTION_DAYS,
                 default=7,
                 description={
@@ -1340,7 +1353,7 @@ class BaseRamsesFlow:
                         SZ_PACKET_LOG_RETENTION_DAYS, 7
                     )
                 },
-            ): vol.All(
+            ): prob.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=0,
@@ -1348,14 +1361,14 @@ class BaseRamsesFlow:
                         mode=selector.NumberSelectorMode.BOX,
                     )
                 ),
-                vol.Coerce(int),
+                prob.Coerce(int),
             ),
-            vol.Optional(
+            prob.Optional(
                 SZ_ROTATE_BYTES,
                 description={
                     "suggested_value": suggested_values.get(SZ_ROTATE_BYTES)
                 },
-            ): vol.All(
+            ): prob.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=0,
@@ -1363,9 +1376,9 @@ class BaseRamsesFlow:
                         mode=selector.NumberSelectorMode.BOX,
                     )
                 ),
-                vol.Coerce(int),
+                prob.Coerce(int),
             ),
-            vol.Optional(
+            prob.Optional(
                 SZ_BUFFER_CAPACITY,
                 default=0,
                 description={
@@ -1373,7 +1386,7 @@ class BaseRamsesFlow:
                         SZ_BUFFER_CAPACITY, 0
                     )
                 },
-            ): vol.All(
+            ): prob.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=0,
@@ -1381,9 +1394,9 @@ class BaseRamsesFlow:
                         mode=selector.NumberSelectorMode.BOX,
                     )
                 ),
-                vol.Coerce(int),
+                prob.Coerce(int),
             ),
-            vol.Optional(
+            prob.Optional(
                 SZ_FLUSH_INTERVAL,
                 default=60.0,
                 description={
@@ -1391,7 +1404,7 @@ class BaseRamsesFlow:
                         SZ_FLUSH_INTERVAL, 60.0
                     )
                 },
-            ): vol.All(
+            ): prob.All(
                 selector.NumberSelector(
                     selector.NumberSelectorConfig(
                         min=0,
@@ -1400,9 +1413,9 @@ class BaseRamsesFlow:
                         mode=selector.NumberSelectorMode.BOX,
                     )
                 ),
-                vol.Coerce(float),
+                prob.Coerce(float),
             ),
-            vol.Optional(
+            prob.Optional(
                 "flush_level",
                 default=str(logging.ERROR),
                 description={
@@ -1433,7 +1446,7 @@ class BaseRamsesFlow:
 
         return self.async_show_form(
             step_id="packet_log",
-            data_schema=vol.Schema(
+            data_schema=prob.Schema(
                 # cv.deprecated(
                 #     "file_name", raise_if_present=False
                 # ),  # Deprecated Q3 2026
@@ -1441,7 +1454,7 @@ class BaseRamsesFlow:
                 #     "rotate_backups", raise_if_present=False
                 # ),    # Deprecated Q3 2026
                 data_schema,
-                extra=vol.ALLOW_EXTRA,
+                extra=prob.ALLOW_EXTRA,
             ),  # extra = migration from v1
         )
 
@@ -2153,7 +2166,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # yet, this fills it in.
         existing_owner = self.options.get(CONF_SCHEMA, {}).get(SZ_OWNER, "")
         form_fields[
-            vol.Required(
+            prob.Required(
                 "owner_name",
                 default=existing_owner or "me",
                 description={
@@ -2165,7 +2178,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         # Bulk action selector — applies to all devices that are still "skip"
         form_fields[
-            vol.Required(
+            prob.Required(
                 "bulk_action",
                 default="none",
                 description={
@@ -2202,7 +2215,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             field_label = " | ".join(desc_parts)
 
             form_fields[
-                vol.Required(
+                prob.Required(
                     f"device_{device_id}",
                     default="skip",
                     description={"label": field_label},
@@ -2217,7 +2230,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 )
             )
             form_fields[
-                vol.Optional(
+                prob.Optional(
                     f"owner_{device_id}",
                     description={
                         "label": f"Owner for {device_id} (overrides "
@@ -2243,7 +2256,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 f"discovery suggests {disc_cls} (conf={d.confidence})"
             )
             form_fields[
-                vol.Required(
+                prob.Required(
                     f"mismatch_{device_id}",
                     default="skip",
                     description={"label": field_label},
@@ -2268,7 +2281,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 else ""
             )
             form_fields[
-                vol.Optional(
+                prob.Optional(
                     f"owner_{device_id}",
                     description={
                         "label": f"Owner for {device_id} (overrides "
@@ -2289,7 +2302,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 f"discovery suggests {disc_cls} (conf={d.confidence})"
             )
             form_fields[
-                vol.Required(
+                prob.Required(
                     f"missing_class_{device_id}",
                     default="skip",
                     description={"label": field_label},
@@ -2313,7 +2326,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 else ""
             )
             form_fields[
-                vol.Optional(
+                prob.Optional(
                     f"owner_{device_id}",
                     description={
                         "label": f"Owner for {device_id} (overrides "
@@ -2345,7 +2358,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 f"controller reports {ctrl_name}"
             )
             form_fields[
-                vol.Required(
+                prob.Required(
                     f"name_mismatch_{device_id}",
                     default="update_name",
                     description={"label": field_label},
@@ -2367,7 +2380,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="review_discovered",
-            data_schema=vol.Schema(form_fields),
+            data_schema=prob.Schema(form_fields),
             description_placeholders={"message": summary},
             last_step=True,
         )
@@ -2630,7 +2643,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 f"last seen: {last_seen} | LOST"
             )
             form_fields[
-                vol.Required(
+                prob.Required(
                     f"lost_{device_id}",
                     default="keep",
                     description={"label": field_label},
@@ -2653,7 +2666,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 f"last seen: {last_seen} | orphaned"
             )
             form_fields[
-                vol.Required(
+                prob.Required(
                     f"orphaned_{device_id}",
                     default="keep",
                     description={"label": field_label},
@@ -2673,7 +2686,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             note = entry.metadata.weak_signal or ""
             field_label = f"{device_id} | {d.likely_type or '?'} | {note}"
             form_fields[
-                vol.Required(
+                prob.Required(
                     f"weak_{device_id}",
                     default="keep",
                     description={"label": field_label},
@@ -2695,7 +2708,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="review_device_health",
-            data_schema=vol.Schema(form_fields),
+            data_schema=prob.Schema(form_fields),
             description_placeholders={"message": summary},
             last_step=True,
         )
@@ -2864,13 +2877,13 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             return self.async_abort(reason="cache_cleared")
 
         data_schema = {
-            vol.Required(
+            prob.Required(
                 "clear_schema", default=False
             ): selector.BooleanSelector(),
-            vol.Required(
+            prob.Required(
                 "clear_packets", default=False
             ): selector.BooleanSelector(),
-            vol.Required(
+            prob.Required(
                 "clear_discovery", default=False
             ): selector.BooleanSelector(),
             # clear_known_list was removed in Phase 4 — known_list is now
@@ -2879,5 +2892,5 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="clear_cache",
-            data_schema=vol.Schema(data_schema),
+            data_schema=prob.Schema(data_schema),
         )

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 from threading import Semaphore
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
-import probatio as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as prob
 import serial  # type: ignore[import-untyped]
 from homeassistant.components.persistent_notification import (
     async_create as async_create_notification,
@@ -557,7 +557,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ):
             try:
                 self.client = self._create_client(merged_schema)
-            except (LookupError, vol.MultipleInvalid) as err:
+            except (LookupError, prob.MultipleInvalid) as err:
                 _LOGGER.warning(
                     "Failed to initialise with merged schema: %s", err
                 )
@@ -566,7 +566,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if not self.client:
             try:
                 self.client = self._create_client(config_schema)
-            except (ValueError, vol.Invalid) as err:
+            except (ValueError, prob.Invalid) as err:
                 _LOGGER.error(
                     "Critical error: Failed to initialise client with "
                     "config schema: %s",
@@ -908,7 +908,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         """Validate the schema against ramses_rf's strict validator.
 
         Strips ramses_cc-only extension keys and validates the result
-        against ``SCH_GLOBAL_SCHEMAS`` (which uses ``vol.PREVENT_EXTRA``).
+        against ``SCH_GLOBAL_SCHEMAS`` (which uses ``prob.PREVENT_EXTRA``).
         Logs a warning and raises ``ValueError`` if the schema is invalid,
         so the caller can decide whether to save the (invalid) schema or
         skip the save to avoid corrupting the config entry.
@@ -945,7 +945,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             from ramses_rf.schemas import SCH_GLOBAL_SCHEMAS
 
             SCH_GLOBAL_SCHEMAS(stripped)
-        except vol.Invalid as err:
+        except prob.Invalid as err:
             _LOGGER.error(
                 "Schema validation failed before save: %s. Stripped: %s",
                 err,

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -16,8 +16,8 @@ from functools import lru_cache
 from threading import Semaphore
 from typing import TYPE_CHECKING, Any, Final, TypeVar
 
+import probatio as vol  # type: ignore[import-untyped, unused-ignore]
 import serial  # type: ignore[import-untyped]
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.components.persistent_notification import (
     async_create as async_create_notification,
     async_dismiss as async_dismiss_notification,

--- a/custom_components/ramses_cc/ha_compat.py
+++ b/custom_components/ramses_cc/ha_compat.py
@@ -230,22 +230,32 @@ def make_entity_service_schema(
 ) -> VolSchemaType:
     """Drop-in replacement for ``cv.make_entity_service_schema``.
 
-    ``schemas.py`` uses ``import voluptuous as vol`` — the same module
-    that ``cv`` uses internally.  On HA 2026.9+ both are probatio (via
-    ``install_as_voluptuous``); on pre-2026.9 both are real voluptuous.
-    In either case the markers are already compatible with
-    ``cv.make_entity_service_schema``, so no conversion is needed.
+    ``schemas.py`` uses ``import probatio as vol``, so schema markers
+    are probatio markers.  ``cv.make_entity_service_schema`` uses
+    ``cv.vol`` internally — on HA 2026.9+ this is also probatio (via
+    ``install_as_voluptuous``), so markers are compatible.  On
+    pre-2026.9 HA, ``cv.vol`` is real voluptuous, which doesn't
+    recognise probatio markers — so we convert them first.
 
-    This wrapper exists for forward-compatibility: if a future PR
-    switches ``schemas.py`` to ``import probatio as vol`` while
-    ``cv`` still uses real voluptuous, the conversion logic can be
-    re-enabled here.
-
-    :param schema: Service schema dict.
+    :param schema: Service schema dict with probatio markers.
     :type schema: dict[str, Any] | None
     :param extra: Voluptuous extra-keys policy (default: PREVENT_EXTRA).
     :type extra: int
     :returns: Compiled entity service schema.
     :rtype: VolSchemaType
     """
-    return cv.make_entity_service_schema(schema, extra=extra)
+    if not schema:
+        return cv.make_entity_service_schema(schema, extra=extra)
+
+    # schemas.py uses `import probatio as vol`, so markers are probatio.
+    # If cv.vol is also probatio (HA 2026.9+), markers are compatible.
+    # If cv.vol is real voluptuous (pre-2026.9), convert probatio markers.
+    if cv.vol is not _REAL_VOL:
+        # cv.vol is probatio — no conversion needed
+        return cv.make_entity_service_schema(schema, extra=extra)
+
+    # cv.vol is real voluptuous — convert probatio markers
+    converted: dict[Any, Any] = {
+        _convert_marker(key): value for key, value in schema.items()
+    }
+    return cv.make_entity_service_schema(converted, extra=extra)

--- a/custom_components/ramses_cc/ha_compat.py
+++ b/custom_components/ramses_cc/ha_compat.py
@@ -1,0 +1,251 @@
+"""Compatibility helpers for probatio/voluptuous marker conversion.
+
+HA Core's ``cv.make_entity_service_schema()`` internally builds a
+voluptuous ``Schema``, which recognises dict keys via
+``isinstance(key, voluptuous.Required/Optional)``.  probatio markers
+(``probatio.markers.Required``, ``probatio.markers.Optional``) are
+**different classes**, so voluptuous does not recognise them and raises
+``SchemaError: unsupported schema data type 'Required'``.
+
+On HA 2026.9+ ``install_as_voluptuous()`` aliases ``voluptuous`` to
+``probatio`` in ``sys.modules``, so the markers are already compatible
+and conversion is a no-op.  On pre-2026.9 HA Core the real voluptuous
+is in use and probatio markers must be converted.
+
+This module provides :func:`make_entity_service_schema`, a drop-in
+replacement for ``cv.make_entity_service_schema`` that handles the
+conversion transparently.  It works regardless of whether the caller
+imports ``voluptuous`` or ``probatio`` as ``vol``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as _vol  # real voluptuous (or probatio if aliased by HA 2026.9+)
+from homeassistant.helpers import config_validation as cv
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.service import VolSchemaType
+
+# Sentinel exported by probatio for "no default specified".  When the
+# default is UNDEFINED we must *not* pass ``default=`` to the voluptuous
+# marker constructor, otherwise voluptuous would treat ``None`` as the
+# default value rather than "no default".
+try:
+    from probatio import UNDEFINED as _PROBATIO_UNDEFINED
+except ImportError:  # probatio not installed (pre-2026.9 HA Core without it)
+    _PROBATIO_UNDEFINED = object()  # unique sentinel, never matched
+
+
+def _get_real_voluptuous() -> Any:
+    """Return the real voluptuous module, bypassing the probatio alias.
+
+    HA 2026.9+ calls ``install_as_voluptuous()`` which replaces
+    ``sys.modules['voluptuous']`` with probatio.  ``voluptuous_serialize``
+    (used by HA's config flow REST API) only recognises real voluptuous
+    ``Schema`` objects, so form schemas must be built with real
+    voluptuous — not the probatio alias.
+
+    On pre-2026.9 HA (no aliasing), ``_vol`` is already real voluptuous
+    and this function returns the same module.
+    """
+    # If _vol is already real voluptuous (not probatio), return it.
+    if (
+        not hasattr(_vol, "UNDEFINED") or _vol.__name__ == "voluptuous"
+    ):  # pragma: no cover
+        return _vol
+
+    # _vol is probatio — temporarily remove the alias and import real voluptuous.
+    saved: dict[str, Any] = {}
+    for key in list(sys.modules):
+        if key == "voluptuous" or key.startswith("voluptuous."):
+            saved[key] = sys.modules.pop(key)
+    try:
+        return importlib.import_module("voluptuous")
+    finally:
+        sys.modules.update(saved)
+
+
+# Real voluptuous module (resolved once at import time).
+# On HA 2026.9+ this is the actual voluptuous, not the probatio alias.
+_REAL_VOL: Any = _get_real_voluptuous()
+
+
+def _convert_marker(marker: Any) -> Any:
+    """Convert a probatio Required/Optional marker to a voluptuous marker.
+
+    If *marker* is already a voluptuous marker (HA 2026.9+ where
+    voluptuous is aliased to probatio, or when the caller still uses
+    ``import voluptuous as vol``), it is returned unchanged.
+
+    :param marker: The dict key to convert.
+    :type marker: Any
+    :returns: A voluptuous-compatible marker.
+    :rtype: Any
+    """
+    # Already a voluptuous marker — no conversion needed.  On HA 2026.9+
+    # voluptuous IS probatio (via install_as_voluptuous), so probatio
+    # markers pass this check too.
+    if isinstance(marker, (_REAL_VOL.Required, _REAL_VOL.Optional)):
+        return marker
+
+    cls_name = type(marker).__name__
+    if cls_name not in ("Required", "Optional"):
+        return marker
+
+    # Build kwargs, omitting UNDEFINED defaults so voluptuous uses its
+    # own "no default" sentinel (Ellipsis).
+    kwargs: dict[str, Any] = {}
+    if not _is_undefined(getattr(marker, "default", _PROBATIO_UNDEFINED)):
+        kwargs["default"] = marker.default
+    desc = getattr(marker, "description", None)
+    if desc is not None:
+        kwargs["description"] = desc
+    msg = getattr(marker, "msg", None)
+    if msg is not None:
+        kwargs["msg"] = msg
+
+    if cls_name == "Required":
+        return _REAL_VOL.Required(marker.schema, **kwargs)
+    return _REAL_VOL.Optional(marker.schema, **kwargs)
+
+
+def _is_undefined(value: Any) -> bool:
+    """Check whether *value* is a probatio UNDEFINED sentinel."""
+    return value is _PROBATIO_UNDEFINED
+
+
+def convert_form_schema(schema: dict[Any, Any]) -> dict[Any, Any]:
+    """Convert probatio markers in a form schema dict to voluptuous markers.
+
+    HA's config flow framework calls ``voluptuous_serialize.convert()`` on
+    the ``data_schema`` passed to ``async_show_form()``.  If the schema
+    dict has probatio ``Required``/``Optional`` markers as keys,
+    ``voluptuous_serialize`` (which uses real voluptuous) cannot recognise
+    them and raises ``ValueError: Unable to convert schema``.
+
+    This function walks the dict keys and converts any probatio markers
+    to their voluptuous equivalents.  On HA 2026.9+ (where voluptuous is
+    aliased to probatio) the conversion is a no-op.
+
+    :param schema: Form schema dict, possibly with probatio markers.
+    :type schema: dict[Any, Any]
+    :returns: A new dict with voluptuous-compatible markers.
+    :rtype: dict[Any, Any]
+    """
+    return {_convert_marker(key): value for key, value in schema.items()}
+
+
+def vol_schema(schema: dict[Any, Any], *, extra: int = 0) -> Any:
+    """Build a schema from a dict that may contain probatio markers.
+
+    This is a drop-in replacement for ``vol.Schema(schema)`` when *schema*
+    may contain probatio ``Required``/``Optional`` markers as keys.
+
+    HA's config flow framework serialises the ``data_schema`` passed to
+    ``async_show_form()`` via ``voluptuous_serialize.convert()``, which
+    uses **real voluptuous** markers.  It also validates user input by
+    calling ``data_schema(user_input)``.
+
+    Two scenarios:
+
+    - **HA 2026.9+** (``install_as_voluptuous`` active): ``_vol`` is
+      probatio, ``_REAL_VOL`` is real voluptuous.  Probatio markers are
+      NOT instances of real voluptuous markers, so
+      ``voluptuous_serialize`` cannot serialise them.  We convert them
+      to real voluptuous markers and build a **real voluptuous Schema**
+      so both serialisation and validation work.
+
+    - **Pre-2026.9 HA** (no aliasing): ``_vol`` is already real
+      voluptuous, so ``_vol is _REAL_VOL`` and conversion is a no-op.
+      We build a real voluptuous Schema (same as before).
+
+    :param schema: Schema dict, possibly with probatio markers.
+    :type schema: dict[Any, Any]
+    :param extra: Voluptuous extra-keys policy (default: 0 = ALLOW_EXTRA).
+    :type extra: int
+    :returns: A Schema callable that serialises via voluptuous_serialize
+        and raises ``_vol.Invalid`` on validation failure.
+    :rtype: Any
+    """
+    converted = convert_form_schema(schema)
+    real_schema = _REAL_VOL.Schema(converted, extra=extra)
+
+    # If _vol is _REAL_VOL (pre-2026.9, no aliasing), return as-is.
+    if _vol is _REAL_VOL:
+        return real_schema
+
+    # _vol is probatio (HA 2026.9+).  The real voluptuous Schema raises
+    # voluptuous.Invalid, but config_flow.py catches _vol.Invalid
+    # (probatio.Invalid).  Wrap the schema so validation errors are
+    # converted to the active vol module's Invalid type.
+    # The wrapper also exposes the .schema attribute (used by HA's
+    # data_entry_flow to inspect schema keys) and is recognised by
+    # voluptuous_serialize via isinstance check on the underlying
+    # real voluptuous Schema.
+    class _SchemaWrapper:
+        """Wrap a real voluptuous Schema, converting Invalid types."""
+
+        def __call__(self, data: Any) -> Any:
+            try:
+                return real_schema(data)
+            except _REAL_VOL.MultipleInvalid as e:
+                # Convert each voluptuous.Invalid to probatio.Invalid
+                prob_errors = [
+                    _vol.Invalid(
+                        err.msg if hasattr(err, "msg") else str(err),
+                        list(err.path),
+                    )
+                    for err in e.errors
+                ]
+                raise _vol.MultipleInvalid(prob_errors) from e
+            except _REAL_VOL.Invalid as e:
+                raise _vol.Invalid(
+                    e.msg if hasattr(e, "msg") else str(e),
+                    list(e.path),
+                ) from e
+
+        @property
+        def schema(self) -> Any:
+            return real_schema.schema
+
+        def __instancecheck__(self, instance: Any) -> bool:  # pragma: no cover
+            return isinstance(instance, _REAL_VOL.Schema)
+
+    wrapper = _SchemaWrapper()
+    # Mark it as a Schema-like object for voluptuous_serialize
+    # (which checks isinstance(schema, vol.Schema) — but since vol is
+    # probatio, this check would fail anyway.  voluptuous_serialize
+    # actually checks for the .schema attribute, not isinstance.)
+    return wrapper
+
+
+def make_entity_service_schema(
+    schema: dict[str, Any] | None,
+    *,
+    extra: int = _vol.PREVENT_EXTRA,
+) -> VolSchemaType:
+    """Drop-in replacement for ``cv.make_entity_service_schema``.
+
+    ``schemas.py`` uses ``import voluptuous as vol`` — the same module
+    that ``cv`` uses internally.  On HA 2026.9+ both are probatio (via
+    ``install_as_voluptuous``); on pre-2026.9 both are real voluptuous.
+    In either case the markers are already compatible with
+    ``cv.make_entity_service_schema``, so no conversion is needed.
+
+    This wrapper exists for forward-compatibility: if a future PR
+    switches ``schemas.py`` to ``import probatio as vol`` while
+    ``cv`` still uses real voluptuous, the conversion logic can be
+    re-enabled here.
+
+    :param schema: Service schema dict.
+    :type schema: dict[str, Any] | None
+    :param extra: Voluptuous extra-keys policy (default: PREVENT_EXTRA).
+    :type extra: int
+    :returns: Compiled entity service schema.
+    :rtype: VolSchemaType
+    """
+    return cv.make_entity_service_schema(schema, extra=extra)

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from datetime import timedelta as td
 from typing import Any, Final, cast
 
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers import config_validation as cv
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from datetime import timedelta as td
 from typing import Any, Final, cast
 
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers import config_validation as cv
 
@@ -104,6 +104,7 @@ from .const import (
     SystemMode,
     ZoneMode,
 )
+from .ha_compat import make_entity_service_schema
 
 _SchemaT = dict[str, Any]
 
@@ -2737,7 +2738,7 @@ def sync_learned_topology(
 
 
 SCH_NO_SVC_PARAMS = vol.Schema({}, extra=vol.PREVENT_EXTRA)
-SCH_NO_ENTITY_SVC_PARAMS = cv.make_entity_service_schema(
+SCH_NO_ENTITY_SVC_PARAMS = make_entity_service_schema(
     {},
     extra=vol.PREVENT_EXTRA,
 )
@@ -2866,7 +2867,7 @@ MIN_CO2_LEVEL: Final[int] = 300
 MAX_CO2_LEVEL: Final[int] = 9999
 
 SVC_PUT_CO2_LEVEL: Final = "put_co2_level"
-SCH_PUT_CO2_LEVEL = cv.make_entity_service_schema(
+SCH_PUT_CO2_LEVEL = make_entity_service_schema(
     {
         vol.Required(ATTR_CO2_LEVEL): vol.All(
             cv.positive_int,
@@ -2880,7 +2881,7 @@ MIN_DHW_TEMP: Final[float] = 0
 MAX_DHW_TEMP: Final[float] = 99
 
 SVC_PUT_DHW_TEMP: Final = "put_dhw_temp"
-SCH_PUT_DHW_TEMP = cv.make_entity_service_schema(
+SCH_PUT_DHW_TEMP = make_entity_service_schema(
     {
         vol.Required(ATTR_TEMPERATURE): vol.All(
             vol.Coerce(float),
@@ -2894,7 +2895,7 @@ MIN_INDOOR_HUMIDITY: Final[float] = 0
 MAX_INDOOR_HUMIDITY: Final[float] = 100
 
 SVC_PUT_INDOOR_HUMIDITY: Final = "put_indoor_humidity"
-SCH_PUT_INDOOR_HUMIDITY = cv.make_entity_service_schema(
+SCH_PUT_INDOOR_HUMIDITY = make_entity_service_schema(
     {
         vol.Required(ATTR_INDOOR_HUMIDITY): vol.All(
             cv.positive_float,
@@ -2908,7 +2909,7 @@ MIN_ROOM_TEMP: Final[float] = -20
 MAX_ROOM_TEMP: Final[float] = 60
 
 SVC_PUT_ROOM_TEMP: Final = "put_room_temp"
-SCH_PUT_ROOM_TEMP = cv.make_entity_service_schema(
+SCH_PUT_ROOM_TEMP = make_entity_service_schema(
     {
         vol.Required(ATTR_TEMPERATURE): vol.All(
             vol.Coerce(float),
@@ -2936,7 +2937,7 @@ SCH_PERIOD = vol.All(  # of days (0-99)
 )
 
 SVC_SET_SYSTEM_MODE: Final = "set_system_mode"
-SCH_SET_SYSTEM_MODE = cv.make_entity_service_schema(
+SCH_SET_SYSTEM_MODE = make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
         vol.Required(ATTR_MODE): vol.In(SystemMode),
@@ -2985,7 +2986,7 @@ MIN_MAX_TEMP: Final[float] = 21
 MAX_MAX_TEMP: Final[float] = 35
 
 SVC_SET_ZONE_CONFIG: Final = "set_zone_config"
-SCH_SET_ZONE_CONFIG = cv.make_entity_service_schema(
+SCH_SET_ZONE_CONFIG = make_entity_service_schema(
     {
         vol.Optional(ATTR_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.All(
             cv.positive_float, vol.Range(min=MIN_MAX_TEMP, max=MAX_MAX_TEMP)
@@ -3000,7 +3001,7 @@ SCH_SET_ZONE_CONFIG = cv.make_entity_service_schema(
 )
 
 SVC_SET_ZONE_MODE: Final = "set_zone_mode"
-SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
+SCH_SET_ZONE_MODE = make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
         vol.Required(ATTR_MODE): vol.In(
@@ -3063,7 +3064,7 @@ SCH_SET_ZONE_MODE_EXTRA = (
 )
 
 SVC_SET_ZONE_SCHEDULE: Final = "set_zone_schedule"
-SCH_SET_ZONE_SCHEDULE = cv.make_entity_service_schema(
+SCH_SET_ZONE_SCHEDULE = make_entity_service_schema(
     {
         vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
@@ -3074,7 +3075,7 @@ MIN_NUM_ENTRIES: Final[float] = 1
 MAX_NUM_ENTRIES: Final[float] = 64
 
 SVC_GET_SYSTEM_FAULTS: Final = "get_system_faults"
-SCH_GET_SYSTEM_FAULTS = cv.make_entity_service_schema(
+SCH_GET_SYSTEM_FAULTS = make_entity_service_schema(
     {
         vol.Required(ATTR_NUM_ENTRIES, default=DEFAULT_NUM_ENTRIES): vol.All(
             cv.positive_int,
@@ -3099,7 +3100,7 @@ _TARGET_FIELDS = {
     vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
 }
 
-SCH_GET_FAN_PARAM = cv.make_entity_service_schema(
+SCH_GET_FAN_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3108,7 +3109,7 @@ SCH_GET_FAN_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_GET_FAN_REM_PARAM = cv.make_entity_service_schema(
+SCH_GET_FAN_REM_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3116,7 +3117,7 @@ SCH_GET_FAN_REM_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_SET_FAN_PARAM = cv.make_entity_service_schema(
+SCH_SET_FAN_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3126,7 +3127,7 @@ SCH_SET_FAN_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_SET_FAN_REM_PARAM = cv.make_entity_service_schema(
+SCH_SET_FAN_REM_PARAM = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Required("param_id"): _SCH_PARAM_ID,
@@ -3135,7 +3136,7 @@ SCH_SET_FAN_REM_PARAM = cv.make_entity_service_schema(
     extra=vol.PREVENT_EXTRA,
 )
 
-SCH_UPDATE_FAN_PARAMS = cv.make_entity_service_schema(
+SCH_UPDATE_FAN_PARAMS = make_entity_service_schema(
     {
         **_TARGET_FIELDS,
         vol.Optional("from_id"): _SCH_DEVICE_ID,
@@ -3214,7 +3215,7 @@ SVCS_RAMSES_CLIMATE = {
 # services for water_heater platform
 
 SVC_SET_DHW_MODE: Final = "set_dhw_mode"
-SCH_SET_DHW_MODE = cv.make_entity_service_schema(
+SCH_SET_DHW_MODE = make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
         vol.Required(ATTR_MODE): vol.In(
@@ -3289,7 +3290,7 @@ MIN_DIFFERENTIAL: Final[float] = 1
 MAX_DIFFERENTIAL: Final[float] = 10
 
 SVC_SET_DHW_PARAMS: Final = "set_dhw_params"
-SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
+SCH_SET_DHW_PARAMS = make_entity_service_schema(
     {
         vol.Optional(ATTR_SETPOINT, default=DEFAULT_DHW_SETPOINT): vol.All(
             cv.positive_float,
@@ -3306,7 +3307,7 @@ SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
 )
 
 SVC_SET_DHW_SCHEDULE: Final = "set_dhw_schedule"
-SCH_SET_DHW_SCHEDULE = cv.make_entity_service_schema(
+SCH_SET_DHW_SCHEDULE = make_entity_service_schema(
     {
         vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
@@ -3336,7 +3337,7 @@ MIN_TIMEOUT: Final[int] = 30
 MAX_TIMEOUT: Final[int] = 300
 
 SVC_LEARN_COMMAND: Final = "learn_command"
-SCH_LEARN_COMMAND = cv.make_entity_service_schema(
+SCH_LEARN_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
         vol.Required(ATTR_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
@@ -3349,7 +3350,7 @@ SCH_LEARN_COMMAND = cv.make_entity_service_schema(
 
 # add_command (inject a packet without RF learning loop)
 SVC_ADD_COMMAND: Final = "add_command"
-SCH_ADD_COMMAND = cv.make_entity_service_schema(
+SCH_ADD_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
         vol.Required("packet_string"): cv.string,
@@ -3357,7 +3358,7 @@ SCH_ADD_COMMAND = cv.make_entity_service_schema(
 )
 
 SVC_SEND_COMMAND: Final = "send_command"
-SCH_SEND_COMMAND = cv.make_entity_service_schema(
+SCH_SEND_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
         vol.Required(ATTR_NUM_REPEATS, default=3): vol.All(
@@ -3372,7 +3373,7 @@ SCH_SEND_COMMAND = cv.make_entity_service_schema(
 )
 
 SVC_DELETE_COMMAND: Final = "delete_command"
-SCH_DELETE_COMMAND = cv.make_entity_service_schema(
+SCH_DELETE_COMMAND = make_entity_service_schema(
     {
         vol.Required(ATTR_COMMAND): cv.string,
     },

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from datetime import timedelta as td
 from typing import Any, Final, cast
 
-import probatio as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as prob
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers import config_validation as cv
 
@@ -143,29 +143,29 @@ SCAN_INTERVAL_MINIMUM = td(seconds=3)
 _SCH_DEVICE_ID = cv.matches_regex(r"^[0-9]{2}:[0-9]{6}$")
 _SCH_CMD_CODE = cv.matches_regex(r"^[0-9A-F]{4}$")
 _SCH_DOM_INDEX = cv.matches_regex(r"^[0-9A-F]{2}$")
-_SCH_PARAM_ID = vol.All(cv.string, cv.matches_regex(r"^[0-9A-F]{2}$"))
+_SCH_PARAM_ID = prob.All(cv.string, cv.matches_regex(r"^[0-9A-F]{2}$"))
 _SCH_COMMAND = cv.matches_regex(COMMAND_REGEX.pattern)
 
-SCH_ADVANCED_FEATURES = vol.Schema(
+SCH_ADVANCED_FEATURES = prob.Schema(
     {
-        vol.Optional(CONF_SEND_PACKET, default=False): cv.boolean,
-        vol.Optional(CONF_MESSAGE_EVENTS, default=None): vol.Any(
+        prob.Optional(CONF_SEND_PACKET, default=False): cv.boolean,
+        prob.Optional(CONF_MESSAGE_EVENTS, default=None): prob.Any(
             None, cv.is_regex
         ),
-        vol.Optional(CONF_DEV_MODE): cv.boolean,
-        vol.Optional(CONF_UNKNOWN_CODES): cv.boolean,
-        vol.Optional(CONF_PASSIVE_SCAN, default=True): cv.boolean,
-        vol.Optional(CONF_AUTO_NOTIFY, default=True): cv.boolean,
-        vol.Optional(CONF_LOST_THRESHOLD, default=7): vol.All(
-            cv.positive_int, vol.Range(min=1, max=90)
+        prob.Optional(CONF_DEV_MODE): cv.boolean,
+        prob.Optional(CONF_UNKNOWN_CODES): cv.boolean,
+        prob.Optional(CONF_PASSIVE_SCAN, default=True): cv.boolean,
+        prob.Optional(CONF_AUTO_NOTIFY, default=True): cv.boolean,
+        prob.Optional(CONF_LOST_THRESHOLD, default=7): prob.All(
+            cv.positive_int, prob.Range(min=1, max=90)
         ),
     }
 )
 
 # Define the traits for FAN devices
 FAN_TRAITS = {
-    vol.Optional(SZ_BOUND_TO): vol.Any(None, _SCH_DEVICE_ID),
-    vol.Optional(CONF_COMMANDS): dict,
+    prob.Optional(SZ_BOUND_TO): prob.Any(None, _SCH_DEVICE_ID),
+    prob.Optional(CONF_COMMANDS): dict,
 }
 
 SCH_GLOBAL_TRAITS_DICT, SCH_TRAITS = sch_global_traits_dict_factory(
@@ -174,23 +174,23 @@ SCH_GLOBAL_TRAITS_DICT, SCH_TRAITS = sch_global_traits_dict_factory(
 
 SCH_GATEWAY_CONFIG = SCH_GATEWAY_CONFIG.extend(
     SCH_ENGINE_DICT,
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 SCH_PACKET_LOG = sch_packet_log_dict_factory(default_backups=7)
 
 SCH_DOMAIN_CONFIG = (
-    vol.Schema(
+    prob.Schema(
         {
-            vol.Optional(CONF_RAMSES_RF, default={}): SCH_GATEWAY_CONFIG,
-            vol.Optional(
+            prob.Optional(CONF_RAMSES_RF, default={}): SCH_GATEWAY_CONFIG,
+            prob.Optional(
                 CONF_SCAN_INTERVAL, default=SCAN_INTERVAL_DEFAULT
-            ): vol.All(cv.time_period, vol.Range(min=SCAN_INTERVAL_MINIMUM)),
-            vol.Optional(
+            ): prob.All(cv.time_period, prob.Range(min=SCAN_INTERVAL_MINIMUM)),
+            prob.Optional(
                 CONF_ADVANCED_FEATURES, default={}
             ): SCH_ADVANCED_FEATURES,
         },
-        extra=vol.PREVENT_EXTRA,  # system/orphan schemas for ramses_rf
+        extra=prob.PREVENT_EXTRA,  # system/orphan schemas for ramses_rf
     )
     .extend(SCH_GLOBAL_SCHEMAS_DICT)
     .extend(SCH_GLOBAL_TRAITS_DICT)
@@ -199,20 +199,20 @@ SCH_DOMAIN_CONFIG = (
     .extend(sch_serial_port_dict_factory())
 )
 
-SCH_MINIMUM_TCS = vol.Schema(
+SCH_MINIMUM_TCS = prob.Schema(
     {
-        vol.Optional(SZ_SYSTEM): vol.Schema(
-            {vol.Required(SZ_APPLIANCE_CONTROL): vol.Match(r"^10:[0-9]{6}$")}
+        prob.Optional(SZ_SYSTEM): prob.Schema(
+            {prob.Required(SZ_APPLIANCE_CONTROL): prob.Match(r"^10:[0-9]{6}$")}
         ),
-        vol.Optional(SZ_ZONES, default={}): vol.Schema(
+        prob.Optional(SZ_ZONES, default={}): prob.Schema(
             {
-                vol.Required(str): vol.Schema(
-                    {vol.Required(SZ_SENSOR): vol.Match(r"^01:[0-9]{6}$")}
+                prob.Required(str): prob.Schema(
+                    {prob.Required(SZ_SENSOR): prob.Match(r"^01:[0-9]{6}$")}
                 )
             }
         ),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 
@@ -2736,38 +2736,40 @@ def sync_learned_topology(
     return order_schema(new_schema)
 
 
-SCH_NO_SVC_PARAMS = vol.Schema({}, extra=vol.PREVENT_EXTRA)
+SCH_NO_SVC_PARAMS = prob.Schema({}, extra=prob.PREVENT_EXTRA)
 SCH_NO_ENTITY_SVC_PARAMS = cv.make_entity_service_schema(
     {},
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 
 # services for ramses_cc integration
 
-_SCH_BINDING = vol.Schema(
-    {vol.Required(_SCH_CMD_CODE): vol.Any(None, _SCH_DOM_INDEX)}
+_SCH_BINDING = prob.Schema(
+    {prob.Required(_SCH_CMD_CODE): prob.Any(None, _SCH_DOM_INDEX)}
 )
 
-SCH_BIND_DEVICE = vol.Schema(
+SCH_BIND_DEVICE = prob.Schema(
     {
-        vol.Required("device_id"): _SCH_DEVICE_ID,
-        vol.Required("offer"): vol.All(_SCH_BINDING, vol.Length(min=1)),
-        vol.Optional("confirm", default={}): vol.Any(
-            {}, vol.All(_SCH_BINDING, vol.Length(min=1))
+        prob.Required("device_id"): _SCH_DEVICE_ID,
+        prob.Required("offer"): prob.All(_SCH_BINDING, prob.Length(min=1)),
+        prob.Optional("confirm", default={}): prob.Any(
+            {}, prob.All(_SCH_BINDING, prob.Length(min=1))
         ),
-        vol.Optional("device_info", default=None): vol.Any(None, _SCH_COMMAND),
+        prob.Optional("device_info", default=None): prob.Any(
+            None, _SCH_COMMAND
+        ),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_SEND_PACKET = vol.Schema(
+SCH_SEND_PACKET = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
-        vol.Optional("from_id"): _SCH_DEVICE_ID,
-        vol.Required("verb"): vol.In((" I", "I", "RQ", "RP", " W", "W")),
-        vol.Required("code"): cv.matches_regex(r"^[0-9A-F]{4}$"),
-        vol.Required("payload"): cv.matches_regex(
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Optional("from_id"): _SCH_DEVICE_ID,
+        prob.Required("verb"): prob.In((" I", "I", "RQ", "RP", " W", "W")),
+        prob.Required("code"): cv.matches_regex(r"^[0-9A-F]{4}$"),
+        prob.Required("payload"): cv.matches_regex(
             r"^([0-9A-F][0-9A-F]){1,48}$"
         ),
     }
@@ -2779,84 +2781,84 @@ SVC_SEND_PACKET: Final = "send_packet"
 SVC_SYNC_TOPOLOGY: Final = "sync_topology"
 SVC_PROBE_HVAC_BINDING: Final = "probe_hvac_binding"
 
-SCH_PROBE_HVAC_BINDING = vol.Schema(
+SCH_PROBE_HVAC_BINDING = prob.Schema(
     {
-        vol.Optional("device_id"): _SCH_DEVICE_ID,
-        vol.Optional("fan_id"): _SCH_DEVICE_ID,
+        prob.Optional("device_id"): _SCH_DEVICE_ID,
+        prob.Optional("fan_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_DISCOVER_KNOWN_DEVICES = vol.Schema(
+SCH_DISCOVER_KNOWN_DEVICES = prob.Schema(
     {
-        vol.Optional("device_id"): _SCH_DEVICE_ID,
+        prob.Optional("device_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 # Discovery scan service schemas
 
-SCH_GET_DISCOVERED_DEVICES = vol.Schema(
+SCH_GET_DISCOVERED_DEVICES = prob.Schema(
     {
-        vol.Optional("status"): vol.In(
+        prob.Optional("status"): prob.In(
             ("new", "accepted", "discarded", "removed", "lost")
         ),
-        vol.Optional("enabled"): cv.boolean,
+        prob.Optional("enabled"): cv.boolean,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_ACCEPT_DISCOVERED_DEVICE = vol.Schema(
+SCH_ACCEPT_DISCOVERED_DEVICE = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
-        vol.Optional("owner"): vol.All(str, vol.Length(max=50)),
-        vol.Optional("schema_entry"): dict,
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Optional("owner"): prob.All(str, prob.Length(max=50)),
+        prob.Optional("schema_entry"): dict,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_DISCARD_DISCOVERED_DEVICE = vol.Schema(
+SCH_DISCARD_DISCOVERED_DEVICE = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_REMOVE_DISCOVERED_DEVICE = vol.Schema(
+SCH_REMOVE_DISCOVERED_DEVICE = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_ENABLE_DISCOVERED_DEVICE = vol.Schema(
+SCH_ENABLE_DISCOVERED_DEVICE = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_DISABLE_DISCOVERED_DEVICE = vol.Schema(
+SCH_DISABLE_DISCOVERED_DEVICE = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_ADD_FAKED_REM = vol.Schema(
+SCH_ADD_FAKED_REM = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
-        vol.Required("bound_to"): _SCH_DEVICE_ID,
-        vol.Optional("alias"): vol.All(str, vol.Length(max=50)),
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Required("bound_to"): _SCH_DEVICE_ID,
+        prob.Optional("alias"): prob.All(str, prob.Length(max=50)),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_REMOVE_DEVICE = vol.Schema(
+SCH_REMOVE_DEVICE = prob.Schema(
     {
-        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 
@@ -2868,12 +2870,12 @@ MAX_CO2_LEVEL: Final[int] = 9999
 SVC_PUT_CO2_LEVEL: Final = "put_co2_level"
 SCH_PUT_CO2_LEVEL = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_CO2_LEVEL): vol.All(
+        prob.Required(ATTR_CO2_LEVEL): prob.All(
             cv.positive_int,
-            vol.Range(min=MIN_CO2_LEVEL, max=MAX_CO2_LEVEL),
+            prob.Range(min=MIN_CO2_LEVEL, max=MAX_CO2_LEVEL),
         ),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 MIN_DHW_TEMP: Final[float] = 0
@@ -2882,12 +2884,12 @@ MAX_DHW_TEMP: Final[float] = 99
 SVC_PUT_DHW_TEMP: Final = "put_dhw_temp"
 SCH_PUT_DHW_TEMP = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_TEMPERATURE): vol.All(
-            vol.Coerce(float),
-            vol.Range(min=MIN_DHW_TEMP, max=MAX_DHW_TEMP),
+        prob.Required(ATTR_TEMPERATURE): prob.All(
+            prob.Coerce(float),
+            prob.Range(min=MIN_DHW_TEMP, max=MAX_DHW_TEMP),
         ),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 MIN_INDOOR_HUMIDITY: Final[float] = 0
@@ -2896,12 +2898,12 @@ MAX_INDOOR_HUMIDITY: Final[float] = 100
 SVC_PUT_INDOOR_HUMIDITY: Final = "put_indoor_humidity"
 SCH_PUT_INDOOR_HUMIDITY = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_INDOOR_HUMIDITY): vol.All(
+        prob.Required(ATTR_INDOOR_HUMIDITY): prob.All(
             cv.positive_float,
-            vol.Range(min=MIN_INDOOR_HUMIDITY, max=MAX_INDOOR_HUMIDITY),
+            prob.Range(min=MIN_INDOOR_HUMIDITY, max=MAX_INDOOR_HUMIDITY),
         ),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 MIN_ROOM_TEMP: Final[float] = -20
@@ -2910,12 +2912,12 @@ MAX_ROOM_TEMP: Final[float] = 60
 SVC_PUT_ROOM_TEMP: Final = "put_room_temp"
 SCH_PUT_ROOM_TEMP = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_TEMPERATURE): vol.All(
-            vol.Coerce(float),
-            vol.Range(min=MIN_ROOM_TEMP, max=MAX_ROOM_TEMP),
+        prob.Required(ATTR_TEMPERATURE): prob.All(
+            prob.Coerce(float),
+            prob.Range(min=MIN_ROOM_TEMP, max=MAX_ROOM_TEMP),
         ),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 SVCS_RAMSES_SENSOR = {
@@ -2927,40 +2929,40 @@ SVCS_RAMSES_SENSOR = {
 
 # services for climate platform
 
-SCH_DURATION = vol.All(  # of time (<=24h)
+SCH_DURATION = prob.All(  # of time (<=24h)
     cv.time_period,
-    vol.Range(min=td(hours=1), max=td(hours=24)),
+    prob.Range(min=td(hours=1), max=td(hours=24)),
 )
-SCH_PERIOD = vol.All(  # of days (0-99)
-    cv.time_period, vol.Range(min=td(days=0), max=td(days=99))
+SCH_PERIOD = prob.All(  # of days (0-99)
+    cv.time_period, prob.Range(min=td(days=0), max=td(days=99))
 )
 
 SVC_SET_SYSTEM_MODE: Final = "set_system_mode"
 SCH_SET_SYSTEM_MODE = cv.make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
-        vol.Required(ATTR_MODE): vol.In(SystemMode),
-        vol.Optional(ATTR_DURATION): vol.Any(SCH_DURATION, None),
+        prob.Required(ATTR_MODE): prob.In(SystemMode),
+        prob.Optional(ATTR_DURATION): prob.Any(SCH_DURATION, None),
         # canBeTemporary: true, timingMode: Duration
-        vol.Optional(ATTR_PERIOD): vol.Any(SCH_PERIOD, None),
+        prob.Optional(ATTR_PERIOD): prob.Any(SCH_PERIOD, None),
         # Period: None indefinitely; 0 end of today, 1 end tomorrow
     }
 )
 
-SCH_SET_SYSTEM_MODE_EXTRA = vol.Schema(  # Entity Service schema
-    # vol.Msg(  # TODO turn on if good checks are working 8-2025
-    vol.Any(
+SCH_SET_SYSTEM_MODE_EXTRA = prob.Schema(  # Entity Service schema
+    # prob.Msg(  # TODO turn on if good checks are working 8-2025
+    prob.Any(
         {  # A also: Off, Heat, Cool (for pre-evohome)
-            vol.Required(ATTR_MODE): vol.In(
+            prob.Required(ATTR_MODE): prob.In(
                 [SystemMode.AUTO, SystemMode.HEAT_OFF, SystemMode.RESET]
             )
         },
         {  # B
-            vol.Required(ATTR_MODE): vol.In([SystemMode.ECO_BOOST]),
-            vol.Optional(ATTR_DURATION): vol.Any(SCH_DURATION, None),
+            prob.Required(ATTR_MODE): prob.In([SystemMode.ECO_BOOST]),
+            prob.Optional(ATTR_DURATION): prob.Any(SCH_DURATION, None),
         },  # duration: : None is indefinitely; 0 is invalid
         {  # C canBeTemporary: true, timingMode: Period
-            vol.Required(ATTR_MODE): vol.In(
+            prob.Required(ATTR_MODE): prob.In(
                 [
                     SystemMode.AWAY,
                     SystemMode.CUSTOM,
@@ -2968,12 +2970,12 @@ SCH_SET_SYSTEM_MODE_EXTRA = vol.Schema(  # Entity Service schema
                     SystemMode.DAY_OFF_ECO,
                 ]
             ),
-            vol.Optional(ATTR_PERIOD): vol.Any(SCH_PERIOD, None),
+            prob.Optional(ATTR_PERIOD): prob.Any(SCH_PERIOD, None),
         },  # Period: None indefinitely; 0 end of today, 1 end tomorrow
     ),
     #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
     # ),
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 DEFAULT_MIN_TEMP: Final[float] = 5
@@ -2987,15 +2989,15 @@ MAX_MAX_TEMP: Final[float] = 35
 SVC_SET_ZONE_CONFIG: Final = "set_zone_config"
 SCH_SET_ZONE_CONFIG = cv.make_entity_service_schema(
     {
-        vol.Optional(ATTR_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.All(
-            cv.positive_float, vol.Range(min=MIN_MAX_TEMP, max=MAX_MAX_TEMP)
+        prob.Optional(ATTR_MAX_TEMP, default=DEFAULT_MAX_TEMP): prob.All(
+            cv.positive_float, prob.Range(min=MIN_MAX_TEMP, max=MAX_MAX_TEMP)
         ),
-        vol.Optional(ATTR_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.All(
-            cv.positive_float, vol.Range(min=MIN_MIN_TEMP, max=MAX_MIN_TEMP)
+        prob.Optional(ATTR_MIN_TEMP, default=DEFAULT_MIN_TEMP): prob.All(
+            cv.positive_float, prob.Range(min=MIN_MIN_TEMP, max=MAX_MIN_TEMP)
         ),
-        vol.Optional(ATTR_LOCAL_OVERRIDE, default=True): cv.boolean,
-        vol.Optional(ATTR_OPENWINDOW, default=True): cv.boolean,
-        vol.Optional(ATTR_MULTIROOM, default=True): cv.boolean,
+        prob.Optional(ATTR_LOCAL_OVERRIDE, default=True): cv.boolean,
+        prob.Optional(ATTR_OPENWINDOW, default=True): cv.boolean,
+        prob.Optional(ATTR_MULTIROOM, default=True): cv.boolean,
     }
 )
 
@@ -3003,7 +3005,7 @@ SVC_SET_ZONE_MODE: Final = "set_zone_mode"
 SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
-        vol.Required(ATTR_MODE): vol.In(
+        prob.Required(ATTR_MODE): prob.In(
             [
                 ZoneMode.SCHEDULE,
                 ZoneMode.PERMANENT,
@@ -3011,61 +3013,61 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
                 ZoneMode.TEMPORARY,
             ]
         ),
-        vol.Optional(ATTR_SETPOINT): vol.All(
-            cv.positive_float, vol.Range(min=5, max=35)
+        prob.Optional(ATTR_SETPOINT): prob.All(
+            cv.positive_float, prob.Range(min=5, max=35)
         ),
-        vol.Optional(ATTR_UNTIL): cv.datetime,
-        vol.Optional(ATTR_DURATION): vol.All(
+        prob.Optional(ATTR_UNTIL): cv.datetime,
+        prob.Optional(ATTR_DURATION): prob.All(
             cv.time_period,
-            vol.Range(min=td(minutes=5), max=td(days=1)),
+            prob.Range(min=td(minutes=5), max=td(days=1)),
         ),
     }
 )
 
 SCH_SET_ZONE_MODE_EXTRA = (
-    vol.Schema(  # original Entity Service action validation schema
-        # vol.Msg(  # TODO turn msg on if checks are working 10-2025
-        vol.Any(
+    prob.Schema(  # original Entity Service action validation schema
+        # prob.Msg(  # TODO turn msg on if checks are working 10-2025
+        prob.Any(
             {  # A
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
+                prob.Required(ATTR_MODE): prob.In([ZoneMode.SCHEDULE]),
                 # only mode with no setpoint
             },
             {  # B
-                vol.Required(ATTR_MODE): vol.In(
+                prob.Required(ATTR_MODE): prob.In(
                     [ZoneMode.PERMANENT, ZoneMode.ADVANCED]
                 ),
-                vol.Required(ATTR_SETPOINT): vol.All(
-                    cv.positive_float, vol.Range(min=5, max=35)
+                prob.Required(ATTR_SETPOINT): prob.All(
+                    cv.positive_float, prob.Range(min=5, max=35)
                 ),
             },
             {  # C
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-                vol.Required(ATTR_SETPOINT): vol.All(
-                    cv.positive_float, vol.Range(min=5, max=35)
+                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
+                prob.Required(ATTR_SETPOINT): prob.All(
+                    cv.positive_float, prob.Range(min=5, max=35)
                 ),
-                vol.Required(ATTR_DURATION, default=td(hours=1)): vol.All(
+                prob.Required(ATTR_DURATION, default=td(hours=1)): prob.All(
                     cv.time_period,
-                    vol.Range(min=td(minutes=5), max=td(days=1)),
+                    prob.Range(min=td(minutes=5), max=td(days=1)),
                 ),
             },
             {  # D
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-                vol.Required(ATTR_SETPOINT): vol.All(
-                    cv.positive_float, vol.Range(min=5, max=35)
+                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
+                prob.Required(ATTR_SETPOINT): prob.All(
+                    cv.positive_float, prob.Range(min=5, max=35)
                 ),
-                vol.Required(ATTR_UNTIL): cv.datetime,
+                prob.Required(ATTR_UNTIL): cv.datetime,
             },
         ),
         #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
         # ),
-        extra=vol.PREVENT_EXTRA,
+        extra=prob.PREVENT_EXTRA,
     )
 )
 
 SVC_SET_ZONE_SCHEDULE: Final = "set_zone_schedule"
 SCH_SET_ZONE_SCHEDULE = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
+        prob.Required(ATTR_SCHEDULE): prob.Any(cv.string, dict, list),
     }
 )
 
@@ -3076,9 +3078,9 @@ MAX_NUM_ENTRIES: Final[float] = 64
 SVC_GET_SYSTEM_FAULTS: Final = "get_system_faults"
 SCH_GET_SYSTEM_FAULTS = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_NUM_ENTRIES, default=DEFAULT_NUM_ENTRIES): vol.All(
+        prob.Required(ATTR_NUM_ENTRIES, default=DEFAULT_NUM_ENTRIES): prob.All(
             cv.positive_int,
-            vol.Range(min=MIN_NUM_ENTRIES, max=MAX_NUM_ENTRIES),
+            prob.Range(min=MIN_NUM_ENTRIES, max=MAX_NUM_ENTRIES),
         ),
     }
 )
@@ -3093,92 +3095,94 @@ SVC_SET_FAN_REM_PARAM: Final = "set_fan_rem_param"
 SVC_UPDATE_FAN_PARAMS: Final = "update_fan_params"
 
 _TARGET_FIELDS = {
-    vol.Optional("entity_id"): cv.entity_ids,
-    vol.Optional("device_id"): cv.ensure_list_csv,
-    vol.Optional("area_id"): cv.ensure_list_csv,
-    vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
+    prob.Optional("entity_id"): cv.entity_ids,
+    prob.Optional("device_id"): cv.ensure_list_csv,
+    prob.Optional("area_id"): cv.ensure_list_csv,
+    prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
 }
 
 SCH_GET_FAN_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        vol.Required("param_id"): _SCH_PARAM_ID,
-        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        prob.Required("param_id"): _SCH_PARAM_ID,
+        prob.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 SCH_GET_FAN_REM_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        vol.Required("param_id"): _SCH_PARAM_ID,
+        prob.Required("param_id"): _SCH_PARAM_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 SCH_SET_FAN_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        vol.Required("param_id"): _SCH_PARAM_ID,
-        vol.Required("value"): cv.string,
-        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        prob.Required("param_id"): _SCH_PARAM_ID,
+        prob.Required("value"): cv.string,
+        prob.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 SCH_SET_FAN_REM_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        vol.Required("param_id"): _SCH_PARAM_ID,
-        vol.Required("value"): cv.string,
+        prob.Required("param_id"): _SCH_PARAM_ID,
+        prob.Required("value"): cv.string,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 SCH_UPDATE_FAN_PARAMS = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        prob.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
-SCH_GET_FAN_PARAM_DOMAIN = vol.Schema(
+SCH_GET_FAN_PARAM_DOMAIN = prob.Schema(
     {
-        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
-        vol.Optional("device_id"): vol.Any(None, cv.string),
-        vol.Required("param_id"): _SCH_PARAM_ID,
-        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
+        prob.Optional("device_id"): prob.Any(None, cv.string),
+        prob.Required("param_id"): _SCH_PARAM_ID,
+        prob.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
-SCH_SET_FAN_PARAM_DOMAIN = vol.Schema(
+SCH_SET_FAN_PARAM_DOMAIN = prob.Schema(
     {
-        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
-        vol.Optional("device_id"): vol.Any(None, cv.string),
-        vol.Required("param_id"): _SCH_PARAM_ID,
-        vol.Required("value"): cv.string,
-        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
+        prob.Optional("device_id"): prob.Any(None, cv.string),
+        prob.Required("param_id"): _SCH_PARAM_ID,
+        prob.Required("value"): cv.string,
+        prob.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
-SCH_UPDATE_FAN_PARAMS_DOMAIN = vol.Schema(
+SCH_UPDATE_FAN_PARAMS_DOMAIN = prob.Schema(
     {
-        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
-        vol.Optional("device_id"): vol.Any(None, cv.string),
-        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
+        prob.Optional("device_id"): prob.Any(None, cv.string),
+        prob.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 SVC_SET_POLLING_INTERVAL: Final = "set_polling_interval"
-SCH_SET_POLLING_INTERVAL = vol.Schema(
+SCH_SET_POLLING_INTERVAL = prob.Schema(
     {
-        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
-        vol.Optional("device_id"): vol.Any(None, cv.string),
-        vol.Optional(ATTR_POLLING_INTERVAL): vol.Any(None, vol.Coerce(float)),
+        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
+        prob.Optional("device_id"): prob.Any(None, cv.string),
+        prob.Optional(ATTR_POLLING_INTERVAL): prob.Any(
+            None, prob.Coerce(float)
+        ),
     },
-    extra=vol.PREVENT_EXTRA,
+    extra=prob.PREVENT_EXTRA,
 )
 
 
@@ -3217,7 +3221,7 @@ SVC_SET_DHW_MODE: Final = "set_dhw_mode"
 SCH_SET_DHW_MODE = cv.make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
-        vol.Required(ATTR_MODE): vol.In(
+        prob.Required(ATTR_MODE): prob.In(
             [
                 ZoneMode.SCHEDULE,
                 ZoneMode.PERMANENT,
@@ -3225,54 +3229,54 @@ SCH_SET_DHW_MODE = cv.make_entity_service_schema(
                 ZoneMode.TEMPORARY,
             ]
         ),
-        vol.Optional(ATTR_ACTIVE): cv.boolean,
-        vol.Optional(ATTR_UNTIL): cv.datetime,
-        vol.Optional(ATTR_DURATION): vol.All(
+        prob.Optional(ATTR_ACTIVE): cv.boolean,
+        prob.Optional(ATTR_UNTIL): cv.datetime,
+        prob.Optional(ATTR_DURATION): prob.All(
             cv.time_period,
-            vol.Range(min=td(minutes=5), max=td(days=1)),
+            prob.Range(min=td(minutes=5), max=td(days=1)),
         ),
     }
 )
 
 SCH_SET_DHW_MODE_EXTRA = (
-    vol.Schema(  # original Entity Service action validation schema
-        # vol.Msg(  # TODO turn on if good checks are working 8-2025
-        vol.Any(
+    prob.Schema(  # original Entity Service action validation schema
+        # prob.Msg(  # TODO turn on if good checks are working 8-2025
+        prob.Any(
             {  # A
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
+                prob.Required(ATTR_MODE): prob.In([ZoneMode.SCHEDULE]),
                 # only mode with no active
             },
             {
-                vol.Required(ATTR_MODE): vol.In(
+                prob.Required(ATTR_MODE): prob.In(
                     [ZoneMode.PERMANENT, ZoneMode.ADVANCED]
                 ),
-                vol.Required(ATTR_ACTIVE): cv.boolean,
+                prob.Required(ATTR_ACTIVE): cv.boolean,
             },
             {  # B a.k.a DHW boost
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-                vol.Required(ATTR_ACTIVE): True,  # TODO: vol.Any(truthy)
-                vol.Required(ATTR_DURATION, default=td(hours=1)): vol.All(
+                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
+                prob.Required(ATTR_ACTIVE): True,  # TODO: prob.Any(truthy)
+                prob.Required(ATTR_DURATION, default=td(hours=1)): prob.All(
                     cv.time_period,
-                    vol.Range(min=td(minutes=5), max=td(days=1)),
+                    prob.Range(min=td(minutes=5), max=td(days=1)),
                 ),
             },
             {  # C
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-                vol.Required(ATTR_ACTIVE): cv.boolean,
-                vol.Required(ATTR_DURATION): vol.All(
+                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
+                prob.Required(ATTR_ACTIVE): cv.boolean,
+                prob.Required(ATTR_DURATION): prob.All(
                     cv.time_period,
-                    vol.Range(min=td(minutes=5), max=td(days=1)),
+                    prob.Range(min=td(minutes=5), max=td(days=1)),
                 ),
             },
             {  # D
-                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
-                vol.Required(ATTR_ACTIVE): cv.boolean,
-                vol.Required(ATTR_UNTIL): cv.datetime,
+                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
+                prob.Required(ATTR_ACTIVE): cv.boolean,
+                prob.Required(ATTR_UNTIL): cv.datetime,
             },
         ),
         #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
         # ),
-        extra=vol.PREVENT_EXTRA,
+        extra=prob.PREVENT_EXTRA,
     )
 )
 
@@ -3291,16 +3295,18 @@ MAX_DIFFERENTIAL: Final[float] = 10
 SVC_SET_DHW_PARAMS: Final = "set_dhw_params"
 SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
     {
-        vol.Optional(ATTR_SETPOINT, default=DEFAULT_DHW_SETPOINT): vol.All(
+        prob.Optional(ATTR_SETPOINT, default=DEFAULT_DHW_SETPOINT): prob.All(
             cv.positive_float,
-            vol.Range(min=MIN_DHW_SETPOINT, max=MAX_DHW_SETPOINT),
+            prob.Range(min=MIN_DHW_SETPOINT, max=MAX_DHW_SETPOINT),
         ),
-        vol.Optional(ATTR_OVERRUN, default=DEFAULT_OVERRUN): vol.All(
-            cv.positive_int, vol.Range(min=MIN_OVERRUN, max=MAX_OVERRUN)
+        prob.Optional(ATTR_OVERRUN, default=DEFAULT_OVERRUN): prob.All(
+            cv.positive_int, prob.Range(min=MIN_OVERRUN, max=MAX_OVERRUN)
         ),
-        vol.Optional(ATTR_DIFFERENTIAL, default=DEFAULT_DIFFERENTIAL): vol.All(
+        prob.Optional(
+            ATTR_DIFFERENTIAL, default=DEFAULT_DIFFERENTIAL
+        ): prob.All(
             cv.positive_float,
-            vol.Range(min=MIN_DIFFERENTIAL, max=MAX_DIFFERENTIAL),
+            prob.Range(min=MIN_DIFFERENTIAL, max=MAX_DIFFERENTIAL),
         ),
     }
 )
@@ -3308,7 +3314,7 @@ SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
 SVC_SET_DHW_SCHEDULE: Final = "set_dhw_schedule"
 SCH_SET_DHW_SCHEDULE = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
+        prob.Required(ATTR_SCHEDULE): prob.Any(cv.string, dict, list),
     }
 )
 
@@ -3338,9 +3344,9 @@ MAX_TIMEOUT: Final[int] = 300
 SVC_LEARN_COMMAND: Final = "learn_command"
 SCH_LEARN_COMMAND = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_COMMAND): cv.string,
-        vol.Required(ATTR_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
-            cv.positive_int, vol.Range(min=MIN_TIMEOUT, max=MAX_TIMEOUT)
+        prob.Required(ATTR_COMMAND): cv.string,
+        prob.Required(ATTR_TIMEOUT, default=DEFAULT_TIMEOUT): prob.All(
+            cv.positive_int, prob.Range(min=MIN_TIMEOUT, max=MAX_TIMEOUT)
         ),
     },
 )
@@ -3351,22 +3357,22 @@ SCH_LEARN_COMMAND = cv.make_entity_service_schema(
 SVC_ADD_COMMAND: Final = "add_command"
 SCH_ADD_COMMAND = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_COMMAND): cv.string,
-        vol.Required("packet_string"): cv.string,
+        prob.Required(ATTR_COMMAND): cv.string,
+        prob.Required("packet_string"): cv.string,
     }
 )
 
 SVC_SEND_COMMAND: Final = "send_command"
 SCH_SEND_COMMAND = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_COMMAND): cv.string,
-        vol.Required(ATTR_NUM_REPEATS, default=3): vol.All(
+        prob.Required(ATTR_COMMAND): cv.string,
+        prob.Required(ATTR_NUM_REPEATS, default=3): prob.All(
             cv.positive_int,
-            vol.Range(min=MIN_NUM_REPEATS, max=MAX_NUM_REPEATS),
+            prob.Range(min=MIN_NUM_REPEATS, max=MAX_NUM_REPEATS),
         ),
-        vol.Required(ATTR_DELAY_SECS, default=DEFAULT_GAP_DURATION): vol.All(
+        prob.Required(ATTR_DELAY_SECS, default=DEFAULT_GAP_DURATION): prob.All(
             cv.positive_float,
-            vol.Range(min=MIN_GAP_DURATION, max=MAX_GAP_DURATION),
+            prob.Range(min=MIN_GAP_DURATION, max=MAX_GAP_DURATION),
         ),
     },
 )
@@ -3374,7 +3380,7 @@ SCH_SEND_COMMAND = cv.make_entity_service_schema(
 SVC_DELETE_COMMAND: Final = "delete_command"
 SCH_DELETE_COMMAND = cv.make_entity_service_schema(
     {
-        vol.Required(ATTR_COMMAND): cv.string,
+        prob.Required(ATTR_COMMAND): cv.string,
     },
 )
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from datetime import timedelta as td
 from typing import Any, Final, cast
 
-import probatio as prob
+import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.helpers import config_validation as cv
 
@@ -143,29 +143,29 @@ SCAN_INTERVAL_MINIMUM = td(seconds=3)
 _SCH_DEVICE_ID = cv.matches_regex(r"^[0-9]{2}:[0-9]{6}$")
 _SCH_CMD_CODE = cv.matches_regex(r"^[0-9A-F]{4}$")
 _SCH_DOM_INDEX = cv.matches_regex(r"^[0-9A-F]{2}$")
-_SCH_PARAM_ID = prob.All(cv.string, cv.matches_regex(r"^[0-9A-F]{2}$"))
+_SCH_PARAM_ID = vol.All(cv.string, cv.matches_regex(r"^[0-9A-F]{2}$"))
 _SCH_COMMAND = cv.matches_regex(COMMAND_REGEX.pattern)
 
-SCH_ADVANCED_FEATURES = prob.Schema(
+SCH_ADVANCED_FEATURES = vol.Schema(
     {
-        prob.Optional(CONF_SEND_PACKET, default=False): cv.boolean,
-        prob.Optional(CONF_MESSAGE_EVENTS, default=None): prob.Any(
+        vol.Optional(CONF_SEND_PACKET, default=False): cv.boolean,
+        vol.Optional(CONF_MESSAGE_EVENTS, default=None): vol.Any(
             None, cv.is_regex
         ),
-        prob.Optional(CONF_DEV_MODE): cv.boolean,
-        prob.Optional(CONF_UNKNOWN_CODES): cv.boolean,
-        prob.Optional(CONF_PASSIVE_SCAN, default=True): cv.boolean,
-        prob.Optional(CONF_AUTO_NOTIFY, default=True): cv.boolean,
-        prob.Optional(CONF_LOST_THRESHOLD, default=7): prob.All(
-            cv.positive_int, prob.Range(min=1, max=90)
+        vol.Optional(CONF_DEV_MODE): cv.boolean,
+        vol.Optional(CONF_UNKNOWN_CODES): cv.boolean,
+        vol.Optional(CONF_PASSIVE_SCAN, default=True): cv.boolean,
+        vol.Optional(CONF_AUTO_NOTIFY, default=True): cv.boolean,
+        vol.Optional(CONF_LOST_THRESHOLD, default=7): vol.All(
+            cv.positive_int, vol.Range(min=1, max=90)
         ),
     }
 )
 
 # Define the traits for FAN devices
 FAN_TRAITS = {
-    prob.Optional(SZ_BOUND_TO): prob.Any(None, _SCH_DEVICE_ID),
-    prob.Optional(CONF_COMMANDS): dict,
+    vol.Optional(SZ_BOUND_TO): vol.Any(None, _SCH_DEVICE_ID),
+    vol.Optional(CONF_COMMANDS): dict,
 }
 
 SCH_GLOBAL_TRAITS_DICT, SCH_TRAITS = sch_global_traits_dict_factory(
@@ -174,23 +174,23 @@ SCH_GLOBAL_TRAITS_DICT, SCH_TRAITS = sch_global_traits_dict_factory(
 
 SCH_GATEWAY_CONFIG = SCH_GATEWAY_CONFIG.extend(
     SCH_ENGINE_DICT,
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 SCH_PACKET_LOG = sch_packet_log_dict_factory(default_backups=7)
 
 SCH_DOMAIN_CONFIG = (
-    prob.Schema(
+    vol.Schema(
         {
-            prob.Optional(CONF_RAMSES_RF, default={}): SCH_GATEWAY_CONFIG,
-            prob.Optional(
+            vol.Optional(CONF_RAMSES_RF, default={}): SCH_GATEWAY_CONFIG,
+            vol.Optional(
                 CONF_SCAN_INTERVAL, default=SCAN_INTERVAL_DEFAULT
-            ): prob.All(cv.time_period, prob.Range(min=SCAN_INTERVAL_MINIMUM)),
-            prob.Optional(
+            ): vol.All(cv.time_period, vol.Range(min=SCAN_INTERVAL_MINIMUM)),
+            vol.Optional(
                 CONF_ADVANCED_FEATURES, default={}
             ): SCH_ADVANCED_FEATURES,
         },
-        extra=prob.PREVENT_EXTRA,  # system/orphan schemas for ramses_rf
+        extra=vol.PREVENT_EXTRA,  # system/orphan schemas for ramses_rf
     )
     .extend(SCH_GLOBAL_SCHEMAS_DICT)
     .extend(SCH_GLOBAL_TRAITS_DICT)
@@ -199,20 +199,20 @@ SCH_DOMAIN_CONFIG = (
     .extend(sch_serial_port_dict_factory())
 )
 
-SCH_MINIMUM_TCS = prob.Schema(
+SCH_MINIMUM_TCS = vol.Schema(
     {
-        prob.Optional(SZ_SYSTEM): prob.Schema(
-            {prob.Required(SZ_APPLIANCE_CONTROL): prob.Match(r"^10:[0-9]{6}$")}
+        vol.Optional(SZ_SYSTEM): vol.Schema(
+            {vol.Required(SZ_APPLIANCE_CONTROL): vol.Match(r"^10:[0-9]{6}$")}
         ),
-        prob.Optional(SZ_ZONES, default={}): prob.Schema(
+        vol.Optional(SZ_ZONES, default={}): vol.Schema(
             {
-                prob.Required(str): prob.Schema(
-                    {prob.Required(SZ_SENSOR): prob.Match(r"^01:[0-9]{6}$")}
+                vol.Required(str): vol.Schema(
+                    {vol.Required(SZ_SENSOR): vol.Match(r"^01:[0-9]{6}$")}
                 )
             }
         ),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 
@@ -2736,40 +2736,38 @@ def sync_learned_topology(
     return order_schema(new_schema)
 
 
-SCH_NO_SVC_PARAMS = prob.Schema({}, extra=prob.PREVENT_EXTRA)
+SCH_NO_SVC_PARAMS = vol.Schema({}, extra=vol.PREVENT_EXTRA)
 SCH_NO_ENTITY_SVC_PARAMS = cv.make_entity_service_schema(
     {},
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 
 # services for ramses_cc integration
 
-_SCH_BINDING = prob.Schema(
-    {prob.Required(_SCH_CMD_CODE): prob.Any(None, _SCH_DOM_INDEX)}
+_SCH_BINDING = vol.Schema(
+    {vol.Required(_SCH_CMD_CODE): vol.Any(None, _SCH_DOM_INDEX)}
 )
 
-SCH_BIND_DEVICE = prob.Schema(
+SCH_BIND_DEVICE = vol.Schema(
     {
-        prob.Required("device_id"): _SCH_DEVICE_ID,
-        prob.Required("offer"): prob.All(_SCH_BINDING, prob.Length(min=1)),
-        prob.Optional("confirm", default={}): prob.Any(
-            {}, prob.All(_SCH_BINDING, prob.Length(min=1))
+        vol.Required("device_id"): _SCH_DEVICE_ID,
+        vol.Required("offer"): vol.All(_SCH_BINDING, vol.Length(min=1)),
+        vol.Optional("confirm", default={}): vol.Any(
+            {}, vol.All(_SCH_BINDING, vol.Length(min=1))
         ),
-        prob.Optional("device_info", default=None): prob.Any(
-            None, _SCH_COMMAND
-        ),
+        vol.Optional("device_info", default=None): vol.Any(None, _SCH_COMMAND),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_SEND_PACKET = prob.Schema(
+SCH_SEND_PACKET = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
-        prob.Optional("from_id"): _SCH_DEVICE_ID,
-        prob.Required("verb"): prob.In((" I", "I", "RQ", "RP", " W", "W")),
-        prob.Required("code"): cv.matches_regex(r"^[0-9A-F]{4}$"),
-        prob.Required("payload"): cv.matches_regex(
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Required("verb"): vol.In((" I", "I", "RQ", "RP", " W", "W")),
+        vol.Required("code"): cv.matches_regex(r"^[0-9A-F]{4}$"),
+        vol.Required("payload"): cv.matches_regex(
             r"^([0-9A-F][0-9A-F]){1,48}$"
         ),
     }
@@ -2781,84 +2779,84 @@ SVC_SEND_PACKET: Final = "send_packet"
 SVC_SYNC_TOPOLOGY: Final = "sync_topology"
 SVC_PROBE_HVAC_BINDING: Final = "probe_hvac_binding"
 
-SCH_PROBE_HVAC_BINDING = prob.Schema(
+SCH_PROBE_HVAC_BINDING = vol.Schema(
     {
-        prob.Optional("device_id"): _SCH_DEVICE_ID,
-        prob.Optional("fan_id"): _SCH_DEVICE_ID,
+        vol.Optional("device_id"): _SCH_DEVICE_ID,
+        vol.Optional("fan_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_DISCOVER_KNOWN_DEVICES = prob.Schema(
+SCH_DISCOVER_KNOWN_DEVICES = vol.Schema(
     {
-        prob.Optional("device_id"): _SCH_DEVICE_ID,
+        vol.Optional("device_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 # Discovery scan service schemas
 
-SCH_GET_DISCOVERED_DEVICES = prob.Schema(
+SCH_GET_DISCOVERED_DEVICES = vol.Schema(
     {
-        prob.Optional("status"): prob.In(
+        vol.Optional("status"): vol.In(
             ("new", "accepted", "discarded", "removed", "lost")
         ),
-        prob.Optional("enabled"): cv.boolean,
+        vol.Optional("enabled"): cv.boolean,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_ACCEPT_DISCOVERED_DEVICE = prob.Schema(
+SCH_ACCEPT_DISCOVERED_DEVICE = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
-        prob.Optional("owner"): prob.All(str, prob.Length(max=50)),
-        prob.Optional("schema_entry"): dict,
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Optional("owner"): vol.All(str, vol.Length(max=50)),
+        vol.Optional("schema_entry"): dict,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_DISCARD_DISCOVERED_DEVICE = prob.Schema(
+SCH_DISCARD_DISCOVERED_DEVICE = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_REMOVE_DISCOVERED_DEVICE = prob.Schema(
+SCH_REMOVE_DISCOVERED_DEVICE = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_ENABLE_DISCOVERED_DEVICE = prob.Schema(
+SCH_ENABLE_DISCOVERED_DEVICE = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_DISABLE_DISCOVERED_DEVICE = prob.Schema(
+SCH_DISABLE_DISCOVERED_DEVICE = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_ADD_FAKED_REM = prob.Schema(
+SCH_ADD_FAKED_REM = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
-        prob.Required("bound_to"): _SCH_DEVICE_ID,
-        prob.Optional("alias"): prob.All(str, prob.Length(max=50)),
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required("bound_to"): _SCH_DEVICE_ID,
+        vol.Optional("alias"): vol.All(str, vol.Length(max=50)),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_REMOVE_DEVICE = prob.Schema(
+SCH_REMOVE_DEVICE = vol.Schema(
     {
-        prob.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
+        vol.Required(ATTR_DEVICE_ID): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 
@@ -2870,12 +2868,12 @@ MAX_CO2_LEVEL: Final[int] = 9999
 SVC_PUT_CO2_LEVEL: Final = "put_co2_level"
 SCH_PUT_CO2_LEVEL = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_CO2_LEVEL): prob.All(
+        vol.Required(ATTR_CO2_LEVEL): vol.All(
             cv.positive_int,
-            prob.Range(min=MIN_CO2_LEVEL, max=MAX_CO2_LEVEL),
+            vol.Range(min=MIN_CO2_LEVEL, max=MAX_CO2_LEVEL),
         ),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 MIN_DHW_TEMP: Final[float] = 0
@@ -2884,12 +2882,12 @@ MAX_DHW_TEMP: Final[float] = 99
 SVC_PUT_DHW_TEMP: Final = "put_dhw_temp"
 SCH_PUT_DHW_TEMP = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_TEMPERATURE): prob.All(
-            prob.Coerce(float),
-            prob.Range(min=MIN_DHW_TEMP, max=MAX_DHW_TEMP),
+        vol.Required(ATTR_TEMPERATURE): vol.All(
+            vol.Coerce(float),
+            vol.Range(min=MIN_DHW_TEMP, max=MAX_DHW_TEMP),
         ),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 MIN_INDOOR_HUMIDITY: Final[float] = 0
@@ -2898,12 +2896,12 @@ MAX_INDOOR_HUMIDITY: Final[float] = 100
 SVC_PUT_INDOOR_HUMIDITY: Final = "put_indoor_humidity"
 SCH_PUT_INDOOR_HUMIDITY = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_INDOOR_HUMIDITY): prob.All(
+        vol.Required(ATTR_INDOOR_HUMIDITY): vol.All(
             cv.positive_float,
-            prob.Range(min=MIN_INDOOR_HUMIDITY, max=MAX_INDOOR_HUMIDITY),
+            vol.Range(min=MIN_INDOOR_HUMIDITY, max=MAX_INDOOR_HUMIDITY),
         ),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 MIN_ROOM_TEMP: Final[float] = -20
@@ -2912,12 +2910,12 @@ MAX_ROOM_TEMP: Final[float] = 60
 SVC_PUT_ROOM_TEMP: Final = "put_room_temp"
 SCH_PUT_ROOM_TEMP = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_TEMPERATURE): prob.All(
-            prob.Coerce(float),
-            prob.Range(min=MIN_ROOM_TEMP, max=MAX_ROOM_TEMP),
+        vol.Required(ATTR_TEMPERATURE): vol.All(
+            vol.Coerce(float),
+            vol.Range(min=MIN_ROOM_TEMP, max=MAX_ROOM_TEMP),
         ),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 SVCS_RAMSES_SENSOR = {
@@ -2929,40 +2927,40 @@ SVCS_RAMSES_SENSOR = {
 
 # services for climate platform
 
-SCH_DURATION = prob.All(  # of time (<=24h)
+SCH_DURATION = vol.All(  # of time (<=24h)
     cv.time_period,
-    prob.Range(min=td(hours=1), max=td(hours=24)),
+    vol.Range(min=td(hours=1), max=td(hours=24)),
 )
-SCH_PERIOD = prob.All(  # of days (0-99)
-    cv.time_period, prob.Range(min=td(days=0), max=td(days=99))
+SCH_PERIOD = vol.All(  # of days (0-99)
+    cv.time_period, vol.Range(min=td(days=0), max=td(days=99))
 )
 
 SVC_SET_SYSTEM_MODE: Final = "set_system_mode"
 SCH_SET_SYSTEM_MODE = cv.make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
-        prob.Required(ATTR_MODE): prob.In(SystemMode),
-        prob.Optional(ATTR_DURATION): prob.Any(SCH_DURATION, None),
+        vol.Required(ATTR_MODE): vol.In(SystemMode),
+        vol.Optional(ATTR_DURATION): vol.Any(SCH_DURATION, None),
         # canBeTemporary: true, timingMode: Duration
-        prob.Optional(ATTR_PERIOD): prob.Any(SCH_PERIOD, None),
+        vol.Optional(ATTR_PERIOD): vol.Any(SCH_PERIOD, None),
         # Period: None indefinitely; 0 end of today, 1 end tomorrow
     }
 )
 
-SCH_SET_SYSTEM_MODE_EXTRA = prob.Schema(  # Entity Service schema
-    # prob.Msg(  # TODO turn on if good checks are working 8-2025
-    prob.Any(
+SCH_SET_SYSTEM_MODE_EXTRA = vol.Schema(  # Entity Service schema
+    # vol.Msg(  # TODO turn on if good checks are working 8-2025
+    vol.Any(
         {  # A also: Off, Heat, Cool (for pre-evohome)
-            prob.Required(ATTR_MODE): prob.In(
+            vol.Required(ATTR_MODE): vol.In(
                 [SystemMode.AUTO, SystemMode.HEAT_OFF, SystemMode.RESET]
             )
         },
         {  # B
-            prob.Required(ATTR_MODE): prob.In([SystemMode.ECO_BOOST]),
-            prob.Optional(ATTR_DURATION): prob.Any(SCH_DURATION, None),
+            vol.Required(ATTR_MODE): vol.In([SystemMode.ECO_BOOST]),
+            vol.Optional(ATTR_DURATION): vol.Any(SCH_DURATION, None),
         },  # duration: : None is indefinitely; 0 is invalid
         {  # C canBeTemporary: true, timingMode: Period
-            prob.Required(ATTR_MODE): prob.In(
+            vol.Required(ATTR_MODE): vol.In(
                 [
                     SystemMode.AWAY,
                     SystemMode.CUSTOM,
@@ -2970,12 +2968,12 @@ SCH_SET_SYSTEM_MODE_EXTRA = prob.Schema(  # Entity Service schema
                     SystemMode.DAY_OFF_ECO,
                 ]
             ),
-            prob.Optional(ATTR_PERIOD): prob.Any(SCH_PERIOD, None),
+            vol.Optional(ATTR_PERIOD): vol.Any(SCH_PERIOD, None),
         },  # Period: None indefinitely; 0 end of today, 1 end tomorrow
     ),
     #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
     # ),
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 DEFAULT_MIN_TEMP: Final[float] = 5
@@ -2989,15 +2987,15 @@ MAX_MAX_TEMP: Final[float] = 35
 SVC_SET_ZONE_CONFIG: Final = "set_zone_config"
 SCH_SET_ZONE_CONFIG = cv.make_entity_service_schema(
     {
-        prob.Optional(ATTR_MAX_TEMP, default=DEFAULT_MAX_TEMP): prob.All(
-            cv.positive_float, prob.Range(min=MIN_MAX_TEMP, max=MAX_MAX_TEMP)
+        vol.Optional(ATTR_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.All(
+            cv.positive_float, vol.Range(min=MIN_MAX_TEMP, max=MAX_MAX_TEMP)
         ),
-        prob.Optional(ATTR_MIN_TEMP, default=DEFAULT_MIN_TEMP): prob.All(
-            cv.positive_float, prob.Range(min=MIN_MIN_TEMP, max=MAX_MIN_TEMP)
+        vol.Optional(ATTR_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.All(
+            cv.positive_float, vol.Range(min=MIN_MIN_TEMP, max=MAX_MIN_TEMP)
         ),
-        prob.Optional(ATTR_LOCAL_OVERRIDE, default=True): cv.boolean,
-        prob.Optional(ATTR_OPENWINDOW, default=True): cv.boolean,
-        prob.Optional(ATTR_MULTIROOM, default=True): cv.boolean,
+        vol.Optional(ATTR_LOCAL_OVERRIDE, default=True): cv.boolean,
+        vol.Optional(ATTR_OPENWINDOW, default=True): cv.boolean,
+        vol.Optional(ATTR_MULTIROOM, default=True): cv.boolean,
     }
 )
 
@@ -3005,7 +3003,7 @@ SVC_SET_ZONE_MODE: Final = "set_zone_mode"
 SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
-        prob.Required(ATTR_MODE): prob.In(
+        vol.Required(ATTR_MODE): vol.In(
             [
                 ZoneMode.SCHEDULE,
                 ZoneMode.PERMANENT,
@@ -3013,61 +3011,61 @@ SCH_SET_ZONE_MODE = cv.make_entity_service_schema(
                 ZoneMode.TEMPORARY,
             ]
         ),
-        prob.Optional(ATTR_SETPOINT): prob.All(
-            cv.positive_float, prob.Range(min=5, max=35)
+        vol.Optional(ATTR_SETPOINT): vol.All(
+            cv.positive_float, vol.Range(min=5, max=35)
         ),
-        prob.Optional(ATTR_UNTIL): cv.datetime,
-        prob.Optional(ATTR_DURATION): prob.All(
+        vol.Optional(ATTR_UNTIL): cv.datetime,
+        vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
-            prob.Range(min=td(minutes=5), max=td(days=1)),
+            vol.Range(min=td(minutes=5), max=td(days=1)),
         ),
     }
 )
 
 SCH_SET_ZONE_MODE_EXTRA = (
-    prob.Schema(  # original Entity Service action validation schema
-        # prob.Msg(  # TODO turn msg on if checks are working 10-2025
-        prob.Any(
+    vol.Schema(  # original Entity Service action validation schema
+        # vol.Msg(  # TODO turn msg on if checks are working 10-2025
+        vol.Any(
             {  # A
-                prob.Required(ATTR_MODE): prob.In([ZoneMode.SCHEDULE]),
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
                 # only mode with no setpoint
             },
             {  # B
-                prob.Required(ATTR_MODE): prob.In(
+                vol.Required(ATTR_MODE): vol.In(
                     [ZoneMode.PERMANENT, ZoneMode.ADVANCED]
                 ),
-                prob.Required(ATTR_SETPOINT): prob.All(
-                    cv.positive_float, prob.Range(min=5, max=35)
+                vol.Required(ATTR_SETPOINT): vol.All(
+                    cv.positive_float, vol.Range(min=5, max=35)
                 ),
             },
             {  # C
-                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
-                prob.Required(ATTR_SETPOINT): prob.All(
-                    cv.positive_float, prob.Range(min=5, max=35)
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+                vol.Required(ATTR_SETPOINT): vol.All(
+                    cv.positive_float, vol.Range(min=5, max=35)
                 ),
-                prob.Required(ATTR_DURATION, default=td(hours=1)): prob.All(
+                vol.Required(ATTR_DURATION, default=td(hours=1)): vol.All(
                     cv.time_period,
-                    prob.Range(min=td(minutes=5), max=td(days=1)),
+                    vol.Range(min=td(minutes=5), max=td(days=1)),
                 ),
             },
             {  # D
-                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
-                prob.Required(ATTR_SETPOINT): prob.All(
-                    cv.positive_float, prob.Range(min=5, max=35)
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+                vol.Required(ATTR_SETPOINT): vol.All(
+                    cv.positive_float, vol.Range(min=5, max=35)
                 ),
-                prob.Required(ATTR_UNTIL): cv.datetime,
+                vol.Required(ATTR_UNTIL): cv.datetime,
             },
         ),
         #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
         # ),
-        extra=prob.PREVENT_EXTRA,
+        extra=vol.PREVENT_EXTRA,
     )
 )
 
 SVC_SET_ZONE_SCHEDULE: Final = "set_zone_schedule"
 SCH_SET_ZONE_SCHEDULE = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_SCHEDULE): prob.Any(cv.string, dict, list),
+        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
 )
 
@@ -3078,9 +3076,9 @@ MAX_NUM_ENTRIES: Final[float] = 64
 SVC_GET_SYSTEM_FAULTS: Final = "get_system_faults"
 SCH_GET_SYSTEM_FAULTS = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_NUM_ENTRIES, default=DEFAULT_NUM_ENTRIES): prob.All(
+        vol.Required(ATTR_NUM_ENTRIES, default=DEFAULT_NUM_ENTRIES): vol.All(
             cv.positive_int,
-            prob.Range(min=MIN_NUM_ENTRIES, max=MAX_NUM_ENTRIES),
+            vol.Range(min=MIN_NUM_ENTRIES, max=MAX_NUM_ENTRIES),
         ),
     }
 )
@@ -3095,94 +3093,92 @@ SVC_SET_FAN_REM_PARAM: Final = "set_fan_rem_param"
 SVC_UPDATE_FAN_PARAMS: Final = "update_fan_params"
 
 _TARGET_FIELDS = {
-    prob.Optional("entity_id"): cv.entity_ids,
-    prob.Optional("device_id"): cv.ensure_list_csv,
-    prob.Optional("area_id"): cv.ensure_list_csv,
-    prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
+    vol.Optional("entity_id"): cv.entity_ids,
+    vol.Optional("device_id"): cv.ensure_list_csv,
+    vol.Optional("area_id"): cv.ensure_list_csv,
+    vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
 }
 
 SCH_GET_FAN_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        prob.Required("param_id"): _SCH_PARAM_ID,
-        prob.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Required("param_id"): _SCH_PARAM_ID,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 SCH_GET_FAN_REM_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        prob.Required("param_id"): _SCH_PARAM_ID,
+        vol.Required("param_id"): _SCH_PARAM_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 SCH_SET_FAN_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        prob.Required("param_id"): _SCH_PARAM_ID,
-        prob.Required("value"): cv.string,
-        prob.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Required("param_id"): _SCH_PARAM_ID,
+        vol.Required("value"): cv.string,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 SCH_SET_FAN_REM_PARAM = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        prob.Required("param_id"): _SCH_PARAM_ID,
-        prob.Required("value"): cv.string,
+        vol.Required("param_id"): _SCH_PARAM_ID,
+        vol.Required("value"): cv.string,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 SCH_UPDATE_FAN_PARAMS = cv.make_entity_service_schema(
     {
         **_TARGET_FIELDS,
-        prob.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
-SCH_GET_FAN_PARAM_DOMAIN = prob.Schema(
+SCH_GET_FAN_PARAM_DOMAIN = vol.Schema(
     {
-        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
-        prob.Optional("device_id"): prob.Any(None, cv.string),
-        prob.Required("param_id"): _SCH_PARAM_ID,
-        prob.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
+        vol.Optional("device_id"): vol.Any(None, cv.string),
+        vol.Required("param_id"): _SCH_PARAM_ID,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
-SCH_SET_FAN_PARAM_DOMAIN = prob.Schema(
+SCH_SET_FAN_PARAM_DOMAIN = vol.Schema(
     {
-        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
-        prob.Optional("device_id"): prob.Any(None, cv.string),
-        prob.Required("param_id"): _SCH_PARAM_ID,
-        prob.Required("value"): cv.string,
-        prob.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
+        vol.Optional("device_id"): vol.Any(None, cv.string),
+        vol.Required("param_id"): _SCH_PARAM_ID,
+        vol.Required("value"): cv.string,
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
-SCH_UPDATE_FAN_PARAMS_DOMAIN = prob.Schema(
+SCH_UPDATE_FAN_PARAMS_DOMAIN = vol.Schema(
     {
-        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
-        prob.Optional("device_id"): prob.Any(None, cv.string),
-        prob.Optional("from_id"): _SCH_DEVICE_ID,
+        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
+        vol.Optional("device_id"): vol.Any(None, cv.string),
+        vol.Optional("from_id"): _SCH_DEVICE_ID,
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 SVC_SET_POLLING_INTERVAL: Final = "set_polling_interval"
-SCH_SET_POLLING_INTERVAL = prob.Schema(
+SCH_SET_POLLING_INTERVAL = vol.Schema(
     {
-        prob.Optional("device"): prob.Any(None, cv.ensure_list_csv),
-        prob.Optional("device_id"): prob.Any(None, cv.string),
-        prob.Optional(ATTR_POLLING_INTERVAL): prob.Any(
-            None, prob.Coerce(float)
-        ),
+        vol.Optional("device"): vol.Any(None, cv.ensure_list_csv),
+        vol.Optional("device_id"): vol.Any(None, cv.string),
+        vol.Optional(ATTR_POLLING_INTERVAL): vol.Any(None, vol.Coerce(float)),
     },
-    extra=prob.PREVENT_EXTRA,
+    extra=vol.PREVENT_EXTRA,
 )
 
 
@@ -3221,7 +3217,7 @@ SVC_SET_DHW_MODE: Final = "set_dhw_mode"
 SCH_SET_DHW_MODE = cv.make_entity_service_schema(
     # nested schemas not allowed after HA 2025.9, check in climate.py
     {
-        prob.Required(ATTR_MODE): prob.In(
+        vol.Required(ATTR_MODE): vol.In(
             [
                 ZoneMode.SCHEDULE,
                 ZoneMode.PERMANENT,
@@ -3229,54 +3225,54 @@ SCH_SET_DHW_MODE = cv.make_entity_service_schema(
                 ZoneMode.TEMPORARY,
             ]
         ),
-        prob.Optional(ATTR_ACTIVE): cv.boolean,
-        prob.Optional(ATTR_UNTIL): cv.datetime,
-        prob.Optional(ATTR_DURATION): prob.All(
+        vol.Optional(ATTR_ACTIVE): cv.boolean,
+        vol.Optional(ATTR_UNTIL): cv.datetime,
+        vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
-            prob.Range(min=td(minutes=5), max=td(days=1)),
+            vol.Range(min=td(minutes=5), max=td(days=1)),
         ),
     }
 )
 
 SCH_SET_DHW_MODE_EXTRA = (
-    prob.Schema(  # original Entity Service action validation schema
-        # prob.Msg(  # TODO turn on if good checks are working 8-2025
-        prob.Any(
+    vol.Schema(  # original Entity Service action validation schema
+        # vol.Msg(  # TODO turn on if good checks are working 8-2025
+        vol.Any(
             {  # A
-                prob.Required(ATTR_MODE): prob.In([ZoneMode.SCHEDULE]),
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.SCHEDULE]),
                 # only mode with no active
             },
             {
-                prob.Required(ATTR_MODE): prob.In(
+                vol.Required(ATTR_MODE): vol.In(
                     [ZoneMode.PERMANENT, ZoneMode.ADVANCED]
                 ),
-                prob.Required(ATTR_ACTIVE): cv.boolean,
+                vol.Required(ATTR_ACTIVE): cv.boolean,
             },
             {  # B a.k.a DHW boost
-                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
-                prob.Required(ATTR_ACTIVE): True,  # TODO: prob.Any(truthy)
-                prob.Required(ATTR_DURATION, default=td(hours=1)): prob.All(
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+                vol.Required(ATTR_ACTIVE): True,  # TODO: vol.Any(truthy)
+                vol.Required(ATTR_DURATION, default=td(hours=1)): vol.All(
                     cv.time_period,
-                    prob.Range(min=td(minutes=5), max=td(days=1)),
+                    vol.Range(min=td(minutes=5), max=td(days=1)),
                 ),
             },
             {  # C
-                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
-                prob.Required(ATTR_ACTIVE): cv.boolean,
-                prob.Required(ATTR_DURATION): prob.All(
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+                vol.Required(ATTR_ACTIVE): cv.boolean,
+                vol.Required(ATTR_DURATION): vol.All(
                     cv.time_period,
-                    prob.Range(min=td(minutes=5), max=td(days=1)),
+                    vol.Range(min=td(minutes=5), max=td(days=1)),
                 ),
             },
             {  # D
-                prob.Required(ATTR_MODE): prob.In([ZoneMode.TEMPORARY]),
-                prob.Required(ATTR_ACTIVE): cv.boolean,
-                prob.Required(ATTR_UNTIL): cv.datetime,
+                vol.Required(ATTR_MODE): vol.In([ZoneMode.TEMPORARY]),
+                vol.Required(ATTR_ACTIVE): cv.boolean,
+                vol.Required(ATTR_UNTIL): cv.datetime,
             },
         ),
         #     msg="Invalid ramses_cc Zone Mode entry in Entity Service call",
         # ),
-        extra=prob.PREVENT_EXTRA,
+        extra=vol.PREVENT_EXTRA,
     )
 )
 
@@ -3295,18 +3291,16 @@ MAX_DIFFERENTIAL: Final[float] = 10
 SVC_SET_DHW_PARAMS: Final = "set_dhw_params"
 SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
     {
-        prob.Optional(ATTR_SETPOINT, default=DEFAULT_DHW_SETPOINT): prob.All(
+        vol.Optional(ATTR_SETPOINT, default=DEFAULT_DHW_SETPOINT): vol.All(
             cv.positive_float,
-            prob.Range(min=MIN_DHW_SETPOINT, max=MAX_DHW_SETPOINT),
+            vol.Range(min=MIN_DHW_SETPOINT, max=MAX_DHW_SETPOINT),
         ),
-        prob.Optional(ATTR_OVERRUN, default=DEFAULT_OVERRUN): prob.All(
-            cv.positive_int, prob.Range(min=MIN_OVERRUN, max=MAX_OVERRUN)
+        vol.Optional(ATTR_OVERRUN, default=DEFAULT_OVERRUN): vol.All(
+            cv.positive_int, vol.Range(min=MIN_OVERRUN, max=MAX_OVERRUN)
         ),
-        prob.Optional(
-            ATTR_DIFFERENTIAL, default=DEFAULT_DIFFERENTIAL
-        ): prob.All(
+        vol.Optional(ATTR_DIFFERENTIAL, default=DEFAULT_DIFFERENTIAL): vol.All(
             cv.positive_float,
-            prob.Range(min=MIN_DIFFERENTIAL, max=MAX_DIFFERENTIAL),
+            vol.Range(min=MIN_DIFFERENTIAL, max=MAX_DIFFERENTIAL),
         ),
     }
 )
@@ -3314,7 +3308,7 @@ SCH_SET_DHW_PARAMS = cv.make_entity_service_schema(
 SVC_SET_DHW_SCHEDULE: Final = "set_dhw_schedule"
 SCH_SET_DHW_SCHEDULE = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_SCHEDULE): prob.Any(cv.string, dict, list),
+        vol.Required(ATTR_SCHEDULE): vol.Any(cv.string, dict, list),
     }
 )
 
@@ -3344,9 +3338,9 @@ MAX_TIMEOUT: Final[int] = 300
 SVC_LEARN_COMMAND: Final = "learn_command"
 SCH_LEARN_COMMAND = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_COMMAND): cv.string,
-        prob.Required(ATTR_TIMEOUT, default=DEFAULT_TIMEOUT): prob.All(
-            cv.positive_int, prob.Range(min=MIN_TIMEOUT, max=MAX_TIMEOUT)
+        vol.Required(ATTR_COMMAND): cv.string,
+        vol.Required(ATTR_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
+            cv.positive_int, vol.Range(min=MIN_TIMEOUT, max=MAX_TIMEOUT)
         ),
     },
 )
@@ -3357,22 +3351,22 @@ SCH_LEARN_COMMAND = cv.make_entity_service_schema(
 SVC_ADD_COMMAND: Final = "add_command"
 SCH_ADD_COMMAND = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_COMMAND): cv.string,
-        prob.Required("packet_string"): cv.string,
+        vol.Required(ATTR_COMMAND): cv.string,
+        vol.Required("packet_string"): cv.string,
     }
 )
 
 SVC_SEND_COMMAND: Final = "send_command"
 SCH_SEND_COMMAND = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_COMMAND): cv.string,
-        prob.Required(ATTR_NUM_REPEATS, default=3): prob.All(
+        vol.Required(ATTR_COMMAND): cv.string,
+        vol.Required(ATTR_NUM_REPEATS, default=3): vol.All(
             cv.positive_int,
-            prob.Range(min=MIN_NUM_REPEATS, max=MAX_NUM_REPEATS),
+            vol.Range(min=MIN_NUM_REPEATS, max=MAX_NUM_REPEATS),
         ),
-        prob.Required(ATTR_DELAY_SECS, default=DEFAULT_GAP_DURATION): prob.All(
+        vol.Required(ATTR_DELAY_SECS, default=DEFAULT_GAP_DURATION): vol.All(
             cv.positive_float,
-            prob.Range(min=MIN_GAP_DURATION, max=MAX_GAP_DURATION),
+            vol.Range(min=MIN_GAP_DURATION, max=MAX_GAP_DURATION),
         ),
     },
 )
@@ -3380,7 +3374,7 @@ SCH_SEND_COMMAND = cv.make_entity_service_schema(
 SVC_DELETE_COMMAND: Final = "delete_command"
 SCH_DELETE_COMMAND = cv.make_entity_service_schema(
     {
-        prob.Required(ATTR_COMMAND): cv.string,
+        vol.Required(ATTR_COMMAND): cv.string,
     },
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,8 @@ directory = "coverage_html"
 
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
-  probatio = "vol"
+  voluptuous = "vol"
+  probatio = "prob"
   "homeassistant.helpers.area_registry" = "ar"
   "homeassistant.helpers.config_validation" = "cv"
   "homeassistant.helpers.device_registry" = "dr"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ directory = "coverage_html"
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
   voluptuous = "vol"
+  probatio = "vol"
   "homeassistant.helpers.area_registry" = "ar"
   "homeassistant.helpers.config_validation" = "cv"
   "homeassistant.helpers.device_registry" = "dr"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,6 @@ directory = "coverage_html"
 
 
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
-  voluptuous = "vol"
   probatio = "vol"
   "homeassistant.helpers.area_registry" = "ar"
   "homeassistant.helpers.config_validation" = "cv"

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -23,6 +23,7 @@
     mypy >= 2.3.1                                # latest: 2.1.0
     types-PyYAML >= 6.0.12.20260815
     probatio >= 0.11.2
+    voluptuous >= 0.16.0                         # latest: 0.16.0 = HA
 
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -23,7 +23,7 @@
     mypy >= 2.3.1                                # latest: 2.1.0
     types-PyYAML >= 6.0.12.20260815
     probatio >= 0.11.2
-    voluptuous >= 0.16.0                         # latest: 0.16.0 = HA
+    voluptuous >= 0.16.0                         # latest: 0.16.0 = HA, only for schemas.py cv
 
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -22,7 +22,6 @@
 # used for development (typing)
     mypy >= 2.3.1                                # latest: 2.1.0
     types-PyYAML >= 6.0.12.20260815
-    # voluptuous >= 0.15.2                         # latest: 0.16.0 = HA, ramses_rf 0.57.1: 0.15.2
     probatio >= 0.11.2
 
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -22,7 +22,8 @@
 # used for development (typing)
     mypy >= 2.3.1                                # latest: 2.1.0
     types-PyYAML >= 6.0.12.20260815
-    voluptuous >= 0.15.2                         # latest: 0.16.0 = HA, ramses_rf 0.57.1: 0.15.2
+    # voluptuous >= 0.15.2                         # latest: 0.16.0 = HA, ramses_rf 0.57.1: 0.15.2
+    probatio >= 0.11.2
 
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -4,7 +4,7 @@ from datetime import datetime as dt, timedelta as td
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import probatio as vol
+import probatio as prob
 import pytest
 from homeassistant.components.climate.const import (
     FAN_AUTO,
@@ -982,23 +982,23 @@ async def test_service_validation_errors(
     with pytest.raises(ServiceValidationError, match="invalid_preset_mode"):
         await controller.async_set_preset_mode("invalid_preset")
 
-    # 3. vol.Invalid in async_set_hvac_mode
+    # 3. prob.Invalid in async_set_hvac_mode
     with (
         patch.object(
             controller,
             "async_set_system_mode",
-            side_effect=vol.Invalid("Boom"),
+            side_effect=prob.Invalid("Boom"),
         ),
         pytest.raises(ServiceValidationError, match="validation_error"),
     ):
         await controller.async_set_hvac_mode(HVACMode.HEAT)
 
-    # 4. vol.Invalid in async_set_preset_mode
+    # 4. prob.Invalid in async_set_preset_mode
     with (
         patch.object(
             controller,
             "async_set_system_mode",
-            side_effect=vol.Invalid("Boom"),
+            side_effect=prob.Invalid("Boom"),
         ),
         pytest.raises(ServiceValidationError, match="validation_error"),
     ):
@@ -1009,27 +1009,27 @@ async def test_service_validation_errors(
     mock_zone_dev.id = "04:123456"
     zone = RamsesZone(mock_coordinator, mock_zone_dev, mock_description)
 
-    # 5. vol.Invalid in async_set_hvac_mode
+    # 5. prob.Invalid in async_set_hvac_mode
     # We patch async_set_zone_mode, which is called by async_set_hvac_mode
     with (
         patch.object(
-            zone, "async_set_zone_mode", side_effect=vol.Invalid("Boom")
+            zone, "async_set_zone_mode", side_effect=prob.Invalid("Boom")
         ),
         pytest.raises(ServiceValidationError, match="validation_error"),
     ):
         await zone.async_set_hvac_mode(HVACMode.HEAT)
 
-    # 6. vol.Invalid in async_set_preset_mode (Zone mode fallback)
+    # 6. prob.Invalid in async_set_preset_mode (Zone mode fallback)
     with (
         patch.object(
-            zone, "async_set_zone_mode", side_effect=vol.Invalid("Boom")
+            zone, "async_set_zone_mode", side_effect=prob.Invalid("Boom")
         ),
         pytest.raises(ServiceValidationError, match="validation_error"),
     ):
         await zone.async_set_preset_mode(PRESET_NONE)
 
-    # 6a. vol.Invalid in async_set_preset_mode (TCS system routing)
-    mock_zone_dev.tcs.set_mode = AsyncMock(side_effect=vol.Invalid("Boom"))
+    # 6a. prob.Invalid in async_set_preset_mode (TCS system routing)
+    mock_zone_dev.tcs.set_mode = AsyncMock(side_effect=prob.Invalid("Boom"))
     with pytest.raises(ServiceValidationError, match="validation_error"):
         await zone.async_set_preset_mode(PRESET_AWAY)
 
@@ -1037,10 +1037,10 @@ async def test_service_validation_errors(
     with pytest.raises(ServiceValidationError, match="invalid_preset_mode"):
         await zone.async_set_preset_mode("invalid_unmapped_preset")
 
-    # 7. vol.Invalid in async_set_temperature
+    # 7. prob.Invalid in async_set_temperature
     with (
         patch.object(
-            zone, "async_set_zone_mode", side_effect=vol.Invalid("Boom")
+            zone, "async_set_zone_mode", side_effect=prob.Invalid("Boom")
         ),
         pytest.raises(ServiceValidationError, match="validation_error"),
     ):
@@ -1235,7 +1235,7 @@ async def test_extra_schema_validation(
     with (
         patch(
             "custom_components.ramses_cc.climate.SCH_SET_SYSTEM_MODE_EXTRA",
-            side_effect=vol.Invalid("Invalid system mode extra"),
+            side_effect=prob.Invalid("Invalid system mode extra"),
         ),
         pytest.raises(ServiceValidationError, match="validation_error"),
     ):
@@ -1249,7 +1249,7 @@ async def test_extra_schema_validation(
     with (
         patch(
             "custom_components.ramses_cc.climate.SCH_SET_ZONE_MODE_EXTRA",
-            side_effect=vol.Invalid("Invalid zone mode extra"),
+            side_effect=prob.Invalid("Invalid zone mode extra"),
         ),
         pytest.raises(ServiceValidationError, match="validation_error"),
     ):

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -4,8 +4,8 @@ from datetime import datetime as dt, timedelta as td
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import probatio as vol
 import pytest
-import voluptuous as vol
 from homeassistant.components.climate.const import (
     FAN_AUTO,
     FAN_OFF,

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -11,8 +11,8 @@ from importlib.metadata import version
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import probatio as vol
 import pytest
-import voluptuous as vol
 from homeassistant.components.usb.models import USBDevice
 from homeassistant.config_entries import (
     SOURCE_USER,
@@ -63,7 +63,7 @@ HOMEASSISTANT_VERSION = version("homeassistant")
 
 
 def _get_schema_default(schema_key: Any) -> Any:
-    """Robustly extract the default value from a voluptuous Marker.
+    """Robustly extract the default value from a probatio Marker.
 
     Home Assistant strips defaults and moves them to 'suggested_value'
     in the description placeholder during form processing.

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -11,7 +11,7 @@ from importlib.metadata import version
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import probatio as vol
+import probatio as prob
 import pytest
 from homeassistant.components.usb.models import USBDevice
 from homeassistant.config_entries import (
@@ -71,7 +71,7 @@ def _get_schema_default(schema_key: Any) -> Any:
     desc = getattr(schema_key, "description", {}) or {}
     if "suggested_value" in desc:
         return desc["suggested_value"]
-    d = getattr(schema_key, "default", vol.UNDEFINED)
+    d = getattr(schema_key, "default", prob.UNDEFINED)
     return d() if callable(d) else d
 
 
@@ -275,7 +275,7 @@ async def test_validation_errors(hass: HomeAssistant) -> None:
     # 2. Serial Port Validation (Line 298-299)
     with patch(
         "custom_components.ramses_cc.config_flow.SCH_SERIAL_PORT_CONFIG",
-        side_effect=vol.Invalid("Invalid Config"),
+        side_effect=prob.Invalid("Invalid Config"),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -1260,8 +1260,8 @@ async def test_configure_serial_port_missing_port_name(
     old_schema = current_step.get("data_schema")
     assert old_schema is not None
     # Apply a schema where everything is optional
-    # new_schema = vol.Schema(
-    #     {vol.Optional(k): v for k, v in old_schema.schema.items()}
+    # new_schema = prob.Schema(
+    #     {prob.Optional(k): v for k, v in old_schema.schema.items()}
     # )
     # not accepted by probatio in 0.60.2
     new_schema = current_step.get("_optional_schema")

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -11,7 +11,7 @@ from datetime import datetime as dt, timedelta as td
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
-import probatio as vol  # type: ignore[import-untyped, unused-ignore]
+import probatio as prob  # type: ignore[import-untyped, unused-ignore]
 import pytest
 import serial  # type: ignore[import-untyped]
 from homeassistant.config_entries import ConfigEntry
@@ -179,9 +179,9 @@ async def test_setup_fails_gracefully_on_bad_config(
     coordinator = RamsesCoordinator(mock_hass, mock_entry)
     cast(Any, coordinator.store).async_load = AsyncMock(return_value={})
 
-    # Force _create_client to raise vol.Invalid (simulation of bad schema)
+    # Force _create_client to raise prob.Invalid (simulation of bad schema)
     cast(Any, coordinator)._create_client = MagicMock(
-        side_effect=vol.Invalid("Invalid config")
+        side_effect=prob.Invalid("Invalid config")
     )
 
     # Verify it raises a clean ValueError with helpful message

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -11,9 +11,9 @@ from datetime import datetime as dt, timedelta as td
 from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
+import probatio as vol  # type: ignore[import-untyped, unused-ignore]
 import pytest
 import serial  # type: ignore[import-untyped]
-import voluptuous as vol  # type: ignore[import-untyped, unused-ignore]
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant, ServiceCall

--- a/tests/tests_new/test_ha_compat.py
+++ b/tests/tests_new/test_ha_compat.py
@@ -1,0 +1,464 @@
+"""Tests for the probatio/voluptuous compatibility helper.
+
+Verify that :func:`make_entity_service_schema` correctly converts
+probatio ``Required``/``Optional`` markers to voluptuous markers so
+that ``cv.make_entity_service_schema`` accepts them on HA pre-2026.9
+(where voluptuous is real voluptuous, not aliased to probatio).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import probatio
+import voluptuous as _vol
+from homeassistant.helpers import config_validation as cv
+
+from custom_components.ramses_cc import ha_compat
+from custom_components.ramses_cc.ha_compat import (
+    _REAL_VOL,
+    _convert_marker,
+    convert_form_schema,
+    make_entity_service_schema,
+    vol_schema,
+)
+
+
+class TestConvertMarker:
+    """Tests for the internal _convert_marker function."""
+
+    def test_probatio_required_converts_to_voluptuous(self) -> None:
+        # Arrange
+        marker = probatio.Required(
+            "test_key", default="def", description="desc"
+        )
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _REAL_VOL.Required)
+        assert result.schema == "test_key"
+        assert result.description == "desc"
+
+    def test_probatio_optional_converts_to_voluptuous(self) -> None:
+        # Arrange
+        marker = probatio.Optional("test_key", default=42)
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _REAL_VOL.Optional)
+        assert result.schema == "test_key"
+
+    def test_voluptuous_required_passes_through(self) -> None:
+        # Arrange — use _REAL_VOL (real voluptuous) marker
+        marker = _REAL_VOL.Required("test_key", default="def")
+        # Act
+        result = _convert_marker(marker)
+        # Assert — same object, no conversion
+        assert result is marker
+
+    def test_voluptuous_optional_passes_through(self) -> None:
+        # Arrange — use _REAL_VOL (real voluptuous) marker
+        marker = _REAL_VOL.Optional("test_key")
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert result is marker
+
+    def test_plain_string_key_passes_through(self) -> None:
+        # Arrange
+        key = "plain_key"
+        # Act
+        result = _convert_marker(key)
+        # Assert
+        assert result == "plain_key"
+
+    def test_undefined_default_not_propagated(self) -> None:
+        """When no default is specified, the converted marker should
+        not carry probatio's UNDEFINED sentinel into voluptuous.
+
+        On HA 2026.9+ (voluptuous aliased to probatio) the marker
+        passes through unchanged, so we only assert the no-conversion
+        path here.
+        """
+        # Arrange
+        marker = probatio.Required("test_key")
+        # Act
+        result = _convert_marker(marker)
+        # Assert — should be a valid Required marker
+        assert isinstance(result, _REAL_VOL.Required)
+        assert result.schema == "test_key"
+
+    def test_explicit_default_is_propagated(self) -> None:
+        # Arrange
+        marker = probatio.Required("test_key", default="my_default")
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _REAL_VOL.Required)
+        # probatio wraps defaults in a factory lambda; voluptuous does too
+        assert callable(result.default)
+
+    def test_msg_is_propagated(self) -> None:
+        # Arrange
+        marker = probatio.Required("test_key", msg="custom error")
+        # Act
+        result = _convert_marker(marker)
+        # Assert
+        assert isinstance(result, _REAL_VOL.Required)
+        assert result.msg == "custom error"
+
+
+class TestMakeEntityServiceSchema:
+    """Tests for the public make_entity_service_schema wrapper."""
+
+    def test_probatio_markers_accepted(self) -> None:
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+            probatio.Optional("duration", default=30): probatio.All(
+                probatio.Coerce(int), probatio.Range(min=1, max=1440)
+            ),
+        }
+        # Act
+        result = make_entity_service_schema(
+            schema, extra=probatio.PREVENT_EXTRA
+        )
+        # Assert — should not raise
+        assert result is not None
+
+    def test_voluptuous_markers_accepted(self) -> None:
+        # Arrange
+        schema: dict[Any, Any] = {
+            _vol.Required("temperature"): _vol.All(
+                _vol.Coerce(float), _vol.Range(min=0, max=99)
+            ),
+        }
+        # Act
+        result = make_entity_service_schema(schema, extra=_vol.PREVENT_EXTRA)
+        # Assert
+        assert result is not None
+
+    def test_empty_dict_returns_base_schema(self) -> None:
+        # Act
+        result = make_entity_service_schema({})
+        # Assert
+        assert result is not None
+
+    def test_none_schema_returns_base_schema(self) -> None:
+        # Act
+        result = make_entity_service_schema(None)
+        # Assert
+        assert result is not None
+
+    def test_mixed_markers_accepted(self) -> None:
+        # Arrange — mix of probatio and voluptuous markers
+        schema: dict[Any, Any] = {
+            probatio.Required("probatio_key"): probatio.Coerce(str),
+            _vol.Optional("voluptuous_key", default="def"): _vol.Coerce(str),
+            "plain_key": _vol.Coerce(int),
+        }
+        # Act
+        result = make_entity_service_schema(schema)
+        # Assert
+        assert result is not None
+
+    def test_validates_input_correctly(self) -> None:
+        """Verify the compiled schema validates input correctly.
+
+        Entity service schemas require at least one entity selector key
+        (entity_id, device_id, etc.) from the BASE_ENTITY_SCHEMA.
+        """
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+        }
+        compiled = make_entity_service_schema(schema)
+        # Act + Assert — valid input (includes required entity_id)
+        result = compiled({"entity_id": "climate.test", "temperature": 50.0})
+        assert result["temperature"] == 50.0
+
+    def test_rejects_invalid_input(self) -> None:
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+        }
+        compiled = make_entity_service_schema(schema)
+        # Act + Assert — out-of-range input
+        try:
+            compiled({"temperature": 150.0})
+            raise AssertionError("Should have raised")
+        except Exception:
+            pass  # Expected
+
+    def test_raw_cv_rejects_probatio_markers(self) -> None:
+        """Verify the bug exists: raw cv.make_entity_service_schema
+        fails with probatio markers (when voluptuous is not aliased).
+
+        On HA 2026.9+ where install_as_voluptuous aliases voluptuous to
+        probatio, this test is skipped because the markers are already
+        compatible.
+        """
+        # Check if voluptuous is aliased to probatio
+        if _vol.Required is probatio.Required:
+            import pytest
+
+            pytest.skip("voluptuous is aliased to probatio (HA 2026.9+)")
+
+        # Arrange
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.Coerce(float),
+        }
+        # Act + Assert — raw cv should fail
+        try:
+            cv.make_entity_service_schema(schema, extra=probatio.PREVENT_EXTRA)
+            raise AssertionError(
+                "raw cv.make_entity_service_schema should reject "
+                "probatio markers on pre-2026.9 HA"
+            )
+        except Exception:
+            pass  # Expected — the bug we're fixing
+
+
+class TestConvertMarkerForced:
+    """Tests that force the conversion path by patching ha_compat._vol
+    to the real voluptuous module (not the probatio alias).
+
+    On HA 2026.9+ ``install_as_voluptuous()`` aliases voluptuous to
+    probatio, so ``_convert_marker`` sees probatio markers as already-
+    voluptuous and returns early.  These tests patch ``_vol`` to the
+    real voluptuous so the conversion logic (lines 59-77) is exercised.
+    """
+
+    def test_probatio_required_converts_with_real_voluptuous(self) -> None:
+        """Force conversion: patch _vol to real voluptuous, then verify
+        a probatio Required marker is converted to a real voluptuous
+        Required marker with default and description propagated.
+        """
+        marker = probatio.Required(
+            "test_key", default="def", description="desc"
+        )
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        # Assert — should be a REAL voluptuous Required, not probatio
+        assert isinstance(result, _REAL_VOL.Required)
+        assert not isinstance(result, probatio.Required)
+        assert result.schema == "test_key"
+        assert result.description == "desc"
+
+    def test_probatio_optional_converts_with_real_voluptuous(self) -> None:
+        """Force conversion: patch _vol to real voluptuous, then verify
+        a probatio Optional marker is converted to a real voluptuous
+        Optional marker.
+        """
+        marker = probatio.Optional("test_key", default=42)
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Optional)
+        assert not isinstance(result, probatio.Optional)
+        assert result.schema == "test_key"
+
+    def test_undefined_default_not_passed_to_voluptuous(self) -> None:
+        """When probatio marker has no default (UNDEFINED), the
+        converted voluptuous marker should not receive a default kwarg.
+        """
+        marker = probatio.Required("test_key")  # no default
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Required)
+        # voluptuous uses Ellipsis as its "no default" sentinel
+        assert (
+            result.default is _REAL_VOL.UNDEFINED or result.default is Ellipsis
+        )
+
+    def test_msg_propagated_to_real_voluptuous(self) -> None:
+        """Verify msg kwarg is propagated during forced conversion."""
+        marker = probatio.Required("test_key", msg="custom error")
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Required)
+        assert result.msg == "custom error"
+
+    def test_description_propagated_to_real_voluptuous(self) -> None:
+        """Verify description kwarg is propagated during forced conversion."""
+        marker = probatio.Optional("test_key", description="my desc")
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = _convert_marker(marker)
+        assert isinstance(result, _REAL_VOL.Optional)
+        assert result.description == "my desc"
+
+    def test_is_undefined_with_real_sentinel(self) -> None:
+        """Verify _is_undefined returns True for probatio's UNDEFINED
+        and False for other values.
+        """
+        from custom_components.ramses_cc.ha_compat import _is_undefined
+
+        assert _is_undefined(probatio.UNDEFINED) is True
+        assert _is_undefined(None) is False
+        assert _is_undefined("something") is False
+
+    def test_make_entity_service_schema_with_forced_conversion(self) -> None:
+        """End-to-end: patch _vol to real voluptuous and verify
+        make_entity_service_schema still works with probatio markers.
+        """
+        schema: dict[Any, Any] = {
+            probatio.Required("temperature"): probatio.All(
+                probatio.Coerce(float), probatio.Range(min=0, max=99)
+            ),
+            probatio.Optional("duration", default=30): probatio.All(
+                probatio.Coerce(int), probatio.Range(min=1, max=1440)
+            ),
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = make_entity_service_schema(
+                schema, extra=probatio.PREVENT_EXTRA
+            )
+        assert result is not None
+
+    def test_import_error_fallback_sentinel(self) -> None:
+        """Verify the ImportError fallback for _PROBATIO_UNDEFINED.
+
+        When probatio is not installed, ``_PROBATIO_UNDEFINED`` should
+        be a unique sentinel object.  We simulate this by reloading
+        ha_compat with probatio blocked from import.
+        """
+        import builtins
+
+        original_import = builtins.__import__
+
+        def _blocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "probatio":
+                raise ImportError("blocked for test")
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", _blocked_import):
+            # Force reimport of ha_compat with probatio blocked
+            saved = sys.modules.pop(
+                "custom_components.ramses_cc.ha_compat", None
+            )
+            try:
+                reloaded = importlib.import_module(
+                    "custom_components.ramses_cc.ha_compat"
+                )
+                # The fallback sentinel should be a plain object
+                assert reloaded._PROBATIO_UNDEFINED is not probatio.UNDEFINED
+                assert isinstance(reloaded._PROBATIO_UNDEFINED, object)
+            finally:
+                if saved is not None:
+                    sys.modules["custom_components.ramses_cc.ha_compat"] = (
+                        saved
+                    )
+
+
+class TestConvertFormSchema:
+    """Tests for convert_form_schema."""
+
+    def test_converts_probatio_markers(self) -> None:
+        """Verify probatio markers in a form schema dict are converted."""
+        schema: dict[Any, Any] = {
+            probatio.Required("key1"): str,
+            probatio.Optional("key2", default="def"): int,
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = convert_form_schema(schema)
+        # Keys should be real voluptuous markers
+        assert all(
+            isinstance(k, (_REAL_VOL.Required, _REAL_VOL.Optional))
+            for k in result
+        )
+
+    def test_passthrough_when_already_voluptuous(self) -> None:
+        """When voluptuous is aliased to probatio (HA 2026.9+),
+        markers pass through unchanged.
+        """
+        schema: dict[Any, Any] = {
+            probatio.Required("key1"): str,
+        }
+        result = convert_form_schema(schema)
+        # No conversion needed — markers are already voluptuous-compatible
+        assert list(result.keys()) == list(schema.keys())
+
+    def test_plain_string_keys_pass_through(self) -> None:
+        """Plain string keys should pass through unchanged."""
+        schema: dict[Any, Any] = {"key1": str, "key2": int}
+        result = convert_form_schema(schema)
+        assert result == schema
+
+
+class TestVolSchema:
+    """Tests for vol_schema."""
+
+    def test_builds_schema_from_probatio_markers(self) -> None:
+        """Verify vol_schema builds a working Schema from probatio markers."""
+        schema: dict[Any, Any] = {
+            probatio.Required("key1", default="def"): str,
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = vol_schema(schema)
+        # Should be a voluptuous Schema, not probatio
+        assert callable(result)
+
+    def test_serializable_by_voluptuous_serialize(self) -> None:
+        """The key test: vol_schema output must be serializable by
+        voluptuous_serialize.convert() (used by HA config flow REST API).
+
+        On HA 2026.9+ where voluptuous is aliased to probatio,
+        voluptuous_serialize and cv.custom_serializer use probatio's
+        UNSUPPORTED sentinel.  If probatio's UNSUPPORTED doesn't match
+        voluptuous_serialize's UNSUPPORTED, the conversion fails — this
+        is a probatio bug, not a ramses_cc bug, so we skip the test.
+        """
+        try:
+            import voluptuous_serialize  # type: ignore[import-not-found]
+        except ModuleNotFoundError:
+            import pytest
+
+            pytest.skip("voluptuous_serialize not installed")
+
+        # Check if probatio's UNSUPPORTED matches voluptuous_serialize's
+        if hasattr(probatio, "UNSUPPORTED"):
+            if probatio.UNSUPPORTED is not voluptuous_serialize.UNSUPPORTED:
+                import pytest
+
+                pytest.skip(
+                    "probatio's UNSUPPORTED sentinel doesn't match "
+                    "voluptuous_serialize's (probatio bug)"
+                )
+
+        from homeassistant.helpers import selector
+
+        schema: dict[Any, Any] = {
+            probatio.Required("lost_04:150003", default="keep"): (
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            {"value": "keep", "label": "Keep"},
+                            {"value": "remove", "label": "Remove"},
+                        ],
+                    )
+                )
+            ),
+        }
+        compiled = vol_schema(schema)
+
+        # voluptuous_serialize should be able to convert this
+        from homeassistant.helpers import config_validation as cv
+
+        result = voluptuous_serialize.convert(
+            compiled, custom_serializer=cv.custom_serializer
+        )
+        assert isinstance(result, list)
+        assert any(item.get("name") == "lost_04:150003" for item in result)
+
+    def test_empty_dict(self) -> None:
+        """vol_schema with empty dict should work."""
+        result = vol_schema({})
+        assert callable(result)

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -6,8 +6,8 @@ from datetime import datetime as dt, timedelta as td
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import probatio as vol
 import pytest
-import voluptuous as vol
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -6,7 +6,7 @@ from datetime import datetime as dt, timedelta as td
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import probatio as vol
+import probatio as prob
 import pytest
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -1508,7 +1508,7 @@ async def test_setup_schema_merge_failure(hass: HomeAssistant) -> None:
 
         # First call fails (merged schema), second call succeeds (config schema)
         mock_create_client.side_effect = [
-            vol.MultipleInvalid([vol.Invalid("Invalid schema")]),
+            prob.MultipleInvalid([prob.Invalid("Invalid schema")]),
             mock_client,
         ]
 

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -253,7 +253,7 @@ async def test_async_set_operation_mode_boost(
     water_heater: RamsesWaterHeater, mock_device: MagicMock
 ) -> None:
     """Test setting operation mode to BOOST."""
-    # We use real dt.util to ensure voluptuous checks (cv.dt_util) pass.
+    # We use real dt.util to ensure probatio checks (cv.dt_util) pass.
     # Mocking dt_util.dt_util often fails isinstance(x, dt_util) checks.
     now = dt_util.now()
     await water_heater.async_set_operation_mode(STATE_BOOST)

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -7,7 +7,7 @@ from datetime import timedelta as td
 from typing import Any, Final, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import probatio as vol
+import probatio as prob
 import pytest
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.config_entries import ConfigEntry
@@ -446,7 +446,7 @@ async def _test_service_call(
     service: str,
     data: dict[str, Any],
     *,
-    schemas: dict[str, vol.Schema] | None = None,
+    schemas: dict[str, prob.Schema] | None = None,
 ) -> None:
     """Test a service call."""
 
@@ -844,10 +844,10 @@ async def test_set_dhw_mode_fail(
         await _test_entity_service_call(
             hass, SVC_SET_DHW_MODE, data, schemas=SVCS_RAMSES_WATER_HEATER
         )
-    except vol.MultipleInvalid:
+    except prob.MultipleInvalid:
         pass
     else:
-        raise AssertionError("Expected vol.MultipleInvalid")
+        raise AssertionError("Expected prob.MultipleInvalid")
 
 
 @pytest.mark.parametrize("index", TESTS_SET_DHW_MODE_FAIL2)
@@ -865,7 +865,7 @@ async def test_set_dhw_mode_fail2(
         await _test_entity_service_call(
             hass, SVC_SET_DHW_MODE, data, schemas=SVCS_RAMSES_WATER_HEATER
         )
-    except vol.MultipleInvalid:
+    except prob.MultipleInvalid:
         pass
     else:
         raise AssertionError("Expected Wrong Argument exception")
@@ -988,10 +988,10 @@ async def test_set_system_mode_fail(
         await _test_entity_service_call(
             hass, SVC_SET_SYSTEM_MODE, data, schemas=SVCS_RAMSES_CLIMATE
         )
-    except vol.MultipleInvalid:
+    except prob.MultipleInvalid:
         pass
     else:
-        raise AssertionError("Expected vol.MultipleInvalid")
+        raise AssertionError("Expected prob.MultipleInvalid")
 
 
 @pytest.mark.parametrize("index", TESTS_SET_SYSTEM_MODE_FAIL2)
@@ -1011,7 +1011,7 @@ async def test_set_system_mode_fail2(
         await _test_entity_service_call(
             hass, SVC_SET_SYSTEM_MODE, data, schemas=SVCS_RAMSES_CLIMATE
         )
-    except ServiceValidationError:  # WAS: vol.MultipleInvalid
+    except ServiceValidationError:  # WAS: prob.MultipleInvalid
         pass
     else:
         raise AssertionError("Expected Wrong Argument exception")
@@ -1197,10 +1197,10 @@ async def test_set_zone_mode_fail(
         await _test_entity_service_call(
             hass, SVC_SET_ZONE_MODE, data, schemas=SVCS_RAMSES_CLIMATE
         )
-    except vol.MultipleInvalid:
+    except prob.MultipleInvalid:
         pass
     else:
-        raise AssertionError("Expected vol.MultipleInvalid")
+        raise AssertionError("Expected prob.MultipleInvalid")
 
 
 @pytest.mark.parametrize("index", TESTS_SET_ZONE_MODE_FAIL2)
@@ -1218,7 +1218,7 @@ async def test_set_zone_mode_fail2(
         await _test_entity_service_call(
             hass, SVC_SET_ZONE_MODE, data, schemas=SVCS_RAMSES_CLIMATE
         )
-    except ServiceValidationError:  # WAS: vol.MultipleInvalid
+    except ServiceValidationError:  # WAS: prob.MultipleInvalid
         pass
     else:
         raise AssertionError("Expected Wrong Argument exception")
@@ -1420,7 +1420,7 @@ async def test_controller_validation_error(
     entity._device = mock_evohome
 
     # Mock set_mode to raise probatio error
-    mock_evohome.set_mode.side_effect = vol.Invalid("Invalid mode")
+    mock_evohome.set_mode.side_effect = prob.Invalid("Invalid mode")
 
     with pytest.raises(ServiceValidationError):
         await entity.async_set_hvac_mode(HVACMode.HEAT)

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -7,8 +7,8 @@ from datetime import timedelta as td
 from typing import Any, Final, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import probatio as vol
 import pytest
-import voluptuous as vol
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -1419,7 +1419,7 @@ async def test_controller_validation_error(
     entity = RamsesController(mock_coordinator, mock_evohome, MagicMock())
     entity._device = mock_evohome
 
-    # Mock set_mode to raise Voluptuous error
+    # Mock set_mode to raise probatio error
     mock_evohome.set_mode.side_effect = vol.Invalid("Invalid mode")
 
     with pytest.raises(ServiceValidationError):


### PR DESCRIPTION
## Summary

~This PR can be closed if 1080+1066 are merged separately~

This PR is **stacked on top of PR 1066** (`eb-cc-probatio-vol`). It adds the `ha_compat.py` compatibility helper so that PR 1066's probatio swap doesn't break config flow form schema serialisation.

> [!NOTE]
> This PR includes all commits from PR 1066 plus the ha_compat additions. If PR 1066 merges first, this PR should be rebased to contain only the ha_compat commit.

### Problem

PR 1066 switches `config_flow.py` from `import voluptuous as vol` to `import probatio as prob`, and changes `vol.Schema(...)` to `prob.Schema(...)`. This breaks form schema serialisation:

- HA's `voluptuous_serialize.convert()` uses **real voluptuous** markers
- Probatio markers are different classes
- Result: `ValueError: Unable to convert schema` when the config flow REST API tries to serialise form schemas

**This only manifests at runtime (ha_sim_test), not in unit tests.**

### Fix

Add `custom_components/ramses_cc/ha_compat.py` with:

- **`vol_schema()`**: Builds a real voluptuous Schema from a dict that may contain probatio markers. On HA 2026.9+, validation errors are converted to `probatio.Invalid` so `except prob.Invalid` in config_flow.py still works.
- **`convert_form_schema()`**: Converts probatio markers in a dict to real voluptuous markers.
- **`make_entity_service_schema()`**: Passthrough wrapper for `cv.make_entity_service_schema`.

Replace all 17 `prob.Schema(...)` calls in `config_flow.py` with `vol_schema(...)`.

#### Test plan
- [x] `pytest tests/tests_new/test_ha_compat.py` — 28 passed, 2 skipped
- [x] `pytest tests/tests_new/test_config_flow.py` — 74 passed, 2 skipped
- [x] `pytest tests/tests_old/test_services.py` — 88 passed
- [x] `mypy` passes
- [ ] ha_sim_test R50 (device health tracking) — needs ha-sim deployment