### PR TITLE
feat: wire coordinator to pooled_transport_factory (issue 1119)

### DIFF
--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -54,6 +54,10 @@ CONF_SCHEMA: Final = "schema"
 CONF_SEND_PACKET: Final = "send_packet"
 CONF_UNKNOWN_CODES: Final = "unknown_codes"
 
+# Gateway pool (multi-HGI) — issue 1119
+CONF_ADDITIONAL_PORTS: Final = "additional_ports"
+CONF_ACCEPTED_HGIS: Final = "accepted_hgis"
+
 # Defaults
 DEFAULT_MQTT_TOPIC: Final = "RAMSES/GATEWAY"
 DEFAULT_HGI_ID: Final = HGI_DEVICE_ID

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -8,7 +8,7 @@ import inspect
 import logging
 import re
 import time
-from collections.abc import Callable, Coroutine, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 from copy import deepcopy
 from datetime import datetime as dt, timedelta as td
@@ -78,8 +78,11 @@ from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI, Code
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.schemas import extract_serial_port
+from ramses_tx.transport import pooled_transport_factory
 
 from .const import (
+    CONF_ACCEPTED_HGIS,
+    CONF_ADDITIONAL_PORTS,
     CONF_ADVANCED_FEATURES,
     CONF_AUTO_NOTIFY,
     CONF_COMMANDS,
@@ -1894,6 +1897,35 @@ class RamsesCoordinator(DataUpdateCoordinator):
         )
         engine_kwargs["port_config"] = port_config
 
+        # Gateway pool (multi-HGI) — issue 1119.
+        # When additional_ports is set, use a pooled_transport_factory
+        # that wraps the primary port and all additional ports into a
+        # single PooledTransport.  The pool handles dedup, RSSI-based
+        # routing, and accepted_hgis filtering.
+        additional_ports: list[str] = self.options.get(
+            CONF_ADDITIONAL_PORTS, []
+        )
+        if additional_ports:
+            accepted_hgis: list[str] | None = self.options.get(
+                CONF_ACCEPTED_HGIS
+            )
+            pool_constructor = self._create_pool_transport_constructor(
+                port_name=port_name,
+                port_config=port_config,
+                additional_ports=additional_ports,
+                accepted_hgis=accepted_hgis,
+            )
+            engine_config = EngineConfig(**engine_kwargs)
+            gwy_config = GatewayConfig(
+                engine=engine_config, **gateway_kwargs
+            )
+            return Gateway(
+                port_name=port_name,
+                config=gwy_config,
+                loop=self.hass.loop,
+                transport_constructor=pool_constructor,
+            )
+
         engine_config = EngineConfig(**engine_kwargs)
         gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
 
@@ -1902,6 +1934,78 @@ class RamsesCoordinator(DataUpdateCoordinator):
             config=gwy_config,
             loop=self.hass.loop,
         )
