### PR TITLE
fix: await faked indoor humidity updates and clean coroutine annotations

### DIFF
--- a/custom_components/ramses_cc/climate.py
+++ b/custom_components/ramses_cc/climate.py
@@ -531,7 +531,6 @@ class RamsesController(RamsesEntity, ClimateEntity):
 
     # the following methods are integration-specific service calls
 
-    @callback
     async def async_get_system_faults(self, num_entries: int) -> None:
         """Get the nth latest fault log entries from the Controller.
 
@@ -1626,7 +1625,6 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
 
     # the 2411 fan_param services, copied to numbers and to remote.py
 
-    @callback
     async def async_get_fan_clim_param(self, **kwargs: Any) -> None:
         """Handle 'get_fan_param' service call.
 
@@ -1653,7 +1651,6 @@ class RamsesHvac(RamsesEntity, ClimateEntity):
                 f"Failed to get fan param: {err}"
             ) from err
 
-    @callback
     async def async_set_fan_clim_param(self, **kwargs: Any) -> None:
         """Handle 'set_fan_param' service call.
 

--- a/custom_components/ramses_cc/remote.py
+++ b/custom_components/ramses_cc/remote.py
@@ -795,7 +795,6 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
 
     # 2411 fan_param services, adapted from climate.py (no REM update_all)
 
-    @callback
     async def async_get_fan_rem_param(self, **kwargs: Any) -> None:
         """Handle 'get_fan_param' service call.
 
@@ -819,7 +818,6 @@ class RamsesRemote(RamsesEntity, RemoteEntity):
         else:
             _LOGGER.warning("REM %s not bound to a FAN", self._device.id)
 
-    @callback
     async def async_set_fan_rem_param(self, **kwargs: Any) -> None:
         """Handle 'set_fan_param' service call.
 

--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -260,8 +260,7 @@ class RamsesSensor(RamsesEntity, SensorEntity):
         await device.set_temperature(temperature)
         self.async_write_ha_state()
 
-    @callback
-    def async_put_indoor_humidity(self, indoor_humidity: float) -> None:
+    async def async_put_indoor_humidity(self, indoor_humidity: float) -> None:
         """Cast the indoor humidity level (if faked).
 
         :param indoor_humidity: The humidity percentage (0-100).
@@ -276,8 +275,8 @@ class RamsesSensor(RamsesEntity, SensorEntity):
             raise TypeError(f"Cannot set indoor humidity level on {device}")
         # TODO: Until here
 
-        # setter will raise an exception if device is not faked
-        device.indoor_humidity = indoor_humidity / 100  # would accept None
+        # set_indoor_humidity() will raise DeviceNotFaked if device is not faked
+        await device.set_indoor_humidity(indoor_humidity / 100)
 
     async def async_put_room_temp(self, temperature: float) -> None:
         """Cast the room temperature (if faked).

--- a/tests/tests_new/test_sensor.py
+++ b/tests/tests_new/test_sensor.py
@@ -427,10 +427,12 @@ async def test_async_put_dhw_temp(mock_coordinator: MagicMock) -> None:
         await sensor_bad.async_put_dhw_temp(50.0)
 
 
-def test_async_put_indoor_humidity(mock_coordinator: MagicMock) -> None:
+async def test_async_put_indoor_humidity(mock_coordinator: MagicMock) -> None:
     """Test async_put_indoor_humidity."""
+    # Arrange
     device = MagicMock(spec=HvacHumiditySensor)
     device.id = "30:222222"
+    device.set_indoor_humidity = AsyncMock()
     desc = MagicMock(spec=RamsesSensorEntityDescription)
     desc.key = "hum"
     desc.ramses_rf_attr = "indoor_humidity"
@@ -439,11 +441,11 @@ def test_async_put_indoor_humidity(mock_coordinator: MagicMock) -> None:
     sensor._attr_device_class = SensorDeviceClass.HUMIDITY
     sensor._attr_native_unit_of_measurement = PERCENTAGE
 
-    # 1. Success
-    sensor.async_put_indoor_humidity(50.0)
-    assert device.indoor_humidity == 0.5
+    # 1. Success - Act & Assert
+    await sensor.async_put_indoor_humidity(50.0)
+    device.set_indoor_humidity.assert_awaited_once_with(0.5)
 
-    # 2. TypeError
+    # 2. TypeError - Act & Assert
     wrong_device = MagicMock(spec=RamsesRFEntity)
     wrong_device.id = "01:333333"
     sensor_bad = RamsesSensor(mock_coordinator, wrong_device, desc)
@@ -451,7 +453,7 @@ def test_async_put_indoor_humidity(mock_coordinator: MagicMock) -> None:
     sensor_bad._attr_native_unit_of_measurement = PERCENTAGE
 
     with pytest.raises(TypeError, match="Cannot set indoor humidity"):
-        sensor_bad.async_put_indoor_humidity(50.0)
+        await sensor_bad.async_put_indoor_humidity(50.0)
 
 
 async def test_async_put_room_temp(mock_coordinator: MagicMock) -> None:


### PR DESCRIPTION
- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 75%

Follow-up to #1135: audit and tidy remaining faked sensor services and entity service coroutine annotations.

### The Problem:
- In `custom_components/ramses_cc/sensor.py`, `async_put_indoor_humidity` was decorated with `@callback` and executed `device.indoor_humidity = indoor_humidity / 100`. In `ramses_rf`, `IndoorHumidity.indoor_humidity` has no property setter; `device.set_indoor_humidity()` is an asynchronous coroutine that dispatches the `PUT_INDOOR_HUMIDITY` (`Code._12A0`) intent over the RF transport. Direct attribute mutation simply overwrote the method on the object instance without transmitting an RF packet or validating `is_faked`.
- In `custom_components/ramses_cc/climate.py` and `remote.py`, five entity service handlers (`async_get_system_faults`, `async_get_fan_clim_param`, `async_set_fan_clim_param`, `async_get_fan_rem_param`, `async_set_fan_rem_param`) were decorated with `@callback` despite being defined as `async def`. In Home Assistant, `@callback` designates non-yielding synchronous callbacks; decorating coroutines with `@callback` violates HA typing and architecture conventions.

### The Fix:
- **`sensor.py`**: Converted `async_put_indoor_humidity` to `async def`, removed `@callback`, and called `await device.set_indoor_humidity(indoor_humidity / 100)`.
- **`climate.py` & `remote.py`**: Removed redundant `@callback` decorators from the five `async def` service handlers.
- **`test_sensor.py`**: Updated `test_async_put_indoor_humidity` to an async test using `AsyncMock` to verify that `device.set_indoor_humidity` is awaited with `0.5`.

### Testing Performed:
- Direct unit & blast-radius tests: `.venv/bin/python -u -m pytest tests/tests_new/test_sensor.py tests/tests_new/test_climate.py tests/tests_new/test_remote.py tests/tests_old/test_services.py` (284 passed, 6 skipped).
- Full test suite: `.venv/bin/python -u -m pytest -n auto` (1,538 passed, 15 skipped, 3 snapshots passed, 0 failures).
- Pre-commit and linters: `.venv/bin/prek run -a` and `.venv/bin/mypy custom_components` passed cleanly.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.8 Flash for code generation, inspection, testing, and documentation. All logic and implementations were reviewed and verified by the author.