### PR TITLE
fix(coordinator): normalise controller default naming and zone fallback

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -41,10 +41,11 @@ from homeassistant.util import dt as dt_util
 from serialx import SerialException
 
 from ramses_rf.config import strip_and_map_traits as _strip_and_map_traits
-from ramses_rf.const import SZ_NAME
+from ramses_rf.const import SZ_NAME, DevType
 from ramses_rf.devices import (
     _CLASS_BY_SLUG,
     DEV_TYPE_MAP,
+    Controller,
     Device,
     DeviceHvac,
     HvacRemoteBase,
@@ -2572,40 +2573,41 @@ class RamsesCoordinator(DataUpdateCoordinator):
         suggested_area: str | None = None
 
         # Fallback names if the device doesn't supply a valid one
+        info: dict[str, Any] | None = None
+        state_store = getattr(device, "state_store", None)
+        if state_store:
+            info = await state_store._msg_value_code(Code._10E0)
+
+        description: str | None = info.get("description") if info else None
+
         if isinstance(device, UfhCircuit):
             device_name = f"UFH Circuit {device.id}"
             model: str | None = f"UFH Circuit {device.ufh_index}"
             if device.zone and getattr(device.zone, SZ_NAME, None):
                 suggested_area = str(device.zone.name)
-        elif not device_name:
-            if isinstance(device, System):
+        elif isinstance(device, Zone):
+            if not device_name:
+                with suppress(ValueError):
+                    device_name = f"Zone {int(device._child_id, 16)}"
+                if not device_name:
+                    device_name = f"Zone {device._child_id}"
+            model = description or getattr(device, "_SLUG", None)
+        elif (
+            isinstance(device, (System, Controller))
+            or getattr(device, "_SLUG", None) == DevType.CTL
+        ):
+            if not device_name:
                 device_name = f"Controller {device.id}"
-            elif getattr(device, "_SLUG", None):
+            model = description or "Controller"
+        elif not device_name:
+            if getattr(device, "_SLUG", None):
                 device_name = f"{getattr(device, '_SLUG', None)} {device.id}"
             else:
                 device_name = str(device.id)
 
-            info: dict[str, Any] | None = None
-            state_store = getattr(device, "state_store", None)
-            if state_store:
-                info = await state_store._msg_value_code(Code._10E0)
-
-            model = (
-                info.get("description")
-                if info
-                else getattr(device, "_SLUG", None)
-            )
+            model = description or getattr(device, "_SLUG", None)
         else:
-            info = None
-            state_store = getattr(device, "state_store", None)
-            if state_store:
-                info = await state_store._msg_value_code(Code._10E0)
-
-            model = (
-                info.get("description")
-                if info
-                else getattr(device, "_SLUG", None)
-            )
+            model = description or getattr(device, "_SLUG", None)
 
         device_registry = dr.async_get(self.hass)
 

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -4,7 +4,7 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 System status',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 System status',
         'id': '01:145038',
         'working_schema': dict({
           'orphans': list([
@@ -28,7 +28,7 @@
         }),
       }),
       'context': <ANY>,
-      'entity_id': 'binary_sensor.ctl_01_145038_system_status',
+      'entity_id': 'binary_sensor.controller_01_145038_system_status',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -38,13 +38,13 @@
       'attributes': ReadOnlyDict({
         'active_faults': None,
         <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 Active fault',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 Active fault',
         'id': '01:145038',
         'latest_event': None,
         'latest_fault': None,
       }),
       'context': <ANY>,
-      'entity_id': 'binary_sensor.ctl_01_145038_active_fault',
+      'entity_id': 'binary_sensor.controller_01_145038_active_fault',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -53,11 +53,11 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'window',
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '01:145038_00 Window open',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zone 0 Window open',
         'id': '01:145038_00',
       }),
       'context': <ANY>,
