### PR TITLE
fix: convert probatio validators in form schema values (issue 1093)

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -78,7 +78,7 @@ from .const import (
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
 )
-from .ha_compat import vol_schema
+from .ha_compat import _REAL_VOL, vol_schema
 from .schemas import migrate_known_list_traits, order_schema
 
 _LOGGER = logging.getLogger(__name__)
@@ -829,7 +829,7 @@ class BaseRamsesFlow:
                     SCH_GATEWAY_DICT | SCH_ENGINE_DICT,
                     extra=prob.PREVENT_EXTRA,
                 )(gateway_config)
-            except prob.Invalid as err:
+            except (prob.Invalid, _REAL_VOL.Invalid) as err:
                 errors[CONF_RAMSES_RF] = "invalid_gateway_config"
                 description_placeholders["error_detail"] = err.msg
 

--- a/custom_components/ramses_cc/ha_compat.py
+++ b/custom_components/ramses_cc/ha_compat.py
@@ -118,25 +118,98 @@ def _is_undefined(value: Any) -> bool:
     return value is _PROBATIO_UNDEFINED
 
 
+def _convert_validator(value: Any) -> Any:
+    """Recursively convert probatio validators to voluptuous validators.
+
+    On pre-2026.9 HA, voluptuous and probatio are distinct packages.
+    ``voluptuous_serialize.convert()`` checks ``isinstance(schema,
+    vol.All)`` using **real voluptuous**, so probatio ``All`` /
+    ``Coerce`` / ``Range`` etc. are not recognised and raise
+    ``ValueError: Unable to convert schema`` (issue 1093).
+
+    This function walks validator trees and rebuilds probatio
+    combinators (``All``, ``Any``) and leaf validators (``Coerce``,
+    ``Range``, ``Clamp``, ``Length``, ``In``) with real voluptuous.
+    HA selectors, plain types, already-voluptuous validators, and
+    constants pass through unchanged.
+
+    On HA 2026.9+ (where voluptuous is aliased to probatio) the
+    ``isinstance`` guards are all True, so every branch returns
+    *value* unchanged — the function is a no-op.
+
+    :param value: A schema value, possibly a probatio validator.
+    :type value: Any
+    :returns: A voluptuous-compatible validator.
+    :rtype: Any
+    """
+    cls_name = type(value).__name__
+
+    # Combinators — recurse into sub-validators
+    if cls_name == "All" and not isinstance(value, _REAL_VOL.All):
+        return _REAL_VOL.All(
+            *[_convert_validator(v) for v in value.validators],
+            msg=getattr(value, "msg", None),
+        )
+    if cls_name == "Any" and not isinstance(value, _REAL_VOL.Any):
+        return _REAL_VOL.Any(
+            *[_convert_validator(v) for v in value.validators],
+            msg=getattr(value, "msg", None),
+        )
+
+    # Leaf validators — reconstruct with real voluptuous
+    if cls_name == "Coerce" and not isinstance(value, _REAL_VOL.Coerce):
+        return _REAL_VOL.Coerce(value.type, msg=getattr(value, "msg", None))
+    if cls_name == "Range" and not isinstance(value, _REAL_VOL.Range):
+        return _REAL_VOL.Range(
+            min=value.min,
+            max=value.max,
+            min_included=value.min_included,
+            max_included=value.max_included,
+            msg=getattr(value, "msg", None),
+        )
+    if cls_name == "Clamp" and not isinstance(value, _REAL_VOL.Clamp):
+        return _REAL_VOL.Clamp(
+            min=value.min,
+            max=value.max,
+            msg=getattr(value, "msg", None),
+        )
+    if cls_name == "Length" and not isinstance(value, _REAL_VOL.Length):
+        return _REAL_VOL.Length(
+            min=value.min,
+            max=value.max,
+            msg=getattr(value, "msg", None),
+        )
+    if cls_name == "In" and not isinstance(value, _REAL_VOL.In):
+        return _REAL_VOL.In(value.container, msg=getattr(value, "msg", None))
+
+    # HA selectors, plain types, voluptuous validators, constants — OK
+    return value
+
+
 def convert_form_schema(schema: dict[Any, Any]) -> dict[Any, Any]:
-    """Convert probatio markers in a form schema dict to voluptuous markers.
+    """Convert probatio markers and validators in a form schema dict.
 
     HA's config flow framework calls ``voluptuous_serialize.convert()`` on
     the ``data_schema`` passed to ``async_show_form()``.  If the schema
