### PR TITLE
feat(device_registry): migrate zones and circuits to HA Core 2026.9 child devices

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -134,6 +134,8 @@ from .services import RamsesServiceHandler
 from .store import RamsesStore
 
 if TYPE_CHECKING:
+    from homeassistant.helpers.device_registry import ChildDeviceInfo
+
     from .entity import RamsesEntity
     from .number import RamsesNumberParam
 
@@ -257,7 +259,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         self._platform_setup_tasks: dict[str, asyncio.Task[Any]] = {}
         self._entities: dict[str, RamsesEntity] = {}  # domain entities
-        self._device_info: dict[str, DeviceInfo] = {}
+        self._device_info: dict[str, DeviceInfo | ChildDeviceInfo] = {}
         self._disabled_device_ids: set[str] = (
             set()
         )  # _disabled devices (no entities)
@@ -2607,51 +2609,84 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         device_registry = dr.async_get(self.hass)
 
-        via_device: tuple[str, str] | None = None
+        parent_ramses_device: RamsesRFEntity | None = None
         if isinstance(device, Zone) and device.tcs:
-            _LOGGER.info("ZONE %s via_device SET to %s", model, device.tcs.id)
-            via_device = (DOMAIN, str(device.tcs.id))
+            parent_ramses_device = device.tcs
         elif isinstance(device, UfhCircuit) and device.ufc:
