### PR TITLE
test(dto): align test_dto_alignment with hardware-pure DTO architecture

### DIFF
--- a/tests/tests_new/test_dto_alignment.py
+++ b/tests/tests_new/test_dto_alignment.py
@@ -1,7 +1,15 @@
+from datetime import datetime as dt
+
 from custom_components.ramses_cc.helpers import dto_to_dict, extract_demand
 from ramses_rf.enums import ThermalMode
 from ramses_rf.models import (
-    ActuatorStateDTO,
+    ActuatorCycleDTO,
+    BdrStateDTO,
+    JimStateDTO,
+    OpenThermCounters,
+    OpenThermFlags,
+    OpenThermStateDTO,
+    OpenThermTemperatures,
     ThermalDemandDTO,
     UfhCircuitDemandDTO,
 )
@@ -37,12 +45,50 @@ def test_dto_to_dict_conversion() -> None:
             ufh_index="1", thermal_demand=0.4, mode=ThermalMode.HEAT
         )
     ]
-    actuator_dto = ActuatorStateDTO(ch_active=True, ch_enabled=True)
+    bdr_dto = BdrStateDTO(modulation_level=0.5, actuator_enabled=True)
+    jim_dto = JimStateDTO(
+        ch_active=True,
+        dhw_active=False,
+        flame_active=True,
+        cooling_active=False,
+        actuator_enabled=True,
+    )
+    cycle_dto = ActuatorCycleDTO(
+        actuator_countdown=30,
+        cycle_countdown=120,
+        actuator_enabled=True,
+        modulation_level=0.75,
+    )
+    timestamp = dt(2026, 8, 30, 12, 0, 0)
+    otb_dto = OpenThermStateDTO(
+        flags=OpenThermFlags(
+            flame_active=True,
+            ch_active=True,
+            dhw_active=False,
+            cooling_active=False,
+        ),
+        temperatures=OpenThermTemperatures(
+            boiler_output=65.5,
+            boiler_return=45.0,
+            dhw=55.0,
+            outside=18.5,
+        ),
+        counters=OpenThermCounters(burner_starts=120, burner_hours=350),
+        ch_water_pressure=1.8,
+        dhw_flow_rate=0.0,
+        max_rel_modulation=1.0,
+        rel_modulation_level=0.45,
+        oem_code="00",
+        last_updated=timestamp,
+    )
 
     # Act
     converted_dto = dto_to_dict(dto)
     converted_list = dto_to_dict(dto_list)
-    converted_actuator = dto_to_dict(actuator_dto)
+    converted_bdr = dto_to_dict(bdr_dto)
+    converted_jim = dto_to_dict(jim_dto)
+    converted_cycle = dto_to_dict(cycle_dto)
+    converted_otb = dto_to_dict(otb_dto)
 
     # Assert
     assert converted_dto == {
@@ -54,5 +100,33 @@ def test_dto_to_dict_conversion() -> None:
     assert converted_list == [
         {"ufh_index": "1", "thermal_demand": 0.4, "mode": "heat"}
     ]
-    assert converted_actuator["ch_active"] is True
-    assert converted_actuator["ch_enabled"] is True
+    assert converted_bdr == {
+        "modulation_level": 0.5,
+        "actuator_enabled": True,
+        "last_updated": None,
+    }
+    assert converted_jim == {
+        "modulation_level": None,
+        "actuator_enabled": True,
+        "last_updated": None,
+        "ch_active": True,
+        "dhw_active": False,
+        "flame_active": True,
+        "cooling_active": False,
+    }
+    assert converted_cycle == {
+        "actuator_countdown": 30,
+        "cycle_countdown": 120,
+        "actuator_enabled": True,
+        "modulation_level": 0.75,
+    }
+    assert converted_otb["flags"]["flame_active"] is True
+    assert converted_otb["flags"]["ch_active"] is True
+    assert converted_otb["flags"]["dhw_active"] is False
+    assert converted_otb["temperatures"]["boiler_output"] == 65.5
+    assert converted_otb["temperatures"]["boiler_return"] == 45.0
+    assert converted_otb["counters"]["burner_starts"] == 120
+    assert converted_otb["counters"]["burner_hours"] == 350
+    assert converted_otb["ch_water_pressure"] == 1.8
+    assert converted_otb["rel_modulation_level"] == 0.45
+    assert converted_otb["last_updated"] == timestamp


### PR DESCRIPTION
### The Problem
The hardware-pure DTO architecture refactor in ramses-rf/ramses_rf#1163 (part of tracking issue ramses-rf/ramses_rf#1147) replaced `ActuatorStateDTO` with hardware-pure DTO models (`BdrStateDTO`, `JimStateDTO`, and `OpenThermStateDTO`). This caused an `ImportError` during test collection in `tests/tests_new/test_dto_alignment.py` when running tests against the updated library. Production code in `custom_components/ramses_cc/` was unaffected.

### The Fix
- Replaced the deprecated `ActuatorStateDTO` import in `tests/tests_new/test_dto_alignment.py` with the complete suite of hardware DTO models: `BdrStateDTO`, `JimStateDTO`, `OpenThermStateDTO` (with `OpenThermFlags`, `OpenThermTemperatures`, `OpenThermCounters`), `ActuatorCycleDTO`, `ThermalDemandDTO`, and `UfhCircuitDemandDTO`.
- Expanded `test_dto_to_dict_conversion()` to verify serialization fidelity for relay actuators, appliance modules, cycle timers, and OpenTherm telemetry.

### Related PRs
- Depends on / aligned with: ramses-rf/ramses_rf#1163 (and PR stack ramses-rf/ramses_rf#1167 / tracking issue ramses-rf/ramses_rf#1147)

### Testing Performed
- `prek run -a`: Passed
- `ruff check tests/tests_new/test_dto_alignment.py`: Passed (0 errors)
- `mypy custom_components`: Passed (0 errors across 22 source files)
- `pytest tests/tests_new/test_dto_alignment.py -vv`: Passed (3 passed)
- `pytest -n auto`: Passed (1,433 passed, 12 skipped, 3 snapshots passed)

### AI Assistance Disclosure
This contribution was developed with the assistance of Google Gemini 3.7 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.