### PR TITLE
Expose HVAC diagnostic flags as binary sensors

### DIFF
--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -31,11 +31,20 @@ from ramses_rf.const import (
     SZ_DHW_BLOCKING,
     SZ_DHW_ENABLED,
     SZ_FAULT_PRESENT,
+    SZ_FILTER_DIRTY,
     SZ_FLAME_ACTIVE,
+    SZ_FROST_CYCLE,
+    SZ_HAS_FAULT,
     SZ_OTC_ACTIVE,
     SZ_SUMMER_MODE,
 )
-from ramses_rf.devices import BdrSwitch, HgiGateway, OtbGateway, TrvActuator
+from ramses_rf.devices import (
+    BdrSwitch,
+    HgiGateway,
+    HvacVentilator,
+    OtbGateway,
+    TrvActuator,
+)
 from ramses_rf.entity import Entity as RamsesRFEntity
 from ramses_rf.gateway import Gateway
 from ramses_rf.schemas import SZ_CONFIG, SZ_SCHEMA
@@ -498,6 +507,28 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
         ramses_rf_attr=SZ_BYPASS_POSITION,
         ramses_cc_class=RamsesBypassBinarySensor,
         name="Bypass position",
+    ),
+    RamsesBinarySensorEntityDescription(
+        key=SZ_FILTER_DIRTY,
+        ramses_rf_attr=SZ_FILTER_DIRTY,
+        ramses_rf_class=HvacVentilator,
+        name="Filter dirty",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    RamsesBinarySensorEntityDescription(
+        key=SZ_FROST_CYCLE,
+        ramses_rf_attr=SZ_FROST_CYCLE,
+        ramses_rf_class=HvacVentilator,
+        name="Frost cycle",
+        icon="mdi:snowflake",
+        icon_off="mdi:snowflake-off",
+    ),
+    RamsesBinarySensorEntityDescription(
+        key=SZ_HAS_FAULT,
+        ramses_rf_attr=SZ_HAS_FAULT,
+        ramses_rf_class=HvacVentilator,
+        name="Fault",
+        device_class=BinarySensorDeviceClass.PROBLEM,
     ),
     # Special projects
     RamsesBinarySensorEntityDescription(

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -1016,6 +1016,60 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+        'effective_polling_interval': dict({
+          '10D0': 86400,
+          '10E0': 86400,
+          '3150': 3600,
+        }),
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FAN 32:157747 Filter dirty',
+        'id': '32:157747',
+      }),
+      'context': <ANY>,
+      'entity_id': 'binary_sensor.fan_32_157747_filter_dirty',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'effective_polling_interval': dict({
+          '10D0': 86400,
+          '10E0': 86400,
+          '3150': 3600,
+        }),
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FAN 32:157747 Frost cycle',
+        <EntityStateAttribute.ICON: 'icon'>: 'mdi:snowflake-off',
+        'id': '32:157747',
+      }),
+      'context': <ANY>,
+      'entity_id': 'binary_sensor.fan_32_157747_frost_cycle',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+        'effective_polling_interval': dict({
+          '10D0': 86400,
+          '10E0': 86400,
+          '3150': 3600,
+        }),
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FAN 32:157747 Fault',
+        'id': '32:157747',
+      }),
+      'context': <ANY>,
+      'entity_id': 'binary_sensor.fan_32_157747_fault',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'unknown',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
         'config': dict({
           'enforce_known_list': True,
         }),

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.core import HomeAssistant
 
 from custom_components.ramses_cc.binary_sensor import (
+    BINARY_SENSOR_DESCRIPTIONS,
     SZ_BATTERY_LEVEL,
     SZ_BATTERY_LOW,
     SZ_BATTERY_STATE,
@@ -23,7 +24,8 @@ from custom_components.ramses_cc.binary_sensor import (
     RamsesSystemBinarySensor,
     async_setup_entry,
 )
-from ramses_rf.devices import HgiGateway
+from ramses_rf.const import SZ_FILTER_DIRTY, SZ_FROST_CYCLE, SZ_HAS_FAULT
+from ramses_rf.devices import HgiGateway, HvacVentilator
 from ramses_rf.systems.tcs import Logbook, System
 from ramses_tx.const import SZ_IS_EVOFW3
 
@@ -71,6 +73,35 @@ async def test_async_setup_entry(
     assert mock_add_entities.called
     assert len(created_entities) == 1
     assert isinstance(created_entities[0], RamsesGatewayBinarySensor)
+
+
+def test_hvac_diagnostic_binary_sensor_descriptions() -> None:
+    """Expose ventilator diagnostic flags with safe HA semantics."""
+    descriptions = {
+        description.key: description
+        for description in BINARY_SENSOR_DESCRIPTIONS
+        if description.key in (SZ_FILTER_DIRTY, SZ_FROST_CYCLE, SZ_HAS_FAULT)
+    }
+
+    assert set(descriptions) == {
+        SZ_FILTER_DIRTY,
+        SZ_FROST_CYCLE,
+        SZ_HAS_FAULT,
+    }
+    assert all(
+        description.ramses_rf_class is HvacVentilator
+        for description in descriptions.values()
+    )
+    assert (
+        descriptions[SZ_FILTER_DIRTY].device_class
+        is BinarySensorDeviceClass.PROBLEM
+    )
+    assert (
+        descriptions[SZ_HAS_FAULT].device_class
+        is BinarySensorDeviceClass.PROBLEM
+    )
+    assert descriptions[SZ_FROST_CYCLE].icon == "mdi:snowflake"
+    assert descriptions[SZ_FROST_CYCLE].icon_off == "mdi:snowflake-off"
 
 
 @patch("custom_components.ramses_cc.binary_sensor.resolve_async_attr")

--- a/tests/tests_old/test_services.py
+++ b/tests/tests_old/test_services.py
@@ -100,7 +100,7 @@ NUM_SVCS_AFTER = (
 # Passive scan services (registered when advanced_features.passive_scan
 # is enabled, e.g. after v2→v3 migration).  7 services.
 _NUM_PASSIVE_SCAN_SVCS = 7
-NUM_ENTS_AFTER = 72  # proxy for success (Phase 4: more devices in known_list)
+NUM_ENTS_AFTER = 75  # proxy for success (includes 3 FAN diagnostics)
 NUM_ENTS_AFTER_ALT = (
     NUM_ENTS_AFTER - 9
 )  # adjust number to subtract when adding sensors in sensors.py


### PR DESCRIPTION
HvacVentilator already projects filter_dirty, frost_cycle, and has_fault from 31D9 status, but ramses_cc does not create entities for them. Assuming there's no reason these are not exposed, this PR adds ventilator-scoped diagnostic binary sensors, using Home Assistant problem semantics for dirty-filter and hardware-fault flags and explicit snowflake icons for frost-cycle activity.

PR template:

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 75%
