### PR TITLE
fix: clear _skipped when adding _class in review_discovered

### DIFF
--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -278,6 +278,10 @@ class DiscoveryManager:
         # Populated by sync_with_schema().
         self._schema_no_owner_ids: set[str] = set()
         self._foreign_device_ids: set[str] = set()
+        # Devices in schema with _skipped: True — the user deferred them
+        # in a previous review.  They should stay NEW so they reappear
+        # in review_discovered when the user opens it again.
+        self._schema_skipped_ids: set[str] = set()
 
         # Track which mismatches we've already warned about (to avoid
         # repeating the WARNING every checkpoint cycle).  Cleared when
@@ -581,17 +585,25 @@ class DiscoveryManager:
         # candidates that need review (e.g. HGIs discovered via MQTT).
         # check_for_new_devices should NOT suppress them (issue 1119).
         self._schema_no_owner_ids = set()
+        # Devices in the schema with _skipped: True — the user deferred
+        # them in a previous review.  They should stay NEW so they
+        # reappear in review_discovered when the user opens it again.
+        self._schema_skipped_ids = set()
         if schema and isinstance(schema, dict):
             import re
 
             device_id_re = re.compile(r"^[0-9]{2}:[0-9]{6}$")
             for dev_id, entry in schema.items():
-                if (
-                    isinstance(entry, dict)
-                    and SZ_TR_OWNER not in entry
-                    and device_id_re.match(str(dev_id))
+                if not isinstance(entry, dict):
+                    continue
+                if SZ_TR_OWNER not in entry and device_id_re.match(
+                    str(dev_id)
                 ):
                     self._schema_no_owner_ids.add(dev_id)
+                if entry.get(SZ_TR_SKIPPED) and device_id_re.match(
+                    str(dev_id)
+                ):
+                    self._schema_skipped_ids.add(dev_id)
 
         _LOGGER.info(
             "DiscoveryManager: sync_with_schema with schema_device_ids=%s",
@@ -652,6 +664,10 @@ class DiscoveryManager:
                 # candidates — they're in the schema but haven't been
                 # accepted yet.  Keep status NEW so they appear in the
                 # review form for the user to accept (issue 1119).
+                #
+                # Exception: devices with _skipped: True in the schema were
+                # deferred by the user in a previous review.  Keep them NEW
+                # so they reappear in review_discovered when opened again.
                 if (
                     device_id.startswith(HGI_PREFIX)
                     and device_id in self._schema_no_owner_ids
@@ -659,6 +675,12 @@ class DiscoveryManager:
                     _LOGGER.info(
                         "DiscoveryManager: HGI %s is in schema without "
                         "_owner, keeping NEW status for review (issue 1119)",
+                        device_id,
+                    )
+                elif device_id in self._schema_skipped_ids:
+                    _LOGGER.info(
+                        "DiscoveryManager: device %s has _skipped in "
+                        "schema, keeping NEW status for re-review",
                         device_id,
                     )
                 else:
@@ -670,6 +692,23 @@ class DiscoveryManager:
                         "NEW status, marked as ACCEPTED",
                         device_id,
                     )
+            elif (
+                device_id in self._schema_skipped_ids
+                and meta.status == DiscoveryStatus.ACCEPTED
+            ):
+                # Device was previously accepted but now has _skipped in
+                # the schema (e.g. user manually added _skipped, or a
+                # previous review skip wrote it).  Reset to NEW so it
+                # reappears in review_discovered.
+                meta.status = DiscoveryStatus.NEW
+                meta.enabled = False
+                self._metadata[device_id] = meta
+                self._notified.discard(device_id)
+                _LOGGER.info(
+                    "DiscoveryManager: device %s has _skipped in schema, "
+                    "resetting ACCEPTED → NEW for re-review",
+                    device_id,
+                )
             elif (
                 device_id.startswith(HGI_PREFIX)
                 and meta.status == DiscoveryStatus.LOST

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -3586,6 +3586,77 @@ class TestSyncWithSchemaNoOwner:
         )
         assert manager._schema_no_owner_ids == set()
 
+    def test_sync_with_schema_skipped_ids_populated(self) -> None:
+        """sync_with_schema populates _schema_skipped_ids for _skipped devices."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111", "37:002222"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+                "37:002222": {"_class": "REM", "_owner": "me"},
+            },
+        )
+        assert "37:001111" in manager._schema_skipped_ids
+        assert "37:002222" not in manager._schema_skipped_ids
+
+    def test_sync_with_schema_skipped_keeps_new(self) -> None:
+        """sync_with_schema keeps NEW status for _skipped devices."""
+        from custom_components.ramses_cc.discovery import (
+            DeviceMetadata,
+            DiscoveryStatus,
+        )
+
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Device with _skipped in schema and NEW status
+        manager._metadata["37:001111"] = DeviceMetadata(
+            status=DiscoveryStatus.NEW
+        )
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+            },
+        )
+        # Should stay NEW, not be auto-accepted
+        assert manager._metadata["37:001111"].status == DiscoveryStatus.NEW
+
+    def test_sync_with_schema_skipped_resets_accepted(self) -> None:
+        """sync_with_schema resets ACCEPTED → NEW for _skipped devices."""
+        from custom_components.ramses_cc.discovery import (
+            DeviceMetadata,
+            DiscoveryStatus,
+        )
+
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Device was previously accepted but now has _skipped in schema
+        manager._metadata["37:001111"] = DeviceMetadata(
+            status=DiscoveryStatus.ACCEPTED, enabled=True
+        )
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+            },
+        )
+        # Should be reset to NEW for re-review
+        assert manager._metadata["37:001111"].status == DiscoveryStatus.NEW
+        assert manager._metadata["37:001111"].enabled is False
+
 
 class TestHgiNoOwnerKeepsNew:
     """Test that HGIs without _owner keep NEW status (line 658)."""


### PR DESCRIPTION
## Summary

When a device appeared in the missing_class section of review_discovered
(in schema but no `_class`, scan engine has a `likely_type`) and the user
chose "Add _class", the `_skipped` flag was never cleared. The device got
a `_class` but stayed deferred — no entities were created, commands were
blocked.

Fix: clear `_skipped` when adding `_class`. This effectively accepts the
device in one step. If a new msg code later suggests a different class,
`check_class_mismatches` will catch it via the mismatch review path.

## Verification

- All 1679 tests pass.
- Pre-commit hooks pass (ruff, mypy, codespell, etc.).

#### Test plan

- [x] `pytest tests/` passes (1679 passed, 15 skipped)
- [x] ruff + mypy pass
- [x] Manual: add _class to a skipped device → device is accepted with entities