### PR TITLE
Move `via_device` parent link to `parent_device_id`/ChildDeviceInfo

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -27,7 +27,10 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device_registry import ChildDeviceInfo, DeviceInfo
+from homeassistant.helpers.device_registry import (
+    ChildDeviceInfo,
+    DeviceInfo,
+)
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -2606,23 +2609,26 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if suggested_area is not None:
             kwargs["suggested_area"] = suggested_area
         if parent_device_id is not None:
-            parent = device_registry.async_get_device_by_identifier(
-                (DOMAIN, parent_device_id), self.entry.entry_id
-            )
-            if parent is None:
+            # parent must exist
+            parent = device_registry.async_get(parent_device_id)
+            if parent not in device_registry.devices:
                 _LOGGER.warning(
                     "Parent %s does not exist. Must create it first",
                     parent_device_id,
                 )
-                # create parent first
-                await self._async_create_device(parent_device_id, None, None)
-            elif (
-                parent.__class__ == ChildDeviceInfo
-            ):  # children can't be nested
+                # update/create parent first
+                await self._async_update_device_info(
+                    parent_device_id, None, None
+                )
+
+            # children can't be nested
+            if parent in device_registry.child_devices:
                 _LOGGER.warning(
                     "Parent %s is itself a Child, can't nest", parent_device_id
                 )
                 return
+
+            # update Info attr
             kwargs["parent_device_id"] = parent_device_id
             if (
                 isinstance(device, UfhCircuit)
@@ -2646,9 +2652,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 config_entry_id=self.entry.entry_id, **device_info
             )
         else:
-            await self._async_create_device(device.id, device_name, model)
+            await self._async_update_device_info(device.id, device_name, model)
 
-    async def _async_create_device(
+    async def _async_update_device_info(
         self,
         dev_id: str,
         dev_name: str | None,

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2570,9 +2570,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         device_registry = dr.async_get(self.hass)
 
-        parent_device_id: tuple[str, str] | None = None
+        parent_device_id: str | None = None
         if isinstance(device, Zone) and device.tcs:
-            _LOGGER.info("ZONE %s parent_device_id SET to %s", model, device.tcs.id)
+            _LOGGER.info(
+                "ZONE %s parent_device_id SET to %s", model, device.tcs.id
+            )
             parent_device_id = str(device.tcs.id)
         elif isinstance(device, UfhCircuit) and device.ufc:
             ufc_id = str(device.ufc.id)
@@ -2611,7 +2613,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if parent_device_id is not None:
             # parent must exist
             parent = device_registry.async_get(parent_device_id)
-            if parent not in device_registry.devices:
+            if parent is None:
                 _LOGGER.warning(
                     "Parent %s does not exist. Must create it first",
                     parent_device_id,
@@ -2622,7 +2624,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 )
 
             # children can't be nested
-            if parent in device_registry.child_devices:
+            elif parent in device_registry.child_devices:
                 _LOGGER.warning(
                     "Parent %s is itself a Child, can't nest", parent_device_id
                 )
@@ -2637,13 +2639,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
             ):
                 kwargs["parent_device_id"] = parent_device_id
 
-            kwargs["parent_device_id"] = parent_device_id
             device_info = ChildDeviceInfo(
                 identifiers={(DOMAIN, str(device.id))},
                 name=device_name,
                 **kwargs,
             )
             if self._device_info.get(str(device.id)) == device_info:
+                # already known and set
                 return
 
             self._device_info[str(device.id)] = device_info
@@ -2659,7 +2661,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         dev_id: str,
         dev_name: str | None,
         dev_model: str | None,
-        **kwargs,
+        **kwargs: dict[str, Any],
     ) -> None:
 
         device_info = DeviceInfo(
@@ -2672,6 +2674,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         )
 
         if self._device_info.get(str(dev_id)) == device_info:
+            # already known and set
             return
 
         self._device_info[str(dev_id)] = device_info

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -27,7 +27,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import ChildDeviceInfo, DeviceInfo
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -2567,24 +2567,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         device_registry = dr.async_get(self.hass)
 
-        via_device: tuple[str, str] | None = None
+        parent_device_id: tuple[str, str] | None = None
         if isinstance(device, Zone) and device.tcs:
