### PR TITLE
fix: Phase 1 multi-HGI MQTT pooling — bind, skipped, primary HGI, notifications

### DIFF
--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -821,6 +821,29 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         schema = copy.deepcopy(self.entry.options.get(CONF_SCHEMA, {}))
         schema_changed = False
+
+        # Ensure the primary HGI is in the schema with _class: HGI and
+        # _owner: root_owner.  With a clean schema (e.g. after the user
+        # cleared it for testing), the primary HGI won't be in the schema
+        # until sync_learned_topology runs (30-min cycle).  Without this,
+        # enforce_known_list blocks all commands because the known_list
+        # is derived from the schema and the primary HGI is missing.
+        primary_hgi = self._get_primary_hgi_id()
+        if (
+            primary_hgi
+            and primary_hgi.startswith(HGI_PREFIX)
+            and primary_hgi not in schema
+        ):
+            root_owner = schema.get(SZ_OWNER)
+            schema[primary_hgi] = {"_class": "HGI"}
+            if root_owner:
+                schema[primary_hgi][SZ_TR_OWNER] = root_owner
+            schema_changed = True
+            _LOGGER.info(
+                "Registered primary HGI %s in schema (was missing)",
+                primary_hgi,
+            )
+
         for dev_id, entry in schema.items():
             if (
                 dev_id.startswith(HGI_PREFIX)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -861,6 +861,25 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 "Registered primary HGI %s in schema (was missing)",
                 primary_hgi,
             )
+        elif (
+            primary_hgi
+            and primary_hgi in schema
+            and isinstance(schema[primary_hgi], dict)
+            and schema[primary_hgi].get("_class", "").upper() == "HGI"
+            and SZ_TR_OWNER not in schema[primary_hgi]
+        ):
+            # Primary HGI is in the schema but missing _owner — enrich
+            # it so it's treated as an accepted pool member (issue 1119).
+            root_owner = schema.get(SZ_OWNER)
+            if root_owner:
+                schema[primary_hgi][SZ_TR_OWNER] = root_owner
+                schema_changed = True
+                _LOGGER.info(
+                    "Enriched primary HGI %s with _owner=%s "
+                    "(was in schema without _owner)",
+                    primary_hgi,
+                    root_owner,
+                )
 
         for dev_id, entry in schema.items():
             if (

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -852,10 +852,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
             and primary_hgi.startswith(HGI_PREFIX)
             and primary_hgi not in schema
         ):
-            root_owner = schema.get(SZ_OWNER)
+            root_owner = schema.get(SZ_OWNER, "me")
             schema[primary_hgi] = {"_class": "HGI"}
-            if root_owner:
-                schema[primary_hgi][SZ_TR_OWNER] = root_owner
+            schema[primary_hgi][SZ_TR_OWNER] = root_owner
             schema_changed = True
             _LOGGER.info(
                 "Registered primary HGI %s in schema (was missing)",
@@ -870,16 +869,17 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ):
             # Primary HGI is in the schema but missing _owner — enrich
             # it so it's treated as an accepted pool member (issue 1119).