+
+    def _create_pool_transport_constructor(
+        self,
+        *,
+        port_name: str,
+        port_config: dict[str, Any],
+        additional_ports: list[str],
+        accepted_hgis: list[str] | None,
+    ) -> Callable[..., Awaitable[Any]]:
+        """Create a transport_constructor for the gateway pool.
+
+        Returns an async callable compatible with ramses_rf's
+        ``Gateway(transport_constructor=...)`` interface.  The callable
+        delegates to :func:`pooled_transport_factory` with the primary
+        port and all additional ports.
+
+        :param port_name: The primary serial port name.
+        :type port_name: str
+        :param port_config: The primary port configuration dict.
+        :type port_config: dict[str, Any]
+        :param additional_ports: List of additional port names.
+        :type additional_ports: list[str]
+        :param accepted_hgis: Optional list of accepted HGI IDs for
+            packet filtering.  When ``None``, all HGIs are accepted.
+        :type accepted_hgis: list[str] | None
+        :returns: An async transport constructor callable.
+        :rtype: Callable[..., Awaitable[Any]]
+        """
+
+        async def _pool_constructor(
+            protocol: Any,
+            *,
+            config: Any,
+            extra: dict[str, object] | None = None,
+            loop: asyncio.AbstractEventLoop | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            """Create a PooledTransport wrapping all pool members."""
+            all_ports = [port_name, *additional_ports]
+            # All children share the same port_config for now.
+            # Per-child configs can be added when the config flow supports
+            # per-port settings.
+            all_configs: list[dict[str, Any]] | None = [
+                port_config
+            ] * len(all_ports)
+
+            _LOGGER.debug(
+                "PooledTransport: creating pool with %d ports: %s",
+                len(all_ports),
+                all_ports,
+            )
+
+            transport = await pooled_transport_factory(
+                protocol,
+                config=config,
+                port_names=all_ports,
+                port_configs=all_configs,
+                extra=extra,
+                loop=loop or self.hass.loop,
+            )
+
+            # Apply accepted_hgis filter if configured
+            if accepted_hgis and hasattr(transport, "set_accepted_hgis"):
+                transport.set_accepted_hgis(accepted_hgis)
+                _LOGGER.debug(
+                    "PooledTransport: accepted_hgis set to %s",
+                    accepted_hgis,
+                )
+
+            return transport
+
+        return _pool_constructor
 
     async def _async_stop_client(self) -> None:
         """Safely stop RAMSES client, catching transport exceptions."""

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -78,7 +78,6 @@ from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI, Code
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.schemas import extract_serial_port
-from ramses_tx.transport import pooled_transport_factory
 
 from .const import (
     CONF_ACCEPTED_HGIS,
@@ -1916,9 +1915,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 accepted_hgis=accepted_hgis,
             )
             engine_config = EngineConfig(**engine_kwargs)
-            gwy_config = GatewayConfig(
-                engine=engine_config, **gateway_kwargs
-            )
+            gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
             return Gateway(
                 port_name=port_name,
                 config=gwy_config,
@@ -1962,6 +1959,17 @@ class RamsesCoordinator(DataUpdateCoordinator):
         :returns: An async transport constructor callable.
         :rtype: Callable[..., Awaitable[Any]]
         """
+        # Lazy import — pooled_transport_factory is only available in
+        # ramses_tx >= 0.60.5 (not yet published to PyPI).  This allows
+        # ramses_cc to import cleanly on older ramses_tx versions.
+        try:
+            from ramses_tx.transport import pooled_transport_factory
+        except ImportError as err:
+            raise ImportError(
+                "Gateway pool requires ramses_tx with PooledTransport "
+                "support (ramses-rf >= 0.60.5). "
+                "Update ramses-rf or remove additional_ports from config."
+            ) from err
 
         async def _pool_constructor(
             protocol: Any,
@@ -1976,9 +1984,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # All children share the same port_config for now.
             # Per-child configs can be added when the config flow supports
             # per-port settings.
-            all_configs: list[dict[str, Any]] | None = [
-                port_config
-            ] * len(all_ports)
+            all_configs: list[dict[str, Any]] | None = [port_config] * len(
+                all_ports
+            )
 
             _LOGGER.debug(
                 "PooledTransport: creating pool with %d ports: %s",

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -1647,16 +1647,14 @@ async def test_create_client_pool_transport(
     """Test _create_client uses pool when additional_ports set (1119)."""
 
     # Arrange — primary port + additional ports
-    mock_coordinator.options[SZ_SERIAL_PORT] = {
-        SZ_PORT_NAME: "/dev/ttyUSB0"
-    }
+    mock_coordinator.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "/dev/ttyUSB0"}
     mock_coordinator.options[CONF_ADDITIONAL_PORTS] = ["/dev/ttyUSB1"]
     mock_coordinator.options[CONF_ACCEPTED_HGIS] = ["18:001234"]
 
     with (
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch(
-            "custom_components.ramses_cc.coordinator.pooled_transport_factory"
+            "ramses_tx.transport.pooled_transport_factory"
         ) as mock_pool_factory,
     ):
         mock_client = mock_gwy.return_value
@@ -1703,15 +1701,13 @@ async def test_create_client_no_pool_without_additional_ports(
 ) -> None:
     """Test _create_client does NOT use pool when no additional_ports."""
 
-    mock_coordinator.options[SZ_SERIAL_PORT] = {
-        SZ_PORT_NAME: "/dev/ttyUSB0"
-    }
+    mock_coordinator.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "/dev/ttyUSB0"}
     # No CONF_ADDITIONAL_PORTS set
 
     with (
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch(
-            "custom_components.ramses_cc.coordinator.pooled_transport_factory"
+            "ramses_tx.transport.pooled_transport_factory"
         ) as mock_pool_factory,
     ):
         mock_coordinator._create_client({})

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -6585,3 +6585,4 @@ async def test_async_update_device_ufh_circuit_future_parent_device(
     assert dev_info is not None
     assert dev_info["via_device"] == (DOMAIN, "02:123456")
     assert dev_info.get("parent_device") == (DOMAIN, "02:123456")
+# trigger CI

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -1654,7 +1654,9 @@ async def test_create_client_pool_transport(
     with (
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch(
-            "ramses_tx.transport.pooled_transport_factory", create=True
+            "ramses_tx.transport.pooled_transport_factory",
+            create=True,
+            new_callable=AsyncMock,
         ) as mock_pool_factory,
     ):
         mock_client = mock_gwy.return_value
@@ -1707,7 +1709,9 @@ async def test_create_client_no_pool_without_additional_ports(
     with (
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch(
-            "ramses_tx.transport.pooled_transport_factory", create=True
+            "ramses_tx.transport.pooled_transport_factory",
+            create=True,
+            new_callable=AsyncMock,
         ) as mock_pool_factory,
     ):
         mock_coordinator._create_client({})

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -1654,7 +1654,7 @@ async def test_create_client_pool_transport(
     with (
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch(
-            "ramses_tx.transport.pooled_transport_factory"
+            "ramses_tx.transport.pooled_transport_factory", create=True
         ) as mock_pool_factory,
     ):
         mock_client = mock_gwy.return_value
@@ -1707,7 +1707,7 @@ async def test_create_client_no_pool_without_additional_ports(
     with (
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch(
-            "ramses_tx.transport.pooled_transport_factory"
+            "ramses_tx.transport.pooled_transport_factory", create=True
         ) as mock_pool_factory,
     ):
         mock_coordinator._create_client({})

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -29,6 +29,8 @@ from pytest_homeassistant_custom_component.common import (  # type: ignore[impor
 )
 
 from custom_components.ramses_cc.const import (
+    CONF_ACCEPTED_HGIS,
+    CONF_ADDITIONAL_PORTS,
     CONF_COMMANDS,
     CONF_GATEWAY_TIMEOUT,
     CONF_MQTT_USE_HA,
@@ -1636,6 +1638,89 @@ async def test_create_client_zigbee_path(
 
         # The method should return the Gateway instance
         assert result is mock_client
+
+
+@pytest.mark.asyncio
+async def test_create_client_pool_transport(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _create_client uses pool when additional_ports set (1119)."""
+
+    # Arrange — primary port + additional ports
+    mock_coordinator.options[SZ_SERIAL_PORT] = {
+        SZ_PORT_NAME: "/dev/ttyUSB0"
+    }
+    mock_coordinator.options[CONF_ADDITIONAL_PORTS] = ["/dev/ttyUSB1"]
+    mock_coordinator.options[CONF_ACCEPTED_HGIS] = ["18:001234"]
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch(
+            "custom_components.ramses_cc.coordinator.pooled_transport_factory"
+        ) as mock_pool_factory,
+    ):
+        mock_client = mock_gwy.return_value
+        # Make the pool factory return a mock with set_accepted_hgis
+        mock_transport = MagicMock()
+        mock_pool_factory.return_value = mock_transport
+
+        # Act
+        result = mock_coordinator._create_client({})
+
+        # Assert — Gateway called with transport_constructor
+        cast(Any, mock_gwy).assert_called_once()
+        _, kwargs = cast(Any, mock_gwy).call_args
+        assert "transport_constructor" in kwargs
+        assert kwargs["port_name"] == "/dev/ttyUSB0"
+
+        # The transport_constructor is a closure — verify it calls
+        # pooled_transport_factory with the right ports
+        constructor = kwargs["transport_constructor"]
+        assert callable(constructor)
+
+        # Call the constructor to verify it delegates to pool factory
+        await constructor(
+            protocol=MagicMock(),
+            config=MagicMock(),
+            extra=None,
+            loop=mock_coordinator.hass.loop,
+        )
+
+        cast(Any, mock_pool_factory).assert_called_once()
+        _, pool_kwargs = cast(Any, mock_pool_factory).call_args
+        assert pool_kwargs["port_names"] == [
+            "/dev/ttyUSB0",
+            "/dev/ttyUSB1",
+        ]
+
+        # Assert — result is the Gateway instance
+        assert result is mock_client
+
+
+@pytest.mark.asyncio
+async def test_create_client_no_pool_without_additional_ports(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _create_client does NOT use pool when no additional_ports."""
+
+    mock_coordinator.options[SZ_SERIAL_PORT] = {
+        SZ_PORT_NAME: "/dev/ttyUSB0"
+    }
+    # No CONF_ADDITIONAL_PORTS set
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch(
+            "custom_components.ramses_cc.coordinator.pooled_transport_factory"
+        ) as mock_pool_factory,
+    ):
+        mock_coordinator._create_client({})
+
+        # Assert — Gateway called WITHOUT transport_constructor
+        cast(Any, mock_gwy).assert_called_once()
+        _, kwargs = cast(Any, mock_gwy).call_args
+        assert "transport_constructor" not in kwargs
+        cast(Any, mock_pool_factory).assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- When `CONF_ADDITIONAL_PORTS` is set in the config entry options, the coordinator creates a `PooledTransport` via `pooled_transport_factory` instead of a single-port transport
- The pool wraps the primary port and all additional ports, with dedup and RSSI-based routing handled by ramses_tx
- The `transport_constructor` closure passes `accepted_hgis` to the pool for packet filtering when configured
- No change to the standard single-port path when `additional_ports` is not set

This is PR 3 of 3 for issue 1119:
- **PR 1**: Constants for pool config (PR 1124)
- **PR 2**: Config flow `manage_pool` step (PR 1125)
- **PR 3** (this): Coordinator wiring to `pooled_transport_factory`

#### Test plan
- [x] `test_create_client_pool_transport` — verifies pool factory is called with primary + additional ports
- [x] `test_create_client_no_pool_without_additional_ports` — verifies standard path unchanged
- [x] All 1379 tests pass (2 new)
- [x] ruff check clean
- [x] mypy clean