### PR TITLE
fix(discovery): exclude HGI gateway from lost-device detection

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -2467,17 +2468,25 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 device_id = entry.device.device_id
                 action = user_input.get(f"lost_{device_id}", "keep")
                 if action == "remove":
-                    await self.hass.services.async_call(
-                        DOMAIN,
-                        "remove_device",
-                        {"device_id": device_id},
-                        blocking=True,
-                    )
-                    removed_any = True
-                    _LOGGER.info(
-                        "review_device_health: removed lost device %s",
-                        device_id,
-                    )
+                    try:
+                        await self.hass.services.async_call(
+                            DOMAIN,
+                            "remove_device",
+                            {"device_id": device_id},
+                            blocking=True,
+                        )
+                        removed_any = True
+                        _LOGGER.info(
+                            "review_device_health: removed lost device %s",
+                            device_id,
+                        )
+                    except ServiceValidationError as err:
+                        _LOGGER.warning(
+                            "review_device_health: cannot remove lost "
+                            "device %s: %s",
+                            device_id,
+                            err,
+                        )
                 elif action == "keep":
                     # Clear LOST status → back to ACCEPTED, clear orphaned.
                     # Set _suppress_not_seen in the schema so future
@@ -2503,17 +2512,25 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 device_id = entry.device.device_id
                 action = user_input.get(f"orphaned_{device_id}", "keep")
                 if action == "remove":