-            root_owner = schema.get(SZ_OWNER)
-            if root_owner:
-                schema[primary_hgi][SZ_TR_OWNER] = root_owner
-                schema_changed = True
-                _LOGGER.info(
-                    "Enriched primary HGI %s with _owner=%s "
-                    "(was in schema without _owner)",
-                    primary_hgi,
-                    root_owner,
-                )
+            # Default to "me" when the schema root has no _owner (e.g.
+            # after clear_cached_state in ha_sim_test).
+            root_owner = schema.get(SZ_OWNER, "me")
+            schema[primary_hgi][SZ_TR_OWNER] = root_owner
+            schema_changed = True
+            _LOGGER.info(
+                "Enriched primary HGI %s with _owner=%s "
+                "(was in schema without _owner)",
+                primary_hgi,
+                root_owner,
+            )
 
         for dev_id, entry in schema.items():
             if (

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -593,6 +593,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     # in-memory cache by setting a flag
                     self._skip_discovery_restore = True
 
+                    # Dismiss any stale discovery notifications so the
+                    # user doesn't click a notification that leads to
+                    # an empty review form (the devices haven't been
+                    # re-discovered by the scan yet).
+                    from homeassistant.components.persistent_notification import (
+                        async_dismiss as _async_dismiss_notification,
+                    )
+
+                    _async_dismiss_notification(
+                        self.hass, f"{DOMAIN}_discovery"
+                    )
+                    _async_dismiss_notification(
+                        self.hass, f"{DOMAIN}_discovery_mismatches"
+                    )
+                    _async_dismiss_notification(
+                        self.hass, f"{DOMAIN}_discovery_lost"
+                    )
+
         # 2. Schema Handling
         _LOGGER.debug("CONFIG_SCHEMA: %s", config_schema)  # noqa: E501  # marker: after-migration
 

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -277,6 +277,10 @@ class DiscoveryManager:
         # Devices in schema without _owner — need review (issue 1119).
         # Populated by sync_with_schema().
         self._schema_no_owner_ids: set[str] = set()
+        # Devices in schema with _skipped=True — deferred but not
+        # permanently hidden.  Removing _skipped should re-surface
+        # them in review_discovered (issue 1136).
+        self._schema_skipped_ids: set[str] = set()
         self._foreign_device_ids: set[str] = set()
 
         # Track which mismatches we've already warned about (to avoid
@@ -581,17 +585,22 @@ class DiscoveryManager:
         # candidates that need review (e.g. HGIs discovered via MQTT).
         # check_for_new_devices should NOT suppress them (issue 1119).
         self._schema_no_owner_ids = set()
+        # Devices in the schema with _skipped=True — deferred but not
+        # permanently hidden (issue 1136).
+        self._schema_skipped_ids = set()
         if schema and isinstance(schema, dict):
             import re
 
             device_id_re = re.compile(r"^[0-9]{2}:[0-9]{6}$")
             for dev_id, entry in schema.items():
-                if (
-                    isinstance(entry, dict)
-                    and SZ_TR_OWNER not in entry
-                    and device_id_re.match(str(dev_id))
-                ):
+                if not isinstance(entry, dict):
+                    continue
+                if not device_id_re.match(str(dev_id)):
+                    continue
+                if SZ_TR_OWNER not in entry:
                     self._schema_no_owner_ids.add(dev_id)
+                if entry.get(SZ_TR_SKIPPED):
+                    self._schema_skipped_ids.add(dev_id)
 
         _LOGGER.info(
             "DiscoveryManager: sync_with_schema with schema_device_ids=%s",
@@ -648,10 +657,14 @@ class DiscoveryManager:
                 # a class mismatch, the review form will show it in the
                 # mismatch section where the user can resolve it.
                 #
-                # Exception: HGIs (18:) without _owner are discovery
+                # Exception 1: HGIs (18:) without _owner are discovery
                 # candidates — they're in the schema but haven't been
                 # accepted yet.  Keep status NEW so they appear in the
                 # review form for the user to accept (issue 1119).
+                #
+                # Exception 2: devices with _skipped=True are deferred
+                # by the user.  Keep status NEW so they don't get
+                # permanently accepted (issue 1136).
                 if (
                     device_id.startswith(HGI_PREFIX)
                     and device_id in self._schema_no_owner_ids
@@ -659,6 +672,12 @@ class DiscoveryManager:
                     _LOGGER.info(
                         "DiscoveryManager: HGI %s is in schema without "
                         "_owner, keeping NEW status for review (issue 1119)",
+                        device_id,
+                    )
+                elif device_id in self._schema_skipped_ids:
+                    _LOGGER.info(
+                        "DiscoveryManager: device %s is _skipped in "
+                        "schema, keeping NEW status (issue 1136)",
                         device_id,
                     )
                 else:
@@ -670,6 +689,22 @@ class DiscoveryManager:
                         "NEW status, marked as ACCEPTED",
                         device_id,
                     )
+            elif (
+                device_id in self._schema_skipped_ids
+                and meta.status == DiscoveryStatus.ACCEPTED
+            ):
+                # Device was previously accepted but is now _skipped in
+                # the schema — reset to NEW so it reappears in review
+                # when the user removes _skipped (issue 1136).
+                meta.status = DiscoveryStatus.NEW
+                meta.enabled = False
+                self._notified.discard(device_id)
+                self._metadata[device_id] = meta
+                _LOGGER.info(
+                    "DiscoveryManager: device %s is _skipped in schema, "
+                    "reset ACCEPTED -> NEW (issue 1136)",
+                    device_id,
+                )
             elif (
                 device_id.startswith(HGI_PREFIX)
                 and meta.status == DiscoveryStatus.LOST

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -167,6 +167,21 @@ class RamsesMqttPoolBridge:
 
         loop = kwargs.pop("loop", None) or self._hass.loop
 
+        # 0. Wait for HA's MQTT integration to be connected before
+        #    subscribing.  The pool bridge relies on LWT (retained)
+        #    messages, which are only delivered after the MQTT client
+        #    connects.  Without this wait, the 30s wait_online_timeout
+        #    can expire before the MQTT client is even connected
+        #    (issue 1119 — clean-schema startup race).
+        try:
+            await mqtt.async_wait_for_mqtt_client(self._hass)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "MqttPoolBridge: timed out waiting for HA MQTT "
+                "client to connect: %s",
+                err,
+            )
+
         # 1. Subscribe to wildcard MQTT topics before starting.
         await self._async_attach()
 

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -167,19 +167,17 @@ class RamsesMqttPoolBridge:
 
         loop = kwargs.pop("loop", None) or self._hass.loop
 
-        # 0. Wait for HA's MQTT integration to be connected before
-        #    subscribing.  The pool bridge relies on LWT (retained)
-        #    messages, which are only delivered after the MQTT client
-        #    connects.  Without this wait, the 30s wait_online_timeout
-        #    can expire before the MQTT client is even connected
-        #    (issue 1119 — clean-schema startup race).
+        # 0. Wait for HA's MQTT integration to be available before
+        #    subscribing.  async_subscribe requires the MQTT entry
+        #    to be loaded.  This is a quick check — the actual MQTT
+        #    client connection may happen later, and LWT messages
+        #    will be delivered as retained messages when it connects.
         try:
             await mqtt.async_wait_for_mqtt_client(self._hass)
-        except Exception as err:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             _LOGGER.warning(
                 "MqttPoolBridge: timed out waiting for HA MQTT "
-                "client to connect: %s",
-                err,
+                "client setup — continuing anyway"
             )
 
         # 1. Subscribe to wildcard MQTT topics before starting.
@@ -207,8 +205,24 @@ class RamsesMqttPoolBridge:
             accepted_hgi_ids=self._accepted_hgi_ids,
         )
 
-        # 4. Wait for at least one child to come online.
+        # 4. Bind the protocol immediately.  The pool is connected to
+        #    the MQTT broker via HA's MQTT integration — children (HGIs)
+        #    may come online later via LWT.  Without this, the engine's
+        #    wait_for_connection_made() times out if no HGI is online
+        #    within the bind timeout (issue 1119 — clean-schema startup).
+        if not self._pool._protocol_connected:
+            self._pool._protocol_connected = True
+            self._pool._protocol.connection_made(self._pool, ramses=True)
+        if (
+            self._pool._conn_fut is not None
+            and not self._pool._conn_fut.done()
+        ):
+            self._pool._conn_fut.set_result(self._pool)
+
+        # 5. Wait for at least one child to come online (best-effort).
         #    LWT online messages arrive asynchronously from MQTT.
+        #    If no child comes online within the timeout, continue
+        #    anyway — children may come online later.
         try:
             await self._pool._wait_for_any_connection(
                 timeout=self._wait_online_timeout

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -3586,6 +3586,77 @@ class TestSyncWithSchemaNoOwner:
         )
         assert manager._schema_no_owner_ids == set()
 
+    def test_sync_with_schema_skipped_ids_populated(self) -> None:
+        """sync_with_schema populates _schema_skipped_ids for _skipped devices."""
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111", "37:002222"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+                "37:002222": {"_class": "REM", "_owner": "me"},
+            },
+        )
+        assert "37:001111" in manager._schema_skipped_ids
+        assert "37:002222" not in manager._schema_skipped_ids
+
+    def test_sync_with_schema_skipped_keeps_new(self) -> None:
+        """sync_with_schema keeps NEW status for _skipped devices."""
+        from custom_components.ramses_cc.discovery import (
+            DeviceMetadata,
+            DiscoveryStatus,
+        )
+
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Device with _skipped in schema and NEW status
+        manager._metadata["37:001111"] = DeviceMetadata(
+            status=DiscoveryStatus.NEW
+        )
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+            },
+        )
+        # Should stay NEW, not be auto-accepted
+        assert manager._metadata["37:001111"].status == DiscoveryStatus.NEW
+
+    def test_sync_with_schema_skipped_resets_accepted(self) -> None:
+        """sync_with_schema resets ACCEPTED → NEW for _skipped devices."""
+        from custom_components.ramses_cc.discovery import (
+            DeviceMetadata,
+            DiscoveryStatus,
+        )
+
+        scan = make_mock_scan()
+        manager = DiscoveryManager(make_mock_hass(), scan, auto_notify=False)
+        # Device was previously accepted but now has _skipped in schema
+        manager._metadata["37:001111"] = DeviceMetadata(
+            status=DiscoveryStatus.ACCEPTED, enabled=True
+        )
+        manager.sync_with_schema(
+            schema_device_ids={"37:001111"},
+            schema={
+                "37:001111": {
+                    "_class": "REM",
+                    "_owner": "me",
+                    "_skipped": True,
+                },
+            },
+        )
+        # Should be reset to NEW for re-review
+        assert manager._metadata["37:001111"].status == DiscoveryStatus.NEW
+        assert manager._metadata["37:001111"].enabled is False
+
 
 class TestHgiNoOwnerKeepsNew:
     """Test that HGIs without _owner keep NEW status (line 658)."""


