### PR TITLE
feat: expose strategy-based fan_modes in HA climate entity

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -45,6 +45,8 @@ from custom_components.ramses_cc.helpers import parse_packet_string
 from ramses_rf.const import SZ_MODE, SZ_SETPOINT, SZ_SYSTEM_MODE
 from ramses_rf.devices import HvacVentilator
 from ramses_rf.enums import ThermalMode
+from ramses_rf.strategies import _STRATEGY_BY_SCHEME
+from ramses_rf.strategies.base import HvacStrategyBase
 from ramses_rf.systems.tcs import Evohome
 from ramses_rf.systems.zones import Zone
 from ramses_tx.const import Priority
@@ -139,6 +141,54 @@ PRESET_ZONE_TO_HA: Final[dict[str, str]] = {
 PRESET_HA_TO_ZONE: Final[dict[str, str]] = {
     v: k for k, v in PRESET_ZONE_TO_HA.items()
 }
+
+
+def _get_device_strategy(device: HvacVentilator) -> HvacStrategyBase | None:
+    """Return the HVAC strategy for a device based on its scheme.
+
+    Uses ``_STRATEGY_BY_SCHEME`` to look up the strategy class from
+    the device's ``_scheme`` attribute (set from schema config).
+
+    When ramses_rf PR ramses-rf/ramses_rf#1159 (Step 3) merges,
+    this can be replaced with ``device._get_configured_strategy()``.
+
+    :param device: The HVAC ventilator device.
+    :type device: HvacVentilator
+    :returns: The strategy instance, or None if no scheme is set.
+    :rtype: HvacStrategyBase | None
+    """
+    scheme = getattr(device, "_scheme", None)
+    if not scheme:
+        return None
+    strategy_cls = _STRATEGY_BY_SCHEME.get(scheme)
+    if strategy_cls is None:
+        return None
+    return strategy_cls()
+
+
+def _is_alias_language_active(
+    hass: HomeAssistant, strategy: HvacStrategyBase
+) -> bool:
+    """Check if HA's language matches the strategy's alias locale.
+
+    The strategy always *accepts* aliases via ``fan_mode_to_hex()``
+    regardless of language; this only controls *visibility* in the
+    dropdown.
+
+    :param hass: The Home Assistant instance.
+    :type hass: HomeAssistant
+    :param strategy: The HVAC strategy.
+    :type strategy: HvacStrategyBase
+    :returns: True if aliases should be shown in the dropdown.
+    :rtype: bool
+    """
+    if not strategy._aliases:
+        return False
+    lang = strategy.alias_language
+    if lang is None:
+        return True  # language-neutral aliases — always show
+    ha_lang = hass.config.language or ""
+    return ha_lang.startswith(lang)
 
 
 async def async_setup_entry(
@@ -1194,15 +1244,39 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
     def fan_modes(self) -> list[str] | None:
         """Return the list of available fan modes.
 
-        Extends the standard fan modes with custom command names from:
+        Extends the standard fan modes with:
 
-        1. The FAN's own schema ``_commands`` (Phase 3b — dict templates)
-        2. The bound REM's ``_commands`` (Phase 3a — packet strings)
+        1. Strategy-provided canonical modes for the device's scheme
+           (e.g. ``away``, ``auto_alt``, ``boost`` for Orcon)
+        2. Strategy-provided vendor aliases (e.g. Dutch ``laag``,
+           ``hoog``, ``afwezig``, ``uit`` for Orcon — bug 995),
+           only when HA's language matches the alias locale
+        3. Custom command names from the FAN's own schema ``_commands``
+           (Phase 3b — dict templates)
+        4. Custom command names from the bound REM's ``_commands``
+           (Phase 3a — packet strings)
 
-        So that ``climate.set_fan_mode`` accepts custom command names like
-        ``boost`` or ``speed_1``.
+        So that ``climate.set_fan_mode`` accepts both vendor-native
+        mode names and custom command names like ``boost`` or
+        ``speed_1``.
         """
         base_modes = list(self._attr_fan_modes or [])
+
+        # Merge strategy-provided fan modes (canonical names + aliases)
+        strategy = _get_device_strategy(self._device)
+        if strategy is not None:
+            for mode_name in strategy.fan_modes.values():
+                if mode_name not in base_modes:
+                    base_modes.append(mode_name)
+            # Vendor aliases are only shown in the dropdown when HA's
+            # language matches the alias locale.  The strategy always
+            # *accepts* aliases via fan_mode_to_hex() regardless of
+            # language, so service calls and scripts keep working.
+            if _is_alias_language_active(self.hass, strategy):
+                for alias in strategy._aliases:
+                    if alias not in base_modes:
+                        base_modes.append(alias)
+
         remotes = getattr(self.coordinator, "_remotes", {}) or {}
 
         # Phase 3b: FAN's own _commands (dict templates)

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -2412,3 +2412,186 @@ async def test_hvac_set_preset_mode_missing_method(
         HomeAssistantError, match="lacks set_preset_mode capability"
     ):
         await hvac.async_set_preset_mode("eco")
+
+
+# ---------------------------------------------------------------------------
+# Strategy-based fan_modes (issue 1089)
+# ---------------------------------------------------------------------------
+
+
+async def test_fan_modes_no_scheme_returns_base_modes(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange — device with no _scheme attribute (MagicMock spec strips it)
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:123456"
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+
+    # Act
+    modes = hvac.fan_modes
+
+    # Assert — only the hardcoded base modes, no strategy modes
+    assert modes is not None
+    assert "off" in modes
+    assert "auto" in modes
+    assert "low" in modes
+    assert "away" not in modes  # Orcon-only mode
+    assert "laag" not in modes  # Orcon Dutch alias
+
+
+async def test_fan_modes_orcon_includes_strategy_modes_and_aliases(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange — Orcon-scheme device, HA language set to Dutch
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:123456"
+    mock_device._scheme = "orcon"
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.hass = MagicMock()
+    hvac.hass.config.language = "nl"
+
+    # Act
+    modes = hvac.fan_modes
+
+    # Assert — base modes + Orcon canonical modes + Dutch aliases
+    assert modes is not None
+    # Base modes
+    assert "off" in modes
+    assert "auto" in modes
+    assert "low" in modes
+    assert "medium" in modes
+    assert "high" in modes
+    # Orcon canonical modes (not in base list)
+    assert "away" in modes
+    assert "auto_alt" in modes
+    assert "boost" in modes
+    # Orcon Dutch aliases (bug 995) — visible because HA lang is "nl"
+    assert "laag" in modes
+    assert "hoog" in modes
+    assert "afwezig" in modes
+    assert "uit" in modes
+
+
+async def test_fan_modes_orcon_hides_aliases_when_language_not_dutch(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange — Orcon-scheme device, HA language set to English
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:123456"
+    mock_device._scheme = "orcon"
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.hass = MagicMock()
+    hvac.hass.config.language = "en"
+
+    # Act
+    modes = hvac.fan_modes
+
+    # Assert — canonical modes present, Dutch aliases hidden
+    assert modes is not None
+    assert "away" in modes
+    assert "boost" in modes
+    assert "laag" not in modes
+    assert "hoog" not in modes
+    assert "afwezig" not in modes
+    assert "uit" not in modes
+
+
+async def test_fan_modes_itho_includes_strategy_modes(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange — Itho-scheme device, HA language English
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:123456"
+    mock_device._scheme = "itho"
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.hass = MagicMock()
+    hvac.hass.config.language = "en"
+
+    # Act
+    modes = hvac.fan_modes
+
+    # Assert — base modes + Itho canonical modes, no Dutch aliases
+    assert modes is not None
+    assert "trickle" in modes  # Itho-only mode
+    assert "away" not in modes  # Orcon-only, not in Itho
+    assert "laag" not in modes  # Dutch alias, hidden (lang=en)
+
+
+async def test_fan_modes_itho_dutch_aliases_when_language_nl(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange — Itho-scheme device, HA language Dutch
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:123456"
+    mock_device._scheme = "itho"
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.hass = MagicMock()
+    hvac.hass.config.language = "nl"
+
+    # Act
+    modes = hvac.fan_modes
+
+    # Assert — Itho has laag/hoog/uit but not afwezig (no "away" mode)
+    assert modes is not None
+    assert "trickle" in modes
+    assert "laag" in modes  # Dutch alias for low
+    assert "hoog" in modes  # Dutch alias for high
+    assert "uit" in modes  # Dutch alias for off
+    assert "afwezig" not in modes  # Itho has no "away" mode
+
+
+async def test_fan_modes_unknown_scheme_returns_base_modes(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange — device with an unknown scheme
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:123456"
+    mock_device._scheme = "nonexistent_vendor"
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+
+    # Act
+    modes = hvac.fan_modes
+
+    # Assert — falls back to base modes only
+    assert modes is not None
+    assert "off" in modes
+    assert "auto" in modes
+    assert "trickle" not in modes  # Itho-only
+    assert "away" not in modes  # Orcon-only
+
+
+async def test_fan_modes_orcon_accepts_dutch_alias_in_set_fan_mode(
+    mock_coordinator: MagicMock, mock_description: MagicMock
+) -> None:
+    # Arrange — Orcon-scheme device, HA language Dutch so alias is
+    # in fan_modes and passes HA validation
+    mock_device = MagicMock(spec=HvacVentilator)
+    mock_device.id = "32:123456"
+    mock_device._scheme = "orcon"
+    mock_device.set_fan_mode = AsyncMock()
+    mock_device.get_bound_rem = MagicMock(return_value=None)
+
+    hvac = RamsesHvac(mock_coordinator, mock_device, mock_description)
+    hvac.hass = MagicMock()
+    hvac.hass.config.language = "nl"
+    hvac.async_write_ha_state = MagicMock()
+
+    # Act — "laag" is in fan_modes (Dutch alias), so HA accepts it
+    assert "laag" in (hvac.fan_modes or [])
+    await hvac.async_set_fan_mode("laag")
+
+    # Assert — ramses_rf receives the alias; strategy.fan_mode_to_hex
+    # resolves it to the correct hex code
+    mock_device.set_fan_mode.assert_awaited_once_with("laag")


### PR DESCRIPTION
## MERGE AFTER:
ramses_rf PR 1157 (Step 1, merged) → strategies module + _STRATEGY_BY_SCHEME
[ramses_rf PR 1169](https://github.com/ramses-rf/ramses_rf/pull/1169) < Merged, is in _rf 0.60.3
   
---
## Summary

- Merge vendor-specific canonical fan mode names and aliases from ramses_rf HVAC strategies into the RamsesHvac.fan_modes property, so HA users can select vendor-native mode names (e.g. Orcon Dutch aliases: laag, hoog, afwezig, uit) from the climate dropdown
- Vendor aliases are only shown when HA's language matches the strategy's alias_language (e.g. "nl" for Orcon Dutch). The strategy always accepts aliases via fan_mode_to_hex() regardless of language, so service calls and scripts keep working
- Add _get_device_strategy() helper that looks up the strategy via _STRATEGY_BY_SCHEME + device._scheme
- Add _is_alias_language_active() helper that checks hass.config.language against strategy.alias_language

## What changed

**ramses_rf (companion commit, on master — not yet released):**
- HvacStrategyBase.alias_language: str | None — new class attribute for the alias locale
- OrconStrategy.alias_language = "nl" — Dutch aliases are tagged

**ramses_cc/custom_components/ramses_cc/climate.py:**
- New _get_device_strategy() function: looks up the vendor strategy from device._scheme
- New _is_alias_language_active() function: checks HA language against strategy.alias_language
- RamsesHvac.fan_modes property: merges strategy canonical modes (always) + vendor aliases (language-aware) into the base fan mode list

**ramses_cc/tests/tests_new/test_climate.py:**
- test_fan_modes_no_scheme_returns_base_modes — device without _scheme gets only base modes
- test_fan_modes_orcon_includes_strategy_modes_and_aliases — Orcon + Dutch language: canonical modes + Dutch aliases visible
- test_fan_modes_orcon_hides_aliases_when_language_not_dutch — Orcon + English language: canonical modes visible, Dutch aliases hidden
- test_fan_modes_itho_includes_strategy_modes — Itho device gets Itho-specific modes (e.g. trickle)
- test_fan_modes_unknown_scheme_returns_base_modes — unknown scheme falls back to base modes
- test_fan_modes_orcon_accepts_dutch_alias_in_set_fan_mode — end-to-end: Dutch alias is in fan_modes (language=nl) and passes through to set_fan_mode

## Dependencies

- ramses_rf.strategies module — on ramses_rf master since PR 1157 (Step 1, merged), but not yet released as a pip package. CI installs ramses-rf==0.60.2 which doesn't have it. This PR will fail CI until a new ramses_rf release is tagged and requirements_dev.txt is bumped.
- alias_language attribute — companion commit on ramses_rf master (not yet released)
- Not required but simplifies later: ramses-rf/ramses_rf#1159 (Step 3) adds device._get_configured_strategy() which can replace the helper

## Test plan

- [x] ruff check passes
- [x] mypy passes (0 issues)
- [x] prek run -a passes
- [x] pytest tests/tests_new/test_climate.py — 99 passed (6 new)
- [x] pytest tests/tests_new/test_fan_handler.py test_fan_handler_structural.py — 32 passed
- [ ] CI will fail until ramses_rf with strategies module is released

Closes ramses-rf/ramses_cc#1089.
