### PR TITLE
Preserve indexed duplicate binding offers

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2750,11 +2750,21 @@ SCH_NO_ENTITY_SVC_PARAMS = make_entity_service_schema(
 _SCH_BINDING = vol.Schema(
     {vol.Required(_SCH_CMD_CODE): vol.Any(None, _SCH_DOM_INDEX)}
 )
+_SCH_INDEXED_BINDING = vol.Schema(
+    {
+        vol.Required("index"): _SCH_DOM_INDEX,
+        vol.Required("code"): _SCH_CMD_CODE,
+    },
+    extra=vol.PREVENT_EXTRA,
+)
 
 SCH_BIND_DEVICE = vol.Schema(
     {
         vol.Required("device_id"): _SCH_DEVICE_ID,
-        vol.Required("offer"): vol.All(_SCH_BINDING, vol.Length(min=1)),
+        vol.Required("offer"): vol.Any(
+            vol.All(_SCH_BINDING, vol.Length(min=1)),
+            vol.All([_SCH_INDEXED_BINDING], vol.Length(min=1)),
+        ),
         vol.Optional("confirm", default={}): vol.Any(
             {}, vol.All(_SCH_BINDING, vol.Length(min=1))
         ),

--- a/custom_components/ramses_cc/services.py
+++ b/custom_components/ramses_cc/services.py
@@ -340,8 +340,18 @@ class RamsesServiceHandler:
             confirm_data = call.data.get("confirm", {})
             confirm_code = next(iter(confirm_data), None)
 
+            offer = call.data["offer"]
+            if isinstance(offer, dict):
+                offer_bindings = [
+                    (index or "00", code) for code, index in offer.items()
+                ]
+            else:
+                offer_bindings = [
+                    (binding["index"], binding["code"]) for binding in offer
+                ]
+
             await device._initiate_binding_process(
-                list(call.data["offer"].keys()),
+                offer_bindings,
                 confirm_code=confirm_code,
                 ratify_command=cmd,
             )

--- a/custom_components/ramses_cc/services.yaml
+++ b/custom_components/ramses_cc/services.yaml
@@ -12,6 +12,9 @@ bind_device:
 
     offer:
       # The command_code / domain_idx pairs for the binding offer.
+      # Example with duplicate codes: [{"index": "00", "code": "31E0"},
+      #                                {"index": "01", "code": "31E0"},
+      #                                {"index": "00", "code": "1298"}]
       example: '{"30C9": "00"}'
       required: true
 

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -445,6 +445,41 @@ async def test_bind_device_success(
     )
 
 
+async def test_bind_device_preserves_indexed_duplicate_offers(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    mock_device = MagicMock(id="29:150156")
+    mock_device._initiate_binding_process = AsyncMock(return_value=None)
+    mock_client = cast(Any, mock_coordinator.client)
+    mock_client.device_registry.fake_device = AsyncMock(
+        return_value=mock_device
+    )
+    call = MagicMock()
+    call.data = {
+        "device_id": "29:150156",
+        "offer": [
+            {"index": "00", "code": "31E0"},
+            {"index": "01", "code": "31E0"},
+            {"index": "00", "code": "1298"},
+        ],
+        "confirm": {},
+        "device_info": None,
+    }
+
+    with patch.object(mock_coordinator, "async_request_refresh"):
+        await mock_coordinator.async_bind_device(call)
+        async_fire_time_changed(
+            mock_coordinator.hass, dt_util.utcnow() + td(seconds=10)
+        )
+        await mock_coordinator.hass.async_block_till_done()
+
+    mock_device._initiate_binding_process.assert_awaited_once_with(
+        [("00", "31E0"), ("01", "31E0"), ("00", "1298")],
+        confirm_code=None,
+        ratify_command=None,
+    )
+
+
 async def test_send_packet_hgi_alias(
     mock_coordinator: RamsesCoordinator,
 ) -> None:


### PR DESCRIPTION
Orcon CO2 sensor pairing advertises 31E0 twice, once for index 00 and once for index 01, alongside 1298. The bind_device service currently models offers as a mapping keyed by command code, which collapses the duplicate 31E0 entries and cannot reproduce the valid Orcon offer.

Accept an ordered list of {index, code} objects in addition to the existing mapping form. Normalize both representations to indexed tuples before handing them to ramses_rf, preserving order and duplicate command codes while retaining backward compatibility for existing service callers.

This allows an Orcon CO2 sensor binding to be recreated through the Home Assistant service instead of requiring a hand-crafted packet.

Integration-side follow-up to ramses-rf/ramses_rf#1188. < merged into master
That PR allows ramses_rf to retain indexed duplicate binding offers; this change lets ramses_cc.bind_device express and forward that representation.

Validated locally on my HRC 350; with this I've managed to bind a fake CO2 sensor I can then use to induce demand.

PR template:

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used/used for 75%