-            _LOGGER.info("ZONE %s via_device SET to %s", model, device.tcs.id)
-            via_device = (DOMAIN, str(device.tcs.id))
+            _LOGGER.info("ZONE %s parent_device_id SET to %s", model, device.tcs.id)
+            parent_device_id = (DOMAIN, str(device.tcs.id))
         elif isinstance(device, UfhCircuit) and device.ufc:
             ufc_id = str(device.ufc.id)
             _LOGGER.info(
-                "UFH Circuit %s via_device SET to %s", device.id, ufc_id
+                "UFH Circuit %s parent_device_id SET to %s", device.id, ufc_id
             )
-            via_device = (DOMAIN, ufc_id)
+            parent_device_id = (DOMAIN, ufc_id)
         elif isinstance(device, Child) and getattr(device, "_parent", None):
             parent = getattr(device, "_parent", None)
             child_parent_id = getattr(parent, "id", None) if parent else None
             _LOGGER.info(
-                "CHILD %s via_device SET to %s", model, child_parent_id
+                "CHILD %s parent_device_id SET to %s", model, child_parent_id
             )
             if child_parent_id:
-                via_device = (DOMAIN, str(child_parent_id))
+                parent_device_id = (DOMAIN, str(child_parent_id))
         elif isinstance(device, DeviceHvac) and getattr(
             device, "_parent_fan", None
         ):
@@ -2593,43 +2593,70 @@ class RamsesCoordinator(DataUpdateCoordinator):
             parent_fan_id = (
                 getattr(parent_fan, "id", None) if parent_fan else None
             )
-            _LOGGER.info("HVAC %s via_device SET to %s", model, parent_fan_id)
+            _LOGGER.info(
+                "HVAC %s parent_device_id SET to %s", model, parent_fan_id
+            )
             if parent_fan_id:
-                via_device = (DOMAIN, str(parent_fan_id))
+                parent_device_id = str(parent_fan_id)
         else:
-            via_device = None
+            parent_device_id = None
 
         # Conditionally assemble kwargs to protect HA TypedDict strict checks
         kwargs: dict[str, Any] = {}
-        if via_device is not None:
-            kwargs["via_device"] = via_device
+        if suggested_area is not None:
+            kwargs["suggested_area"] = suggested_area
+        if parent_device_id is not None:
+            if (
+                device_registry.async_get(
+                    config_entry_id=self.entry.entry_id,
+                    device_id=parent_device_id,
+                ).__class__
+                == ChildDeviceInfo
+            ):  # children can't be nested
+                _LOGGER.warning(
+                    "Parent %s is a Child, can't nest", parent_device_id
+                )
+                return
+            kwargs["parent_device_id"] = parent_device_id
             if (
                 isinstance(device, UfhCircuit)
                 and hasattr(DeviceInfo, "__annotations__")
-                and "parent_device" in DeviceInfo.__annotations__
+                and "parent_device_id" in DeviceInfo.__annotations__
             ):
-                kwargs["parent_device"] = via_device
+                kwargs["parent_device_id"] = parent_device_id
 
-        if suggested_area is not None:
-            kwargs["suggested_area"] = suggested_area
+            kwargs["parent_device_id"] = parent_device_id
+            device_info = ChildDeviceInfo(
+                identifiers={(DOMAIN, str(device.id))},
+                name=device_name,
+                **kwargs,
+            )
+            if self._device_info.get(str(device.id)) == device_info:
+                return
 
-        device_info = DeviceInfo(
-            identifiers={(DOMAIN, str(device.id))},
-            name=device_name,
-            manufacturer=None,
-            model=model,
-            serial_number=str(device.id),
-            **kwargs,
-        )
+            self._device_info[str(device.id)] = device_info
 
-        if self._device_info.get(str(device.id)) == device_info:
-            return
+            device_registry.async_get_or_create_child(
+                config_entry_id=self.entry.entry_id, **device_info
+            )
+        else:
+            device_info = DeviceInfo(
+                identifiers={(DOMAIN, str(device.id))},
+                name=device_name,
+                manufacturer=None,
+                model=model,
+                serial_number=str(device.id),
+                **kwargs,
+            )
 
-        self._device_info[str(device.id)] = device_info
+            if self._device_info.get(str(device.id)) == device_info:
+                return
 
-        device_registry.async_get_or_create(
-            config_entry_id=self.entry.entry_id, **device_info
-        )
+            self._device_info[str(device.id)] = device_info
+
+            device_registry.async_get_or_create(
+                config_entry_id=self.entry.entry_id, **device_info
+            )
 
     async def _async_update_data(self) -> None:
         """Fetch data from the RAMSES RF client."""
