### PR TITLE
docs: fix probe_hvac_binding docstring — scan engine catches RQ, not RP

### DIFF
--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -434,13 +434,16 @@ class RamsesServiceHandler:
 
         For each 37:/29: device without a known FAN parent, sends a
         spoofed ``RQ 22F1`` (fan_mode query) to each known FAN (32:).
-        If the FAN responds with a directed ``RP 22F1``, the scan
-        engine's passive listener catches it and sets ``bound_to`` on
-        the 37: device → "belongs to" comment → ``remotes[]``/``sensors[]``.
+        The scan engine's REM→FAN inference catches the directed RQ
+        itself (REM is source, FAN is destination) and sets
+        ``bound_to`` on the 37: device → "belongs to" comment →
+        ``remotes[]``/``sensors[]``.  No ``RP 22F1`` response from the
+        FAN is needed — the RQ alone is proof of binding because a
+        REM only sends directed packets to its 1FC9-paired FAN.
 
         This is the HVAC equivalent of forcing a 000C binding table
-        read — it actively provokes the FAN to reveal its relationship
-        with the REM instead of waiting passively for the REM to poll.
+        read — it actively provokes a directed REM→FAN exchange
+        instead of waiting passively for the REM to poll.
 
         :param call: Service call with optional ``device_id`` (probe
             only this 37:/29: device) and ``fan_id`` (probe only this


### PR DESCRIPTION
## Summary

- The `probe_hvac_binding` service sends a spoofed `RQ 22F1` from REM to FAN. The scan engine's REM→FAN inference catches the directed RQ itself (REM is source, FAN is destination) and sets `bound_to` — no `RP 22F1` response from the FAN is needed.
- The previous docstring incorrectly claimed the scan engine waits for the FAN's `RP 22F1` response. Verified from production logs: REMs send `I 22F1` (fire-and-forget fan mode commands), not `RQ 22F1`, and there is zero traffic between `37:` devices (REMs/DISs don't talk to each other — they all talk to the FAN independently).
- The FAN's protocol table does allow `RP 22F1`, so the FAN may respond, but the scan engine sets `bound_to` from the RQ alone (REM→FAN inference path in `discovery_scan.py`).

#### Test plan

- [x] Docstring-only change — no functional impact
- [ ] Pre-commit hooks pass (ruff, codespell)