-            ufc_id = str(device.ufc.id)
-            _LOGGER.info(
-                "UFH Circuit %s via_device SET to %s", device.id, ufc_id
+            parent_ramses_device = device.ufc
+
+        if hasattr(dr, "ChildDeviceInfo") and parent_ramses_device is not None:
+            parent_ramses_id = str(parent_ramses_device.id)
+            parent_entry = device_registry.async_get_device_by_identifier(
+                (DOMAIN, parent_ramses_id), self.entry.entry_id
             )
-            via_device = (DOMAIN, ufc_id)
-        elif isinstance(device, Child) and getattr(device, "_parent", None):
-            parent = getattr(device, "_parent", None)
-            child_parent_id = getattr(parent, "id", None) if parent else None
-            _LOGGER.info(
-                "CHILD %s via_device SET to %s", model, child_parent_id
+            if parent_entry is None:
+                await self._async_update_device(parent_ramses_device)
+                parent_entry = device_registry.async_get_device_by_identifier(
+                    (DOMAIN, parent_ramses_id), self.entry.entry_id
+                )
+
+            if parent_entry is not None:
+                _LOGGER.info(
+                    "CHILD %s parent_device_id SET to %s",
+                    model or device_name,
+                    parent_entry.id,
+                )
+                child_info = dr.ChildDeviceInfo(
+                    identifiers={(DOMAIN, str(device.id))},
+                    name=device_name,
+                    parent_device_id=parent_entry.id,
+                )
+                if suggested_area is not None:
+                    child_info["suggested_area"] = suggested_area
+
+                if self._device_info.get(str(device.id)) == child_info:
+                    return
+
+                self._device_info[str(device.id)] = child_info
+                device_registry.async_get_or_create_child(
+                    config_entry_id=self.entry.entry_id,
+                    **child_info,
+                )
+                return
+
+            _LOGGER.warning(
+                "Parent device %s could not be registered for child %s",
+                parent_ramses_id,
+                device.id,
             )
-            if child_parent_id:
-                via_device = (DOMAIN, str(child_parent_id))
-        elif isinstance(device, DeviceHvac) and getattr(
-            device, "_parent_fan", None
-        ):
-            # 6d: HVAC devices (REM/CO2) grouped under their FAN parent
-            parent_fan = getattr(device, "_parent_fan", None)
-            parent_fan_id = (
-                getattr(parent_fan, "id", None) if parent_fan else None
-            )
-            _LOGGER.info("HVAC %s via_device SET to %s", model, parent_fan_id)
-            if parent_fan_id:
-                via_device = (DOMAIN, str(parent_fan_id))
-        else:
-            via_device = None
 
         # Conditionally assemble kwargs to protect HA TypedDict strict checks
         kwargs: dict[str, Any] = {}
-        if via_device is not None:
-            kwargs["via_device"] = via_device
-            if (
-                isinstance(device, UfhCircuit)
-                and hasattr(DeviceInfo, "__annotations__")
-                and "parent_device" in DeviceInfo.__annotations__
-            ):
-                kwargs["parent_device"] = via_device
-
         if suggested_area is not None:
             kwargs["suggested_area"] = suggested_area
+
+        # Backward compatibility for HA < 2026.9 without ChildDeviceInfo
+        if not hasattr(dr, "ChildDeviceInfo"):
+            via_device: tuple[str, str] | None = None
+            if parent_ramses_device is not None:
+                via_device = (DOMAIN, str(parent_ramses_device.id))
+            elif isinstance(device, Child) and getattr(
+                device, "_parent", None
+            ):
+                parent = getattr(device, "_parent", None)
+                child_parent_id = (
+                    getattr(parent, "id", None) if parent else None
+                )
+                if child_parent_id:
+                    via_device = (DOMAIN, str(child_parent_id))
+            elif isinstance(device, DeviceHvac) and getattr(
+                device, "_parent_fan", None
+            ):
+                parent_fan = getattr(device, "_parent_fan", None)
+                parent_fan_id = (
+                    getattr(parent_fan, "id", None) if parent_fan else None
+                )
+                if parent_fan_id:
+                    via_device = (DOMAIN, str(parent_fan_id))
+
+            if via_device is not None:
+                kwargs["via_device"] = via_device
 
         device_info = DeviceInfo(
             identifiers={(DOMAIN, str(device.id))},

--- a/custom_components/ramses_cc/entity.py
+++ b/custom_components/ramses_cc/entity.py
@@ -24,6 +24,8 @@ from .helpers import (
 )
 
 if TYPE_CHECKING:
+    from homeassistant.helpers.device_registry import ChildDeviceInfo
+
     from .coordinator import RamsesCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,6 +80,22 @@ class RamsesEntity(CoordinatorEntity):
         self._update_lock = asyncio.Lock()
         self._dropped_updates: int = 0
         self._last_drop_report: float = time.monotonic()
+
+    @property
+    def device_info(self) -> DeviceInfo | ChildDeviceInfo | None:
+        """Return device registry information for this entity.
+
+        Return cached ChildDeviceInfo or DeviceInfo from the coordinator
+        to ensure child devices link cleanly during entity registration.
+        """
+        coordinator_device_info = getattr(
+            self.coordinator, "_device_info", None
+        )
+        if isinstance(coordinator_device_info, dict) and (
+            dev_info := coordinator_device_info.get(str(self._device.id))
+        ):
+            return dev_info
+        return self._attr_device_info
 
     @property
     def available(self) -> bool:

--- a/custom_components/ramses_cc/helpers.py
+++ b/custom_components/ramses_cc/helpers.py
@@ -80,6 +80,7 @@ def ramses_device_id_to_ha_device_id(
         return None
 
     dev_reg = dr.async_get(hass)
+    device_entry: dr.DeviceEntry | dr.ChildDeviceEntry | None = None
     if entry_id is None:  # TODO: remove Q2 2027
         device_entry = dev_reg.async_get_device(
             identifiers={(DOMAIN, ramses_device_id)}
@@ -92,11 +93,17 @@ def ramses_device_id_to_ha_device_id(
         device_entry = dev_reg.async_get_device_by_identifier(
             (DOMAIN, ramses_device_id), entry_id
         )
+        if device_entry is None and hasattr(
+            dev_reg, "async_get_child_device_by_identifier"
+        ):
+            device_entry = dev_reg.async_get_child_device_by_identifier(
+                (DOMAIN, ramses_device_id), entry_id
+            )
     # add entry to method args
     if not device_entry:
         return None
 
-    return cast(str | None, device_entry.id)
+    return device_entry.id
 
 
 def fields_to_aware(dt_or_none: dt | str | None) -> dt | None:

--- a/tests/tests_new/test_child_devices.py
+++ b/tests/tests_new/test_child_devices.py
@@ -1,0 +1,454 @@
+"""Unit tests for child device registry integration in ramses_cc.
+
+Tests compliance with Home Assistant Core 2026.9+ parent_device_id and
+ChildDeviceInfo specifications for Zones and UFH Circuits (Issue #1007).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import EntityDescription
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.ramses_cc.const import DOMAIN
+from custom_components.ramses_cc.coordinator import RamsesCoordinator
+from custom_components.ramses_cc.entity import RamsesEntity
+from ramses_rf.devices import DeviceHvac, UfhCircuit, UfhController
+from ramses_rf.systems import System, Zone
+from ramses_rf.topology import Child
+
+
+@pytest.fixture
+def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Provide a mock ConfigEntry for ramses_cc tests."""
+    entry = MockConfigEntry(domain=DOMAIN, entry_id="test_entry_child_devs")
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.fixture
+def mock_coordinator(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> RamsesCoordinator:
+    """Provide a minimal RamsesCoordinator instance."""
+    coordinator = MagicMock(spec=RamsesCoordinator)
+    coordinator.hass = hass
+    coordinator.entry = mock_config_entry
+    coordinator._device_info = {}
+    coordinator.client = MagicMock()
+    # Bind actual _async_update_device method for testing
+    coordinator._async_update_device = (  # type: ignore[method-assign]
+        RamsesCoordinator._async_update_device.__get__(
+            coordinator, RamsesCoordinator
+        )
+    )
+    return coordinator
+
+
+async def test_zone_registered_as_child_of_tcs(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify an Evohome Zone registers as a ChildDeviceInfo of its TCS."""
+    # Arrange
+    dev_reg = dr.async_get(hass)
+    parent_tcs_entry = dev_reg.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "01:123456")},
+        name="Controller 01:123456",
+    )
+
+    mock_tcs = MagicMock(spec=System)
+    mock_tcs.id = "01:123456"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.id = "01:123456_01"
+    mock_zone.name = "Living Room"
+    mock_zone.tcs = mock_tcs
+
+    # Act
+    await mock_coordinator._async_update_device(mock_zone)
+
+    # Assert
+    cached_info = mock_coordinator._device_info.get("01:123456_01")
+    assert cached_info is not None
+    assert cached_info["identifiers"] == {(DOMAIN, "01:123456_01")}
+    assert cached_info["name"] == "Living Room"
+    assert cached_info["parent_device_id"] == parent_tcs_entry.id
+
+    child_entry = dev_reg.async_get_child_device_by_identifier(
+        (DOMAIN, "01:123456_01"), mock_config_entry.entry_id
+    )
+    assert child_entry is not None
+    assert child_entry.parent_device_id == parent_tcs_entry.id
+
+
+async def test_ufh_circuit_registered_as_child_of_ufc(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify an Underfloor Heating Circuit registers as a ChildDeviceInfo of its UFC."""
+    # Arrange
+    dev_reg = dr.async_get(hass)
+    parent_ufc_entry = dev_reg.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "02:222222")},
+        name="UFH Controller 02:222222",
+    )
+
+    mock_ufc = MagicMock(spec=UfhController)
+    mock_ufc.id = "02:222222"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.name = "Kitchen"
+
+    mock_circuit = MagicMock(spec=UfhCircuit)
+    mock_circuit.id = "02:222222_00"
+    mock_circuit.ufh_index = "00"
+    mock_circuit.ufc = mock_ufc
+    mock_circuit.zone = mock_zone
+    mock_circuit.name = None
+
+    # Act
+    await mock_coordinator._async_update_device(mock_circuit)
+
+    # Assert
+    cached_info = mock_coordinator._device_info.get("02:222222_00")
+    assert cached_info is not None
+    assert cached_info["identifiers"] == {(DOMAIN, "02:222222_00")}
+    assert cached_info["name"] == "UFH Circuit 02:222222_00"
+    assert cached_info["parent_device_id"] == parent_ufc_entry.id
+    assert cached_info.get("suggested_area") == "Kitchen"
+
+    circuit_entry = dev_reg.async_get_child_device_by_identifier(
+        (DOMAIN, "02:222222_00"), mock_config_entry.entry_id
+    )
+    assert circuit_entry is not None
+    assert circuit_entry.parent_device_id == parent_ufc_entry.id
+
+
+async def test_eager_parent_registration_when_child_updated_first(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify that an unhydrated parent is eagerly registered if child is discovered first."""
+    # Arrange - Neither parent nor child is registered yet
+    dev_reg = dr.async_get(hass)
+    assert (
+        dev_reg.async_get_device_by_identifier(
+            (DOMAIN, "01:654321"), mock_config_entry.entry_id
+        )
+        is None
+    )
+
+    mock_tcs = MagicMock(spec=System)
+    mock_tcs.id = "01:654321"
+    mock_tcs.name = "Controller 01:654321"
+    mock_tcs._SLUG = "CTL"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.id = "01:654321_02"
+    mock_zone.name = "Bedroom"
+    mock_zone.tcs = mock_tcs
+
+    # Act
+    await mock_coordinator._async_update_device(mock_zone)
+
+    # Assert - Parent should have been registered eagerly
+    parent_entry = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, "01:654321"), mock_config_entry.entry_id
+    )
+    assert parent_entry is not None
+
+    child_entry = dev_reg.async_get_child_device_by_identifier(
+        (DOMAIN, "01:654321_02"), mock_config_entry.entry_id
+    )
+    assert child_entry is not None
+    assert child_entry.parent_device_id == parent_entry.id
+
+
+async def test_entity_device_info_property_resolves_child_info(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify RamsesEntity.device_info returns the coordinator's cached ChildDeviceInfo."""
+    # Arrange
+    dev_reg = dr.async_get(hass)
+    parent_entry = dev_reg.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "01:999999")},
+        name="Controller 01:999999",
+    )
+
+    mock_tcs = MagicMock(spec=System)
+    mock_tcs.id = "01:999999"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.id = "01:999999_01"
+    mock_zone.name = "Hallway"
+    mock_zone.tcs = mock_tcs
+
+    await mock_coordinator._async_update_device(mock_zone)
+
+    entity_description = EntityDescription(key="temperature")
+    entity = RamsesEntity(mock_coordinator, mock_zone, entity_description)
+
+    # Act
+    resolved_info = entity.device_info
+
+    # Assert
+    assert resolved_info is not None
+    assert resolved_info["identifiers"] == {(DOMAIN, "01:999999_01")}
+    assert resolved_info["parent_device_id"] == parent_entry.id
+
+    # Simulate EntityPlatform linking entity device_info to registry
+    res = dev_reg.async_get_or_create_child(
+        config_entry_id=mock_config_entry.entry_id,
+        **cast(dr.ChildDeviceInfo, resolved_info),
+    )
+    assert res.parent_device_id == parent_entry.id
+
+
+async def test_standalone_devices_remain_main_devices(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify TRVs, relays, and REM accessories remain main devices (DeviceInfo)."""
+    # Arrange
+    dev_reg = dr.async_get(hass)
+
+    mock_trv = MagicMock(spec=Child)
+    mock_trv.id = "04:111111"
+    mock_trv.name = "TRV Actuator"
+    mock_trv._SLUG = "TRV"
+    mock_trv._parent = MagicMock()
+    mock_trv._parent.id = "01:123456_01"
+
+    mock_rem = MagicMock(spec=DeviceHvac)
+    mock_rem.id = "37:222222"
+    mock_rem.name = "Remote Sensor"
+    mock_rem._SLUG = "REM"
+    mock_rem._parent_fan = MagicMock()
+    mock_rem._parent_fan.id = "32:111111"
+
+    # Act
+    await mock_coordinator._async_update_device(mock_trv)
+    await mock_coordinator._async_update_device(mock_rem)
+
+    # Assert
+    trv_info = mock_coordinator._device_info.get("04:111111")
+    assert trv_info is not None
+    assert "parent_device_id" not in trv_info
+    assert "via_device" not in trv_info
+
+    rem_info = mock_coordinator._device_info.get("37:222222")
+    assert rem_info is not None
+    assert "parent_device_id" not in rem_info
+    assert "via_device" not in rem_info
+
+    # Verify they were created as standard devices in device registry
+    trv_entry = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, "04:111111"), mock_config_entry.entry_id
+    )
+    assert trv_entry is not None
+    assert (
+        not hasattr(trv_entry, "parent_device_id")
+        or trv_entry.parent_device_id is None
+    )
+
+
+async def test_backward_compatibility_fallback(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Verify fallback behavior when ChildDeviceInfo is unavailable (pre-2026.9)."""
+    # Arrange
+    mock_tcs = MagicMock(spec=System)
+    mock_tcs.id = "01:888888"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.id = "01:888888_01"
+    mock_zone.name = "Study"
+    mock_zone.tcs = mock_tcs
+
+    with (
+        patch(
+            "homeassistant.helpers.device_registry.ChildDeviceInfo",
+            create=False,
+        ),
+        patch.object(dr, "ChildDeviceInfo", create=False),
+        patch(
+            "homeassistant.helpers.device_registry.async_get"
+        ) as mock_dr_get,
+    ):
+        delattr(dr, "ChildDeviceInfo")
+        mock_registry = MagicMock()
+        mock_dr_get.return_value = mock_registry
+
+        # Act
+        await mock_coordinator._async_update_device(mock_zone)
+
+        # Assert
+        call_kwargs = mock_registry.async_get_or_create.call_args[1]
+        assert call_kwargs["via_device"] == (DOMAIN, "01:888888")
+
+
+async def test_child_device_unresolvable_parent_logs_warning(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Verify warning is logged when a parent device cannot be resolved."""
+    # Arrange
+    mock_tcs = MagicMock(spec=System)
+    mock_tcs.id = "01:000000"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.id = "01:000000_01"
+    mock_zone.name = "Attic"
+    mock_zone.tcs = mock_tcs
+
+    with patch(
+        "homeassistant.helpers.device_registry.async_get"
+    ) as mock_dr_get:
+        mock_registry = MagicMock()
+        # Ensure parent resolution returns None even after update
+        mock_registry.async_get_device_by_identifier.return_value = None
+        mock_dr_get.return_value = mock_registry
+
+        # Act
+        await mock_coordinator._async_update_device(mock_zone)
+
+        # Assert
+        assert (
+            "Parent device 01:000000 could not be registered for child"
+            in caplog.text
+        )
+
+
+async def test_child_device_already_cached_early_return(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify early return when child device is already cached identically."""
+    # Arrange
+    dev_reg = dr.async_get(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "01:112233")},
+        name="Controller 01:112233",
+    )
+
+    mock_tcs = MagicMock(spec=System)
+    mock_tcs.id = "01:112233"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.id = "01:112233_01"
+    mock_zone.name = "Dining Room"
+    mock_zone.tcs = mock_tcs
+
+    # First update caches the child device
+    await mock_coordinator._async_update_device(mock_zone)
+    cached_info = mock_coordinator._device_info.get("01:112233_01")
+    assert cached_info is not None
+
+    with patch.object(
+        dev_reg, "async_get_or_create_child"
+    ) as mock_create_child:
+        # Act - second update with identical info
+        await mock_coordinator._async_update_device(mock_zone)
+
+        # Assert - should return early without creating child again
+        mock_create_child.assert_not_called()
+
+
+async def test_main_device_with_suggested_area(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Verify main devices support suggested_area kwargs correctly."""
+    # Arrange
+    dev_reg = dr.async_get(hass)
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.name = "Living Room"
+
+    mock_circuit = MagicMock(spec=UfhCircuit)
+    mock_circuit.id = "02:123456_99"
+    mock_circuit.ufh_index = "99"
+    mock_circuit.ufc = None
+    mock_circuit.zone = mock_zone
+    mock_circuit.name = None
+
+    # Act
+    await mock_coordinator._async_update_device(mock_circuit)
+
+    # Assert
+    dev_info = mock_coordinator._device_info.get("02:123456_99")
+    assert dev_info is not None
+    assert dev_info.get("suggested_area") == "Living Room"
+
+    device_entry = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, "02:123456_99"), mock_config_entry.entry_id
+    )
+    assert device_entry is not None
+    assert device_entry.suggested_area == "Living Room"
+
+
+async def test_backward_compatibility_fallback_child_and_hvac(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Verify fallback behavior for Child and DeviceHvac when ChildDeviceInfo is absent."""
+    # Arrange
+    mock_parent = MagicMock()
+    mock_parent.id = "01:333333"
+
+    mock_child = MagicMock(spec=Child)
+    mock_child.id = "13:333333"
+    mock_child.name = "Relay"
+    mock_child._parent = mock_parent
+    mock_child._SLUG = "BDR"
+
+    mock_fan = MagicMock()
+    mock_fan.id = "32:444444"
+
+    mock_hvac = MagicMock(spec=DeviceHvac)
+    mock_hvac.id = "37:444444"
+    mock_hvac.name = "Vent Switch"
+    mock_hvac._parent_fan = mock_fan
+    mock_hvac._SLUG = "REM"
+
+    with (
+        patch(
+            "homeassistant.helpers.device_registry.ChildDeviceInfo",
+            create=False,
+        ),
+        patch.object(dr, "ChildDeviceInfo", create=False),
+        patch(
+            "homeassistant.helpers.device_registry.async_get"
+        ) as mock_dr_get,
+    ):
+        delattr(dr, "ChildDeviceInfo")
+        mock_registry = MagicMock()
+        mock_dr_get.return_value = mock_registry
+
+        # Act
+        await mock_coordinator._async_update_device(mock_child)
+        call_kwargs_child = mock_registry.async_get_or_create.call_args[1]
+        assert call_kwargs_child["via_device"] == (DOMAIN, "01:333333")
+
+        await mock_coordinator._async_update_device(mock_hvac)
+        call_kwargs_hvac = mock_registry.async_get_or_create.call_args[1]
+        assert call_kwargs_hvac["via_device"] == (DOMAIN, "32:444444")

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -275,9 +275,14 @@ async def test_update_device_relationships(
             mock_reg = dr_m.return_value
             await mock_coordinator._async_update_device(mock_zone)
 
-            # Verify via_device was set to TCS ID
-            call_kwargs = cast(Any, mock_reg.async_get_or_create).call_args[1]
-            assert call_kwargs["via_device"] == (DOMAIN, "01:999999")
+            # Verify parent_device_id was set to TCS ID
+            call_kwargs = cast(
+                Any, mock_reg.async_get_or_create_child
+            ).call_args[1]
+            assert (
+                call_kwargs["parent_device_id"]
+                == mock_reg.async_get_device_by_identifier.return_value.id
+            )
 
 
 async def test_update_device_child_parent(
@@ -304,7 +309,8 @@ async def test_update_device_child_parent(
         await mock_coordinator._async_update_device(mock_child)
 
         call_kwargs = cast(Any, mock_reg.async_get_or_create).call_args[1]
-        assert call_kwargs["via_device"] == (DOMAIN, "04:123456")
+        assert "via_device" not in call_kwargs
+        assert "parent_device_id" not in call_kwargs
 
 
 async def test_async_start(mock_coordinator: RamsesCoordinator) -> None:
@@ -6433,7 +6439,7 @@ async def test_discover_new_entities_ufh_circuits(
 async def test_async_update_device_ufh_circuit_metadata_and_parent(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    # Arrange - Fallback behavior when parent_device is not in HA DeviceInfo
+    # Arrange - ChildDeviceInfo behavior in HA 2026.9+
     mock_ufc = MagicMock(spec=UfhController)
     mock_ufc.id = "02:123456"
 
@@ -6459,16 +6465,22 @@ async def test_async_update_device_ufh_circuit_metadata_and_parent(
     dev_info = mock_coordinator._device_info.get("02:123456_00")
     assert dev_info is not None
     assert dev_info["name"] == "UFH Circuit 02:123456_00"
-    assert dev_info["model"] == "UFH Circuit 00"
-    assert dev_info["via_device"] == (DOMAIN, "02:123456")
-    assert dev_info.get("parent_device") is None
+    assert (
+        dev_info["parent_device_id"]
+        == mock_registry.async_get_device_by_identifier.return_value.id
+    )
     assert dev_info.get("suggested_area") == "Kitchen Diner"
+    call_kwargs = mock_registry.async_get_or_create_child.call_args[1]
+    assert (
+        call_kwargs["parent_device_id"]
+        == mock_registry.async_get_device_by_identifier.return_value.id
+    )
 
 
 async def test_async_update_device_ufh_circuit_future_parent_device(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    # Arrange - Future HA 2026.9+ behavior with parent_device in DeviceInfo
+    # Arrange - Pre-2026.9 fallback behavior without ChildDeviceInfo
     mock_ufc = MagicMock(spec=UfhController)
     mock_ufc.id = "02:123456"
 
@@ -6480,14 +6492,15 @@ async def test_async_update_device_ufh_circuit_future_parent_device(
 
     with (
         patch(
+            "homeassistant.helpers.device_registry.ChildDeviceInfo",
+            create=False,
+        ),
+        patch.object(dr, "ChildDeviceInfo", create=False),
+        patch(
             "homeassistant.helpers.device_registry.async_get"
         ) as mock_dr_get,
-        patch.dict(
-            dr.DeviceInfo.__annotations__,
-            {"parent_device": tuple[str, str]},
-            clear=False,
-        ),
     ):
+        delattr(dr, "ChildDeviceInfo")
         mock_registry = MagicMock()
         mock_dr_get.return_value = mock_registry
 
@@ -6498,7 +6511,6 @@ async def test_async_update_device_ufh_circuit_future_parent_device(
     dev_info = mock_coordinator._device_info.get("02:123456_00")
     assert dev_info is not None
     assert dev_info["via_device"] == (DOMAIN, "02:123456")
-    assert dev_info.get("parent_device") == (DOMAIN, "02:123456")
 
 
 async def test_coordinator_connection_state_logging(

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -1043,7 +1043,7 @@ async def test_get_device_and_from_id_propagates_exceptions(
 async def test_update_device_via_device_logic(
     mock_coordinator: RamsesCoordinator, hass: HomeAssistant
 ) -> None:
-    """Test the via_device logic in _update_device for Zones and Children."""
+    """Test parent_device_id logic in _async_update_device for Zones and Children."""
     # 1. Test Zone with TCS
     mock_tcs = MagicMock()
     mock_tcs.id = "01:123456"
@@ -1072,15 +1072,18 @@ async def test_update_device_via_device_logic(
     ):
         # Trigger update for Zone
         await mock_coordinator._async_update_device(mock_zone)
-        # Check zone via_device (most recent call)
-        call_args_zone = mock_dr.async_get_or_create.call_args_list[-1][1]
-        assert call_args_zone["via_device"] == (DOMAIN, "01:123456")
+        # Check zone parent_device_id
+        call_args_zone = mock_dr.async_get_or_create_child.call_args[1]
+        assert (
+            call_args_zone["parent_device_id"]
+            == mock_dr.async_get_device_by_identifier.return_value.id
+        )
 
-        # Trigger update for Child
+        # Trigger update for Child (main device in HA 2026.9+)
         await mock_coordinator._async_update_device(mock_child)
-        # Check child via_device (most recent call)
-        call_args_child = mock_dr.async_get_or_create.call_args_list[-1][1]
-        assert call_args_child["via_device"] == (DOMAIN, "02:222222")
+        call_args_child = mock_dr.async_get_or_create.call_args[1]
+        assert "via_device" not in call_args_child
+        assert "parent_device_id" not in call_args_child
 
 
 async def test_adjust_sentinel_packet_early_return(
@@ -1180,9 +1183,11 @@ async def test_update_device_valid_child_type(
     ):
         await mock_coordinator._async_update_device(mock_child)
 
-        # Check that it used the parent for via_device
+        # In HA 2026.9+, Child hardware devices remain main devices without deprecated via_device
         call_args = mock_dr.async_get_or_create.call_args[1]
-        assert call_args["via_device"] == (DOMAIN, "02:888888")
+        assert "via_device" not in call_args
+        assert "parent_device_id" not in call_args
+        assert call_args["identifiers"] == {(DOMAIN, "03:999999")}
 
 
 async def test_get_fan_param_generic_exception(
@@ -1623,14 +1628,13 @@ async def test_update_device_relationships(hass: HomeAssistant) -> None:
 
         await coordinator._async_update_device(child_device)
 
-        # Verify via_device is set to parent
+        # In HA 2026.9+, Child devices (like TRVs/relays) are treated as main devices.
         dev_reg.async_get_or_create.assert_called_with(
             config_entry_id="test_entry",
             identifiers={(DOMAIN, "04:123456")},
             name="Test Child",
             manufacturer=None,
             model="Test Model",
-            via_device=(DOMAIN, "01:123456"),
             serial_number="04:123456",
         )
 


### PR DESCRIPTION
Resolves #1007
Supersedes #1110

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 100%

### The Problem
Home Assistant Core 2026.9 deprecates the `via_device` parameter on `device_registry.async_get_or_create` in favour of `parent_device_id` and `ChildDeviceInfo`. Draft PR #1110 explored this transition but encountered blocking `DeviceInfoError` exceptions (`parent must exist before creating child` and identifier collisions during entity platform setup) because:
1. The RAMSES string ID (`"01:123456"`) was passed instead of the parent's internal Home Assistant registry UUID (`parent_entry.id`).
2. Child entities returned standard `DeviceInfo` from `entity._attr_device_info`, causing Home Assistant's `EntityPlatform` to attempt creating regular devices with overlapping identifiers.
3. Hardware actuators (TRVs, BDRs) and HVAC remotes were converted to child devices, causing nested child errors (depth > 1) and stripping hardware model and version metadata.

### The Fix
This PR supersedes #1110 with an in-place child device conversion:
- **Child Device Registration**: Migrates `Zone` (`Zone` -> `tcs`) and `UfhCircuit` (`UfhCircuit` -> `ufc`) to `dr.ChildDeviceInfo` with `parent_device_id` set to the parent device's internal Home Assistant UUID via `async_get_or_create_child`.
- **Eager Parent Registration**: Guarantees the parent controller is registered prior to child creation, even if child devices are processed first.
- **Dynamic Entity Linkage**: Adds a dynamic `device_info` property on `RamsesEntity` that supplies the coordinator's cached `ChildDeviceInfo` or `DeviceInfo` to `EntityPlatform._async_add_entity`.
- **Hardware Metadata Preservation**: Retains independent `DeviceInfo` for TRVs, thermostats, relays, fans, and remotes, preserving hardware metadata, preventing invalid nested child hierarchies, and avoiding cascade deletions.
- **Backward Compatibility Fallback**: Preserves `via_device` tuple registration when running on Home Assistant Core < 2026.9 (`not hasattr(dr, "ChildDeviceInfo")`).
- **Registry Translation**: Updates `ramses_device_id_to_ha_device_id` in `helpers.py` to check both main devices and child devices (`async_get_child_device_by_identifier`).

### Testing Performed
- **New Unit Tests**: Added `tests/tests_new/test_child_devices.py` covering zone/circuit child registration, eager parent creation, entity platform linkage, standalone device metadata preservation, and pre-2026.9 fallback.
- **Regression Verification**: Updated existing tests in `test_coordinator.py` and `test_services.py` to verify `parent_device_id` semantics.
- **Verification Gate**:
  - `prek run -a`: Passed (all 20 hooks passed cleanly).
  - `ruff check`: Passed (0 errors).
  - `mypy custom_components tests/tests_new/test_child_devices.py`: Passed (0 errors across 23 files).
  - `pytest -n auto`: Passed full test suite (1,556 passed, 15 skipped).
