### PR TITLE
Fix deprecated helper

### DIFF
--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -67,21 +67,32 @@ def ha_device_id_to_ramses_device_id(
 
 
 def ramses_device_id_to_ha_device_id(
-    hass: HomeAssistant, ramses_device_id: str
+    hass: HomeAssistant, ramses_device_id: str, entry_id: str | None = None
 ) -> str | None:
     """Return a HA device registry id for a RAMSES device_id.
 
     :param hass: The Home Assistant instance.
     :param ramses_device_id: The RAMSES device ID (e.g., '01:123456').
+    :param entry_id: The entry ID (e.g., '1234567890').
     :return: The Home Assistant device registry ID or None if not found.
     """
     if not ramses_device_id:
         return None
 
     dev_reg = dr.async_get(hass)
-    device_entry = dev_reg.async_get_device(
-        identifiers={(DOMAIN, ramses_device_id)}
-    )
+    if entry_id is None:  # TODO: remove Q2 2027
+        device_entry = dev_reg.async_get_device(
+            identifiers={(DOMAIN, ramses_device_id)}
+        )
+        # deprecated since 2026.6. Use single config entry.
+        _LOGGER.warning(
+            "dev_reg.async_get_device() is deprecated. Use async_get_device_by_identifier() instead"
+        )
+    else:
+        device_entry = dev_reg.async_get_device_by_identifier(
+            (DOMAIN, ramses_device_id), entry_id
+        )
+    # add entry to method args
     if not device_entry:
         return None
 

--- a/tests/tests_new/test_helpers.py
+++ b/tests/tests_new/test_helpers.py
@@ -74,7 +74,14 @@ def test_ramses_to_ha_id_mapping(hass: HomeAssistant) -> None:
         identifiers={(DOMAIN, RAMSES_ID)},
     )
 
+    # 5. Verify successful mapping - deprecated
     result = ramses_device_id_to_ha_device_id(hass, RAMSES_ID)
+    assert result == device.id
+
+    # 6. Verify successful mapping - current
+    result = ramses_device_id_to_ha_device_id(
+        hass, RAMSES_ID, entry_id="test_config_2"
+    )
     assert result == device.id
 
 

--- a/tests/tests_new/test_helpers.py
+++ b/tests/tests_new/test_helpers.py
@@ -74,7 +74,7 @@ def test_ramses_to_ha_id_mapping(hass: HomeAssistant) -> None:
         identifiers={(DOMAIN, RAMSES_ID)},
     )
 
-    # 5. Verify successful mapping - deprecated
+    # 5. Verify successful mapping - deprecated  # TODO: remove Q2 2027
     result = ramses_device_id_to_ha_device_id(hass, RAMSES_ID)
     assert result == device.id
 

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -330,7 +330,13 @@ def test_ramses_to_ha_id_mapping(hass: HomeAssistant) -> None:
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, RAMSES_ID)},
     )
+    # test deprecated 2026.07  # TODO: remove Q2 2027
     result = ramses_device_id_to_ha_device_id(hass, RAMSES_ID)
+    assert result == device.id
+    # test current 2026.09
+    result = ramses_device_id_to_ha_device_id(
+        hass, RAMSES_ID, entry_id="test_config_2"
+    )
     assert result == device.id
 
 


### PR DESCRIPTION
- Update deprecated helper function (not used in code, only in tests).
- Add log deprecation warning, todo note.

See [dev blog post](https://developers.home-assistant.io/blog/2026/08/24/device-registry-follow-up-changes?_highlight=_async_update_device#async_update_device-merge_connections-and-merge_identifiers-deprecated)