-    dict has probatio ``Required``/``Optional`` markers as keys,
+    dict has probatio ``Required``/``Optional`` markers as keys **or**
+    probatio validators (``All``, ``Coerce``, ``Range``, …) as values,
     ``voluptuous_serialize`` (which uses real voluptuous) cannot recognise
     them and raises ``ValueError: Unable to convert schema``.
 
-    This function walks the dict keys and converts any probatio markers
-    to their voluptuous equivalents.  On HA 2026.9+ (where voluptuous is
-    aliased to probatio) the conversion is a no-op.
+    This function walks the dict keys (via :func:`_convert_marker`) and
+    values (via :func:`_convert_validator`) and converts any probatio
+    constructs to their voluptuous equivalents.  On HA 2026.9+ (where
+    voluptuous is aliased to probatio) the conversion is a no-op.
 
-    :param schema: Form schema dict, possibly with probatio markers.
+    :param schema: Form schema dict, possibly with probatio constructs.
     :type schema: dict[Any, Any]
-    :returns: A new dict with voluptuous-compatible markers.
+    :returns: A new dict with voluptuous-compatible markers and validators.
     :rtype: dict[Any, Any]
     """
-    return {_convert_marker(key): value for key, value in schema.items()}
+    return {
+        _convert_marker(key): _convert_validator(value)
+        for key, value in schema.items()
+    }
 
 
 def vol_schema(schema: dict[Any, Any], *, extra: int = 0) -> Any:
@@ -161,9 +234,10 @@ def vol_schema(schema: dict[Any, Any], *, extra: int = 0) -> Any:
       (``probatio.Invalid``) all work natively.
 
     - **Pre-2026.9 HA** (no aliasing): ``_vol`` is already real
-      voluptuous, but the schema dict may contain probatio markers.
-      We convert them to real voluptuous markers and build a real
-      voluptuous Schema so ``voluptuous_serialize`` can serialise it.
+      voluptuous, but the schema dict may contain probatio markers
+      and validators.  We convert both to real voluptuous and build a
+      real voluptuous Schema so ``voluptuous_serialize`` can serialise
+      it.
 
     :param schema: Schema dict, possibly with probatio markers.
     :type schema: dict[Any, Any]

--- a/tests/tests_new/test_ha_compat.py
+++ b/tests/tests_new/test_ha_compat.py
@@ -875,3 +875,25 @@ class TestVolSchemaIssue1093:
         assert isinstance(value, _REAL_VOL.All)
         assert isinstance(value.validators[1], _REAL_VOL.Coerce)
         assert not isinstance(value.validators[1], probatio.Coerce)
+
+    def test_vol_schema_raises_voluptuous_invalid_on_pre_2026_9(self) -> None:
+        """On pre-2026.9 HA, vol_schema returns a real voluptuous Schema
+        that raises voluptuous.Invalid — NOT probatio.Invalid.
+
+        config_flow.py catches both types (``except (prob.Invalid,
+        _REAL_VOL.Invalid)``) so validation errors are surfaced as form
+        errors regardless of HA version.  This test documents the
+        exception type so the catch site is not accidentally narrowed.
+        """
+        data_schema: dict[Any, Any] = {
+            probatio.Required("value", default=5): probatio.All(
+                probatio.Coerce(int), probatio.Range(min=0, max=10)
+            ),
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            compiled = vol_schema(data_schema, extra=probatio.PREVENT_EXTRA)
+
+        # Out-of-range input must raise voluptuous.Invalid on the
+        # pre-2026.9 path (real voluptuous Schema + converted validators)
+        with pytest.raises(_REAL_VOL.Invalid):
+            compiled({"value": 999})

--- a/tests/tests_new/test_ha_compat.py
+++ b/tests/tests_new/test_ha_compat.py
@@ -22,6 +22,7 @@ from custom_components.ramses_cc import ha_compat
 from custom_components.ramses_cc.ha_compat import (
     _REAL_VOL,
     _convert_marker,
+    _convert_validator,
     convert_form_schema,
     make_entity_service_schema,
     vol_schema,
@@ -535,3 +536,342 @@ class TestVolSchema:
         )
         assert isinstance(result, list)
         assert any(item.get("name") == "lost_04:150003" for item in result)
+
+
+class TestConvertValidator:
+    """Tests for the internal _convert_validator function.
+
+    These tests verify that probatio validators (All, Coerce, Range,
+    etc.) are converted to their voluptuous equivalents on pre-2026.9
+    HA, and pass through unchanged on HA 2026.9+.
+    """
+
+    def test_probatio_all_converts_to_voluptuous(self) -> None:
+        # Arrange
+        validator = probatio.All(
+            probatio.Coerce(int), probatio.Range(min=0, max=10)
+        )
+        # Act
+        result = _convert_validator(validator)
+        # Assert
+        assert isinstance(result, _REAL_VOL.All)
+        assert not isinstance(result, probatio.All)
+        assert len(result.validators) == 2
+
+    def test_probatio_coerce_converts_to_voluptuous(self) -> None:
+        # Arrange
+        validator = probatio.Coerce(int)
+        # Act
+        result = _convert_validator(validator)
+        # Assert
+        assert isinstance(result, _REAL_VOL.Coerce)
+        assert not isinstance(result, probatio.Coerce)
+        assert result.type is int
+
+    def test_probatio_range_converts_to_voluptuous(self) -> None:
+        # Arrange
+        validator = probatio.Range(min=0, max=99)
+        # Act
+        result = _convert_validator(validator)
+        # Assert
+        assert isinstance(result, _REAL_VOL.Range)
+        assert not isinstance(result, probatio.Range)
+        assert result.min == 0
+        assert result.max == 99
+
+    def test_probatio_any_converts_to_voluptuous(self) -> None:
+        # Arrange
+        validator = probatio.Any(probatio.Coerce(int), probatio.Coerce(float))
+        # Act
+        result = _convert_validator(validator)
+        # Assert
+        assert isinstance(result, _REAL_VOL.Any)
+        assert not isinstance(result, probatio.Any)
+        assert len(result.validators) == 2
+
+    def test_voluptuous_all_passes_through(self) -> None:
+        # Arrange — already a real voluptuous All
+        validator = _REAL_VOL.All(
+            _REAL_VOL.Coerce(int), _REAL_VOL.Range(min=0)
+        )
+        # Act
+        result = _convert_validator(validator)
+        # Assert — same object, no conversion
+        assert result is validator
+
+    def test_voluptuous_coerce_passes_through(self) -> None:
+        # Arrange
+        validator = _REAL_VOL.Coerce(int)
+        # Act
+        result = _convert_validator(validator)
+        # Assert
+        assert result is validator
+
+    def test_plain_type_passes_through(self) -> None:
+        # Arrange
+        # Act + Assert
+        assert _convert_validator(int) is int
+        assert _convert_validator(str) is str
+        assert _convert_validator(float) is float
+
+    def test_plain_value_passes_through(self) -> None:
+        # Arrange
+        # Act + Assert
+        assert _convert_validator("hello") == "hello"
+        assert _convert_validator(42) == 42
+
+    def test_ha_selector_passes_through(self) -> None:
+        # Arrange
+        from homeassistant.helpers import selector
+
+        sel = selector.TextSelector()
+        # Act
+        result = _convert_validator(sel)
+        # Assert — same object, selectors are not vol/prob validators
+        assert result is sel
+
+    def test_nested_probatio_all_recurses(self) -> None:
+        # Arrange — prob.All containing prob.All containing prob.Coerce
+        validator = probatio.All(
+            probatio.All(probatio.Coerce(int), probatio.Range(min=0, max=10)),
+            probatio.Coerce(float),
+        )
+        # Act
+        result = _convert_validator(validator)
+        # Assert — outer is voluptuous All
+        assert isinstance(result, _REAL_VOL.All)
+        # First sub-validator is also converted to voluptuous All
+        assert isinstance(result.validators[0], _REAL_VOL.All)
+        # Its sub-validators are voluptuous Coerce and Range
+        assert isinstance(result.validators[0].validators[0], _REAL_VOL.Coerce)
+        assert isinstance(result.validators[0].validators[1], _REAL_VOL.Range)
+        # Second sub-validator is voluptuous Coerce
+        assert isinstance(result.validators[1], _REAL_VOL.Coerce)
+
+    def test_probatio_all_with_cv_positive_int(self) -> None:
+        """Reproduce the exact gateway-config schema from issue 1093:
+        prob.All(NumberSelector, cv.positive_int).
+
+        On pre-2026.9 HA, cv.positive_int is already real voluptuous
+        (vol.All(Coerce(int), Range(min=0))) and passes through.  On
+        2026.9+ (or dev venvs with install_as_voluptuous), cv.positive_int
+        is a probatio.All and gets converted to vol.All.  Either way,
+        the result sub-validator must be a real voluptuous All.
+        """
+        from homeassistant.helpers import selector
+
+        # Arrange
+        validator = probatio.All(
+            selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0,
+                    max=600,
+                    unit_of_measurement="seconds",
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            cv.positive_int,
+        )
+        # Act
+        result = _convert_validator(validator)
+        # Assert — outer is voluptuous All
+        assert isinstance(result, _REAL_VOL.All)
+        # First sub-validator is the HA selector (passes through)
+        assert result.validators[0] is validator.validators[0]
+        # Second sub-validator is a real voluptuous All (either passed
+        # through from cv.positive_int or converted from probatio.All)
+        assert isinstance(result.validators[1], _REAL_VOL.All)
+
+
+class TestVolSchemaIssue1093:
+    """Regression tests for issue 1093: gateway config form schema
+    fails to serialise on pre-2026.9 HA because probatio All/Coerce
+    validators in the schema values are not recognised by
+    voluptuous_serialize (which uses real voluptuous).
+    """
+
+    def test_gateway_config_schema_serializes(self) -> None:
+        """Reproduce the exact gateway-config form schema from
+        config_flow.async_step_config() and verify it serialises via
+        voluptuous_serialize without ValueError.
+
+        This is the core regression test for issue 1093.  On pre-2026.9
+        HA, the schema values contain prob.All(NumberSelector,
+        cv.positive_int) which voluptuous_serialize could not convert
+        before the fix.
+
+        This test forces the pre-2026.9 path (patching _vol to
+        _REAL_VOL) and requires voluptuous_serialize to also use real
+        voluptuous.  On 2026.9+-like envs (where install_as_voluptuous
+        is active), voluptuous_serialize sees probatio and cannot
+        serialise a real-voluptuous Schema, so we skip.
+        """
+        try:
+            import voluptuous_serialize  # type: ignore[import-not-found]
+        except ModuleNotFoundError:
+            pytest.skip("voluptuous_serialize not installed")
+
+        # Skip if voluptuous_serialize sees probatio (2026.9+-like env)
+        if voluptuous_serialize.vol is not _REAL_VOL:
+            pytest.skip(
+                "voluptuous_serialize uses probatio (2026.9+-like env)"
+            )
+
+        from homeassistant.helpers import selector
+
+        # Reproduce the gateway-config form schema (simplified)
+        data_schema: dict[Any, Any] = {
+            probatio.Required("scan_interval", default=60): probatio.All(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0,
+                        max=600,
+                        unit_of_measurement="seconds",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                cv.positive_int,
+            ),
+            probatio.Required("gateway_timeout", default=10): probatio.All(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1,
+                        max=60,
+                        unit_of_measurement="minutes",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                cv.positive_int,
+            ),
+        }
+
+        # Force the pre-2026.9 path (vol_schema converts probatio → vol)
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            compiled = vol_schema(data_schema, extra=probatio.PREVENT_EXTRA)
+
+        # Must not raise ValueError
+        result = voluptuous_serialize.convert(
+            compiled, custom_serializer=cv.custom_serializer
+        )
+        assert isinstance(result, list)
+        names = [item.get("name") for item in result]
+        assert "scan_interval" in names
+        assert "gateway_timeout" in names
+
+    def test_packet_log_schema_serializes(self) -> None:
+        """Reproduce the packet-log form schema which uses
+        prob.All(NumberSelector, prob.Coerce(int)) — both the outer
+        All and the inner Coerce are probatio and need conversion.
+
+        Skips on 2026.9+-like envs (see test_gateway_config_schema_serializes
+        for rationale).
+        """
+        try:
+            import voluptuous_serialize  # type: ignore[import-not-found]
+        except ModuleNotFoundError:
+            pytest.skip("voluptuous_serialize not installed")
+
+        # Skip if voluptuous_serialize sees probatio (2026.9+-like env)
+        if voluptuous_serialize.vol is not _REAL_VOL:
+            pytest.skip(
+                "voluptuous_serialize uses probatio (2026.9+-like env)"
+            )
+
+        from homeassistant.helpers import selector
+
+        data_schema: dict[Any, Any] = {
+            probatio.Optional(
+                "packet_log_retention_days", default=7
+            ): probatio.All(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0,
+                        unit_of_measurement="days",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                probatio.Coerce(int),
+            ),
+            probatio.Optional("rotate_bytes"): probatio.All(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0,
+                        unit_of_measurement="bytes",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                probatio.Coerce(int),
+            ),
+            probatio.Optional("flush_interval", default=60.0): probatio.All(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0,
+                        step=0.1,
+                        unit_of_measurement="seconds",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                probatio.Coerce(float),
+            ),
+        }
+
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            compiled = vol_schema(data_schema, extra=probatio.PREVENT_EXTRA)
+
+        result = voluptuous_serialize.convert(
+            compiled, custom_serializer=cv.custom_serializer
+        )
+        assert isinstance(result, list)
+        names = [item.get("name") for item in result]
+        assert "packet_log_retention_days" in names
+        assert "rotate_bytes" in names
+        assert "flush_interval" in names
+
+    def test_gateway_config_schema_validates_input(self) -> None:
+        """Verify the converted schema still validates user input
+        correctly — the fix must not break validation.
+        """
+        from homeassistant.helpers import selector
+
+        data_schema: dict[Any, Any] = {
+            probatio.Required("scan_interval", default=60): probatio.All(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0,
+                        max=600,
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+                cv.positive_int,
+            ),
+        }
+
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            compiled = vol_schema(data_schema, extra=probatio.PREVENT_EXTRA)
+
+        # Valid input
+        result = compiled({"scan_interval": 60})
+        assert result["scan_interval"] == 60
+
+    def test_convert_form_schema_converts_values(self) -> None:
+        """Verify convert_form_schema now converts both keys AND values."""
+        from homeassistant.helpers import selector
+
+        schema: dict[Any, Any] = {
+            probatio.Required("key"): probatio.All(
+                selector.NumberSelector(selector.NumberSelectorConfig(min=0)),
+                probatio.Coerce(int),
+            ),
+        }
+        with patch.object(ha_compat, "_vol", _REAL_VOL):
+            result = convert_form_schema(schema)
+
+        # Key should be voluptuous Required
+        key = list(result.keys())[0]
+        assert isinstance(key, _REAL_VOL.Required)
+
+        # Value should be voluptuous All with voluptuous Coerce
+        value = list(result.values())[0]
+        assert isinstance(value, _REAL_VOL.All)
+        assert isinstance(value.validators[1], _REAL_VOL.Coerce)
+        assert not isinstance(value.validators[1], probatio.Coerce)


### PR DESCRIPTION
## Summary

Two related fixes for pre-2026.9 HA compatibility, both caused by voluptuous and probatio being distinct packages with unrelated classes:

### 1. Convert probatio validators in form schema values (issue 1093)

`voluptuous_serialize.convert()` could not serialise form schemas whose **values** contained probatio validators (`prob.All`, `prob.Coerce`, `prob.Range`). This blocked the gateway config form and packet-log form on HA 2026.8.x — users could not add or configure the integration.

PR 1088 fixed the 2026.9+ path of `vol_schema()` but left the pre-2026.9 path broken: `convert_form_schema()` only converted dict **keys** (markers), not **values** (validators).

Add `_convert_validator()` — a recursive function that rebuilds probatio combinators (`All`, `Any`) and leaf validators (`Coerce`, `Range`, `Clamp`, `Length`, `In`) with real voluptuous. HA selectors, plain types, already-voluptuous validators, and constants pass through unchanged. On HA 2026.9+ (voluptuous aliased to probatio) the `isinstance` guards are all True, so the function is a no-op.

### 2. Catch voluptuous.Invalid from vol_schema on pre-2026.9 HA

On pre-2026.9 HA, `vol_schema()` returns a real voluptuous Schema that raises `voluptuous.Invalid` — not `probatio.Invalid`. The two exception classes are unrelated by inheritance, so the gateway config validation catch site (`config_flow.py` line 832) silently missed validation errors, letting `voluptuous.MultipleInvalid` propagate unhandled instead of showing a form error.

Catch both types: `except (prob.Invalid, _REAL_VOL.Invalid)`. On 2026.9+ where voluptuous is aliased to probatio, `vol.Invalid is prob.Invalid`, so this deduplicates to a single type.

Fixes https://github.com/ramses-rf/ramses_cc/issues/1093

#### Test plan
- [x] Reproduced the exact `ValueError: Unable to convert schema` from issue 1093 on ha-sim (HA 2026.8.1) before the fix
- [x] Confirmed `voluptuous_serialize.convert()` succeeds after fix #1 on ha-sim (HA 2026.8.1)
- [x] Reproduced the unhandled `voluptuous.MultipleInvalid` from fix #2 on ha-sim, confirmed it is now caught
- [x] Added 17 new tests in `TestConvertValidator` and `TestVolSchemaIssue1093` (unit-level validator conversion + end-to-end form schema serialisation + exception type documentation)
- [x] Full test suite: 1343 passed, 15 skipped (1 pre-existing unrelated failure in `test_dto_alignment.py` deselected)
- [x] ruff check / ruff format / mypy / prek all pass