@@ -2846,7 +2873,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         )
 
         # Process new devices for fan logic: Systems/DHWs before Devices
-        # to ensure via_device parents exist
+        # to ensure parent_device_id parents exist
         for device in (
             new_systems + new_dhws + new_zones + new_devices + new_circuits
         ):

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2576,7 +2576,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             _LOGGER.info(
                 "UFH Circuit %s parent_device_id SET to %s", device.id, ufc_id
             )
-            parent_device_id = (DOMAIN, ufc_id)
+            parent_device_id = str(ufc_id)
         elif isinstance(device, Child) and getattr(device, "_parent", None):
             parent = getattr(device, "_parent", None)
             child_parent_id = getattr(parent, "id", None) if parent else None
@@ -2584,7 +2584,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 "CHILD %s parent_device_id SET to %s", model, child_parent_id
             )
             if child_parent_id:
-                parent_device_id = (DOMAIN, str(child_parent_id))
+                parent_device_id = str(child_parent_id)
         elif isinstance(device, DeviceHvac) and getattr(
             device, "_parent_fan", None
         ):

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2606,15 +2606,21 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if suggested_area is not None:
             kwargs["suggested_area"] = suggested_area
         if parent_device_id is not None:
-            if (
-                device_registry.async_get(
-                    config_entry_id=self.entry.entry_id,
-                    device_id=parent_device_id,
-                ).__class__
-                == ChildDeviceInfo
+            parent = device_registry.async_get_device_by_identifier(
+                (DOMAIN, parent_device_id), self.entry.entry_id
+            )
+            if parent is None:
+                _LOGGER.warning(
+                    "Parent %s does not exist. Must create it first",
+                    parent_device_id,
+                )
+                # create parent first
+                await self._async_create_device(parent_device_id, None, None)
+            elif (
+                parent.__class__ == ChildDeviceInfo
             ):  # children can't be nested
                 _LOGGER.warning(
-                    "Parent %s is a Child, can't nest", parent_device_id
+                    "Parent %s is itself a Child, can't nest", parent_device_id
                 )
                 return
             kwargs["parent_device_id"] = parent_device_id
@@ -2640,23 +2646,34 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 config_entry_id=self.entry.entry_id, **device_info
             )
         else:
-            device_info = DeviceInfo(
-                identifiers={(DOMAIN, str(device.id))},
-                name=device_name,
-                manufacturer=None,
-                model=model,
-                serial_number=str(device.id),
-                **kwargs,
-            )
+            await self._async_create_device(device.id, device_name, model)
 
-            if self._device_info.get(str(device.id)) == device_info:
-                return
+    async def _async_create_device(
+        self,
+        dev_id: str,
+        dev_name: str | None,
+        dev_model: str | None,
+        **kwargs,
+    ) -> None:
 
-            self._device_info[str(device.id)] = device_info
+        device_info = DeviceInfo(
+            identifiers={(DOMAIN, str(dev_id))},
+            name=dev_name,
+            manufacturer=None,
+            model=dev_model,
+            serial_number=str(dev_id),
+            **kwargs,
+        )
 
-            device_registry.async_get_or_create(
-                config_entry_id=self.entry.entry_id, **device_info
-            )
+        if self._device_info.get(str(dev_id)) == device_info:
+            return
+
+        self._device_info[str(dev_id)] = device_info
+
+        device_registry = dr.async_get(self.hass)
+        device_registry.async_get_or_create(
+            config_entry_id=self.entry.entry_id, **device_info
+        )
 
     async def _async_update_data(self) -> None:
         """Fetch data from the RAMSES RF client."""

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2570,7 +2570,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         parent_device_id: tuple[str, str] | None = None
         if isinstance(device, Zone) and device.tcs:
             _LOGGER.info("ZONE %s parent_device_id SET to %s", model, device.tcs.id)
