### PR TITLE
fix(discovery): don't synthesize default NEW metadata in get_devices()

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -1691,7 +1691,24 @@ class DiscoveryManager:
             # coordinator and auto-registered in the schema.
             if self._active_hgi_id and device_id == self._active_hgi_id:
                 continue
-            meta = self._metadata.get(device_id, DeviceMetadata())
+            meta = self._metadata.get(device_id)
+
+            # When a status/enabled filter is applied, skip devices that
+            # have no persisted metadata rather than synthesizing a
+            # default DeviceMetadata() (whose status defaults to NEW).
+            # Without this, live-scan devices already in the schema but
+            # lacking metadata (e.g. after a reload where .storage/ wasn't
+            # updated before teardown) would implicitly satisfy
+            # status=DiscoveryStatus.NEW and appear in the Review
+            # discovered devices config flow even though they're already
+            # configured (issue 1132).  check_for_new_devices() already
+            # suppresses the *notification* for such devices (issue 917),
+            # but get_devices() is a separate code path used by the
+            # review UI.
+            if meta is None:
+                if status is not None or enabled is not None:
+                    continue
+                meta = DeviceMetadata()
 
             if status is not None and meta.status != status:
                 continue

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -361,6 +361,48 @@ class TestGetDevices:
         manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
         assert manager.get_device("99:999999") is None
 
+    def test_status_filter_skips_devices_without_metadata(self) -> None:
+        """Devices in the scan engine but with no persisted metadata must
+        not appear when a status filter is applied.
+
+        Without this, a live-scan device already in the schema but
+        lacking discovery metadata (e.g. after a reload) would get a
+        default DeviceMetadata() with status=NEW and appear in the
+        Review discovered devices config flow (issue 1132).
+        """
+        dev = make_discovered_device("04:056053")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        # Device is in the scan engine but has no metadata entry
+        assert "04:056053" not in manager._metadata  # noqa: SLF001
+
+        # Filtering by NEW must NOT return it — no metadata means we
+        # can't know its real status.
+        new_devices = manager.get_devices(status=DiscoveryStatus.NEW)
+        assert len(new_devices) == 0
+
+        # Filtering by ACCEPTED must also not return it.
+        accepted = manager.get_devices(status=DiscoveryStatus.ACCEPTED)
+        assert len(accepted) == 0
+
+        # Without a filter, the device should still be returned (with a
+        # default metadata) so callers that want all devices still work.
+        all_devices = manager.get_devices()
+        assert len(all_devices) == 1
+        assert all_devices[0].device.device_id == "04:056053"
+
+    def test_enabled_filter_skips_devices_without_metadata(self) -> None:
+        """The enabled filter must also skip devices without metadata."""
+        dev = make_discovered_device("04:056053")
+        scan = make_mock_scan([dev])
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+
+        assert "04:056053" not in manager._metadata  # noqa: SLF001
+
+        enabled = manager.get_devices(enabled=True)
+        assert len(enabled) == 0
+
 
 class TestNewDeviceDetection:
     """Tests for new device detection and notifications."""


### PR DESCRIPTION
## Summary

`DiscoveryManager.get_devices(status=...)` synthesised a default `DeviceMetadata()` (whose `status` defaults to `NEW`) for live-scan devices that have no persisted discovery metadata. This caused existing schema devices that lost their metadata (e.g. after a reload where `.storage/` wasn't updated before teardown) to appear in **Review discovered devices** as NEW, even though they're already configured.

`check_for_new_devices()` already suppresses the *notification* for such devices (issue 917), but `get_devices()` is a separate code path used by the review config flow — this closes that gap.

### Fix

When a `status` or `enabled` filter is applied, skip devices with no persisted metadata instead of creating a default. Unfiltered `get_devices()` (no status/enabled) still returns all devices with a default metadata stub, preserving existing behaviour for callers that want the full device list.

Fixes https://github.com/ramses-rf/ramses_cc/issues/1132

#### Test plan

- [x] 2 unit tests added (`test_status_filter_skips_devices_without_metadata`, `test_enabled_filter_skips_devices_without_metadata`)
- [x] `ruff check` — passed
- [x] `mypy` — passed (0 issues)
- [x] `pytest tests/tests_new/test_discovery_manager.py` — 220 passed, 0 failures
- [x] Pre-commit hooks — all passed