### PR TITLE
fix(discovery): HGI discovery candidates from MQTT (issue 1119)

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -766,7 +766,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         schema_device_ids = self._extract_schema_device_ids(schema)
         foreign_device_ids = self._extract_foreign_device_ids(schema)
         self.discovery_manager.sync_with_schema(
-            schema_device_ids, foreign_device_ids
+            schema_device_ids, foreign_device_ids, schema
         )
 
         # Schedule periodic checkpoint + check for new/lost devices.
@@ -807,7 +807,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         schema_device_ids = self._extract_schema_device_ids(schema)
         foreign_device_ids = self._extract_foreign_device_ids(schema)
         self.discovery_manager.sync_with_schema(
-            schema_device_ids, foreign_device_ids
+            schema_device_ids, foreign_device_ids, schema
         )
         # Check ramses_rf known_list for contradiction-based class changes
         # (e.g. FAN→DIS) before running mismatch checks, so rf-flagged

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -258,6 +258,8 @@ class DiscoveryManager:
         # (issue 917).
         self._schema_device_ids: set[str] = set()
         self._foreign_device_ids: set[str] = set()
+        # Devices in schema without _owner — need review (issue 1119).
+        self._schema_no_owner_ids: set[str] = set()
 
         # Track which mismatches we've already warned about (to avoid
         # repeating the WARNING every checkpoint cycle).  Cleared when
@@ -511,6 +513,7 @@ class DiscoveryManager:
         self,
         schema_device_ids: set[str],
         foreign_device_ids: set[str] | None = None,
+        schema: dict[str, Any] | None = None,
     ) -> None:
         """Sync discovery metadata with the current schema.
 
@@ -523,11 +526,41 @@ class DiscoveryManager:
             (neighbour's devices).  These are excluded from discovery —
             they appear in the scan engine (it sees all RF traffic) but
             should not be offered for review/acceptance.
+        :param schema: The full config schema dict (with _ traits).
+            Used to identify devices that are in the schema but have no
+            ``_owner`` — these need review (issue 1119: HGI discovery
+            candidates).
         """
         # Stash for check_for_new_devices (issue 917: prevents re-notifying
         # devices that are already in the schema but lost their metadata).
         self._schema_device_ids = schema_device_ids
         self._foreign_device_ids = foreign_device_ids or set()