-            parent_device_id = (DOMAIN, str(device.tcs.id))
+            parent_device_id = str(device.tcs.id)
         elif isinstance(device, UfhCircuit) and device.ufc:
             ufc_id = str(device.ufc.id)
             _LOGGER.info(

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -258,7 +258,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         self._platform_setup_tasks: dict[str, asyncio.Task[Any]] = {}
         self._entities: dict[str, RamsesEntity] = {}  # domain entities
-        self._device_info: dict[str, DeviceInfo] = {}
+        self._device_info: dict[str, DeviceInfo | ChildDeviceInfo] = {}
         self._disabled_device_ids: set[str] = (
             set()
         )  # _disabled devices (no entities)
@@ -2531,11 +2531,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
             device_name = str(raw_name) if raw_name else None
 
         suggested_area: str | None = None
+        model: str | None = None
 
         # Fallback names if the device doesn't supply a valid one
         if isinstance(device, UfhCircuit):
             device_name = f"UFH Circuit {device.id}"
-            model: str | None = f"UFH Circuit {device.ufh_index}"
+            model = f"UFH Circuit {device.ufh_index}"  # not used for Child
             if device.zone and getattr(device.zone, SZ_NAME, None):
                 suggested_area = str(device.zone.name)
         elif not device_name:

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -74,7 +74,7 @@ class RamsesEntity(CoordinatorEntity):
         self.entity_description = entity_description
 
         self._attr_unique_id = device.id
-        # basic device_info, TODO use ChildDeviceInfo if applicable
+        # base DeviceInfo TODO use ChildDeviceInfo if applicable
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device.id)})
         self._update_lock = asyncio.Lock()
         self._dropped_updates: int = 0

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -74,6 +74,7 @@ class RamsesEntity(CoordinatorEntity):
         self.entity_description = entity_description
 
         self._attr_unique_id = device.id
