### PR TITLE
feat: add pool config constants for multi-HGI support (issue 1119)

### DIFF
--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -54,6 +54,10 @@ CONF_SCHEMA: Final = "schema"
 CONF_SEND_PACKET: Final = "send_packet"
 CONF_UNKNOWN_CODES: Final = "unknown_codes"
 
+# Gateway pool (multi-HGI) — issue 1119
+CONF_ADDITIONAL_PORTS: Final = "additional_ports"
+CONF_ACCEPTED_HGIS: Final = "accepted_hgis"
+
 # Defaults
 DEFAULT_MQTT_TOPIC: Final = "RAMSES/GATEWAY"
 DEFAULT_HGI_ID: Final = HGI_DEVICE_ID


### PR DESCRIPTION
## Summary

- Add `CONF_ADDITIONAL_PORTS` and `CONF_ACCEPTED_HGIS` constants to `const.py` for the gateway pool feature (issue 1119)
- These are config entry options (validated by the config flow in PR 2), not YAML schema keys

This is PR 1 of 3 for issue 1119:
- **PR 1** (this): Constants for pool config
- **PR 2**: Config flow `manage_pool` step (depends on this)
- **PR 3**: Coordinator wiring to `pooled_transport_factory` (depends on this)

#### Test plan
- [x] All 1377 existing tests pass
- [x] ruff check clean
- [x] mypy clean