### PR TITLE
fix: register primary HGI in schema at startup

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -821,6 +821,29 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         schema = copy.deepcopy(self.entry.options.get(CONF_SCHEMA, {}))
         schema_changed = False
+
+        # Ensure the primary HGI is in the schema with _class: HGI and
+        # _owner: root_owner.  With a clean schema (e.g. after the user
+        # cleared it for testing), the primary HGI won't be in the schema
+        # until sync_learned_topology runs (30-min cycle).  Without this,
+        # enforce_known_list blocks all commands because the known_list
+        # is derived from the schema and the primary HGI is missing.
+        primary_hgi = self._get_primary_hgi_id()
+        if (
+            primary_hgi
+            and primary_hgi.startswith(HGI_PREFIX)
+            and primary_hgi not in schema
+        ):
+            root_owner = schema.get(SZ_OWNER)
+            schema[primary_hgi] = {"_class": "HGI"}
+            if root_owner:
+                schema[primary_hgi][SZ_TR_OWNER] = root_owner
+            schema_changed = True
+            _LOGGER.info(
+                "Registered primary HGI %s in schema (was missing)",
+                primary_hgi,
+            )
+
         for dev_id, entry in schema.items():
             if (
                 dev_id.startswith(HGI_PREFIX)


### PR DESCRIPTION
## Summary

With a clean schema (e.g. after the user cleared it for testing), the primary
HGI was not in the schema until `sync_learned_topology` ran (30-minute cycle).
Because `enforce_known_list` is always-on and the known_list is derived from
the schema, all commands were blocked with "Command excluded by device_id
filter" until the first save cycle.

Fix: in `_register_pool_hgis` (called at startup), add the primary HGI to the
schema with `_class: HGI` and `_owner: root_owner` if it's not already present.
This ensures the known_list includes the primary HGI from startup, so commands
can be sent immediately.

## Verification

- All 1745 tests pass.
- Pre-commit hooks pass (ruff, mypy, codespell, etc.).

#### Test plan

- [x] `pytest tests/` passes (1745 passed, 15 skipped)
- [x] ruff + mypy pass
- [x] Manual: restart with clean schema → primary HGI in schema → commands work