-      'entity_id': 'binary_sensor.01_145038_00_window_open',
+      'entity_id': 'binary_sensor.zone_0_window_open',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -324,7 +324,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 System info',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 System info',
         'id': '01:145038',
         'working_schema': dict({
           'orphans': list([
@@ -348,7 +348,7 @@
         }),
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.ctl_01_145038_system_info',
+      'entity_id': 'sensor.controller_01_145038_system_info',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -356,14 +356,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 Heat demand',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 Heat demand',
         <EntityStateAttribute.ICON: 'icon'>: 'mdi:radiator-off',
         'id': '01:145038',
         <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
         <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.ctl_01_145038_heat_demand',
+      'entity_id': 'sensor.controller_01_145038_heat_demand',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -371,14 +371,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '01:145038_00 Heat demand',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zone 0 Heat demand',
         <EntityStateAttribute.ICON: 'icon'>: 'mdi:radiator-off',
         'id': '01:145038_00',
         <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
         <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.01_145038_00_heat_demand',
+      'entity_id': 'sensor.zone_0_heat_demand',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -662,7 +662,7 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: None,
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038',
         'heat_demand': None,
         'heat_demands': None,
         <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
@@ -689,7 +689,7 @@
         'tpi_params': None,
       }),
       'context': <ANY>,
-      'entity_id': 'climate.ctl_01_145038',
+      'entity_id': 'climate.controller_01_145038',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -699,7 +699,7 @@
       'attributes': ReadOnlyDict({
         'config': None,
         <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: None,
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '01:145038_00',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zone 0',
         'heat_demand': None,
         'heating_type': None,
         <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
@@ -738,7 +738,7 @@
         'zone_index': '00',
       }),
       'context': <ANY>,
-      'entity_id': 'climate.01_145038_00',
+      'entity_id': 'climate.zone_0',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -789,7 +789,7 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 System status',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 System status',
         'id': '01:145038',
         'working_schema': dict({
           'orphans': list([
@@ -806,7 +806,7 @@
         }),
       }),
       'context': <ANY>,
-      'entity_id': 'binary_sensor.ctl_01_145038_system_status',
+      'entity_id': 'binary_sensor.controller_01_145038_system_status',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -816,13 +816,13 @@
       'attributes': ReadOnlyDict({
         'active_faults': None,
         <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 Active fault',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 Active fault',
         'id': '01:145038',
         'latest_event': None,
         'latest_fault': None,
       }),
       'context': <ANY>,
-      'entity_id': 'binary_sensor.ctl_01_145038_active_fault',
+      'entity_id': 'binary_sensor.controller_01_145038_active_fault',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -864,7 +864,7 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 System info',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 System info',
         'id': '01:145038',
         'working_schema': dict({
           'orphans': list([
@@ -881,7 +881,7 @@
         }),
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.ctl_01_145038_system_info',
+      'entity_id': 'sensor.controller_01_145038_system_info',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -889,14 +889,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038 Heat demand',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038 Heat demand',
         <EntityStateAttribute.ICON: 'icon'>: 'mdi:radiator-off',
         'id': '01:145038',
         <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
         <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.ctl_01_145038_heat_demand',
+      'entity_id': 'sensor.controller_01_145038_heat_demand',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -905,7 +905,7 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: None,
-        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CTL 01:145038',
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Controller 01:145038',
         'heat_demand': None,
         'heat_demands': None,
         <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
@@ -932,7 +932,7 @@
         'tpi_params': None,
       }),
       'context': <ANY>,
-      'entity_id': 'climate.ctl_01_145038',
+      'entity_id': 'climate.controller_01_145038',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,

--- a/tests/tests_new/test_child_devices.py
+++ b/tests/tests_new/test_child_devices.py
@@ -18,7 +18,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.ramses_cc.const import DOMAIN
 from custom_components.ramses_cc.coordinator import RamsesCoordinator
 from custom_components.ramses_cc.entity import RamsesEntity
-from ramses_rf.devices import DeviceHvac, UfhCircuit, UfhController
+from ramses_rf.devices import Controller, DeviceHvac, UfhCircuit, UfhController
 from ramses_rf.systems import System, Zone
 from ramses_rf.topology import Child
 
@@ -87,6 +87,80 @@ async def test_zone_registered_as_child_of_tcs(
     )
     assert child_entry is not None
     assert child_entry.parent_device_id == parent_tcs_entry.id
