### PR TITLE
fix(dto): align test_dto_alignment with hardware-pure DTOs (supersedes PR 1092)

### DIFF
--- a/tests/tests_new/test_dto_alignment.py
+++ b/tests/tests_new/test_dto_alignment.py
@@ -1,7 +1,15 @@
+from datetime import datetime as dt
+
 from custom_components.ramses_cc.helpers import dto_to_dict, extract_demand
 from ramses_rf.enums import ThermalMode
 from ramses_rf.models import (
-    ActuatorStateDTO,
+    ActuatorCycleDTO,
+    BdrStateDTO,
+    JimStateDTO,
+    OpenThermCounters,
+    OpenThermFlags,
+    OpenThermStateDTO,
+    OpenThermTemperatures,
     ThermalDemandDTO,
     UfhCircuitDemandDTO,
 )
@@ -37,12 +45,50 @@ def test_dto_to_dict_conversion() -> None:
             ufh_index="1", thermal_demand=0.4, mode=ThermalMode.HEAT
         )
     ]
-    actuator_dto = ActuatorStateDTO(ch_active=True, ch_enabled=True)
+    bdr_dto = BdrStateDTO(modulation_level=0.5, actuator_enabled=True)
+    jim_dto = JimStateDTO(
+        ch_active=True,
+        dhw_active=False,
+        flame_active=True,
+        cooling_active=False,
+        actuator_enabled=True,
+    )
+    cycle_dto = ActuatorCycleDTO(
+        actuator_countdown=30,
+        cycle_countdown=120,
+        actuator_enabled=True,
+        modulation_level=0.75,
+    )
+    timestamp = dt(2026, 8, 30, 12, 0, 0)
+    otb_dto = OpenThermStateDTO(
+        flags=OpenThermFlags(
+            flame_active=True,
+            ch_active=True,
+            dhw_active=False,
+            cooling_active=False,
+        ),
+        temperatures=OpenThermTemperatures(
+            boiler_output=65.5,
+            boiler_return=45.0,
+            dhw=55.0,
+            outside=18.5,
+        ),
+        counters=OpenThermCounters(burner_starts=120, burner_hours=350),
+        ch_water_pressure=1.8,
+        dhw_flow_rate=0.0,
+        max_rel_modulation=1.0,
+        rel_modulation_level=0.45,
+        oem_code="00",
+        last_updated=timestamp,
+    )
 
     # Act
     converted_dto = dto_to_dict(dto)
     converted_list = dto_to_dict(dto_list)
-    converted_actuator = dto_to_dict(actuator_dto)
+    converted_bdr = dto_to_dict(bdr_dto)
+    converted_jim = dto_to_dict(jim_dto)
+    converted_cycle = dto_to_dict(cycle_dto)
+    converted_otb = dto_to_dict(otb_dto)
 
     # Assert
     assert converted_dto == {
@@ -54,5 +100,33 @@ def test_dto_to_dict_conversion() -> None:
     assert converted_list == [
         {"ufh_index": "1", "thermal_demand": 0.4, "mode": "heat"}
     ]
-    assert converted_actuator["ch_active"] is True
-    assert converted_actuator["ch_enabled"] is True
+    assert converted_bdr == {
+        "modulation_level": 0.5,
+        "actuator_enabled": True,
+        "last_updated": None,
+    }
+    assert converted_jim == {
+        "modulation_level": None,
+        "actuator_enabled": True,
+        "last_updated": None,
+        "ch_active": True,
+        "dhw_active": False,
+        "flame_active": True,
+        "cooling_active": False,
+    }
+    assert converted_cycle == {
+        "actuator_countdown": 30,
+        "cycle_countdown": 120,
+        "actuator_enabled": True,
+        "modulation_level": 0.75,
+    }
+    assert converted_otb["flags"]["flame_active"] is True
+    assert converted_otb["flags"]["ch_active"] is True
+    assert converted_otb["flags"]["dhw_active"] is False
+    assert converted_otb["temperatures"]["boiler_output"] == 65.5
+    assert converted_otb["temperatures"]["boiler_return"] == 45.0
+    assert converted_otb["counters"]["burner_starts"] == 120
+    assert converted_otb["counters"]["burner_hours"] == 350
+    assert converted_otb["ch_water_pressure"] == 1.8
+    assert converted_otb["rel_modulation_level"] == 0.45
+    assert converted_otb["last_updated"] == timestamp


### PR DESCRIPTION
## Summary

- Replaces the deprecated `ActuatorStateDTO` import in `tests/tests_new/test_dto_alignment.py` with the hardware-pure DTO models shipped in `ramses_rf` 0.60.3: `BdrStateDTO`, `JimStateDTO`, `OpenThermStateDTO` (+ `OpenThermFlags`, `OpenThermTemperatures`, `OpenThermCounters`), and `ActuatorCycleDTO`.
- Expands `test_dto_to_dict_conversion()` to verify serialization fidelity for relay actuators, appliance modules, cycle timers, and OpenTherm telemetry.

## Why this supersedes PR 1092

This is the same change as https://github.com/ramses-rf/ramses_cc/pull/1092 (credit: @PWhite-Eng), which fixes the `ImportError: cannot import name 'ActuatorStateDTO' from 'ramses_rf.models'` that currently breaks test collection on master against `ramses-rf==0.60.3`.

PR 1092 is stuck on a stale base that still pins `ramses-rf==0.60.2`, so its own CI fails with `ImportError: cannot import name 'BdrStateDTO'` — the very symbols it introduces aren't importable from the 0.60.2 it pins. This PR is based on the synced master (pin `ramses-rf==0.60.3`), so the new DTO symbols are importable and CI can pass.

Once this lands, PR 1092 can be closed, and PR 1090 (strategy-based fan_modes) — which is currently blocked only by this same `ActuatorStateDTO` collection error — will go green on its next CI run.

## Related

- Supersedes: https://github.com/ramses-rf/ramses_cc/pull/1092
- Unblocks: https://github.com/ramses-rf/ramses_cc/pull/1090
- Aligned with: https://github.com/ramses-rf/ramses_rf/pull/1163 (hardware-pure DTO refactor)

#### Test plan

- [x] `prek run -a` (pre-commit hooks) — passed
- [x] Verified all imported symbols + fields exist in `ramses-rf==0.60.3` (AST inspection of the 0.60.3 source)
- [x] Verified all `dto_to_dict` assertions pass against a real `ramses-rf==0.60.3` install (throwaway venv)
- [x] CI green on this PR