-                    await self.hass.services.async_call(
-                        DOMAIN,
-                        "remove_device",
-                        {"device_id": device_id},
-                        blocking=True,
-                    )
-                    removed_any = True
-                    _LOGGER.info(
-                        "review_device_health: removed orphaned device %s",
-                        device_id,
-                    )
+                    try:
+                        await self.hass.services.async_call(
+                            DOMAIN,
+                            "remove_device",
+                            {"device_id": device_id},
+                            blocking=True,
+                        )
+                        removed_any = True
+                        _LOGGER.info(
+                            "review_device_health: removed orphaned device %s",
+                            device_id,
+                        )
+                    except ServiceValidationError as err:
+                        _LOGGER.warning(
+                            "review_device_health: cannot remove "
+                            "orphaned device %s: %s",
+                            device_id,
+                            err,
+                        )
                 elif action == "keep":
                     # Clear orphaned flag and set _suppress_not_seen in
                     # the schema so check_orphaned_devices doesn't re-notify

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -846,6 +846,12 @@ class DiscoveryManager:
         """
         result: list[DiscoveredDeviceEntry] = []
         for entry in self.get_devices():
+            # HGI gateways are never "lost" — they are the receiver, not
+            # remote devices.  This also cleans up any pre-existing LOST
+            # status that may have been set before the check_for_lost_devices
+            # skip was added.
+            if entry.device.device_id.startswith("18:"):
+                continue
             if entry.metadata.status == DiscoveryStatus.LOST:
                 result.append(entry)
         return result
@@ -2367,6 +2373,13 @@ class DiscoveryManager:
 
         for device_id, meta in self._metadata.items():
             if meta.status != DiscoveryStatus.ACCEPTED or not meta.enabled:
+                continue
+
+            # Skip HGI gateways — they are not remote devices and must
+            # never be flagged as lost or offered for removal (the
+            # remove_device service blocks gateway removal with a
+            # ServiceValidationError).  Mirrors check_orphaned_devices.
+            if device_id.startswith("18:"):
                 continue
 
             # Respect _suppress_not_seen from schema (issue 988)

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -22,6 +22,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import ServiceValidationError
 from pytest_homeassistant_custom_component.common import (  # type: ignore[import-untyped]
     MockConfigEntry,
 )
@@ -3656,6 +3657,72 @@ async def test_review_device_health_remove_calls_service(
     # Verify the remove_device service was called with the right device_id
     assert len(remove_calls) == 1
     assert remove_calls[0] == {"device_id": "04:056053"}
+
+
+async def test_review_device_health_remove_service_error_handled(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_device_health handles ServiceValidationError from remove_device.
+
+    If the remove_device service raises ServiceValidationError (e.g. for
+    an HGI gateway), the config flow should not crash with a 500 — it
+    should log a warning and continue saving.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}},
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_meta = MagicMock()
+    mock_meta.orphaned = "last seen 2026-07-01 (>7 days)"
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "18:149488"
+    mock_entry.device.likely_type = "HGI"
+    mock_entry.device.last_seen = "2026-07-01T10:00:00"
+    mock_entry.metadata = mock_meta
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_lost_devices.return_value = []
+    mock_coord.discovery_manager.get_orphaned_devices.return_value = [
+        mock_entry
+    ]
+    mock_coord.discovery_manager._metadata = {"18:149488": mock_meta}
+    mock_coord.async_save_client_state = AsyncMock()
+    mock_coord.options = {SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"}}
+    config_entry.runtime_data = mock_coord
+
+    # Register a mock remove_device service that raises ServiceValidationError
+    # (as the real service does for HGI gateway devices)
+    async def _mock_remove_device(call: Any) -> None:
+        raise ServiceValidationError(
+            f"Cannot remove the HGI gateway device ({call.data['device_id']})"
+        )
+
+    hass.services.async_register(DOMAIN, "remove_device", _mock_remove_device)
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    # Navigate to review_device_health
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_device_health"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+
+    # Submit with "remove" action — should NOT raise, should save gracefully
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"orphaned_18:149488": "remove"},
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
 
 
 async def test_cleanup_stale_known_list_empty_or_non_dict_entry(

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -780,6 +780,21 @@ class TestLostDeviceDetectionExtended:
         lost_ids = manager.check_for_lost_devices()
         assert lost_ids == []
 
+    def test_check_for_lost_devices_skips_hgi_gateway(self) -> None:
+        """HGI gateway devices (18:) are never marked LOST.
+
+        The remove_device service blocks gateway removal, so the HGI
+        must never appear in the lost-devices review list.
+        """
+        old_date = (dt.now() - td(days=30)).isoformat()
+        dev = make_discovered_device("18:149488", "HGI", last_seen=old_date)
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager.accept_device("18:149488")
+        lost_ids = manager.check_for_lost_devices()
+        assert lost_ids == []
+
 
 class TestGenerateSchemaEntryEdgeCases:
     """Tests for generate_schema_entry edge cases."""
@@ -2591,6 +2606,25 @@ class TestGetLostDevices:
 
         manager._metadata["04:056053"] = DeviceMetadata(
             status=DiscoveryStatus.ACCEPTED
+        )
+
+        result = manager.get_lost_devices()
+        assert result == []
+
+    def test_hgi_gateway_not_returned(self) -> None:
+        """HGI gateway devices (18:) are never returned as lost.
+
+        Even if an HGI was previously marked LOST (e.g. before the
+        check_for_lost_devices skip was added), get_lost_devices
+        filters it out so it never appears in the review-device-health
+        UI as removable.
+        """
+        dev = make_discovered_device("18:149488", "HGI")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        manager._metadata["18:149488"] = DeviceMetadata(
+            status=DiscoveryStatus.LOST
         )
 
         result = manager.get_lost_devices()


### PR DESCRIPTION
## Summary

- `check_for_lost_devices` now skips `18:` devices (HGI gateways), mirroring the existing skips in `check_orphaned_devices` (line 1026) and `check_communication_quality` (line 1359).
- `get_lost_devices` now filters out `18:` devices as defense-in-depth, so any HGI that was already marked LOST before this fix is cleaned up and never appears in the review-device-health UI as removable.

## The Problem

The HGI gateway device (`18:...`) was being marked `LOST` by `check_for_lost_devices` when it hadn't been seen for the threshold period. It then appeared in the `review_device_health` config flow step as removable. When the user clicked "remove", the `remove_device` service correctly blocked the removal:

```
ServiceValidationError: Cannot remove the HGI gateway device (18:149488)
```

This surfaced as an unhandled aiohttp 500 error in the config flow.

`check_orphaned_devices` and `check_communication_quality` already skip `18:` devices — `check_for_lost_devices` was the only health check that did not, which is how the gateway ended up in the lost list.

## The Fix

Two changes in `custom_components/ramses_cc/discovery.py`:

1. **`check_for_lost_devices`** — added `if device_id.startswith("18:"): continue` after the ACCEPTED/enabled check, with a comment referencing the same pattern in `check_orphaned_devices`.
2. **`get_lost_devices`** — added `if entry.device.device_id.startswith("18:"): continue` before the LOST status check, so any pre-existing LOST status on an HGI is filtered out.

#### Test plan

- [x] `test_check_for_lost_devices_skips_hgi_gateway` — verifies an HGI with an old `last_seen` is not marked LOST
- [x] `test_hgi_gateway_not_returned` — verifies `get_lost_devices` filters out an HGI even if its metadata status is LOST
- [x] All existing `review_device_health` config flow tests pass
- [x] All existing `check_for_lost_devices` and `get_lost_devices` tests pass
- [x] CI green on this PR