+
+
+async def test_unnamed_zone_fallback_to_friendly_name(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    # Arrange
+    dev_reg = dr.async_get(hass)
+    parent_tcs_entry = dev_reg.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "01:123456")},
+        name="Controller 01:123456",
+        model="Controller",
+    )
+
+    mock_tcs = MagicMock(spec=System)
+    mock_tcs.id = "01:123456"
+
+    mock_zone = MagicMock(spec=Zone)
+    mock_zone.id = "01:123456_04"
+    mock_zone.name = None
+    mock_zone._child_id = "04"
+    mock_zone.tcs = mock_tcs
+
+    # Act
+    await mock_coordinator._async_update_device(mock_zone)
+
+    # Assert
+    cached_info = mock_coordinator._device_info.get("01:123456_04")
+    assert cached_info is not None
+    assert cached_info["identifiers"] == {(DOMAIN, "01:123456_04")}
+    assert cached_info["name"] == "Zone 4"
+    assert cached_info["parent_device_id"] == parent_tcs_entry.id
+
+    child_entry = dev_reg.async_get_child_device_by_identifier(
+        (DOMAIN, "01:123456_04"), mock_config_entry.entry_id
+    )
+    assert child_entry is not None
+    assert child_entry.name == "Zone 4"
+    assert child_entry.parent_device_id == parent_tcs_entry.id
+
+
+async def test_controller_device_registration_and_model(
+    mock_coordinator: RamsesCoordinator,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    # Arrange
+    dev_reg = dr.async_get(hass)
+
+    mock_ctl = MagicMock(spec=Controller)
+    mock_ctl.id = "01:088175"
+    mock_ctl.name = None
+    mock_ctl._SLUG = "CTL"
+    mock_ctl.state_store = None
+
+    # Act
+    await mock_coordinator._async_update_device(mock_ctl)
+
+    # Assert
+    ctl_info = mock_coordinator._device_info.get("01:088175")
+    assert ctl_info is not None
+    assert ctl_info["name"] == "Controller 01:088175"
+    assert ctl_info["model"] == "Controller"
+    assert ctl_info.get("manufacturer") is None
+
+    ctl_entry = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, "01:088175"), mock_config_entry.entry_id
+    )
+    assert ctl_entry is not None
+    assert ctl_entry.name == "Controller 01:088175"
+    assert ctl_entry.model == "Controller"
+    assert ctl_entry.manufacturer is None
 
 
 async def test_ufh_circuit_registered_as_child_of_ufc(


### PR DESCRIPTION
Addresses #1007.

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: used for 100%

### The Problem:
1. Controllers defaulted to their raw hex identifier (e.g. `01:088175`) with model `CTL`, which child devices (such as zones) inherited and displayed as an unclear subtitle in Home Assistant (`CTL • 3 entiteiten`).
2. Unnamed zones defaulted to their internal protocol identifier (e.g. `RAD 01:088175_04`), rather than a friendly fallback.

### The Fix:
- **Controller Normalisation**: In `RamsesCoordinator._async_update_device`, default controller name to `Controller {device.id}` and model to `Controller` (leaving `manufacturer` unset).
- **Zone Fallback**: If an Evohome `Zone` has no broadcast or configured friendly name, fall back to `Zone {index}` (converting hex child IDs to integer, e.g. `04` -> `Zone 4`).
- **Regression Tests**: Added unit tests in `tests/tests_new/test_child_devices.py` for controller registration/model and zone friendly fallback, and refreshed test snapshots in `tests/tests_new/snapshots/test_init.ambr`.

### Testing Performed:
- `prek run -a`: 20/20 hooks passed.
- `ruff check .`: 0 errors.
- `mypy custom_components`: 0 errors across 23 files.
- `python -u -m pytest -n auto`: 1,562 passed, 15 skipped.
- Module statement coverage verification: 100% of modules >= 95.0%.

### AI Assistance Disclosure:
This contribution was developed with the assistance of Google Gemini 3.8 Flash for code generation and documentation. All logic and implementations were reviewed and verified by the author.