### PR TITLE
fix: reconcile serialx pin (issue 1119)

### DIFF
--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -16,7 +16,7 @@
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
       "ramses-rf==0.60.4",
-      "serialx>=1.6.0"
+      "serialx>=1.8.2"
     ],
     "single_config_entry": true,
     "version": "0.60.4"


### PR DESCRIPTION
## Summary

- **serialx**: raise pin from `>=1.6.0` to `>=1.8.2` to match `ramses_rf`'s reconciled pin and the HA container baseline (1.8.2). Pinning to `>=1.8.2` (not `>=1.8.0`) because 1.8.1 fixed a POSIX fd leak, a Win32 close/connection_lost race, and missing USB string descriptors on Linux.

**paho-mqtt is NOT added** to ramses_cc's manifest. ramses_cc does not import paho directly — it is a transitive dependency via `ramses-rf==0.60.4` (declared in ramses_rf's `pyproject.toml`). HA's pip resolver installs it automatically (`pip show paho-mqtt` confirms `Required-by: ramses_rf`). Inside HA, MQTT uses `homeassistant.components.mqtt` via `RamsesMqttBridge`, not direct paho clients.

This is a precondition for the multi-HGI pool PRs (issue 1119). It is independent of the pool architecture and can merge independently.

Companion PR: https://github.com/ramses-rf/ramses_rf/pull/1191 (serialx pin + zigpy graceful degradation)

#### Test plan
- [x] `pytest tests/ -x` passes (1560 passed, 15 skipped)
- [x] Pre-commit hooks pass
- [x] `pip show paho-mqtt` in HA container confirms `Required-by: ramses_rf`