### PR TITLE
fix: always notify when ramses_cc: block exists in `configuration.yaml`

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -81,7 +81,6 @@ from .const import (
     CONF_MQTT_TOPIC,
     CONF_MQTT_USE_HA,
     CONF_PASSIVE_SCAN,
-    CONF_RAMSES_RF,
     CONF_SEND_PACKET,
     DOMAIN,
     STORAGE_KEY,
@@ -163,32 +162,26 @@ PLATFORMS = [Platform.EVENT]
 async def _async_cleanup_yaml_known_list(
     hass: HomeAssistant, domain_config: dict[str, Any]
 ) -> None:
-    """Warn about legacy known_list/block_list in configuration.yaml (issue 1055).
+    """Warn about legacy ramses_cc configuration in configuration.yaml.
 
-    Phase 4 migrated known_list and block_list into the config entry
-    schema (block_list is now derived from _owner/_skipped traits at
-    runtime).  The YAML file was never cleaned up.  This does NOT modify
-    configuration.yaml (to preserve user comments and formatting).
-    Instead it:
+    The entire ``ramses_cc:`` YAML configuration has been migrated to the
+    config flow (Settings > Devices & Services > Ramses RF).  The YAML
+    block is no longer used and will be dropped in a future release.
 
-    1. Backs up the known_list/block_list to ``ramses_cc_backups/`` as a
-       YAML file
+    This does NOT modify configuration.yaml (to preserve user comments and
+    formatting).  Instead it:
+
+    1. Backs up any known_list/block_list to ``ramses_cc_backups/`` as a
+       YAML file (so no data is lost)
     2. Creates a persistent notification telling the user to remove the
-       ``known_list``, ``block_list`` and ``enforce_known_list`` keys
-       manually
+       entire ``ramses_cc:`` block manually
 
-    The backup ensures no data is lost — the user can copy/paste values
-    from the backup into the schema editor if needed.
+    The notification fires for *any* ``ramses_cc:`` block, not just when
+    legacy keys (known_list/block_list/enforce_known_list) are present
+    (issues 1140, 1149).
     """
     known_list = domain_config.get("known_list")
     block_list = domain_config.get("block_list")
-    ramses_rf = domain_config.get(CONF_RAMSES_RF, {})
-    has_enforce = (
-        isinstance(ramses_rf, dict) and "enforce_known_list" in ramses_rf
-    )
-
-    if not known_list and not block_list and not has_enforce:
-        return
 
     # 1. Back up known_list and/or block_list to ramses_cc_backups/
     backup_data: dict[str, Any] = {}
@@ -246,25 +239,20 @@ async def _async_cleanup_yaml_known_list(
     )
 
     lines = [
-        "The `known_list` and `block_list` configuration has been migrated",
-        "to the config flow schema (Phase 4).  `block_list` is now derived",
-        "from `_owner`/`_skipped` traits at runtime.  Please remove the",
-        "following keys from `configuration.yaml` under `ramses_cc:`:",
-        "",
+        "The `ramses_cc` configuration has been migrated to the config",
+        "flow (Settings > Devices & Services > Ramses RF).  Please remove",
+        "the entire `ramses_cc:` block from `configuration.yaml` — it is",
+        "no longer used and will generate this warning on every restart.",
     ]
-    if known_list:
-        lines.append("- `known_list` (backed up to `ramses_cc_backups/`)")
-    if block_list:
-        lines.append(
-            "- `block_list` (now derived from schema `_owner`/`_skipped`)"
-        )
-    if has_enforce:
-        lines.append("- `enforce_known_list` (now always-on)")
-    lines += [
-        "",
-        "The integration will continue to work, but these keys are no",
-        "longer used and will generate warnings on every restart.",
-    ]
+    if known_list or block_list:
+        lines.append("")
+        lines.append("The following legacy keys were backed up:")
+        if known_list:
+            lines.append("- `known_list` (backed up to `ramses_cc_backups/`)")
+        if block_list:
+            lines.append(
+                "- `block_list` (now derived from schema `_owner`/`_skipped`)"
+            )
     if backup_path:
         lines += [
             "",
@@ -274,14 +262,14 @@ async def _async_cleanup_yaml_known_list(
     async_create_notification(
         hass,
         message="\n".join(lines),
-        title="RAMSES CC: Remove legacy known_list from configuration.yaml",
+        title="RAMSES CC: Remove ramses_cc block from configuration.yaml",
         notification_id=f"{DOMAIN}_yaml_known_list_cleanup",
     )
     _LOGGER.warning(
-        "Legacy known_list/block_list/enforce_known_list found in "
-        "configuration.yaml. A backup has been saved and a persistent "
-        "notification created. Please remove these keys from "
-        "configuration.yaml manually."
+        "Legacy ramses_cc configuration found in configuration.yaml. "
+        "The entire ramses_cc: block should be removed — configuration "
+        "is now managed via the config flow. A persistent notification "
+        "has been created."
     )
 
 

--- a/tests/tests_new/test_init.py
+++ b/tests/tests_new/test_init.py
@@ -940,16 +940,21 @@ async def test_yaml_known_list_cleanup_backs_up_and_notifies(
     call_kwargs = mock_notify.call_args.kwargs
     assert "known_list" in call_kwargs["message"]
     assert "block_list" in call_kwargs["message"]
-    assert "enforce_known_list" in call_kwargs["message"]
     assert (
         call_kwargs["notification_id"] == "ramses_cc_yaml_known_list_cleanup"
     )
 
 
-async def test_yaml_known_list_cleanup_noop_without_known_list(
+async def test_yaml_cleanup_notifies_even_without_legacy_keys(
     hass: HomeAssistant, tmp_path: Any
 ) -> None:
-    """async_setup does nothing if no known_list or enforce_known_list."""
+    """Notification fires for any ramses_cc: block, not just legacy keys.
+
+    The entire ramses_cc YAML configuration is deprecated — any
+    ramses_cc: block in configuration.yaml should produce the
+    notification, even without known_list/block_list/enforce_known_list
+    (issues 1140, 1149).
+    """
     domain_config = {"ramses_rf": {}}
 
     with (
@@ -971,9 +976,52 @@ async def test_yaml_known_list_cleanup_noop_without_known_list(
 
         await async_setup(hass, {"ramses_cc": domain_config})
 
-    # No backup, no notification
+    # No backup (no legacy keys), but notification should still fire
     backup_dir = tmp_path / "ramses_cc_backups"
     assert not backup_dir.exists() or not list(
         backup_dir.glob("backup_*_yaml_known_list.yaml")
     )
-    mock_notify.assert_not_called()
+    mock_notify.assert_called_once()
+    call_kwargs = mock_notify.call_args.kwargs
+    assert "ramses_cc:" in call_kwargs["message"]
+    assert (
+        call_kwargs["notification_id"] == "ramses_cc_yaml_known_list_cleanup"
+    )
+
+
+async def test_yaml_cleanup_notifies_with_schema_default_enforce(
+    hass: HomeAssistant, tmp_path: Any
+) -> None:
+    """Notification fires even when enforce_known_list is the schema default.
+
+    CONFIG_SCHEMA injects ``enforce_known_list: False`` via
+    SCH_ENGINE_DICT's ``vol.Optional(..., default=False)``.  The
+    notification should still fire because the entire ramses_cc: block
+    is deprecated (issue 1149).
+    """
+    # Simulate what CONFIG_SCHEMA produces for a user who has a
+    # ramses_cc: block but never wrote enforce_known_list themselves
+    domain_config = {
+        "ramses_rf": {"enforce_known_list": False},
+    }
+
+    with (
+        patch.object(
+            hass.config,
+            "path",
+            side_effect=lambda x: str(tmp_path / x if "/" not in x else x),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_entries",
+            return_value=[MagicMock()],
+        ),
+        patch(
+            "homeassistant.components.persistent_notification.async_create",
+        ) as mock_notify,
+    ):
+        from custom_components.ramses_cc import async_setup
+
+        await async_setup(hass, {"ramses_cc": domain_config})
+
+    mock_notify.assert_called_once()


### PR DESCRIPTION
## Summary

The entire `ramses_cc:` YAML configuration is deprecated — any `ramses_cc:` block in `configuration.yaml` should produce a notification telling the user to remove it, not just when legacy keys (`known_list`/`block_list`/`enforce_known_list`) are present.

### Problems with the previous behaviour

1. **False positive**: `CONFIG_SCHEMA` injects `enforce_known_list: False` as a schema default via `SCH_ENGINE_DICT`. The cleanup check tested for the key's mere presence, which was always `True` after schema validation — so users with any `ramses_cc:` block got the notification even without legacy keys, but with a confusing message about `enforce_known_list`.

2. **False negative**: Users with only `serial_port` or other non-legacy keys got no notification at all, even though the entire YAML block is deprecated.

### Fix

- **Always** create the notification when `async_setup` receives a `ramses_cc:` block — the whole YAML config is deprecated, not just the legacy keys
- Keep the backup logic for `known_list`/`block_list` (so no data is lost)
- Updated the message to say "remove the entire `ramses_cc:` block" per maintainer feedback (issues 1140, 1149)

Fixes https://github.com/ramses-rf/ramses_cc/issues/1149

#### Test plan

- [x] `test_yaml_known_list_cleanup_backs_up_and_notifies` — verifies backup + notification with legacy keys
- [x] `test_yaml_cleanup_notifies_even_without_legacy_keys` — verifies notification fires for any `ramses_cc:` block (no legacy keys)
- [x] `test_yaml_cleanup_notifies_with_schema_default_enforce` — verifies notification fires when `enforce_known_list: False` (schema default)
- [x] `ruff check` / `ruff format` — passed
- [x] `mypy` — passed (0 issues)
- [x] Pre-commit hooks — all passed