+        # Devices in the schema that have no _owner — these are discovery
+        # candidates that need review (e.g. HGIs discovered via MQTT).
+        # check_for_new_devices should NOT suppress them (issue 1119).
+        self._schema_no_owner_ids = set()
+        if schema and isinstance(schema, dict):
+            for dev_id, entry in schema.items():
+                if (
+                    isinstance(entry, dict)
+                    and SZ_TR_OWNER not in entry
+                    and dev_id.startswith(
+                        (
+                            "18:",
+                            "01:",
+                            "04:",
+                            "07:",
+                            "10:",
+                            "12:",
+                            "13:",
+                            "29:",
+                            "32:",
+                            "37:",
+                            "63:",
+                        )
+                    )
+                ):
+                    self._schema_no_owner_ids.add(dev_id)
 
         _LOGGER.info(
             "DiscoveryManager: sync_with_schema with schema_device_ids=%s",
@@ -1716,7 +1749,15 @@ class DiscoveryManager:
                             device_id=device_id,
                             first_seen="",
                             last_seen="",
-                            likely_type="REM" if meta.faked else "unknown",
+                            likely_type=(
+                                "REM"
+                                if meta.faked
+                                else (
+                                    "HGI"
+                                    if device_id.startswith("18:")
+                                    else "unknown"
+                                )
+                            ),
                             codes_seen=[],
                             bound_to=None,
                             zone_index=None,
@@ -2106,6 +2147,14 @@ class DiscoveryManager:
             entry = self.get_device(device_id)
             dev = entry.device if entry else None
             likely_type = dev.likely_type if dev else "unknown"
+            # HGI discovery candidates (from MQTT) are not in the scan
+            # engine, so get_device returns a stub with likely_type=
+            # "unknown".  But 18: devices are always HGIs — use the
+            # prefix as the authoritative class (issue 1119).
+            if device_id.startswith("18:") and (
+                not dev or likely_type.lower() == "unknown"
+            ):
+                likely_type = "HGI"
             bound_to = dev.bound_to if dev else None
             zone_index = dev.zone_index if dev else None
             domain_id = getattr(dev, "domain_id", None) if dev else None
@@ -2298,10 +2347,54 @@ class DiscoveryManager:
         Called periodically by the coordinator. Returns the list of
         newly discovered device IDs (status=NEW, not yet checked).
 
+        HGI discovery candidates (18: devices in the schema without
+        ``_owner``, added by ``_MqttHgiDiscoveryCallback``) are also
+        flagged as NEW here so the user gets a persistent notification
+        to review and accept them (issue 1119).
+
         :return: List of new device IDs that were found this round.
         """
         engine_devices = {d.device_id: d for d in self._scan.get_devices()}
         new_ids: list[str] = []
+
+        # HGI discovery candidates from MQTT are not in the scan engine
+        # (HGIs are gateways, not RF devices).  Flag them as NEW so
+        # they appear in the review form and trigger a notification.
+        for dev_id in self._schema_no_owner_ids:
+            if not dev_id.startswith("18:"):
+                continue
+            # Skip the active HGI — it's managed by the coordinator
+            if self._active_hgi_id and dev_id == self._active_hgi_id:
+                continue
+            meta = self._metadata.get(dev_id)
+            if meta is None:
+                self._metadata[dev_id] = DeviceMetadata()
+                new_ids.append(dev_id)
+                _LOGGER.info(
+                    "check_for_new_devices: HGI discovery candidate %s "
+                    "flagged for review (issue 1119)",
+                    dev_id,
+                )
+            elif (
+                meta.status == DiscoveryStatus.NEW
+                and dev_id not in self._notified
+            ):
+                new_ids.append(dev_id)
+            elif (
+                meta.status == DiscoveryStatus.ACCEPTED
+                and dev_id not in self._notified
+            ):
+                # Previously accepted but lost its _owner (e.g. user
+                # cleared _owner, or config was cleaned) — re-flag for
+                # review so the user can re-accept (issue 1119).
+                _LOGGER.info(
+                    "check_for_new_devices: HGI %s was accepted but "
+                    "has no _owner — re-flagging for review (issue 1119)",
+                    dev_id,
+                )
+                meta.status = DiscoveryStatus.NEW
+                self._metadata[dev_id] = meta
+                new_ids.append(dev_id)
 
         for device_id in engine_devices:
             # Skip local active HGI gateway — it is managed directly by the
@@ -2475,6 +2568,11 @@ class DiscoveryManager:
 
         devices = self.get_devices()
         new_devices = [d for d in devices if d.device.device_id in new_ids]
+        # HGI discovery candidates (issue 1119) may not be in the scan
+        # engine, so get_devices() might not return them.  Add synthetic
+        # lines for any new_ids that are missing.
+        known_ids = {d.device.device_id for d in new_devices}
+        missing_ids = sorted(did for did in new_ids if did not in known_ids)
 
         lines = [f"Found {len(new_ids)} new device(s):\n"]
         for entry in sorted(new_devices, key=lambda e: e.device.device_id):
@@ -2490,6 +2588,11 @@ class DiscoveryManager:
                 line += ", battery"
             line += ")"
             lines.append(line)
+        for dev_id in missing_ids:
+            if dev_id.startswith("18:"):
+                lines.append(f"- `{dev_id}` (HGI — discovery candidate)")
+            else:
+                lines.append(f"- `{dev_id}`")
 
         lines.append(
             "\n[Review discovered devices]"

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -540,25 +540,14 @@ class DiscoveryManager:
         # check_for_new_devices should NOT suppress them (issue 1119).
         self._schema_no_owner_ids = set()
         if schema and isinstance(schema, dict):
+            import re
+
+            device_id_re = re.compile(r"^[0-9]{2}:[0-9]{6}$")
             for dev_id, entry in schema.items():
                 if (
                     isinstance(entry, dict)
                     and SZ_TR_OWNER not in entry
-                    and dev_id.startswith(
-                        (
-                            "18:",
-                            "01:",
-                            "04:",
-                            "07:",
-                            "10:",
-                            "12:",
-                            "13:",
-                            "29:",
-                            "32:",
-                            "37:",
-                            "63:",
-                        )
-                    )
+                    and device_id_re.match(str(dev_id))
                 ):
                     self._schema_no_owner_ids.add(dev_id)
 

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -9,6 +9,21 @@ Wraps the ramses_rf DiscoveryScan engine with HA-specific concerns:
 
 The scan engine itself (ramses_rf.discovery_scan) is read-only and
 HA-agnostic. This module adds the user-facing layer.
+
+HGI gateway handling (issue 1119):
+  HGI gateways (18: devices) are RF receivers, not remote devices.
+  The scan engine sees their traffic but they don't have zone bindings,
+  class mismatches, weak signals, or orphaned/lost status like real
+  devices do.  Most check methods skip them early via ``_is_hgi()``.
+  The exception is MQTT discovery: a second HGI on the same broker
+  appears in the schema without ``_owner`` and must be flagged as a
+  discovery candidate for the user to review — this is handled by the
+  HGI loop in ``check_for_new_devices()`` and the ``_schema_no_owner_ids``
+  set populated by ``sync_with_schema()``.
+
+  TODO: Consider moving HGI-specific knowledge (prefix, class, stub
+  creation) into a small HgiGateway helper class or into ramses_rf's
+  device model, so discovery.py doesn't need prefix checks at all.
 """
 
 from __future__ import annotations
@@ -291,6 +306,30 @@ class DiscoveryManager:
         """Return the underlying scan engine."""
         return self._scan
 
+    # ── HGI helpers ──────────────────────────────────────────────
+    # HGI gateways (18:) are RF receivers, not remote devices.  Most
+    # check methods skip them early.  See the module docstring for the
+    # full rationale and the issue 1119 exception for MQTT discovery.
+
+    @staticmethod
+    def _is_hgi(device_id: str) -> bool:
+        """Return True if ``device_id`` is an HGI gateway (18: prefix)."""
+        return device_id.startswith("18:")
+
+    @staticmethod
+    def _hgi_likely_type(device_id: str, likely_type: str | None) -> str:
+        """Return the authoritative likely_type for an HGI.
+
+        HGIs discovered via MQTT are not in the scan engine, so
+        ``likely_type`` may be ``"unknown"`` or ``None``.  The 18:
+        prefix is authoritative — always use ``"HGI"``.
+        """
+        if device_id.startswith("18:") and (
+            not likely_type or likely_type.lower() == "unknown"
+        ):
+            return "HGI"
+        return likely_type or "unknown"
+
     def get_scan_codes(self) -> dict[str, list[str]]:
         """Return a mapping of device_id → codes_seen from the scan engine.
 
@@ -371,7 +410,7 @@ class DiscoveryManager:
             )
             # HGI gateways (18:) are tracked but don't have zone bindings.
             # Still create comments for them (without zone/bound info).
-            if dev_id.startswith("18:"):
+            if self._is_hgi(dev_id):
                 if (
                     dev_id in result
                     and result[dev_id]
@@ -679,7 +718,7 @@ class DiscoveryManager:
 
         for device_id, dev in scan_devices.items():
             # Skip HGI gateways — they're not classified by the scan engine
-            if device_id.startswith("18:"):
+            if self._is_hgi(device_id):
                 continue
 
             # Get the schema's _class for this device
@@ -872,7 +911,7 @@ class DiscoveryManager:
             # remote devices.  This also cleans up any pre-existing LOST
             # status that may have been set before the check_for_lost_devices
             # skip was added.
-            if entry.device.device_id.startswith("18:"):
+            if self._is_hgi(entry.device.device_id):
                 continue
             if entry.metadata.status == DiscoveryStatus.LOST:
                 result.append(entry)
@@ -896,7 +935,7 @@ class DiscoveryManager:
         mismatches: list[tuple[str, str, str]] = []
 
         for device_id, dev in scan_devices.items():
-            if device_id.startswith("18:"):
+            if self._is_hgi(device_id):
                 continue
 
             schema_entry = schema.get(device_id)
@@ -974,7 +1013,7 @@ class DiscoveryManager:
         missing: list[str] = []
 
         for device_id, dev in scan_devices.items():
-            if device_id.startswith("18:"):
+            if self._is_hgi(device_id):
                 continue
 
             schema_entry = schema.get(device_id)
@@ -1051,7 +1090,7 @@ class DiscoveryManager:
         for device_id, schema_entry in schema.items():
             if not isinstance(schema_entry, dict):
                 continue
-            if device_id.startswith("18:"):
+            if self._is_hgi(device_id):
                 continue  # HGI — not a real device
             # Skip structural keys (main_tcs, _owner, etc.)
             if device_id.startswith("_") or device_id in ("main_tcs",):
@@ -1384,7 +1423,7 @@ class DiscoveryManager:
         for device in devices:
             device_id = str(device.id)
             # Skip HGI gateway — it is the receiver, not a remote device.
-            if device_id.startswith("18:"):
+            if self._is_hgi(device_id):
                 continue
             # Skip foreign-owner devices.
             if device_id in self._foreign_device_ids:
@@ -1741,10 +1780,8 @@ class DiscoveryManager:
                             likely_type=(
                                 "REM"
                                 if meta.faked
-                                else (
-                                    "HGI"
-                                    if device_id.startswith("18:")
-                                    else "unknown"
+                                else self._hgi_likely_type(
+                                    device_id, "unknown"
                                 )
                             ),
                             codes_seen=[],
@@ -2140,10 +2177,7 @@ class DiscoveryManager:
             # engine, so get_device returns a stub with likely_type=
             # "unknown".  But 18: devices are always HGIs — use the
             # prefix as the authoritative class (issue 1119).
-            if device_id.startswith("18:") and (
-                not dev or likely_type.lower() == "unknown"
-            ):
-                likely_type = "HGI"
+            likely_type = self._hgi_likely_type(device_id, likely_type)
             bound_to = dev.bound_to if dev else None
             zone_index = dev.zone_index if dev else None
             domain_id = getattr(dev, "domain_id", None) if dev else None
@@ -2350,7 +2384,7 @@ class DiscoveryManager:
         # (HGIs are gateways, not RF devices).  Flag them as NEW so
         # they appear in the review form and trigger a notification.
         for dev_id in self._schema_no_owner_ids:
-            if not dev_id.startswith("18:"):
+            if not self._is_hgi(dev_id):
                 continue
             # Skip the active HGI — it's managed by the coordinator
             if self._active_hgi_id and dev_id == self._active_hgi_id:
@@ -2461,7 +2495,7 @@ class DiscoveryManager:
             # never be flagged as lost or offered for removal (the
             # remove_device service blocks gateway removal with a
             # ServiceValidationError).  Mirrors check_orphaned_devices.
-            if device_id.startswith("18:"):
+            if self._is_hgi(device_id):
                 continue
 
             # Respect _suppress_not_seen from schema (issue 988)
@@ -2578,7 +2612,7 @@ class DiscoveryManager:
             line += ")"
             lines.append(line)
         for dev_id in missing_ids:
-            if dev_id.startswith("18:"):
+            if self._is_hgi(dev_id):
                 lines.append(f"- `{dev_id}` (HGI — discovery candidate)")
             else:
                 lines.append(f"- `{dev_id}`")

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1478,6 +1478,213 @@ class TestCheckForNewDevicesReReport:
         assert "04:056053" in new_ids
 
 
+class TestHgiDiscoveryCandidate:
+    """Tests for HGI discovery candidates from MQTT (issue 1119).
+
+    HGI gateways discovered via MQTT appear in the schema without _owner
+    but are NOT in the scan engine (HGIs are gateways, not RF devices).
+    check_for_new_devices must still flag them as NEW so the user gets
+    a notification and can review/accept them.
+    """
+
+    def test_hgi_candidate_flagged_as_new(self) -> None:
+        """An 18: device in schema without _owner is flagged as NEW."""
+        scan = make_mock_scan([])  # no scan engine devices
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
+        # Simulate sync_with_schema with a schema containing an HGI
+        # discovery candidate (18:149488, no _owner)
+        manager.sync_with_schema(
+            {"18:130236", "18:149488"},
+            schema={
+                "18:130236": {"_class": "HGI", "_owner": "me"},
+                "18:149488": {"_class": "HGI"},  # no _owner
+            },
+        )
+
+        new_ids = manager.check_for_new_devices()
+        assert "18:149488" in new_ids
+        assert "18:130236" not in new_ids  # active HGI skipped
+
+    def test_hgi_candidate_not_re_notified(self) -> None:
+        """Once notified, HGI candidate is not re-reported."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
+        manager.sync_with_schema(
+            {"18:149488"},
+            schema={"18:149488": {"_class": "HGI"}},
+        )
+
+        # First check — flagged
+        new_ids = manager.check_for_new_devices()
+        assert "18:149488" in new_ids
+
+        # Second check — already notified, not re-flagged
+        new_ids = manager.check_for_new_devices()
+        assert "18:149488" not in new_ids
+
+    def test_accepted_hgi_without_owner_re_flagged(self) -> None:
+        """An accepted HGI that lost _owner is re-flagged as NEW."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
+        # Pre-populate metadata as ACCEPTED (e.g. user previously accepted
+        # but later cleared _owner from the schema)
+        manager._metadata["18:149488"] = DeviceMetadata(
+            status=DiscoveryStatus.ACCEPTED,
+            enabled=True,
+            owner=None,
+        )
+        manager.sync_with_schema(
+            {"18:149488"},
+            schema={"18:149488": {"_class": "HGI"}},  # no _owner
+        )
+
+        new_ids = manager.check_for_new_devices()
+        assert "18:149488" in new_ids
+        assert manager._metadata["18:149488"].status == DiscoveryStatus.NEW
+
+    def test_non_hgi_schema_no_owner_not_flagged_by_hgi_loop(self) -> None:
+        """Non-18: devices in _schema_no_owner_ids are skipped by HGI loop."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+        )
+        manager.sync_with_schema(
+            {"04:056053"},
+            schema={"04:056053": {"_class": "TRV"}},  # no _owner but not 18:
+        )
+
+        new_ids = manager.check_for_new_devices()
+        # 04: device is in _schema_no_owner_ids but not 18:, so the HGI
+        # loop skips it.  It's also not in the scan engine, so the engine
+        # loop doesn't flag it either.
+        assert "04:056053" not in new_ids
+
+    def test_active_hgi_in_no_owner_ids_skipped(self) -> None:
+        """Active HGI without _owner is still skipped by the HGI loop."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
+        # Active HGI is in schema without _owner (edge case)
+        manager.sync_with_schema(
+            {"18:130236"},
+            schema={"18:130236": {"_class": "HGI"}},  # no _owner
+        )
+
+        new_ids = manager.check_for_new_devices()
+        assert "18:130236" not in new_ids  # active HGI always skipped
+
+    def test_hgi_candidate_new_status_re_reported(self) -> None:
+        """HGI candidate with NEW status is re-reported if not notified."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
+        manager.sync_with_schema(
+            {"18:149488"},
+            schema={"18:149488": {"_class": "HGI"}},
+        )
+
+        # First check — creates metadata with NEW status
+        new_ids = manager.check_for_new_devices()
+        assert "18:149488" in new_ids
+
+        # Clear _notified to simulate "not yet notified"
+        manager._notified.clear()
+
+        # Second check — NEW status and not in _notified, re-reported
+        new_ids = manager.check_for_new_devices()
+        assert "18:149488" in new_ids
+
+    def test_get_devices_stub_uses_hgi_class(self) -> None:
+        """get_devices stub for 18: device uses 'HGI' as likely_type."""
+        scan = make_mock_scan([])  # no scan engine devices
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
+        # Add metadata for an HGI not in the scan engine
+        manager._metadata["18:149488"] = DeviceMetadata(
+            status=DiscoveryStatus.NEW,
+        )
+
+        devices = manager.get_devices()
+        hgi_entry = next(
+            (d for d in devices if d.device.device_id == "18:149488"), None
+        )
+        assert hgi_entry is not None
+        assert hgi_entry.device.likely_type == "HGI"
+
+    def test_accept_device_uses_hgi_class(self) -> None:
+        """accept_device for an 18: device generates _class: HGI."""
+        scan = make_mock_scan([])
+        manager = DiscoveryManager(
+            make_mock_hass(),
+            scan,
+            auto_notify=False,
+            active_hgi_id="18:130236",
+        )
+        # Add as NEW so accept_device can find it
+        manager._metadata["18:149488"] = DeviceMetadata(
+            status=DiscoveryStatus.NEW,
+        )
+
+        accepted = manager.accept_device("18:149488", owner="me")
+        assert accepted.metadata.schema_entry is not None
+        # The schema entry should have _class: HGI, not UNKNOWN
+        entry = accepted.metadata.schema_entry.get("18:149488", {})
+        assert entry.get("_class") == "HGI"
+
+    def test_notification_includes_hgi_candidate(self) -> None:
+        """Notification text includes HGI candidates not in scan engine."""
+        scan = make_mock_scan([])
+        hass = make_mock_hass()
+        manager = DiscoveryManager(
+            hass,
+            scan,
+            auto_notify=True,
+            active_hgi_id="18:130236",
+        )
+        manager.sync_with_schema(
+            {"18:149488"},
+            schema={"18:149488": {"_class": "HGI"}},
+        )
+
+        with patch(
+            "custom_components.ramses_cc.discovery.async_create_notification"
+        ) as mock_notify:
+            manager.check_for_new_devices()
+            assert mock_notify.called
+            msg = mock_notify.call_args.kwargs.get("message", "")
+            assert "18:149488" in msg
+            assert "HGI" in msg
+
+
 class TestCheckClassMismatches:
     """Tests for DiscoveryManager.check_class_mismatches.
 


### PR DESCRIPTION
## Summary

HGI gateways discovered via MQTT (`18:` devices in schema without `_owner`) were invisible to the discovery manager — no notification, no review form entry, and accepting them wrote `_class: UNKNOWN` (crashing setup with `MultipleInvalid: expected None or 'BDR' or ... 'HGI' ... at 'class'`).

### Root cause

HGIs are gateways, not RF devices — the scan engine doesn't list them as discovered devices. So `check_for_new_devices` never saw them, and `accept_device` got `likely_type="unknown"` (from a stub or `None` dev), generating a schema entry with `_class: UNKNOWN`.

### Fixes (all in `discovery.py` + `coordinator.py`)

1. **`sync_with_schema`**: accept optional `schema` param, populate `_schema_no_owner_ids` (devices in schema with no `_owner` that need review). Coordinator updated to pass the schema dict.

2. **`check_for_new_devices`**: new HGI loop that flags `18:` devices in `_schema_no_owner_ids` as NEW. Also re-flags previously ACCEPTED HGIs that lost their `_owner`.

3. **`get_devices` stub**: use `"HGI"` as `likely_type` for `18:` devices instead of `"unknown"`.

4. **`accept_device`**: override `likely_type` to `"HGI"` for `18:` devices when the scan engine has no data. Without this, the generated schema entry had `_class: UNKNOWN`, which ramses_rf's validator rejects.

5. **`_send_notification`**: handle HGI discovery candidates that aren't in the scan engine, listing them as "HGI — discovery candidate".

#### Test plan
- [x] `pytest tests/tests_new/` — 1460 passed, 15 skipped
- [x] Manual: HGI discovery candidate appears in notification + review form
- [x] Manual: accepting HGI writes `_class: HGI` (not `UNKNOWN`) — setup succeeds
- [x] Manual: re-flagging works after clearing `_owner`