### PR DESCRIPTION
## Summary

Combined Phase 1 fixes for multi-HGI MQTT pooling (issue 1119):

1. **Register primary HGI in schema at startup** — clean-schema startup
   enriches `_owner: me` with the configured HGI (`18:130236`) so the
   pool bridge has an accepted HGI even without a cached device entry.

2. **`_schema_skipped_ids` implementation** — populate the set in
   `sync_with_schema()` and use it to keep skipped devices as NEW
   (not auto-accepted) and reset ACCEPTED→NEW when `_skipped` is added
   (issue 1136).

3. **Bind protocol immediately on pool creation** — the pool bridge
   now calls `protocol.connection_made()` as soon as the
   `PooledTransport` is created, instead of waiting for an HGI to come
   online.  This eliminates the 60s bind timeout on clean-schema
   startup when no HGI is online yet.  HGIs come online later via LWT.

4. **Wait for HA MQTT client before subscribing** — call
   `mqtt.async_wait_for_mqtt_client()` before `async_subscribe()` so
   retained LWT messages are delivered promptly.

5. **Dismiss stale discovery notifications on schema wipe** — when the
   schema is wiped, persistent notifications from before the wipe are
   dismissed so the user doesn't click a notification that leads to an
   empty review form (devices haven't been re-discovered by the scan
   yet).

#### Test plan

- [x] Restart with clean schema → primary HGI registered in <1s
- [x] Second HGI discovered as ownerless candidate, flagged for review
- [x] FAN/REM discovered and accepted after RF packets arrive
- [x] No bind timeout on clean-schema startup
- [x] No stale notification after schema wipe
- [x] `_skipped` devices reappear in review_discovered
- [x] Adding `_class` clears `_skipped`
- [x] Full ha_sim_test on 3 containers