+        # basic device_info, TODO use ChildDeviceInfo if applicable
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device.id)})
         self._update_lock = asyncio.Lock()
         self._dropped_updates: int = 0

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -67,32 +67,21 @@ def ha_device_id_to_ramses_device_id(
 
 
 def ramses_device_id_to_ha_device_id(
-    hass: HomeAssistant, ramses_device_id: str, entry_id: str | None = None
+    hass: HomeAssistant, ramses_device_id: str
 ) -> str | None:
     """Return a HA device registry id for a RAMSES device_id.
 
     :param hass: The Home Assistant instance.
     :param ramses_device_id: The RAMSES device ID (e.g., '01:123456').
-    :param entry_id: The entry ID (e.g., '1234567890').
     :return: The Home Assistant device registry ID or None if not found.
     """
     if not ramses_device_id:
         return None
 
     dev_reg = dr.async_get(hass)
-    if entry_id is None:  # TODO: remove Q2 2027
-        device_entry = dev_reg.async_get_device(
-            identifiers={(DOMAIN, ramses_device_id)}
-        )
-        # deprecated since 2026.6. Use single config entry.
-        _LOGGER.warning(
-            "dev_reg.async_get_device() is deprecated. Use async_get_device_by_identifier() instead"
-        )
-    else:
-        device_entry = dev_reg.async_get_device_by_identifier(
-            (DOMAIN, ramses_device_id), entry_id
-        )
-    # add entry to method args
+    device_entry = dev_reg.async_get_device(
+        identifiers={(DOMAIN, ramses_device_id)}
+    )
     if not device_entry:
         return None
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -258,7 +258,7 @@ async def test_update_device_relationships(
 
     # We patch the class in the BROKER module so it checks against our dummy
     with patch("custom_components.ramses_cc.coordinator.Zone", DummyZone):
-        # 1. Test Zone with TCS (hits via_device logic for Zones)
+        # 1. Test Zone with TCS (hits parent_device logic for Zones)
         mock_zone = MagicMock(spec=DummyZone)
         mock_zone.id = "04:123456"
         mock_zone.tcs = MagicMock()
@@ -274,9 +274,9 @@ async def test_update_device_relationships(
             mock_reg = dr_m.return_value
             await mock_coordinator._async_update_device(mock_zone)
 
-            # Verify via_device was set to TCS ID
+            # Verify parent_device_id was set to TCS ID
             call_kwargs = cast(Any, mock_reg.async_get_or_create).call_args[1]
-            assert call_kwargs["via_device"] == (DOMAIN, "01:999999")
+            assert call_kwargs["parent_device_id"] == ("01:999999")
 
 
 async def test_update_device_child_parent(
@@ -303,7 +303,7 @@ async def test_update_device_child_parent(
         await mock_coordinator._async_update_device(mock_child)
 
         call_kwargs = cast(Any, mock_reg.async_get_or_create).call_args[1]
-        assert call_kwargs["via_device"] == (DOMAIN, "04:123456")
+        assert call_kwargs["parent_device_id"] == ("04:123456")
 
 
 async def test_async_start(mock_coordinator: RamsesCoordinator) -> None:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -6460,7 +6460,6 @@ async def test_async_update_device_ufh_circuit_metadata_and_parent(
     dev_info = mock_coordinator._device_info.get("02:123456_00")
     assert dev_info is not None
     assert dev_info["name"] == "UFH Circuit 02:123456_00"
-    assert dev_info["model"] == "UFH Circuit 00"
     assert dev_info["parent_device_id"] == "02:123456"
     assert dev_info.get("parent_device") is None
     assert dev_info.get("suggested_area") == "Kitchen Diner"

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -258,7 +258,7 @@ async def test_update_device_relationships(
 
     # We patch the class in the BROKER module so it checks against our dummy
     with patch("custom_components.ramses_cc.coordinator.Zone", DummyZone):
-        # 1. Test Zone with TCS (hits parent_device logic for Zones)
+        # 1. Test Zone with TCS (hits parent_device_id logic for Zones)
         mock_zone = MagicMock(spec=DummyZone)
         mock_zone.id = "04:123456"
         mock_zone.tcs = MagicMock()
@@ -6461,7 +6461,7 @@ async def test_async_update_device_ufh_circuit_metadata_and_parent(
     assert dev_info is not None
     assert dev_info["name"] == "UFH Circuit 02:123456_00"
     assert dev_info["model"] == "UFH Circuit 00"
-    assert dev_info["via_device"] == (DOMAIN, "02:123456")
+    assert dev_info["parent_device_id"] == "02:123456"
     assert dev_info.get("parent_device") is None
     assert dev_info.get("suggested_area") == "Kitchen Diner"
 
@@ -6498,5 +6498,4 @@ async def test_async_update_device_ufh_circuit_future_parent_device(
     # Assert
     dev_info = mock_coordinator._device_info.get("02:123456_00")
     assert dev_info is not None
-    assert dev_info["via_device"] == (DOMAIN, "02:123456")
-    assert dev_info.get("parent_device") == (DOMAIN, "02:123456")
+    assert dev_info.get("parent_device_id") == "02:123456"

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -1038,10 +1038,10 @@ async def test_get_device_and_from_id_propagates_exceptions(
         )
 
 
-async def test_update_device_via_device_logic(
+async def test_update_device_parent_device_logic(
     mock_coordinator: RamsesCoordinator, hass: HomeAssistant
 ) -> None:
-    """Test the via_device logic in _update_device for Zones and Children."""
+    """Test the parent_device logic in _update_device for Zones and Children."""
     # 1. Test Zone with TCS
     mock_tcs = MagicMock()
     mock_tcs.id = "01:123456"
@@ -1070,15 +1070,15 @@ async def test_update_device_via_device_logic(
     ):
         # Trigger update for Zone
         await mock_coordinator._async_update_device(mock_zone)
-        # Check zone via_device (most recent call)
+        # Check zone parent_device_id (most recent call)
         call_args_zone = mock_dr.async_get_or_create.call_args_list[-1][1]
-        assert call_args_zone["via_device"] == (DOMAIN, "01:123456")
+        assert call_args_zone["parent_device_id"] == ("01:123456")
 
         # Trigger update for Child
         await mock_coordinator._async_update_device(mock_child)
-        # Check child via_device (most recent call)
+        # Check child parent_device_id (most recent call)
         call_args_child = mock_dr.async_get_or_create.call_args_list[-1][1]
-        assert call_args_child["via_device"] == (DOMAIN, "02:222222")
+        assert call_args_child["parent_device_id"] == ("02:222222")
 
 
 async def test_adjust_sentinel_packet_early_return(
@@ -1178,9 +1178,9 @@ async def test_update_device_valid_child_type(
     ):
         await mock_coordinator._async_update_device(mock_child)
 
-        # Check that it used the parent for via_device
+        # Check that it used the parent for parent_device_id
         call_args = mock_dr.async_get_or_create.call_args[1]
-        assert call_args["via_device"] == (DOMAIN, "02:888888")
+        assert call_args["parent_device_id"] == ("02:888888")
 
 
 async def test_get_fan_param_generic_exception(
@@ -1472,8 +1472,8 @@ async def test_bind_device_generic_exception(
 async def test_update_device_simple_device(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Test _update_device for a simple device (not Zone, not Child) sets via_device=None."""
-    # A plain device (not Zone, not Child) should fall through to via_device = None
+    """Test _update_device for a simple device (not Zone, not Child) sets parent_device_id=None."""
+    # A plain device (not Zone, not Child) should fall through to parent_device_id=None
     mock_dev = MagicMock()
     mock_dev.id = "63:111111"
     mock_dev._SLUG = "SEN"
@@ -1486,9 +1486,9 @@ async def test_update_device_simple_device(
     ):
         await mock_coordinator._async_update_device(mock_dev)
 
-        # Check that via_device is None using dictionary get method to prevent KeyError
+        # Check that parent_device_id is None using dictionary get method to prevent KeyError
         call_args = mock_dr.async_get_or_create.call_args[1]
-        assert call_args.get("via_device") is None
+        assert call_args.get("parent_device_id") is None
 
 
 async def test_run_fan_param_sequence_errors(
@@ -1621,14 +1621,14 @@ async def test_update_device_relationships(hass: HomeAssistant) -> None:
 
         await coordinator._async_update_device(child_device)
 
-        # Verify via_device is set to parent
+        # Verify parent_device_id is set to parent
         dev_reg.async_get_or_create.assert_called_with(
             config_entry_id="test_entry",
             identifiers={(DOMAIN, "04:123456")},
             name="Test Child",
             manufacturer=None,
             model="Test Model",
-            via_device=(DOMAIN, "01:123456"),
+            parent_device_id=("01:123456"),
             serial_number="04:123456",
         )
 
@@ -1649,9 +1649,9 @@ async def test_update_device_relationships(hass: HomeAssistant) -> None:
 
         await coordinator._async_update_device(generic_device)
 
-        # Verify via_device is None using dictionary get method to prevent KeyError
+        # Verify parent_device_id is None using dictionary get method to prevent KeyError
         args, kwargs = dev_reg.async_get_or_create.call_args
-        assert kwargs.get("via_device") is None
+        assert kwargs.get("parent_device_id") is None
 
 
 async def test_bind_device_lookup_error(hass: HomeAssistant) -> None:
@@ -1894,7 +1894,7 @@ async def test_update_device_already_registered(hass: HomeAssistant) -> None:
         device._SLUG = "BDR"
         device.state_store = MagicMock()
         device.state_store._msg_value_code = AsyncMock(return_value=None)
-        # Ensure it doesn't trigger Child/Zone logic for via_device
+        # Ensure it doesn't trigger Child/Zone logic for parent_device_id
         device._parent = None
 
         # First call - should register the device

--- a/tests/tests_old/test_data/system_1.log
+++ b/tests/tests_old/test_data/system_1.log
@@ -8,7 +8,7 @@
 2024-01-01T00:00:02.002000 045 RP --- 01:145038 18:006402 --:------ 000C 006 02080010DAF5  # {'zone_idx':  '02', 'zone_type': '08', 'device_role': 'rad_actuator', 'devices': ['04:056053']}  # ...and this set is in together with the next set:
 
 2024-01-01T00:00:02.003000 045 RP --- 01:145038 18:006402 --:------ 000C 006 0A04005A23FD  # {'zone_idx':  '0A', 'zone_type': '04', 'device_role': 'zone_sensor',  'devices': ['22:140285']}
-2024-01-01T00:00:02.004000 045 RP --- 01:145038 18:006402 --:------ 000C 006 0A080012E29A  # {'zone_idx':  '0A', 'zone_type': '08', 'device_role': 'rad_actuator', 'devices': ['04:189082']} # this line together with the one before causes non-existing via_device error
+2024-01-01T00:00:02.004000 045 RP --- 01:145038 18:006402 --:------ 000C 006 0A080012E29A  # {'zone_idx':  '0A', 'zone_type': '08', 'device_role': 'rad_actuator', 'devices': ['04:189082']} # this line together with the one before causes non-existing parent_device error
 
 2024-01-01T00:00:03.001000 045 RP --- 01:145038 18:006402 --:------ 0004 022 02004B69746368656E00000000000000000000000000  # {'zone_idx': '02', 'name': 'Kitchen'}
 2024-01-01T00:00:03.002000 045 RP --- 01:145038 18:006402 --:------ 0004 022 0A004F66666963650000000000000000000000000000  # {'zone_idx': '04', 'name': 'Office'}


### PR DESCRIPTION
Store parent link on UFH and Zones as ChildDeviceInfo.

This PR fixes issue #1007
See discussion under that issue.
Requires HA 2026.9.b0 or higher.

Blocker: parent must exist before creating child. Subroutine to check/create if None isn't working.

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used (up to now)