### PR TITLE
fix(schedule): unwrap schedule dictionary payloads in climate and water_heater services

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -58,6 +58,7 @@ from ramses_tx.exceptions import (
 
 from .const import (
     ATTR_DEVICE_ID,
+    ATTR_SCHEDULE,
     DOMAIN,
     PRESET_CUSTOM,
     PRESET_PERMANENT,
@@ -1067,6 +1068,8 @@ class RamsesZone(RamsesEntity, ClimateEntity):
             payload = (
                 json.loads(schedule) if isinstance(schedule, str) else schedule
             )
+            if isinstance(payload, dict):
+                payload = payload.get(ATTR_SCHEDULE, payload)
             await self._device.set_schedule(payload)
             self.async_write_ha_state()
         except (TypeError, ValueError, json.JSONDecodeError) as err:

--- a/custom_components/ramses_cc/water_heater.py
+++ b/custom_components/ramses_cc/water_heater.py
@@ -34,7 +34,7 @@ from ramses_tx.exceptions import (
     TransportError,
 )
 
-from .const import DOMAIN, SystemMode, ZoneMode
+from .const import ATTR_SCHEDULE, DOMAIN, SystemMode, ZoneMode
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
 from .helpers import (
@@ -479,6 +479,8 @@ class RamsesWaterHeater(RamsesEntity, WaterHeaterEntity):
             payload = (
                 json.loads(schedule) if isinstance(schedule, str) else schedule
             )
+            if isinstance(payload, dict):
+                payload = payload.get(ATTR_SCHEDULE, payload)
             await self._device.set_schedule(payload)
             self.async_write_ha_state()
         except (TypeError, ValueError, json.JSONDecodeError) as err:

--- a/tests/tests_new/test_climate.py
+++ b/tests/tests_new/test_climate.py
@@ -752,6 +752,15 @@ async def test_zone_methods_and_services(
     await zone.async_set_zone_schedule({"day": 2})
     mock_device.set_schedule.assert_awaited_with({"day": 2})
 
+    await zone.async_set_zone_schedule('{"schedule": [{"day_of_week": 0}]}')
+    mock_device.set_schedule.assert_awaited_with([{"day_of_week": 0}])
+
+    await zone.async_set_zone_schedule({"schedule": [{"day_of_week": 1}]})
+    mock_device.set_schedule.assert_awaited_with([{"day_of_week": 1}])
+
+    await zone.async_set_zone_schedule([{"day_of_week": 2}])
+    mock_device.set_schedule.assert_awaited_with([{"day_of_week": 2}])
+
 
 async def test_hvac_properties_and_modes(
     mock_coordinator: MagicMock, mock_description: MagicMock

--- a/tests/tests_new/test_water_heater.py
+++ b/tests/tests_new/test_water_heater.py
@@ -378,6 +378,22 @@ async def test_schedule_management(
     await water_heater.async_set_dhw_schedule({"tue": []})
     mock_device.set_schedule.assert_awaited_with({"tue": []})
 
+    # Test Set (Dictionary containing "schedule" key)
+    await water_heater.async_set_dhw_schedule(
+        {"schedule": [{"day_of_week": 0}]}
+    )
+    mock_device.set_schedule.assert_awaited_with([{"day_of_week": 0}])
+
+    # Test Set (JSON String containing "schedule" key)
+    await water_heater.async_set_dhw_schedule(
+        '{"schedule": [{"day_of_week": 1}]}'
+    )
+    mock_device.set_schedule.assert_awaited_with([{"day_of_week": 1}])
+
+    # Test Set (Pure list)
+    await water_heater.async_set_dhw_schedule([{"day_of_week": 2}])
+    mock_device.set_schedule.assert_awaited_with([{"day_of_week": 2}])
+
     # Test Set (Invalid JSON)
     with pytest.raises(ServiceValidationError) as excinfo:
         await water_heater.async_set_dhw_schedule("{invalid")


### PR DESCRIPTION
### The Problem:
Home Assistant service calls to `ramses_cc.set_zone_schedule` and `ramses_cc.set_dhw_schedule` accept schedule payloads as JSON strings, dictionaries, or lists. When users or automations pass the full dictionary payload exported from `get_zone_schedule` / `get_dhw_schedule` (or UI-generated templates formatted as `{"schedule": [...]}`), the integration passed the outer dictionary directly to the underlying `ramses_rf` device method without extracting the inner switchpoint array. When paired with `ramses_rf<=0.60.2`, this caused schedule set calls to fail validation with a `ServiceValidationError`.

### The Fix:
Added defensive unwrapping in `RamsesZone.async_set_zone_schedule()` and `RamsesWaterHeater.async_set_dhw_schedule()`:
```python
if isinstance(payload, dict):
    payload = payload.get(ATTR_SCHEDULE, payload)
```
This ensures immediate backward and forward compatibility whether callers pass a JSON string, a dictionary with an outer `{"schedule": ...}` key, a dictionary with arbitrary zone metadata, or a raw list of switchpoints.

### Technical Implementation:
- Imported canonical `ATTR_SCHEDULE` from `.const` in `custom_components/ramses_cc/climate.py` and `custom_components/ramses_cc/water_heater.py`.
- Added dictionary unwrapping prior to invoking `await self._device.set_schedule(payload)`.
- Complements the underlying payload normalisation in ramses-rf/ramses_rf#1170.

### Testing Performed:
- Expanded unit tests in `tests/tests_new/test_climate.py` and `tests/tests_new/test_water_heater.py` to verify:
  - JSON strings with outer `schedule` key
  - Python dictionaries with outer `schedule` key
  - Pure switchpoint lists
- Verified pre-commit (`.venv/bin/prek run -a`), linters (`.venv/bin/ruff check`), and `mypy` passed with 0 errors across all 70 source files.
- Verified full test suite execution: **1,433 passed, 12 skipped, 3 snapshots passed**.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini for code generation and documentation. All logic and implementations were reviewed and verified by the author.