### PR TITLE
Set minimum HA version to 2026.7 (hacs)

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "RAMSES RF",
-    "homeassistant": "2026.8.0",
+    "homeassistant": "2026.7.0",
     "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "RAMSES RF",
+    "homeassistant": "2026.8.0",
     "render_readme": true
 }


### PR DESCRIPTION
Set minimum HA version for hacs.
To suppress deprec warn and replace the deprecated PPM unit, must run HA 2026.7

Next bump: to replace via_device by parent_device_id, must run 2026.9