### PR TITLE
Await faked CO2 level updates

### DIFF
--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -222,8 +222,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
 
     # the following methods are integration-specific service calls
 
-    @callback
-    def async_put_co2_level(self, co2_level: int) -> None:
+    async def async_put_co2_level(self, co2_level: int) -> None:
         """Cast the CO2 level (if faked).
 
         :param co2_level: The CO2 concentration in parts per million (ppm).
@@ -238,8 +237,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):
             raise TypeError(f"Cannot set CO2 level on {device}")
         # TODO: Until here
 
-        # setter will raise an exception if device is not faked
-        device.co2_level = co2_level  # would accept None
+        # set_co2_level() will raise an exception if device is not faked
+        await device.set_co2_level(co2_level)
 
     async def async_put_dhw_temp(self, temperature: float) -> None:
         """Cast the DHW cylinder temperature (if faked).

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -365,9 +365,10 @@ def test_sensor_icon(
     assert sensor.icon == "mdi:on"
 
 
-def test_async_put_co2_level(mock_coordinator: MagicMock) -> None:
+async def test_async_put_co2_level(mock_coordinator: MagicMock) -> None:
     """Test async_put_co2_level."""
     device = MagicMock(spec=HvacCarbonDioxideSensor)
+    device.set_co2_level = AsyncMock()
     device.id = "30:111111"
     desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "co2"
@@ -378,13 +379,13 @@ def test_async_put_co2_level(mock_coordinator: MagicMock) -> None:
     sensor._attr_native_unit_of_measurement = UnitOfRatio.PARTS_PER_MILLION
 
     # 1. Success
-    sensor.async_put_co2_level(800)
-    assert device.co2_level == 800
+    await sensor.async_put_co2_level(800)
+    device.set_co2_level.assert_awaited_once_with(800)
 
     # 2. Assert fail: Wrong Device Class
     sensor._attr_device_class = SensorDeviceClass.TEMPERATURE
     with pytest.raises(AssertionError):
-        sensor.async_put_co2_level(800)
+        await sensor.async_put_co2_level(800)
     sensor._attr_device_class = SensorDeviceClass.CO2
 
     # 3. TypeError: Wrong device type
@@ -395,7 +396,7 @@ def test_async_put_co2_level(mock_coordinator: MagicMock) -> None:
     sensor_bad._attr_native_unit_of_measurement = UnitOfRatio.PARTS_PER_MILLION
 
     with pytest.raises(TypeError, match="Cannot set CO2 level"):
-        sensor_bad.async_put_co2_level(800)
+        await sensor_bad.async_put_co2_level(800)
 
 
 async def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:


### PR DESCRIPTION
- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 75%

ramses_cc 0.60.4 pins ramses-rf 0.60.4, where CO2 updates use the asynchronous `set_co2_level()` API.

Call and await that method instead of assigning co2_level directly so the Home Assistant service completes the RF announcement before returning.