### PR TITLE
fix: combined _skipped re-surface + primary HGI registration

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -821,6 +821,29 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         schema = copy.deepcopy(self.entry.options.get(CONF_SCHEMA, {}))
         schema_changed = False
+
+        # Ensure the primary HGI is in the schema with _class: HGI and
+        # _owner: root_owner.  With a clean schema (e.g. after the user
+        # cleared it for testing), the primary HGI won't be in the schema
+        # until sync_learned_topology runs (30-min cycle).  Without this,
+        # enforce_known_list blocks all commands because the known_list
+        # is derived from the schema and the primary HGI is missing.
+        primary_hgi = self._get_primary_hgi_id()
+        if (
+            primary_hgi
+            and primary_hgi.startswith(HGI_PREFIX)
+            and primary_hgi not in schema
+        ):
+            root_owner = schema.get(SZ_OWNER)
+            schema[primary_hgi] = {"_class": "HGI"}
+            if root_owner:
+                schema[primary_hgi][SZ_TR_OWNER] = root_owner
+            schema_changed = True
+            _LOGGER.info(
+                "Registered primary HGI %s in schema (was missing)",
+                primary_hgi,
+            )
+
         for dev_id, entry in schema.items():
             if (
                 dev_id.startswith(HGI_PREFIX)

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -3586,6 +3586,77 @@ class TestSyncWithSchemaNoOwner:
         )
         assert manager._schema_no_owner_ids == set()
 
+    def test_sync_with_schema_skipped_ids_populated(self) -> None:
+        """sync_with_schema populates _schema_skipped_ids for _skipped devices."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111", "37:002222"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+                "37:002222": {"_class": "REM", "_owner": "me"},
+            },
+        )
+        assert "37:001111" in manager._schema_skipped_ids
+        assert "37:002222" not in manager._schema_skipped_ids
+
+    def test_sync_with_schema_skipped_keeps_new(self) -> None:
+        """sync_with_schema keeps NEW status for _skipped devices."""
+        from custom_components.ramses_cc.discovery import (
+            DeviceMetadata,
+            DiscoveryStatus,
+        )
+
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Device with _skipped in schema and NEW status
+        manager._metadata["37:001111"] = DeviceMetadata(
+            status=DiscoveryStatus.NEW
+        )
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+            },
+        )
+        # Should stay NEW, not be auto-accepted
+        assert manager._metadata["37:001111"].status == DiscoveryStatus.NEW
+
+    def test_sync_with_schema_skipped_resets_accepted(self) -> None:
+        """sync_with_schema resets ACCEPTED → NEW for _skipped devices."""
+        from custom_components.ramses_cc.discovery import (
+            DeviceMetadata,
+            DiscoveryStatus,
+        )
+
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Device was previously accepted but now has _skipped in schema
+        manager._metadata["37:001111"] = DeviceMetadata(
+            status=DiscoveryStatus.ACCEPTED, enabled=True
+        )
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+            },
+        )
+        # Should be reset to NEW for re-review
+        assert manager._metadata["37:001111"].status == DiscoveryStatus.NEW
+        assert manager._metadata["37:001111"].enabled is False
+
 
 class TestHgiNoOwnerKeepsNew:
     """Test that HGIs without _owner keep NEW status (line 658)."""


### PR DESCRIPTION
## Summary

Combined branch for testing — do not merge separately. Contains:

- PR 1166: clear `_skipped` when adding `_class` + re-surface `_skipped` devices in review_discovered
- PR 1167: register primary HGI in schema at startup

Use integration_tester URL: `github.com/ramses-rf/ramses_cc/pull/<this PR number>`

#### Test plan

- [ ] Restart with clean schema → primary HGI in schema → commands work
- [ ] _skipped devices reappear in review_discovered
- [ ] Adding _class clears _skipped