### PR TITLE
pool config step improvements + fix bugs — primary HGI removal, credential masking (issue 1171)

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -81,8 +81,11 @@ from .const import (
     CONF_MQTT_TOPIC,
     CONF_MQTT_USE_HA,
     CONF_PASSIVE_SCAN,
+    CONF_SCHEMA,
     CONF_SEND_PACKET,
+    DEFAULT_HGI_ID,
     DOMAIN,
+    HGI_PREFIX,
     STORAGE_KEY,
     STORAGE_VERSION,
     SVC_ACCEPT_DISCOVERED_DEVICE,
@@ -94,8 +97,10 @@ from .const import (
     SVC_GET_DISCOVERED_DEVICES,
     SVC_REMOVE_DEVICE,
     SVC_REMOVE_DISCOVERED_DEVICE,
+    SZ_OWNER,
     SZ_PORT_NAME,
     SZ_SERIAL_PORT,
+    SZ_TR_OWNER,
 )
 from .coordinator import RamsesCoordinator
 from .schemas import (
@@ -617,6 +622,24 @@ def _healed_serial_port_options(
         mqtt_hints_present or mqtt_entries_present
     ):
         return None
+
+    # Don't heal if there are no accepted HGIs in the schema — the
+    # user explicitly cleared the pool (issue 1171).  Healing would
+    # undo the clear and re-default to mqtt_ha.
+    schema = options.get(CONF_SCHEMA)
+    if isinstance(schema, dict):
+        root_owner = schema.get(SZ_OWNER)
+        has_accepted_hgi = any(
+            dev_id.startswith(HGI_PREFIX)
+            and isinstance(entry, dict)
+            and entry.get("_class", "").upper() == "HGI"
+            and entry.get(SZ_TR_OWNER) == root_owner
+            and not entry.get("_removed_from_pool")
+            and dev_id != DEFAULT_HGI_ID
+            for dev_id, entry in schema.items()
+        )
+        if not has_accepted_hgi:
+            return None
 
     new_options = {**options}
     new_options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "mqtt_ha"}

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1983,6 +1983,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         for dev_id, entry in schema.items():
             if (
                 dev_id.startswith(HGI_PREFIX)
+                and dev_id != DEFAULT_HGI_ID
                 and isinstance(entry, dict)
                 and entry.get("_class", "").upper() == "HGI"
                 and entry.get(SZ_TR_OWNER) == root_owner

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2045,6 +2045,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             )
                     except (ValueError, AttributeError):
                         pass
+                elif display_url == "mqtt_ha" or self.options.get(
+                    CONF_MQTT_USE_HA
+                ):
+                    # HA MQTT integration path — the topic prefix is
+                    # stored separately in CONF_MQTT_TOPIC, not in the
+                    # port URL.  Show it so the user can see which
+                    # topic the wildcard subscriptions use.
+                    topic = self.options.get(
+                        CONF_MQTT_TOPIC, DEFAULT_MQTT_TOPIC
+                    )
+                    display_url = f"mqtt_ha, topic: {topic}"
                 return (
                     f"HGI: {dev_id} (primary, {_mask_mqtt_url(display_url)})"
                 )

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1757,7 +1757,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         if user_input is not None:
             # Save the current additional ports (removals applied)
-            additional: list[str] = user_input.get(CONF_ADDITIONAL_PORTS, [])
+            # Filter out the __none__ sentinel (shown when no ports exist)
+            additional: list[str] = [
+                p for p in user_input.get(CONF_ADDITIONAL_PORTS, [])
+                if p != "__none__"
+            ]
             # Schema pool members that the user wants to keep (checked)
             keep_schema_members: list[str] = user_input.get(
                 "schema_pool_members", []

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1811,7 +1811,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
                 # Auto-promote: if the primary was removed and another
                 # accepted HGI still exists, promote it to primary.
-                # If no other HGI exists, block removal with an error.
+                # If no other HGI exists, clear the primary port config
+                # so the user can start fresh via Connection / Port.
                 if primary_removed:
                     # Find remaining accepted HGIs (still have _owner)
                     remaining_hgis = []
@@ -1826,19 +1827,13 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             ):
                                 remaining_hgis.append(dev_id)
                     if not remaining_hgis:
-                        # No other HGI to promote — block removal
-                        errors["base"] = "pool_cannot_remove_last_hgi"
-                        # Re-add _owner to the primary
-                        if primary_hgi_id_input and isinstance(
-                            schema_dict, dict
-                        ):
-                            entry = schema_dict.get(primary_hgi_id_input, {})
-                            if isinstance(entry, dict):
-                                entry[SZ_TR_OWNER] = schema_dict.get(
-                                    SZ_OWNER, "me"
-                                )
-                                schema_dict[primary_hgi_id_input] = entry
-                            self.options[CONF_SCHEMA] = schema_dict
+                        # No other HGI to promote — clear the primary
+                        # port so the user starts fresh.  The coordinator
+                        # will have no transport on reload; the user
+                        # configures a new one via Connection / Port.
+                        self.options[SZ_SERIAL_PORT] = {}
+                        self.options.pop(CONF_MQTT_HGI_ID, None)
+                        self.options.pop(CONF_MQTT_USE_HA, None)
                     else:
                         # Promote the first remaining HGI
                         new_primary = sorted(remaining_hgis)[0]
@@ -1878,16 +1873,18 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                 wait_timeout
                             )
                         return await self.async_step_manage_pool_mqtt()
-                else:
-                    # No new port (or invalid selection) — just save
-                    # removals.  Serial and Zigbee are not listed in
-                    # the dropdown at all (Phase 2/3 gating).
+                elif not errors:
+                    # No new port and no errors — just save removals.
+                    # Serial and Zigbee are not listed in the dropdown
+                    # at all (Phase 2/3 gating).
                     self.options[CONF_ADDITIONAL_PORTS] = additional
                     if wait_timeout is not None:
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
                             wait_timeout
                         )
                     return self._async_save()
+                # If errors is non-empty, fall through to show the form
+                # again with the error message.
 
         # Build the current state for display
         primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1702,22 +1702,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
         """
-        self.get_options()
-        # The HGI pool pane is only available for MQTT transports.
-        # Serial/USB pool support is Phase 2 (issue 1119).
-        port_name = self.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME, "")
-        is_mqtt = isinstance(port_name, str) and (
-            port_name.startswith("mqtt://")
-            or port_name == "mqtt_ha"
-            or self.options.get(CONF_MQTT_USE_HA)
-        )
-        menu_options = [
-            "choose_serial_port",
-        ]
-        if is_mqtt:
-            menu_options.append("manage_pool")
-        menu_options.extend(
-            [
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=[
+                "choose_serial_port",
+                "manage_pool",
                 "config",
                 "schema",
                 "advanced_features",
@@ -1725,11 +1714,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 "review_discovered",
                 "review_device_health",
                 "clear_cache",
-            ]
-        )
-        return self.async_show_menu(
-            step_id="init",
-            menu_options=menu_options,
+            ],
         )
 
     def _async_save(self) -> ConfigFlowResult:
@@ -1755,12 +1740,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
     async def async_step_manage_pool(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Manage the gateway pool (multi-HGI, issue 1119).
+        """Manage the HGI pool (issue 1119, 1171).
 
-        Shows the current primary port and any additional pool members.
-        The user can remove additional ports (uncheck them) or add a
-        new one (select a port type from the dropdown).  The primary
-        port is managed via ``choose_serial_port``.
+        Shows all pool members including the primary.  Any member can
+        be removed — removing the primary auto-promotes another
+        accepted HGI.  If no other HGI exists, removal is blocked.
 
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
@@ -1788,9 +1772,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             if primary and primary in additional:
                 errors["base"] = "pool_duplicate_primary"
             else:
-                # Determine the primary HGI ID — it cannot be removed
-                # from the pool via this form (it's managed via
-                # choose_serial_port).
+                # Determine the primary HGI ID
                 primary_hgi_id_input: str | None = None
                 if isinstance(primary, str) and primary.startswith("mqtt://"):
                     primary_hgi_id_input = self.options.get(CONF_MQTT_HGI_ID)
@@ -1804,8 +1786,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # Process schema pool member removals — unchecking a
                 # schema pool member removes _owner from its schema entry,
                 # demoting it back to a discovery candidate (issue 1119).
-                # The primary HGI is always kept (cannot be demoted here).
+                # The primary HGI can also be removed — if it's removed
+                # and another accepted HGI exists, auto-promote that one.
                 schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                primary_removed = False
                 if isinstance(schema_dict, dict):
                     root_owner = schema_dict.get(SZ_OWNER, "me")
                     for dev_id, entry in list(schema_dict.items()):
@@ -1815,13 +1799,66 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             and entry.get("_class", "").upper() == "HGI"
                             and entry.get(SZ_TR_OWNER) == root_owner
                         ):
-                            if dev_id == primary_hgi_id_input:
-                                continue  # primary — always kept
                             if dev_id not in keep_schema_members:
+                                if dev_id == primary_hgi_id_input:
+                                    # Primary is being removed — flag
+                                    # for auto-promotion below
+                                    primary_removed = True
                                 # Demote: remove _owner
                                 entry.pop(SZ_TR_OWNER, None)
                                 schema_dict[dev_id] = entry
                     self.options[CONF_SCHEMA] = schema_dict
+
+                # Auto-promote: if the primary was removed and another
+                # accepted HGI still exists, promote it to primary.
+                # If no other HGI exists, block removal with an error.
+                if primary_removed:
+                    # Find remaining accepted HGIs (still have _owner)
+                    remaining_hgis = []
+                    if isinstance(schema_dict, dict):
+                        for dev_id, entry in schema_dict.items():
+                            if (
+                                dev_id.startswith(HGI_PREFIX)
+                                and isinstance(entry, dict)
+                                and entry.get("_class", "").upper() == "HGI"
+                                and entry.get(SZ_TR_OWNER) == root_owner
+                                and not entry.get("_disabled")
+                            ):
+                                remaining_hgis.append(dev_id)
+                    if not remaining_hgis:
+                        # No other HGI to promote — block removal
+                        errors["base"] = "pool_cannot_remove_last_hgi"
+                        # Re-add _owner to the primary
+                        if primary_hgi_id_input and isinstance(
+                            schema_dict, dict
+                        ):
+                            entry = schema_dict.get(primary_hgi_id_input, {})
+                            if isinstance(entry, dict):
+                                entry[SZ_TR_OWNER] = schema_dict.get(
+                                    SZ_OWNER, "me"
+                                )
+                                schema_dict[primary_hgi_id_input] = entry
+                            self.options[CONF_SCHEMA] = schema_dict
+                    else:
+                        # Promote the first remaining HGI
+                        new_primary = sorted(remaining_hgis)[0]
+                        # Update CONF_MQTT_HGI_ID
+                        self.options[CONF_MQTT_HGI_ID] = new_primary
+                        # Update the primary port URL
+                        if isinstance(primary, str) and primary.startswith(
+                            "mqtt://"
+                        ):
+                            from .coordinator import RamsesCoordinator
+
+                            new_url = (
+                                RamsesCoordinator._build_explicit_mqtt_url(
+                                    primary, new_primary
+                                )
+                            )
+                            if new_url:
+                                self.options[SZ_SERIAL_PORT][
+                                    SZ_PORT_NAME
+                                ] = new_url
 
                 if add_choice == CONF_MQTT_PATH:
                     # Phase 1: MQTT pool children require an MQTT
@@ -1991,13 +2028,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             )
 
         # Schema pool members selector (multi-select for removal).
-        # The primary HGI is excluded from the removable list — it's
-        # managed via choose_serial_port and cannot be demoted here.
-        # It's shown in the description placeholders instead.
-        removable_pool_hgis = sorted(
-            set(schema_pool_members)
-            - ({primary_hgi_id} if primary_hgi_id else set())
-        )
+        # All accepted HGIs are listed, including the primary.
+        # Removing the primary auto-promotes another HGI (or blocks
+        # if it's the last one).
+        removable_pool_hgis = sorted(set(schema_pool_members))
         if removable_pool_hgis:
             schema_pool_selector = selector.SelectSelector(
                 selector.SelectSelectorConfig(

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1702,11 +1702,22 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
         """
-        return self.async_show_menu(
-            step_id="init",
-            menu_options=[
-                "choose_serial_port",
-                "manage_pool",
+        self.get_options()
+        # The HGI pool pane is only available for MQTT transports.
+        # Serial/USB pool support is Phase 2 (issue 1119).
+        port_name = self.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME, "")
+        is_mqtt = isinstance(port_name, str) and (
+            port_name.startswith("mqtt://")
+            or port_name == "mqtt_ha"
+            or self.options.get(CONF_MQTT_USE_HA)
+        )
+        menu_options = [
+            "choose_serial_port",
+        ]
+        if is_mqtt:
+            menu_options.append("manage_pool")
+        menu_options.extend(
+            [
                 "config",
                 "schema",
                 "advanced_features",
@@ -1714,7 +1725,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 "review_discovered",
                 "review_device_health",
                 "clear_cache",
-            ],
+            ]
+        )
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=menu_options,
         )
 
     def _async_save(self) -> ConfigFlowResult:
@@ -1826,16 +1841,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                 wait_timeout
                             )
                         return await self.async_step_manage_pool_mqtt()
-                elif add_choice == CONF_ZIGBEE_DEVICE:
-                    # Zigbee pool members are not yet supported (Phase 3,
-                    # PR 6).  Block the sub-step and show an error.
-                    errors["base"] = "pool_zigbee_not_supported"
-                elif add_choice not in (NO_ADD, ADD_NEW):
-                    # Serial/USB pool members are not yet supported
-                    # (Phase 2, PR 3).  Block and show an error.
-                    errors["base"] = "pool_serial_not_supported"
                 else:
-                    # No new port — just save removals
+                    # No new port (or invalid selection) — just save
+                    # removals.  Serial and Zigbee are not listed in
+                    # the dropdown at all (Phase 2/3 gating).
                     self.options[CONF_ADDITIONAL_PORTS] = additional
                     if wait_timeout is not None:
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
@@ -1944,33 +1953,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         # Build options for the "add new port" dropdown.
         # Phase 1: only MQTT HGIs are supported as pool children.
-        # Serial and Zigbee are gated with "(not yet supported)" markers
-        # until Phase 2 (PR 3) and Phase 3 (PR 6) respectively.
+        # Serial and Zigbee are not listed at all — the pool is
+        # MQTT-only until Phase 2 (serial) and Phase 3 (Zigbee).
         # TODO: re-enable serial when Phase 2 (PR 3) lands.
         # TODO: re-enable zigbee when Phase 3 (PR 6) lands.
-        ports = await async_get_usb_ports(self.hass)
         add_options: list[selector.SelectOptionDict] = [
             selector.SelectOptionDict(value=NO_ADD, label="(nothing to add)"),
         ]
-        # Serial ports — gated (not yet supported for pool membership).
-        for k, v in ports.items():
-            if k not in current_additional:
-                add_options.append(
-                    selector.SelectOptionDict(
-                        value=k, label=f"{v} (not yet supported)"
-                    )
-                )
         # MQTT — supported in Phase 1.
         add_options.append(
             selector.SelectOptionDict(
                 value=CONF_MQTT_PATH, label="MQTT Broker..."
-            )
-        )
-        # Zigbee — gated (not yet supported for pool membership).
-        add_options.append(
-            selector.SelectOptionDict(
-                value=CONF_ZIGBEE_DEVICE,
-                label="Zigbee device (not yet supported)",
             )
         )
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1795,7 +1795,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # The primary HGI can also be removed — if it's removed
                 # and another accepted HGI exists, auto-promote that one.
                 schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
-                primary_removed = False
+                any_hgi_removed = False
                 if isinstance(schema_dict, dict):
                     root_owner = schema_dict.get(SZ_OWNER, "me")
                     for dev_id, entry in list(schema_dict.items()):
@@ -1806,34 +1806,39 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             and entry.get(SZ_TR_OWNER) == root_owner
                         ):
                             if dev_id not in keep_schema_members:
-                                if dev_id == primary_hgi_id_input:
-                                    # Primary is being removed — flag
-                                    # for auto-promotion below
-                                    primary_removed = True
+                                any_hgi_removed = True
                                 # Demote: remove _owner
                                 entry.pop(SZ_TR_OWNER, None)
                                 schema_dict[dev_id] = entry
                     self.options[CONF_SCHEMA] = schema_dict
 
-                # Auto-promote: if the primary was removed and another
-                # accepted HGI still exists, promote it to primary.
-                # If no other HGI exists, clear the primary port config
-                # so the user can start fresh via Connection / Port.
-                if primary_removed:
-                    # Find remaining accepted HGIs (still have _owner)
+                # After removal, check if any owned HGIs remain.
+                # If none remain and the transport is MQTT, either
+                # auto-promote (if the primary was removed but others
+                # survive) or require confirmation to clear all.
+                if any_hgi_removed and isinstance(schema_dict, dict):
                     remaining_hgis = []
-                    if isinstance(schema_dict, dict):
-                        for dev_id, entry in schema_dict.items():
-                            if (
-                                dev_id.startswith(HGI_PREFIX)
-                                and isinstance(entry, dict)
-                                and entry.get("_class", "").upper() == "HGI"
-                                and entry.get(SZ_TR_OWNER) == root_owner
-                                and not entry.get("_disabled")
-                            ):
-                                remaining_hgis.append(dev_id)
-                    if not remaining_hgis:
-                        # No other HGI to promote — require explicit
+                    for dev_id, entry in schema_dict.items():
+                        if (
+                            dev_id.startswith(HGI_PREFIX)
+                            and isinstance(entry, dict)
+                            and entry.get("_class", "").upper() == "HGI"
+                            and entry.get(SZ_TR_OWNER) == root_owner
+                            and not entry.get("_disabled")
+                        ):
+                            remaining_hgis.append(dev_id)
+
+                    is_mqtt_primary = (
+                        isinstance(primary, str)
+                        and (
+                            primary.startswith("mqtt://")
+                            or primary == "mqtt_ha"
+                            or self.options.get(CONF_MQTT_USE_HA)
+                        )
+                    )
+
+                    if not remaining_hgis and is_mqtt_primary:
+                        # No owned HGI remains — require explicit
                         # confirmation before clearing the primary port.
                         if not user_input.get("confirm_clear_last"):
                             errors["base"] = "pool_confirm_clear_last"
@@ -1844,26 +1849,29 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             self.options[SZ_SERIAL_PORT] = {}
                             self.options.pop(CONF_MQTT_HGI_ID, None)
                             self.options.pop(CONF_MQTT_USE_HA, None)
-                    else:
-                        # Promote the first remaining HGI
-                        new_primary = sorted(remaining_hgis)[0]
-                        # Update CONF_MQTT_HGI_ID
-                        self.options[CONF_MQTT_HGI_ID] = new_primary
-                        # Update the primary port URL
-                        if isinstance(primary, str) and primary.startswith(
-                            "mqtt://"
-                        ):
-                            from .coordinator import RamsesCoordinator
+                    elif remaining_hgis and is_mqtt_primary:
+                        # Some HGIs remain — ensure CONF_MQTT_HGI_ID
+                        # points to one of them (promote if the old
+                        # primary was removed or was unknown).
+                        current_hgi_id = self.options.get(CONF_MQTT_HGI_ID)
+                        if current_hgi_id not in remaining_hgis:
+                            new_primary = sorted(remaining_hgis)[0]
+                            self.options[CONF_MQTT_HGI_ID] = new_primary
+                            # Update the primary port URL for mqtt://
+                            if isinstance(primary, str) and primary.startswith(
+                                "mqtt://"
+                            ):
+                                from .coordinator import RamsesCoordinator
 
-                            new_url = (
-                                RamsesCoordinator._build_explicit_mqtt_url(
-                                    primary, new_primary
+                                new_url = (
+                                    RamsesCoordinator._build_explicit_mqtt_url(
+                                        primary, new_primary
+                                    )
                                 )
-                            )
-                            if new_url:
-                                self.options[SZ_SERIAL_PORT][
-                                    SZ_PORT_NAME
-                                ] = new_url
+                                if new_url:
+                                    self.options[SZ_SERIAL_PORT][
+                                        SZ_PORT_NAME
+                                    ] = new_url
 
                 if add_choice == CONF_MQTT_PATH:
                     # Phase 1: MQTT pool children require an MQTT

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1759,7 +1759,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             # Save the current additional ports (removals applied)
             # Filter out the __none__ sentinel (shown when no ports exist)
             additional: list[str] = [
-                p for p in user_input.get(CONF_ADDITIONAL_PORTS, [])
+                p
+                for p in user_input.get(CONF_ADDITIONAL_PORTS, [])
                 if p != "__none__"
             ]
             # Schema pool members that the user wants to keep (checked)

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1795,29 +1795,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # The primary HGI can also be removed — if it's removed
                 # and another accepted HGI exists, auto-promote that one.
                 schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
-                any_hgi_removed = False
                 if isinstance(schema_dict, dict):
                     root_owner = schema_dict.get(SZ_OWNER, "me")
-                    for dev_id, entry in list(schema_dict.items()):
-                        if (
-                            dev_id.startswith(HGI_PREFIX)
-                            and isinstance(entry, dict)
-                            and entry.get("_class", "").upper() == "HGI"
-                            and entry.get(SZ_TR_OWNER) == root_owner
-                        ):
-                            if dev_id not in keep_schema_members:
-                                any_hgi_removed = True
-                                # Demote: remove _owner
-                                entry.pop(SZ_TR_OWNER, None)
-                                schema_dict[dev_id] = entry
-                    self.options[CONF_SCHEMA] = schema_dict
-
-                # After removal, check if any owned HGIs remain.
-                # If none remain and the transport is MQTT, either
-                # auto-promote (if the primary was removed but others
-                # survive) or require confirmation to clear all.
-                if any_hgi_removed and isinstance(schema_dict, dict):
-                    remaining_hgis = []
+                    # First pass: figure out what would be removed and
+                    # what would remain — without modifying yet.
+                    to_demote: list[str] = []
+                    remaining_hgis: list[str] = []
                     for dev_id, entry in schema_dict.items():
                         if (
                             dev_id.startswith(HGI_PREFIX)
@@ -1826,7 +1809,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             and entry.get(SZ_TR_OWNER) == root_owner
                             and not entry.get("_disabled")
                         ):
-                            remaining_hgis.append(dev_id)
+                            if dev_id not in keep_schema_members:
+                                to_demote.append(dev_id)
+                            else:
+                                remaining_hgis.append(dev_id)
 
                     is_mqtt_primary = (
                         isinstance(primary, str)
@@ -1837,41 +1823,66 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         )
                     )
 
-                    if not remaining_hgis and is_mqtt_primary:
-                        # No owned HGI remains — require explicit
-                        # confirmation before clearing the primary port.
+                    # If all owned HGIs are being removed and the
+                    # transport is MQTT, require confirmation.
+                    # Don't demote yet — show the error first so the
+                    # user can retry without losing the members.
+                    if (
+                        to_demote
+                        and not remaining_hgis
+                        and is_mqtt_primary
+                    ):
                         if not user_input.get("confirm_clear_last"):
                             errors["base"] = "pool_confirm_clear_last"
+                            # Don't demote — fall through to form
                         else:
-                            # User confirmed — clear the primary port
-                            # so they can start fresh via Connection /
-                            # Port.
+                            # User confirmed — demote all and clear
+                            # the primary port.  Mark HGIs as
+                            # explicitly removed so the coordinator
+                            # doesn't auto-re-add them via discovery.
+                            for dev_id in to_demote:
+                                entry = schema_dict.get(dev_id, {})
+                                if isinstance(entry, dict):
+                                    entry.pop(SZ_TR_OWNER, None)
+                                    entry["_removed_from_pool"] = True
+                                    schema_dict[dev_id] = entry
+                            self.options[CONF_SCHEMA] = schema_dict
                             self.options[SZ_SERIAL_PORT] = {}
                             self.options.pop(CONF_MQTT_HGI_ID, None)
                             self.options.pop(CONF_MQTT_USE_HA, None)
-                    elif remaining_hgis and is_mqtt_primary:
-                        # Some HGIs remain — ensure CONF_MQTT_HGI_ID
-                        # points to one of them (promote if the old
-                        # primary was removed or was unknown).
-                        current_hgi_id = self.options.get(CONF_MQTT_HGI_ID)
-                        if current_hgi_id not in remaining_hgis:
-                            new_primary = sorted(remaining_hgis)[0]
-                            self.options[CONF_MQTT_HGI_ID] = new_primary
-                            # Update the primary port URL for mqtt://
-                            if isinstance(primary, str) and primary.startswith(
-                                "mqtt://"
-                            ):
-                                from .coordinator import RamsesCoordinator
+                    elif to_demote:
+                        # Normal removal (some HGIs remain) — demote
+                        # now and auto-promote if needed.
+                        for dev_id in to_demote:
+                            entry = schema_dict.get(dev_id, {})
+                            if isinstance(entry, dict):
+                                entry.pop(SZ_TR_OWNER, None)
+                                entry["_removed_from_pool"] = True
+                                schema_dict[dev_id] = entry
+                        self.options[CONF_SCHEMA] = schema_dict
 
-                                new_url = (
-                                    RamsesCoordinator._build_explicit_mqtt_url(
-                                        primary, new_primary
+                        # Auto-promote if the old primary was removed
+                        if remaining_hgis and is_mqtt_primary:
+                            current_hgi_id = self.options.get(
+                                CONF_MQTT_HGI_ID
+                            )
+                            if current_hgi_id not in remaining_hgis:
+                                new_primary = sorted(remaining_hgis)[0]
+                                self.options[CONF_MQTT_HGI_ID] = new_primary
+                                if isinstance(primary, str) and primary.startswith(
+                                    "mqtt://"
+                                ):
+                                    from .coordinator import RamsesCoordinator
+
+                                    new_url = (
+                                        RamsesCoordinator._build_explicit_mqtt_url(
+                                            primary, new_primary
+                                        )
                                     )
-                                )
-                                if new_url:
-                                    self.options[SZ_SERIAL_PORT][
-                                        SZ_PORT_NAME
-                                    ] = new_url
+                                    if new_url:
+                                        self.options[SZ_SERIAL_PORT][
+                                            SZ_PORT_NAME
+                                        ] = new_url
 
                 if add_choice == CONF_MQTT_PATH:
                     # Phase 1: MQTT pool children require an MQTT
@@ -2210,6 +2221,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     schema_dict[hgi_id] = {}
                 schema_dict[hgi_id]["_class"] = "HGI"
                 schema_dict[hgi_id][SZ_TR_OWNER] = root_owner
+                # Clear the _removed_from_pool trait if it was set
+                # (user is explicitly re-adding this HGI)
+                schema_dict[hgi_id].pop("_removed_from_pool", None)
                 self.options[CONF_SCHEMA] = schema_dict
                 _LOGGER.info(
                     "Added MQTT pool HGI %s (schema entry with _owner=%s)",

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1919,28 +1919,35 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         return await self.async_step_manage_pool_mqtt_url()
                 elif add_choice and add_choice.startswith("__readd__"):
                     # Re-add a previously removed HGI
-                    readd_id = add_choice[len("__readd__") :]
-                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
-                    if readd_id in schema_dict and isinstance(
-                        schema_dict[readd_id], dict
-                    ):
-                        root_owner = schema_dict.get(SZ_OWNER, "me")
-                        schema_dict[readd_id][SZ_TR_OWNER] = root_owner
-                        schema_dict[readd_id].pop("_removed_from_pool", None)
-                        self.options[CONF_SCHEMA] = schema_dict
-                    # If no primary is set, this HGI becomes the primary
-                    if not primary and readd_id.startswith(HGI_PREFIX):
-                        self.options[CONF_MQTT_HGI_ID] = readd_id
-                        self.options.setdefault(CONF_MQTT_USE_HA, True)
-                        self.options[SZ_SERIAL_PORT] = {
-                            SZ_PORT_NAME: "mqtt_ha"
-                        }
-                    self.options[CONF_ADDITIONAL_PORTS] = additional
-                    if wait_timeout is not None:
-                        self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
-                            wait_timeout
-                        )
-                    return self._async_save()
+                    # Still requires MQTT primary (or no primary) —
+                    # blocked for serial primary (issue 1171).
+                    if not is_mqtt_or_empty:
+                        errors["base"] = "pool_mqtt_requires_mqtt_primary"
+                    else:
+                        readd_id = add_choice[len("__readd__") :]
+                        schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                        if readd_id in schema_dict and isinstance(
+                            schema_dict[readd_id], dict
+                        ):
+                            root_owner = schema_dict.get(SZ_OWNER, "me")
+                            schema_dict[readd_id][SZ_TR_OWNER] = root_owner
+                            schema_dict[readd_id].pop(
+                                "_removed_from_pool", None
+                            )
+                            self.options[CONF_SCHEMA] = schema_dict
+                        # If no primary is set, this HGI becomes the primary
+                        if not primary and readd_id.startswith(HGI_PREFIX):
+                            self.options[CONF_MQTT_HGI_ID] = readd_id
+                            self.options.setdefault(CONF_MQTT_USE_HA, True)
+                            self.options[SZ_SERIAL_PORT] = {
+                                SZ_PORT_NAME: "mqtt_ha"
+                            }
+                        self.options[CONF_ADDITIONAL_PORTS] = additional
+                        if wait_timeout is not None:
+                            self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                                wait_timeout
+                            )
+                        return self._async_save()
                 elif not errors:
                     # No new port and no errors — just save removals.
                     # Serial and Zigbee are not listed in the dropdown
@@ -1956,7 +1963,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         # Build the current state for display
         primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(
-            SZ_PORT_NAME, "(not set)"
+            SZ_PORT_NAME, ""
         )
         current_additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
 
@@ -2085,8 +2092,18 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 value=CONF_MQTT_FULL_URL, label="MQTT Broker (full URL)..."
             ),
         ]
-        # List removed HGIs so the user can re-add them directly
-        if isinstance(schema, dict):
+        # List removed HGIs so the user can re-add them directly.
+        # Only show re-add options when the primary is MQTT or empty —
+        # re-adding an MQTT HGI with a serial primary is blocked (issue 1171).
+        is_primary_mqtt_or_empty = not primary_port or (
+            isinstance(primary_port, str)
+            and (
+                primary_port.startswith("mqtt://")
+                or primary_port == "mqtt_ha"
+                or self.options.get(CONF_MQTT_USE_HA)
+            )
+        )
+        if is_primary_mqtt_or_empty and isinstance(schema, dict):
             for dev_id, entry in schema.items():
                 if (
                     dev_id.startswith(HGI_PREFIX)
@@ -2204,7 +2221,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         # Mask credentials and ensure topic is shown in the primary
         # port for display
-        display_primary_port = str(primary_port)
+        display_primary_port = (
+            str(primary_port) if primary_port else "(not set)"
+        )
         if isinstance(primary_port, str) and primary_port.startswith(
             "mqtt://"
         ):

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1933,25 +1933,44 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Build a label for each pool member showing its broker info.
         # For the primary HGI: the primary_port URL.
         # For additional HGIs: the explicit per-HGI MQTT URL.
+        def _mask_mqtt_url(url: str) -> str:
+            """Mask credentials in an MQTT URL for display."""
+            from urllib.parse import urlparse, urlunparse
+
+            try:
+                parsed = urlparse(url)
+                if parsed.username:
+                    netloc = f"***:***@{parsed.hostname}"
+                    if parsed.port:
+                        netloc += f":{parsed.port}"
+                    return urlunparse(parsed._replace(netloc=netloc))
+            except (ValueError, AttributeError):
+                pass
+            return url
+
         def _pool_member_label(dev_id: str) -> str:
             """Build a human-readable label with broker info."""
             if dev_id == primary_hgi_id:
-                # Mask credentials in the primary URL for display
-                from urllib.parse import urlparse, urlunparse
-
+                # For the primary, ensure the topic is shown even if
+                # the URL has no path (e.g. mqtt://broker:1883).
                 display_url = primary_port
-                try:
-                    parsed = urlparse(primary_port)
-                    if parsed.username:
-                        netloc = f"***:***@{parsed.hostname}"
-                        if parsed.port:
-                            netloc += f":{parsed.port}"
-                        display_url = urlunparse(
-                            parsed._replace(netloc=netloc)
-                        )
-                except (ValueError, AttributeError):
-                    pass
-                return f"HGI: {dev_id} (primary, {display_url})"
+                if isinstance(display_url, str) and display_url.startswith(
+                    "mqtt://"
+                ):
+                    from urllib.parse import urlparse, urlunparse
+
+                    try:
+                        parsed = urlparse(display_url)
+                        path = (parsed.path or "").rstrip("/")
+                        if not path:
+                            # No topic in URL — show the default
+                            path = "/RAMSES/GATEWAY"
+                            display_url = urlunparse(
+                                parsed._replace(path=path)
+                            )
+                    except (ValueError, AttributeError):
+                        pass
+                return f"HGI: {dev_id} (primary, {_mask_mqtt_url(display_url)})"
             # Build the explicit MQTT URL for this HGI
             if isinstance(primary_port, str) and primary_port.startswith(
                 "mqtt://"
@@ -1962,16 +1981,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     primary_port, dev_id
                 )
                 if explicit:
-                    # Mask credentials in the URL for display
-                    from urllib.parse import urlparse, urlunparse
-
-                    parsed = urlparse(explicit)
-                    if parsed.username:
-                        netloc = f"***:***@{parsed.hostname}"
-                        if parsed.port:
-                            netloc += f":{parsed.port}"
-                        explicit = urlunparse(parsed._replace(netloc=netloc))
-                    return f"HGI: {dev_id} ({explicit})"
+                    return f"HGI: {dev_id} ({_mask_mqtt_url(explicit)})"
             return f"HGI: {dev_id} (schema, _owner: {root_owner})"
 
         # Build options for the "current ports" multi-select (for removal)
@@ -2099,7 +2109,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             ),
         }
 
-        # Mask credentials in the primary port for display
+        # Mask credentials and ensure topic is shown in the primary
+        # port for display
         display_primary_port = str(primary_port)
         if isinstance(primary_port, str) and primary_port.startswith(
             "mqtt://"
@@ -2108,13 +2119,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
             try:
                 parsed = urlparse(primary_port)
+                path = (parsed.path or "").rstrip("/")
+                if not path:
+                    # No topic in URL — show the default
+                    parsed = parsed._replace(path="/RAMSES/GATEWAY")
                 if parsed.username:
                     netloc = f"***:***@{parsed.hostname}"
                     if parsed.port:
                         netloc += f":{parsed.port}"
-                    display_primary_port = urlunparse(
-                        parsed._replace(netloc=netloc)
-                    )
+                    parsed = parsed._replace(netloc=netloc)
+                display_primary_port = urlunparse(parsed)
             except (ValueError, AttributeError):
                 pass
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1884,32 +1884,72 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                             SZ_PORT_NAME
                                         ] = new_url
 
-                if add_choice == CONF_MQTT_PATH:
-                    # Phase 1: MQTT pool children require an MQTT
-                    # primary transport (HA MQTT integration).  A
-                    # serial primary + MQTT additional would require
-                    # paho inside HA, which is not allowed
-                    # (issue 1119).  But if there is no primary at
-                    # all (e.g. after clearing all HGIs), allow adding
-                    # an MQTT HGI — it becomes the new primary.
-                    is_mqtt_or_empty = (
-                        not primary
-                        or (isinstance(primary, str) and (
-                            primary.startswith("mqtt://")
-                            or primary == "mqtt_ha"
-                            or self.options.get(CONF_MQTT_USE_HA)
-                        ))
-                    )
+                # Handle add choices
+                CONF_MQTT_HA_ID = "__mqtt_ha_id__"
+                CONF_MQTT_FULL_URL = "__mqtt_full_url__"
+
+                # Phase 1: MQTT pool children require an MQTT
+                # primary transport (HA MQTT integration).  A
+                # serial primary + MQTT additional would require
+                # paho inside HA, which is not allowed
+                # (issue 1119).  But if there is no primary at
+                # all (e.g. after clearing all HGIs), allow adding
+                # an MQTT HGI — it becomes the new primary.
+                is_mqtt_or_empty = (
+                    not primary
+                    or (isinstance(primary, str) and (
+                        primary.startswith("mqtt://")
+                        or primary == "mqtt_ha"
+                        or self.options.get(CONF_MQTT_USE_HA)
+                    ))
+                )
+
+                if add_choice == CONF_MQTT_HA_ID:
+                    # HA MQTT device ID — just enter 18:NNNNNN
                     if not is_mqtt_or_empty:
                         errors["base"] = "pool_mqtt_requires_mqtt_primary"
                     else:
-                        # Save current state and go to MQTT sub-step
                         self.options[CONF_ADDITIONAL_PORTS] = additional
                         if wait_timeout is not None:
                             self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
                                 wait_timeout
                             )
                         return await self.async_step_manage_pool_mqtt()
+                elif add_choice == CONF_MQTT_FULL_URL:
+                    # Full mqtt:// URL — parse HGI ID from it
+                    if not is_mqtt_or_empty:
+                        errors["base"] = "pool_mqtt_requires_mqtt_primary"
+                    else:
+                        self.options[CONF_ADDITIONAL_PORTS] = additional
+                        if wait_timeout is not None:
+                            self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                                wait_timeout
+                            )
+                        return await self.async_step_manage_pool_mqtt_url()
+                elif add_choice and add_choice.startswith("__readd__"):
+                    # Re-add a previously removed HGI
+                    readd_id = add_choice[len("__readd__"):]
+                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                    if readd_id in schema_dict and isinstance(
+                        schema_dict[readd_id], dict
+                    ):
+                        root_owner = schema_dict.get(SZ_OWNER, "me")
+                        schema_dict[readd_id][SZ_TR_OWNER] = root_owner
+                        schema_dict[readd_id].pop("_removed_from_pool", None)
+                        self.options[CONF_SCHEMA] = schema_dict
+                    # If no primary is set, this HGI becomes the primary
+                    if not primary and readd_id.startswith(HGI_PREFIX):
+                        self.options[CONF_MQTT_HGI_ID] = readd_id
+                        self.options.setdefault(CONF_MQTT_USE_HA, True)
+                        self.options[SZ_SERIAL_PORT] = {
+                            SZ_PORT_NAME: "mqtt_ha"
+                        }
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    if wait_timeout is not None:
+                        self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                            wait_timeout
+                        )
+                    return self._async_save()
                 elif not errors:
                     # No new port and no errors — just save removals.
                     # Serial and Zigbee are not listed in the dropdown
@@ -2040,15 +2080,32 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # MQTT-only until Phase 2 (serial) and Phase 3 (Zigbee).
         # TODO: re-enable serial when Phase 2 (PR 3) lands.
         # TODO: re-enable zigbee when Phase 3 (PR 6) lands.
+        CONF_MQTT_HA_ID = "__mqtt_ha_id__"
+        CONF_MQTT_FULL_URL = "__mqtt_full_url__"
         add_options: list[selector.SelectOptionDict] = [
             selector.SelectOptionDict(value=NO_ADD, label="(nothing to add)"),
-        ]
-        # MQTT — supported in Phase 1.
-        add_options.append(
             selector.SelectOptionDict(
-                value=CONF_MQTT_PATH, label="MQTT Broker..."
-            )
-        )
+                value=CONF_MQTT_HA_ID, label="HA MQTT device ID..."
+            ),
+            selector.SelectOptionDict(
+                value=CONF_MQTT_FULL_URL, label="MQTT Broker (full URL)..."
+            ),
+        ]
+        # List removed HGIs so the user can re-add them directly
+        if isinstance(schema, dict):
+            for dev_id, entry in schema.items():
+                if (
+                    dev_id.startswith(HGI_PREFIX)
+                    and isinstance(entry, dict)
+                    and entry.get("_class", "").upper() == "HGI"
+                    and entry.get("_removed_from_pool")
+                ):
+                    add_options.append(
+                        selector.SelectOptionDict(
+                            value=f"__readd__{dev_id}",
+                            label=f"Re-add HGI: {dev_id}",
+                        )
+                    )
 
         # Build the data schema — if there are current ports, show them
         # in a multi-select for removal; always show the "add new" dropdown
@@ -2253,6 +2310,73 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="manage_pool_mqtt",
+            data_schema=vol_schema(data_schema),
+            errors=errors,
+            description_placeholders={},
+            last_step=False,
+        )
+
+    async def async_step_manage_pool_mqtt_url(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Add an MQTT HGI via a full mqtt:// URL.
+
+        Parses the HGI ID from the URL path and creates a schema entry.
+        The URL is also stored in CONF_ADDITIONAL_PORTS so the pool
+        bridge can create a child transport for it.
+
+        :param user_input: Dict containing user-provided input data.
+        :return: The generated config flow result.
+        """
+        self.get_options()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            url = (user_input.get("mqtt_url") or "").strip()
+            if not url:
+                errors["base"] = "mqtt_url_required"
+            elif not url.startswith("mqtt://"):
+                errors["base"] = "mqtt_url_invalid"
+            else:
+                # Extract HGI ID from the URL path
+                import re as _re
+
+                m = _re.search(r"(18:[0-9]{6})(?:/|$)", url)
+                if not m:
+                    errors["base"] = "mqtt_url_no_hgi_id"
+                else:
+                    hgi_id = m.group(1)
+                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                    root_owner = schema_dict.get(SZ_OWNER, "me")
+                    if hgi_id not in schema_dict or not isinstance(
+                        schema_dict.get(hgi_id), dict
+                    ):
+                        schema_dict[hgi_id] = {}
+                    schema_dict[hgi_id]["_class"] = "HGI"
+                    schema_dict[hgi_id][SZ_TR_OWNER] = root_owner
+                    schema_dict[hgi_id].pop("_removed_from_pool", None)
+                    self.options[CONF_SCHEMA] = schema_dict
+                    # Add the URL to additional ports
+                    additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
+                    if url not in additional:
+                        additional.append(url)
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    _LOGGER.info(
+                        "Added MQTT pool HGI %s via full URL",
+                        hgi_id,
+                    )
+                    return self._async_save()
+
+        data_schema = {
+            prob.Required("mqtt_url", default=""): selector.TextSelector(
+                selector.TextSelectorConfig(
+                    type=selector.TextSelectorType.TEXT,
+                )
+            ),
+        }
+
+        return self.async_show_form(
+            step_id="manage_pool_mqtt_url",
             data_schema=vol_schema(data_schema),
             errors=errors,
             description_placeholders={},

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1998,15 +1998,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             )
 
         # Schema pool members selector (multi-select for removal).
-        # Include the primary HGI in the list (it's also a pool member)
-        # but mark it as "primary" so the user knows which one is the
-        # primary gateway.  The primary cannot be removed here — it's
-        # managed via choose_serial_port.
-        all_pool_hgis = sorted(
+        # The primary HGI is excluded from the removable list — it's
+        # managed via choose_serial_port and cannot be demoted here.
+        # It's shown in the description placeholders instead.
+        removable_pool_hgis = sorted(
             set(schema_pool_members)
-            | ({primary_hgi_id} if primary_hgi_id else set())
+            - ({primary_hgi_id} if primary_hgi_id else set())
         )
-        if all_pool_hgis:
+        if removable_pool_hgis:
             schema_pool_selector = selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[
@@ -2014,7 +2013,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             value=dev_id,
                             label=_pool_member_label(dev_id),
                         )
-                        for dev_id in all_pool_hgis
+                        for dev_id in removable_pool_hgis
                     ],
                     mode=selector.SelectSelectorMode.LIST,
                     multiple=True,
@@ -2037,7 +2036,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         data_schema: dict[str, Any] = {
             prob.Optional(
                 "schema_pool_members",
-                default=all_pool_hgis,
+                default=removable_pool_hgis,
             ): schema_pool_selector,
             prob.Optional(
                 CONF_ADDITIONAL_PORTS,
@@ -2073,12 +2072,31 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             ),
         }
 
+        # Mask credentials in the primary port for display
+        display_primary_port = str(primary_port)
+        if isinstance(primary_port, str) and primary_port.startswith(
+            "mqtt://"
+        ):
+            from urllib.parse import urlparse, urlunparse
+
+            try:
+                parsed = urlparse(primary_port)
+                if parsed.username:
+                    netloc = f"***:***@{parsed.hostname}"
+                    if parsed.port:
+                        netloc += f":{parsed.port}"
+                    display_primary_port = urlunparse(
+                        parsed._replace(netloc=netloc)
+                    )
+            except (ValueError, AttributeError):
+                pass
+
         return self.async_show_form(
             step_id="manage_pool",
             data_schema=vol_schema(data_schema),
             errors=errors,
             description_placeholders={
-                "primary_port": str(primary_port),
+                "primary_port": display_primary_port,
                 "current_count": str(len(current_additional)),
                 "schema_pool_members": (
                     ", ".join(schema_pool_members)

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1889,10 +1889,18 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     # primary transport (HA MQTT integration).  A
                     # serial primary + MQTT additional would require
                     # paho inside HA, which is not allowed
-                    # (issue 1119).
-                    if not isinstance(primary, str) or not primary.startswith(
-                        "mqtt://"
-                    ):
+                    # (issue 1119).  But if there is no primary at
+                    # all (e.g. after clearing all HGIs), allow adding
+                    # an MQTT HGI — it becomes the new primary.
+                    is_mqtt_or_empty = (
+                        not primary
+                        or (isinstance(primary, str) and (
+                            primary.startswith("mqtt://")
+                            or primary == "mqtt_ha"
+                            or self.options.get(CONF_MQTT_USE_HA)
+                        ))
+                    )
+                    if not is_mqtt_or_empty:
                         errors["base"] = "pool_mqtt_requires_mqtt_primary"
                     else:
                         # Save current state and go to MQTT sub-step

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1779,9 +1779,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     or self.options.get(CONF_MQTT_USE_HA)
                 ):
                     primary_hgi_id_input = self.options.get(CONF_MQTT_HGI_ID)
-                    if not primary_hgi_id_input and isinstance(
-                        primary, str
-                    ):
+                    if not primary_hgi_id_input and isinstance(primary, str):
                         import re as _re
 
                         m = _re.search(r"(18:[0-9]{6})", primary)
@@ -1813,24 +1811,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             else:
                                 remaining_hgis.append(dev_id)
 
-                    is_mqtt_primary = (
-                        isinstance(primary, str)
-                        and (
-                            primary.startswith("mqtt://")
-                            or primary == "mqtt_ha"
-                            or self.options.get(CONF_MQTT_USE_HA)
-                        )
+                    is_mqtt_primary = isinstance(primary, str) and (
+                        primary.startswith("mqtt://")
+                        or primary == "mqtt_ha"
+                        or self.options.get(CONF_MQTT_USE_HA)
                     )
 
                     # If all owned HGIs are being removed and the
                     # transport is MQTT, require confirmation.
                     # Don't demote yet — show the error first so the
                     # user can retry without losing the members.
-                    if (
-                        to_demote
-                        and not remaining_hgis
-                        and is_mqtt_primary
-                    ):
+                    if to_demote and not remaining_hgis and is_mqtt_primary:
                         if not user_input.get("confirm_clear_last"):
                             errors["base"] = "pool_confirm_clear_last"
                             # Don't demote — fall through to form
@@ -1862,21 +1853,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
                         # Auto-promote if the old primary was removed
                         if remaining_hgis and is_mqtt_primary:
-                            current_hgi_id = self.options.get(
-                                CONF_MQTT_HGI_ID
-                            )
+                            current_hgi_id = self.options.get(CONF_MQTT_HGI_ID)
                             if current_hgi_id not in remaining_hgis:
                                 new_primary = sorted(remaining_hgis)[0]
                                 self.options[CONF_MQTT_HGI_ID] = new_primary
-                                if isinstance(primary, str) and primary.startswith(
-                                    "mqtt://"
-                                ):
+                                if isinstance(
+                                    primary, str
+                                ) and primary.startswith("mqtt://"):
                                     from .coordinator import RamsesCoordinator
 
-                                    new_url = (
-                                        RamsesCoordinator._build_explicit_mqtt_url(
-                                            primary, new_primary
-                                        )
+                                    new_url = RamsesCoordinator._build_explicit_mqtt_url(
+                                        primary, new_primary
                                     )
                                     if new_url:
                                         self.options[SZ_SERIAL_PORT][
@@ -1894,13 +1881,13 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # (issue 1119).  But if there is no primary at
                 # all (e.g. after clearing all HGIs), allow adding
                 # an MQTT HGI — it becomes the new primary.
-                is_mqtt_or_empty = (
-                    not primary
-                    or (isinstance(primary, str) and (
+                is_mqtt_or_empty = not primary or (
+                    isinstance(primary, str)
+                    and (
                         primary.startswith("mqtt://")
                         or primary == "mqtt_ha"
                         or self.options.get(CONF_MQTT_USE_HA)
-                    ))
+                    )
                 )
 
                 if add_choice == CONF_MQTT_HA_ID:
@@ -1927,7 +1914,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         return await self.async_step_manage_pool_mqtt_url()
                 elif add_choice and add_choice.startswith("__readd__"):
                     # Re-add a previously removed HGI
-                    readd_id = add_choice[len("__readd__"):]
+                    readd_id = add_choice[len("__readd__") :]
                     schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
                     if readd_id in schema_dict and isinstance(
                         schema_dict[readd_id], dict
@@ -2046,7 +2033,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             )
                     except (ValueError, AttributeError):
                         pass
-                return f"HGI: {dev_id} (primary, {_mask_mqtt_url(display_url)})"
+                return (
+                    f"HGI: {dev_id} (primary, {_mask_mqtt_url(display_url)})"
+                )
             # Build the explicit MQTT URL for this HGI
             if isinstance(primary_port, str) and primary_port.startswith(
                 "mqtt://"

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1753,7 +1753,6 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         errors: dict[str, str] = {}
 
         # Sentinel value for "no new port selected"
-        ADD_NEW = "__add_new__"
         NO_ADD = "__none__"
 
         if user_input is not None:

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1973,21 +1973,32 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # demotes them back to discovery candidates (removes _owner).
         # The primary HGI is also listed (marked as "primary") so the
         # user can see the full pool composition.
+        #
+        # Phase 1: the pool is MQTT-only.  When the primary is serial
+        # (not MQTT), schema HGIs are serial-discovered devices and must
+        # NOT be shown as MQTT pool members — they don't have an MQTT
+        # topic or broker (issue 1171).
         schema = self.options.get(CONF_SCHEMA, {})
         if not isinstance(schema, dict):
             schema = {}
         root_owner = schema.get(SZ_OWNER, "me")
+        is_primary_mqtt = isinstance(primary_port, str) and (
+            primary_port.startswith("mqtt://")
+            or primary_port == "mqtt_ha"
+            or self.options.get(CONF_MQTT_USE_HA)
+        )
         schema_pool_members: list[str] = []
-        for dev_id, entry in schema.items():
-            if (
-                dev_id.startswith(HGI_PREFIX)
-                and dev_id != DEFAULT_HGI_ID
-                and isinstance(entry, dict)
-                and entry.get("_class", "").upper() == "HGI"
-                and entry.get(SZ_TR_OWNER) == root_owner
-                and not entry.get("_disabled")
-            ):
-                schema_pool_members.append(dev_id)
+        if is_primary_mqtt or not primary_port:
+            for dev_id, entry in schema.items():
+                if (
+                    dev_id.startswith(HGI_PREFIX)
+                    and dev_id != DEFAULT_HGI_ID
+                    and isinstance(entry, dict)
+                    and entry.get("_class", "").upper() == "HGI"
+                    and entry.get(SZ_TR_OWNER) == root_owner
+                    and not entry.get("_disabled")
+                ):
+                    schema_pool_members.append(dev_id)
 
         # Determine the primary HGI ID (from the MQTT URL or CONF_MQTT_HGI_ID)
         # so we can label it in the pool list.

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1774,9 +1774,15 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             else:
                 # Determine the primary HGI ID
                 primary_hgi_id_input: str | None = None
-                if isinstance(primary, str) and primary.startswith("mqtt://"):
+                if isinstance(primary, str) and (
+                    primary.startswith("mqtt://")
+                    or primary == "mqtt_ha"
+                    or self.options.get(CONF_MQTT_USE_HA)
+                ):
                     primary_hgi_id_input = self.options.get(CONF_MQTT_HGI_ID)
-                    if not primary_hgi_id_input:
+                    if not primary_hgi_id_input and isinstance(
+                        primary, str
+                    ):
                         import re as _re
 
                         m = _re.search(r"(18:[0-9]{6})", primary)
@@ -1827,13 +1833,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             ):
                                 remaining_hgis.append(dev_id)
                     if not remaining_hgis:
-                        # No other HGI to promote — clear the primary
-                        # port so the user starts fresh.  The coordinator
-                        # will have no transport on reload; the user
-                        # configures a new one via Connection / Port.
-                        self.options[SZ_SERIAL_PORT] = {}
-                        self.options.pop(CONF_MQTT_HGI_ID, None)
-                        self.options.pop(CONF_MQTT_USE_HA, None)
+                        # No other HGI to promote — require explicit
+                        # confirmation before clearing the primary port.
+                        if not user_input.get("confirm_clear_last"):
+                            errors["base"] = "pool_confirm_clear_last"
+                        else:
+                            # User confirmed — clear the primary port
+                            # so they can start fresh via Connection /
+                            # Port.
+                            self.options[SZ_SERIAL_PORT] = {}
+                            self.options.pop(CONF_MQTT_HGI_ID, None)
+                            self.options.pop(CONF_MQTT_USE_HA, None)
                     else:
                         # Promote the first remaining HGI
                         new_primary = sorted(remaining_hgis)[0]
@@ -1916,8 +1926,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Determine the primary HGI ID (from the MQTT URL or CONF_MQTT_HGI_ID)
         # so we can label it in the pool list.
         primary_hgi_id: str | None = None
-        if isinstance(primary_port, str) and primary_port.startswith(
-            "mqtt://"
+        if isinstance(primary_port, str) and (
+            primary_port.startswith("mqtt://")
+            or primary_port == "mqtt_ha"
+            or self.options.get(CONF_MQTT_USE_HA)
         ):
             primary_hgi_id = self.options.get(CONF_MQTT_HGI_ID)
             if not primary_hgi_id:
@@ -2104,6 +2116,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 ),
                 prob.Coerce(float),
             ),
+            # Confirmation checkbox for removing the last HGI.
+            # Only relevant when the user unchecks all pool members.
+            prob.Optional(
+                "confirm_clear_last",
+                default=False,
+            ): selector.BooleanSelector(),
         }
 
         # Mask credentials and ensure topic is shown in the primary

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2276,15 +2276,25 @@ class RamsesCoordinator(DataUpdateCoordinator):
         hgi_id: str | None = None
         if _is_mqtt_ha:
             hgi_id = self.options.get(CONF_MQTT_HGI_ID)
+            if hgi_id == DEFAULT_HGI_ID:
+                hgi_id = None
             if not hgi_id and _is_mqtt_url:
                 # Extract HGI ID from the mqtt:// URL path
                 # (e.g. mqtt://user:pass@host:1883/topic/18:001234)
                 import re as _re
 
                 m = _re.search(r"(18:[0-9]{6})(?:/|$)", _port_name_raw)
-                if m:
+                if m and m.group(1) != DEFAULT_HGI_ID:
                     hgi_id = m.group(1)
             if not hgi_id:
+                # Fall back to the first accepted HGI in the schema
+                # (skip DEFAULT_HGI_ID and _removed_from_pool)
+                hgi_id = self._get_primary_hgi_id()
+            if not hgi_id:
+                # Last resort: use the sentinel.  The pool bridge will
+                # still work — it subscribes to wildcard topics and can
+                # discover real HGIs.  The sentinel won't appear in the
+                # pool UI (filtered out by DEFAULT_HGI_ID check).
                 hgi_id = DEFAULT_HGI_ID
             # Also extract the MQTT topic from the URL if not already set
             if not self.options.get(CONF_MQTT_TOPIC) and _is_mqtt_url:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1405,9 +1405,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
         """
         port_name = self.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME, "")
         is_mqtt_ha = (
-            (isinstance(port_name, str) and port_name == "mqtt_ha")
-            or self.options.get(CONF_MQTT_USE_HA)
-        )
+            isinstance(port_name, str) and port_name == "mqtt_ha"
+        ) or self.options.get(CONF_MQTT_USE_HA)
         if isinstance(port_name, str):
             if port_name.startswith("mqtt://"):
                 # Check CONF_MQTT_HGI_ID first

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1485,7 +1485,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return None
         try:
             import re as _re
-
             from urllib.parse import urlparse, urlunparse
 
             parsed = urlparse(primary_url)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1423,26 +1423,34 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ``18:149488``, returns
         ``mqtt://broker:1883/RAMSES/GATEWAY/18:149488``.
 
-        :param primary_url: The primary MQTT URL (may be wildcard).
+        If the URL already contains a different HGI ID (e.g.
+        ``/RAMSES/GATEWAY/18:130236``), it is replaced with the new one.
+
+        :param primary_url: The primary MQTT URL (may be wildcard or
+            already contain an HGI ID).
         :param hgi_id: The HGI device ID (e.g. ``18:149488``).
         :return: Explicit MQTT URL with the HGI ID in the path, or None
-            if the URL already contains the HGI ID.
+            if the URL already contains the same HGI ID.
         """
         if not primary_url or not hgi_id:
             return None
-        # If the URL already has this HGI ID in the path, no need to duplicate
+        # If the URL already has this HGI ID in the path, no change needed
         if hgi_id in primary_url:
             return None
         try:
+            import re as _re
+
             from urllib.parse import urlparse, urlunparse
 
             parsed = urlparse(primary_url)
             path = parsed.path or "/RAMSES/GATEWAY"
-            # Strip trailing slash and ensure it starts with /RAMSES/GATEWAY
             path = path.rstrip("/")
+            # If the path already ends with an HGI ID (18:NNNNNN),
+            # replace it with the new one
+            path = _re.sub(r"/18:[0-9]{6}$", "", path)
             if not path:
                 path = "/RAMSES/GATEWAY"
-            # Append the HGI ID
+            # Append the new HGI ID
             path = f"{path}/{hgi_id}"
             return urlunparse(parsed._replace(path=path))
         except (ValueError, AttributeError):

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1336,6 +1336,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 and isinstance(entry, dict)
                 and entry.get("_class", "").upper() == "HGI"
                 and not entry.get("_disabled")
+                and not entry.get("_removed_from_pool")
                 and dev_id != primary_hgi
             ):
                 continue
@@ -1351,6 +1352,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # received and the scan engine can discover the HGI.
                 # The user must accept it (set _owner) before it can
                 # send commands (issue 1119).
+                # Note: _removed_from_pool HGIs are excluded above
+                # so they don't reappear as discovery candidates
+                # after explicit removal (issue 1171).
                 pool_hgis.append(dev_id)
             # HGIs with a foreign owner are excluded
         return pool_hgis
@@ -1399,6 +1403,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         USB, it's unknown until the first packet (returns None).
         """
         port_name = self.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME, "")
+        is_mqtt_ha = (
+            (isinstance(port_name, str) and port_name == "mqtt_ha")
+            or self.options.get(CONF_MQTT_USE_HA)
+        )
         if isinstance(port_name, str):
             if port_name.startswith("mqtt://"):
                 # Check CONF_MQTT_HGI_ID first
@@ -1413,6 +1421,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     return m.group(1)
                 # Wildcard MQTT — fall back to the first accepted HGI
                 # in the schema (the one the user has been using).
+                # Skip HGIs with _removed_from_pool (issue 1171).
                 schema = self.entry.options.get(CONF_SCHEMA, {})
                 if isinstance(schema, dict):
                     root_owner = schema.get(SZ_OWNER)
@@ -1424,6 +1433,28 @@ class RamsesCoordinator(DataUpdateCoordinator):
                                 and entry.get("_class", "").upper() == "HGI"
                                 and entry.get(SZ_TR_OWNER) == root_owner
                                 and not entry.get("_disabled")
+                                and not entry.get("_removed_from_pool")
+                            ):
+                                return dev_id
+            elif is_mqtt_ha:
+                # HA-native MQTT — check CONF_MQTT_HGI_ID first
+                hgi_id = self.options.get(CONF_MQTT_HGI_ID)
+                if hgi_id:
+                    return str(hgi_id)
+                # Fall back to the first accepted HGI in the schema.
+                # Skip HGIs with _removed_from_pool (issue 1171).
+                schema = self.entry.options.get(CONF_SCHEMA, {})
+                if isinstance(schema, dict):
+                    root_owner = schema.get(SZ_OWNER)
+                    if root_owner:
+                        for dev_id, entry in schema.items():
+                            if (
+                                dev_id.startswith(HGI_PREFIX)
+                                and isinstance(entry, dict)
+                                and entry.get("_class", "").upper() == "HGI"
+                                and entry.get(SZ_TR_OWNER) == root_owner
+                                and not entry.get("_disabled")
+                                and not entry.get("_removed_from_pool")
                             ):
                                 return dev_id
         return None

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -847,7 +847,21 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # enforce_known_list blocks all commands because the known_list
         # is derived from the schema and the primary HGI is missing.
         primary_hgi = self._get_primary_hgi_id()
+        # Skip enrichment if the HGI was explicitly removed from the
+        # pool by the user (issue 1171).  The _removed_from_pool trait
+        # is set by the config flow when the user unchecks an HGI.
+        # It is cleared when the user re-adds the HGI via the pool UI.
         if (
+            primary_hgi
+            and primary_hgi in schema
+            and isinstance(schema[primary_hgi], dict)
+            and schema[primary_hgi].get("_removed_from_pool")
+        ):
+            _LOGGER.info(
+                "Primary HGI %s has _removed_from_pool — skipping enrichment",
+                primary_hgi,
+            )
+        elif (
             primary_hgi
             and primary_hgi.startswith(HGI_PREFIX)
             and primary_hgi not in schema

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1333,6 +1333,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         for dev_id, entry in schema.items():
             if not (
                 dev_id.startswith(HGI_PREFIX)
+                and dev_id != DEFAULT_HGI_ID
                 and isinstance(entry, dict)
                 and entry.get("_class", "").upper() == "HGI"
                 and not entry.get("_disabled")
@@ -1411,13 +1412,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
             if port_name.startswith("mqtt://"):
                 # Check CONF_MQTT_HGI_ID first
                 hgi_id = self.options.get(CONF_MQTT_HGI_ID)
-                if hgi_id:
+                if hgi_id and hgi_id != DEFAULT_HGI_ID:
                     return str(hgi_id)
                 # Extract from URL path
                 import re as _re
 
                 m = _re.search(r"(18:[0-9]{6})(?:/|$)", port_name)
-                if m:
+                if m and m.group(1) != DEFAULT_HGI_ID:
                     return m.group(1)
                 # Wildcard MQTT — fall back to the first accepted HGI
                 # in the schema (the one the user has been using).
@@ -1439,7 +1440,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             elif is_mqtt_ha:
                 # HA-native MQTT — check CONF_MQTT_HGI_ID first
                 hgi_id = self.options.get(CONF_MQTT_HGI_ID)
-                if hgi_id:
+                if hgi_id and hgi_id != DEFAULT_HGI_ID:
                     return str(hgi_id)
                 # Fall back to the first accepted HGI in the schema.
                 # Skip HGIs with _removed_from_pool (issue 1171).

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -598,7 +598,14 @@ class DiscoveryManager:
                 if not device_id_re.match(str(dev_id)):
                     continue
                 if SZ_TR_OWNER not in entry:
-                    self._schema_no_owner_ids.add(dev_id)
+                    # Skip HGIs with _removed_from_pool — they were
+                    # explicitly removed by the user and should not
+                    # reappear as discovery candidates (issue 1171).
+                    if not (
+                        dev_id.startswith(HGI_PREFIX)
+                        and entry.get("_removed_from_pool")
+                    ):
+                        self._schema_no_owner_ids.add(dev_id)
                 if entry.get(SZ_TR_SKIPPED):
                     self._schema_skipped_ids.add(dev_id)
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1343,7 +1343,10 @@ def sync_learned_topology(
             if (
                 dev_id.startswith(HGI_PREFIX)
                 and isinstance(new_schema[dev_id], dict)
-                and new_schema[dev_id].get("_class", "").upper() == "HGI"
+                and (
+                    new_schema[dev_id].get("_class", "").upper() == "HGI"
+                    or new_schema[dev_id].get("_removed_from_pool")
+                )
             ):
                 _LOGGER.debug(
                     "sync_learned_topology: skipping _owner "
@@ -2706,7 +2709,12 @@ def sync_learned_topology(
     for dev_id in sorted(hgi_ids):
         if dev_id not in new_schema:
             new_schema[dev_id] = {SZ_TR_CLASS: "HGI"}
-            if root_owner and active_hgi_id and dev_id == active_hgi_id:
+            if (
+                root_owner
+                and active_hgi_id
+                and dev_id == active_hgi_id
+                and not new_schema[dev_id].get("_removed_from_pool")
+            ):
                 new_schema[dev_id][SZ_TR_OWNER] = root_owner
             changed = True
         elif isinstance(new_schema[dev_id], dict):
@@ -2718,6 +2726,7 @@ def sync_learned_topology(
                 and active_hgi_id
                 and dev_id == active_hgi_id
                 and SZ_TR_OWNER not in new_schema[dev_id]
+                and not new_schema[dev_id].get("_removed_from_pool")
             ):
                 new_schema[dev_id][SZ_TR_OWNER] = root_owner
                 changed = True

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -95,6 +95,7 @@ from .const import (
     CONF_SCHEMA,
     CONF_SEND_PACKET,
     CONF_UNKNOWN_CODES,
+    DEFAULT_HGI_ID,
     HGI_PREFIX,
     SZ_DEVICE_COMMENTS,
     SZ_OWNER,
@@ -2699,12 +2700,17 @@ def sync_learned_topology(
         active_hgi_id
         and isinstance(active_hgi_id, str)
         and active_hgi_id.startswith(HGI_PREFIX)
+        and active_hgi_id != DEFAULT_HGI_ID
     ):
         hgi_ids.add(active_hgi_id)
     device_comments = new_schema.get(SZ_DEVICE_COMMENTS, {})
     if isinstance(device_comments, dict):
         for dev_id in device_comments:
-            if isinstance(dev_id, str) and dev_id.startswith(HGI_PREFIX):
+            if (
+                isinstance(dev_id, str)
+                and dev_id.startswith(HGI_PREFIX)
+                and dev_id != DEFAULT_HGI_ID
+            ):
                 hgi_ids.add(dev_id)
     for dev_id in sorted(hgi_ids):
         if dev_id not in new_schema:

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -145,6 +145,7 @@
             "pool_serial_not_supported": "Serial/USB pool members are not yet supported (planned for Phase 2).",
             "pool_zigbee_not_supported": "Zigbee pool members are not yet supported (planned for Phase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT pool members require an MQTT primary transport. Switch the primary port to MQTT first.",
+            "pool_cannot_remove_last_hgi": "Cannot remove the last HGI from the pool. Add another HGI first, then remove this one.",
             "mqtt_host_required": "MQTT broker host is required.",
             "hgi_id_required": "HGI device ID is required.",
             "hgi_id_invalid": "HGI device ID must be in the format 18:NNNNNN."
@@ -264,13 +265,13 @@
                 "description": "{message}",
                 "data": {}
             },
-            "manage_pool": {
+            "hgi_pool": {
                 "title": "HGI Pool Management",
-                "description": "Primary port: {primary_port}\nCurrent additional ports: {current_count}\nSchema pool members (auto): {schema_pool_members}",
+                "description": "Primary port: {primary_port}\nCurrent additional ports: {current_count}\nPool members (uncheck to remove): {schema_pool_members}",
                 "data": {
-                    "schema_pool_members": "Pool members (uncheck to remove from pool)",
+                    "schema_pool_members": "Pool members (uncheck to remove, primary can be removed — auto-promotes another)",
                     "additional_ports": "Additional ports (USB, Zigbee, external MQTT)",
-                    "add_new_port": "Add/edit port",
+                    "add_new_port": "Add new HGI",
                     "wait_online_timeout": "MQTT pool: seconds to wait for at least one HGI to come online"
                 }
             },

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -145,6 +145,7 @@
             "pool_serial_not_supported": "Serial/USB pool members are not yet supported (planned for Phase 2).",
             "pool_zigbee_not_supported": "Zigbee pool members are not yet supported (planned for Phase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT pool members require an MQTT primary transport. Switch the primary port to MQTT first.",
+            "pool_confirm_clear_last": "You are removing the last HGI. Check 'Confirm: clear all HGIs' below and submit again to proceed.",
             "mqtt_host_required": "MQTT broker host is required.",
             "hgi_id_required": "HGI device ID is required.",
             "hgi_id_invalid": "HGI device ID must be in the format 18:NNNNNN."
@@ -271,7 +272,8 @@
                     "schema_pool_members": "Pool members (uncheck to remove, primary can be removed — auto-promotes another)",
                     "additional_ports": "Additional ports (USB, Zigbee, external MQTT)",
                     "add_new_port": "Add new HGI",
-                    "wait_online_timeout": "MQTT pool: seconds to wait for at least one HGI to come online"
+                    "wait_online_timeout": "MQTT pool: seconds to wait for at least one HGI to come online",
+                    "confirm_clear_last": "Confirm: clear all HGIs and reset connection"
                 }
             },
             "manage_pool_mqtt": {

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -145,7 +145,6 @@
             "pool_serial_not_supported": "Serial/USB pool members are not yet supported (planned for Phase 2).",
             "pool_zigbee_not_supported": "Zigbee pool members are not yet supported (planned for Phase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT pool members require an MQTT primary transport. Switch the primary port to MQTT first.",
-            "pool_cannot_remove_last_hgi": "Cannot remove the last HGI from the pool. Add another HGI first, then remove this one.",
             "mqtt_host_required": "MQTT broker host is required.",
             "hgi_id_required": "HGI device ID is required.",
             "hgi_id_invalid": "HGI device ID must be in the format 18:NNNNNN."

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -152,8 +152,8 @@
         "step": {
             "init": {
                 "menu_options": {
-                    "choose_serial_port": "Primary port",
-                    "manage_pool": "Manage gateway pool",
+                    "choose_serial_port": "Connection / Port",
+                    "manage_pool": "HGI Pool Management",
                     "config": "Gateway configuration",
                     "schema": "System schema",
                     "advanced_features": "Advanced features",
@@ -265,7 +265,7 @@
                 "data": {}
             },
             "manage_pool": {
-                "title": "Gateway Pool Management",
+                "title": "HGI Pool Management",
                 "description": "Primary port: {primary_port}\nCurrent additional ports: {current_count}\nSchema pool members (auto): {schema_pool_members}",
                 "data": {
                     "schema_pool_members": "Pool members (uncheck to remove from pool)",

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -146,6 +146,9 @@
             "pool_zigbee_not_supported": "Zigbee pool members are not yet supported (planned for Phase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT pool members require an MQTT primary transport. Switch the primary port to MQTT first.",
             "pool_confirm_clear_last": "You are removing the last HGI. Check 'Confirm: clear all HGIs' below and submit again to proceed.",
+            "mqtt_url_required": "Please enter an MQTT URL.",
+            "mqtt_url_invalid": "URL must start with mqtt://",
+            "mqtt_url_no_hgi_id": "URL must contain an HGI device ID (18:NNNNNN) in the path.",
             "mqtt_host_required": "MQTT broker host is required.",
             "hgi_id_required": "HGI device ID is required.",
             "hgi_id_invalid": "HGI device ID must be in the format 18:NNNNNN."
@@ -277,10 +280,17 @@
                 }
             },
             "manage_pool_mqtt": {
-                "title": "Add MQTT HGI to Pool",
+                "title": "Add HA MQTT HGI to Pool",
                 "description": "Enter the HGI device ID (18:NNNNNN) for this pool member. The MQTT broker and topic are configured via the Home Assistant MQTT integration.",
                 "data": {
                     "hgi_id": "HGI device ID (18:NNNNNN)"
+                }
+            },
+            "manage_pool_mqtt_url": {
+                "title": "Add MQTT HGI via full URL",
+                "description": "Enter the full MQTT URL including the HGI ID in the path, e.g. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
+                "data": {
+                    "mqtt_url": "MQTT URL"
                 }
             }
         }

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -146,6 +146,9 @@
             "pool_zigbee_not_supported": "Zigbee-poolleden worden nog niet ondersteund (gepland voor Fase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT-poolleden vereisen een MQTT-primaire transport. Schakel de primaire poort eerst naar MQTT.",
             "pool_confirm_clear_last": "U verwijdert de laatste HGI. Vink 'Bevestig: alle HGI's wissen' hieronder aan en dien opnieuw in om door te gaan.",
+            "mqtt_url_required": "Voer een MQTT-URL in.",
+            "mqtt_url_invalid": "URL moet beginnen met mqtt://",
+            "mqtt_url_no_hgi_id": "URL moet een HGI-apparaat-ID (18:NNNNNN) in het pad bevatten.",
             "mqtt_host_required": "MQTT-brokerhost is vereist.",
             "hgi_id_required": "HGI-apparaat-ID is vereist.",
             "hgi_id_invalid": "HGI-apparaat-ID moet de indeling 18:NNNNNN hebben."
@@ -276,10 +279,17 @@
                 }
             },
             "manage_pool_mqtt": {
-                "title": "MQTT HGI aan Pool toevoegen",
+                "title": "HA MQTT HGI aan Pool toevoegen",
                 "description": "Voer het HGI-apparaat-ID (18:NNNNNN) in voor dit pool-lid. De MQTT-broker en topic zijn geconfigureerd via de Home Assistant MQTT-integratie.",
                 "data": {
                     "hgi_id": "HGI-apparaat-ID (18:NNNNNN)"
+                }
+            },
+            "manage_pool_mqtt_url": {
+                "title": "MQTT HGI via volledige URL toevoegen",
+                "description": "Voer de volledige MQTT-URL in inclusief het HGI-ID in het pad, bijv. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
+                "data": {
+                    "mqtt_url": "MQTT URL"
                 }
             }
         }

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -145,7 +145,6 @@
             "pool_serial_not_supported": "Seriële/USB-poolleden worden nog niet ondersteund (gepland voor Fase 2).",
             "pool_zigbee_not_supported": "Zigbee-poolleden worden nog niet ondersteund (gepland voor Fase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT-poolleden vereisen een MQTT-primaire transport. Schakel de primaire poort eerst naar MQTT.",
-            "pool_cannot_remove_last_hgi": "Kan de laatste HGI niet uit de pool verwijderen. Voeg eerst een andere HGI toe, verwijder dan deze.",
             "mqtt_host_required": "MQTT-brokerhost is vereist.",
             "hgi_id_required": "HGI-apparaat-ID is vereist.",
             "hgi_id_invalid": "HGI-apparaat-ID moet de indeling 18:NNNNNN hebben."

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -152,8 +152,8 @@
         "step": {
             "init": {
                 "menu_options": {
-                    "choose_serial_port": "Primaire poort",
-                    "manage_pool": "Beheer gateway pool",
+                    "choose_serial_port": "Verbinding / Poort",
+                    "manage_pool": "HGI Pool Beheer",
                     "config": "Gateway-configuratie",
                     "schema": "Systeemschema",
                     "advanced_features": "Geavanceerde opties",
@@ -265,7 +265,7 @@
                 "data": {}
             },
             "manage_pool": {
-                "title": "Gateway Pool Beheer",
+                "title": "HGI Pool Beheer",
                 "description": "Primaire poort: {primary_port}\nHuidige extra poorten: {current_count}\nSchema pool-leden (auto): {schema_pool_members}",
                 "data": {
                     "schema_pool_members": "Pool-leden (vink uit om uit pool te verwijderen)",

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -145,6 +145,7 @@
             "pool_serial_not_supported": "Seriële/USB-poolleden worden nog niet ondersteund (gepland voor Fase 2).",
             "pool_zigbee_not_supported": "Zigbee-poolleden worden nog niet ondersteund (gepland voor Fase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT-poolleden vereisen een MQTT-primaire transport. Schakel de primaire poort eerst naar MQTT.",
+            "pool_cannot_remove_last_hgi": "Kan de laatste HGI niet uit de pool verwijderen. Voeg eerst een andere HGI toe, verwijder dan deze.",
             "mqtt_host_required": "MQTT-brokerhost is vereist.",
             "hgi_id_required": "HGI-apparaat-ID is vereist.",
             "hgi_id_invalid": "HGI-apparaat-ID moet de indeling 18:NNNNNN hebben."
@@ -264,13 +265,13 @@
                 "description": "{message}",
                 "data": {}
             },
-            "manage_pool": {
+            "hgi_pool": {
                 "title": "HGI Pool Beheer",
-                "description": "Primaire poort: {primary_port}\nHuidige extra poorten: {current_count}\nSchema pool-leden (auto): {schema_pool_members}",
+                "description": "Primaire poort: {primary_port}\nHuidige extra poorten: {current_count}\nPool-leden (vink uit om te verwijderen): {schema_pool_members}",
                 "data": {
-                    "schema_pool_members": "Pool-leden (vink uit om uit pool te verwijderen)",
+                    "schema_pool_members": "Pool-leden (vink uit om te verwijderen, primaire kan verwijderd worden — promoot automatisch een andere)",
                     "additional_ports": "Extra poorten (USB, Zigbee, externe MQTT)",
-                    "add_new_port": "Poort toevoegen/wijzigen"
+                    "add_new_port": "Nieuwe HGI toevoegen"
                 }
             },
             "manage_pool_mqtt": {

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -145,6 +145,7 @@
             "pool_serial_not_supported": "Seriële/USB-poolleden worden nog niet ondersteund (gepland voor Fase 2).",
             "pool_zigbee_not_supported": "Zigbee-poolleden worden nog niet ondersteund (gepland voor Fase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT-poolleden vereisen een MQTT-primaire transport. Schakel de primaire poort eerst naar MQTT.",
+            "pool_confirm_clear_last": "U verwijdert de laatste HGI. Vink 'Bevestig: alle HGI's wissen' hieronder aan en dien opnieuw in om door te gaan.",
             "mqtt_host_required": "MQTT-brokerhost is vereist.",
             "hgi_id_required": "HGI-apparaat-ID is vereist.",
             "hgi_id_invalid": "HGI-apparaat-ID moet de indeling 18:NNNNNN hebben."
@@ -270,7 +271,8 @@
                 "data": {
                     "schema_pool_members": "Pool-leden (vink uit om te verwijderen, primaire kan verwijderd worden — promoot automatisch een andere)",
                     "additional_ports": "Extra poorten (USB, Zigbee, externe MQTT)",
-                    "add_new_port": "Nieuwe HGI toevoegen"
+                    "add_new_port": "Nieuwe HGI toevoegen",
+                    "confirm_clear_last": "Bevestig: alle HGI's wissen en verbinding resetten"
                 }
             },
             "manage_pool_mqtt": {

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5258,6 +5258,73 @@ async def test_options_flow_manage_pool_remove_last_hgi(
     assert SZ_TR_OWNER not in schema.get("18:001111", {})
 
 
+async def test_options_flow_manage_pool_remove_last_hgi_mqtt_ha(
+    hass: HomeAssistant,
+) -> None:
+    """Test removing last HGI with mqtt_ha primary (no CONF_MQTT_HGI_ID).
+
+    The primary HGI ID is unknown when using mqtt_ha without
+    CONF_MQTT_HGI_ID.  The logic should still detect that all owned
+    HGIs are being removed and require confirmation.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt_ha"},
+            CONF_MQTT_USE_HA: True,
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:001111": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        # First attempt: uncheck all without confirmation — should error
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "schema_pool_members": [],
+                "add_new_port": "__none__",
+                "confirm_clear_last": False,
+            },
+        )
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("errors") == {"base": "pool_confirm_clear_last"}
+
+        # Second attempt: with confirmation — should save and clear
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "schema_pool_members": [],
+                "add_new_port": "__none__",
+                "confirm_clear_last": True,
+            },
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    serial_port = config_entry.options.get(SZ_SERIAL_PORT, {})
+    assert not serial_port.get(SZ_PORT_NAME)
+    schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert SZ_TR_OWNER not in schema.get("18:001111", {})
+
+
 async def test_options_flow_manage_pool_zigbee_form_display(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -732,7 +732,7 @@ async def test_options_flow_manage_pool_add_port(hass: HomeAssistant) -> None:
 async def test_options_flow_manage_pool_serial_gated(
     hass: HomeAssistant,
 ) -> None:
-    """Test manage_pool blocks serial ports in Phase 1 (issue 1119)."""
+    """Test manage_pool does not list serial ports in Phase 1 (issue 1119)."""
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -753,18 +753,21 @@ async def test_options_flow_manage_pool_serial_gated(
             result["flow_id"], user_input={"next_step_id": "manage_pool"}
         )
 
-        # Try to add a serial port — should be blocked
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": "/dev/ttyUSB1",
-            },
-        )
+        # Assert — form is shown, serial ports are NOT in the add dropdown
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == "manage_pool"
 
-    # Assert — error form shown, not saved
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {"base": "pool_serial_not_supported"}
+        # The add_new_port dropdown should only have MQTT and "(nothing)"
+        # Serial ports should not be listed at all (Phase 2 gating)
+        schema = result.get("data_schema")
+        if schema and hasattr(schema, "schema"):
+            add_field = schema.schema.get("add_new_port")
+            if add_field and hasattr(add_field, "config"):
+                options = add_field.config.get("options", [])
+                values = [opt["value"] for opt in options]
+                assert "/dev/ttyUSB1" not in values, (
+                    "Serial ports should not be listed in the pool add dropdown"
+                )
 
 
 async def test_options_flow_manage_pool_zigbee_gated(
@@ -791,58 +794,59 @@ async def test_options_flow_manage_pool_zigbee_gated(
             result["flow_id"], user_input={"next_step_id": "manage_pool"}
         )
 
-        # Try to add Zigbee — should be blocked
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_ZIGBEE_DEVICE,
-            },
-        )
+        # Assert — form is shown, Zigbee is NOT in the add dropdown
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == "manage_pool"
 
-    # Assert — error form shown, not saved
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {"base": "pool_zigbee_not_supported"}
+        # The add_new_port dropdown should only have MQTT and "(nothing)"
+        # Zigbee should not be listed at all (Phase 3 gating)
+        schema = result.get("data_schema")
+        if schema and hasattr(schema, "schema"):
+            add_field = schema.schema.get("add_new_port")
+            if add_field and hasattr(add_field, "config"):
+                options = add_field.config.get("options", [])
+                values = [opt["value"] for opt in options]
+                assert CONF_ZIGBEE_DEVICE not in values, (
+                    "Zigbee should not be listed in the pool add dropdown"
+                )
 
 
-async def test_options_flow_manage_pool_duplicate_primary(
+async def test_options_flow_manage_pool_hidden_for_serial_primary(
     hass: HomeAssistant,
 ) -> None:
-    """Test manage_pool rejects primary port in additional (issue 1119)."""
+    """Test manage_pool is not shown in menu for serial/USB primary (issue 1171).
 
-    # Arrange — primary is /dev/ttyUSB0, already in additional_ports
+    The pool feature is MQTT-only until Phase 2.  Serial/USB primary
+    ports should not see the HGI Pool Management option at all.
+    """
+
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         options={
             SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
-            CONF_ADDITIONAL_PORTS: ["/dev/ttyUSB0"],
         },
     )
     config_entry.add_to_hass(hass)
 
-    # Act — navigate to manage_pool and submit with primary still checked
     with patch(
         "custom_components.ramses_cc.config_flow.async_get_usb_ports",
-        return_value={"/dev/ttyUSB0": "USB 0", "/dev/ttyUSB1": "USB 1"},
+        return_value={"/dev/ttyUSB0": "USB 0"},
     ):
         result = await hass.config_entries.options.async_init(
             config_entry.entry_id
         )
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={"next_step_id": "manage_pool"}
-        )
 
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_ADDITIONAL_PORTS: ["/dev/ttyUSB0"],
-                "add_new_port": "__none__",
-            },
-        )
-
-    # Assert — error shown, not saved
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {"base": "pool_duplicate_primary"}
+    # Assert — menu shown, but manage_pool is NOT an option
+    assert result.get("type") == FlowResultType.MENU
+    menu_options = result.get("menu_options", [])
+    # menu_options can be a list of step_ids or a dict
+    if isinstance(menu_options, dict):
+        steps = list(menu_options.keys())
+    else:
+        steps = list(menu_options)
+    assert "manage_pool" not in steps, (
+        "Pool management should not be available for serial/USB primary"
+    )
 
 
 async def test_options_flow_schema_save_preserves_serial_port(
@@ -5053,7 +5057,11 @@ async def test_options_flow_manage_pool_mqtt_invalid_hgi_id(
 async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
     hass: HomeAssistant,
 ) -> None:
-    """Test manage_pool blocks MQTT add when primary is serial (Phase 1)."""
+    """Test manage_pool is hidden when primary is serial (Phase 1, issue 1171).
+
+    Serial/USB primary ports should not see the HGI Pool Management
+    option in the menu at all — the pool is MQTT-only until Phase 2.
+    """
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -5070,21 +5078,17 @@ async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
         result = await hass.config_entries.options.async_init(
             config_entry.entry_id
         )
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={"next_step_id": "manage_pool"}
-        )
-        # Try to add MQTT pool member with serial primary
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
-            },
-        )
 
-    # Should show the form with an error — not navigate to MQTT sub-step
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {"base": "pool_mqtt_requires_mqtt_primary"}
+    # Assert — menu shown, but manage_pool is NOT an option
+    assert result.get("type") == FlowResultType.MENU
+    menu_options = result.get("menu_options", [])
+    if isinstance(menu_options, dict):
+        steps = list(menu_options.keys())
+    else:
+        steps = list(menu_options)
+    assert "manage_pool" not in steps, (
+        "Pool management should not be available for serial/USB primary"
+    )
 
 
 async def test_options_flow_manage_pool_mqtt_form_display(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5191,10 +5191,10 @@ async def test_options_flow_manage_pool_remove_schema_member(
 async def test_options_flow_manage_pool_remove_last_hgi(
     hass: HomeAssistant,
 ) -> None:
-    """Test manage_pool allows removing the last HGI, clearing port (issue 1171).
+    """Test manage_pool requires confirmation to remove the last HGI (issue 1171).
 
-    Removing the last HGI clears the primary port config so the user
-    can start fresh via Connection / Port.
+    First attempt without confirmation shows an error.
+    Second attempt with confirm_clear_last=True clears the port.
     """
 
     config_entry = MockConfigEntry(
@@ -5224,13 +5224,27 @@ async def test_options_flow_manage_pool_remove_last_hgi(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={"next_step_id": "manage_pool"}
         )
-        # Uncheck the only HGI (the primary) — should clear the port
+        # First attempt: uncheck all without confirmation — should error
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
                 "schema_pool_members": [],
                 "add_new_port": "__none__",
+                "confirm_clear_last": False,
+            },
+        )
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("errors") == {"base": "pool_confirm_clear_last"}
+
+        # Second attempt: uncheck all WITH confirmation — should save
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "schema_pool_members": [],
+                "add_new_port": "__none__",
+                "confirm_clear_last": True,
             },
         )
 

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -720,7 +720,7 @@ async def test_options_flow_manage_pool_add_port(hass: HomeAssistant) -> None:
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
 
@@ -4950,7 +4950,7 @@ async def test_options_flow_manage_pool_mqtt_add_port(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
         assert result.get("type") == FlowResultType.FORM
@@ -5001,7 +5001,7 @@ async def test_options_flow_manage_pool_mqtt_missing_hgi_id(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
         # Submit with empty hgi_id
@@ -5041,7 +5041,7 @@ async def test_options_flow_manage_pool_mqtt_invalid_hgi_id(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
         # Submit with a non-HGI device ID (32: is not an HGI)
@@ -5086,7 +5086,7 @@ async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
 
@@ -5130,7 +5130,7 @@ async def test_options_flow_manage_pool_mqtt_add_when_no_primary(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
 
@@ -5138,6 +5138,105 @@ async def test_options_flow_manage_pool_mqtt_add_when_no_primary(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "manage_pool_mqtt"
     assert not result.get("errors")
+
+
+async def test_options_flow_manage_pool_mqtt_url_add(
+    hass: HomeAssistant,
+) -> None:
+    """Test adding an MQTT HGI via full URL (issue 1171)."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt_ha"},
+            CONF_MQTT_USE_HA: True,
+            CONF_SCHEMA: {SZ_OWNER: "me"},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        # Select "MQTT Broker (full URL)..."
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "add_new_port": "__mqtt_full_url__",
+            },
+        )
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == "manage_pool_mqtt_url"
+
+        # Submit a full URL
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "mqtt_url": "mqtt://broker:1883/RAMSES/GATEWAY/18:001111"
+            },
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert schema.get("18:001111", {}).get(SZ_TR_OWNER) == "me"
+    assert "_removed_from_pool" not in schema.get("18:001111", {})
+    additional = config_entry.options.get(CONF_ADDITIONAL_PORTS, [])
+    assert "mqtt://broker:1883/RAMSES/GATEWAY/18:001111" in additional
+
+
+async def test_options_flow_manage_pool_readd_removed_hgi(
+    hass: HomeAssistant,
+) -> None:
+    """Test re-adding a previously removed HGI from the dropdown (issue 1171)."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:001111": {
+                    "_class": "HGI",
+                    "_removed_from_pool": True,
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        # Select "Re-add HGI: 18:001111"
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "add_new_port": "__readd__18:001111",
+            },
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert schema.get("18:001111", {}).get(SZ_TR_OWNER) == "me"
+    assert "_removed_from_pool" not in schema.get("18:001111", {})
+    # Should become the new primary since there was none
+    assert config_entry.options.get(CONF_MQTT_HGI_ID) == "18:001111"
 
 
 async def test_options_flow_manage_pool_mqtt_form_display(
@@ -5169,7 +5268,7 @@ async def test_options_flow_manage_pool_mqtt_form_display(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
 
@@ -5570,7 +5669,7 @@ async def test_options_flow_manage_pool_mqtt_creates_schema_entry(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "add_new_port": CONF_MQTT_PATH,
+                "add_new_port": "__mqtt_ha_id__",
             },
         )
         result = await hass.config_entries.options.async_configure(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -811,13 +811,14 @@ async def test_options_flow_manage_pool_zigbee_gated(
                 )
 
 
-async def test_options_flow_manage_pool_hidden_for_serial_primary(
+async def test_options_flow_manage_pool_visible_for_serial_primary(
     hass: HomeAssistant,
 ) -> None:
-    """Test manage_pool is not shown in menu for serial/USB primary (issue 1171).
+    """Test manage_pool is shown for serial/USB primary (issue 1171).
 
-    The pool feature is MQTT-only until Phase 2.  Serial/USB primary
-    ports should not see the HGI Pool Management option at all.
+    The pool pane is always visible.  For serial primary, adding MQTT
+    pool members is blocked (requires MQTT primary), but the pane
+    itself is accessible so users can see the pool state.
     """
 
     config_entry = MockConfigEntry(
@@ -836,16 +837,15 @@ async def test_options_flow_manage_pool_hidden_for_serial_primary(
             config_entry.entry_id
         )
 
-    # Assert — menu shown, but manage_pool is NOT an option
+    # Assert — menu shown, manage_pool IS an option
     assert result.get("type") == FlowResultType.MENU
     menu_options = result.get("menu_options", [])
-    # menu_options can be a list of step_ids or a dict
     if isinstance(menu_options, dict):
         steps = list(menu_options.keys())
     else:
         steps = list(menu_options)
-    assert "manage_pool" not in steps, (
-        "Pool management should not be available for serial/USB primary"
+    assert "manage_pool" in steps, (
+        "Pool management should be available for all primary types"
     )
 
 
@@ -5057,10 +5057,10 @@ async def test_options_flow_manage_pool_mqtt_invalid_hgi_id(
 async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
     hass: HomeAssistant,
 ) -> None:
-    """Test manage_pool is hidden when primary is serial (Phase 1, issue 1171).
+    """Test manage_pool blocks MQTT add when primary is serial (issue 1171).
 
-    Serial/USB primary ports should not see the HGI Pool Management
-    option in the menu at all — the pool is MQTT-only until Phase 2.
+    The pool pane is visible for serial primary, but adding MQTT pool
+    members is blocked — it requires an MQTT primary transport.
     """
 
     config_entry = MockConfigEntry(
@@ -5078,17 +5078,21 @@ async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
         result = await hass.config_entries.options.async_init(
             config_entry.entry_id
         )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        # Try to add MQTT pool member with serial primary
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "add_new_port": CONF_MQTT_PATH,
+            },
+        )
 
-    # Assert — menu shown, but manage_pool is NOT an option
-    assert result.get("type") == FlowResultType.MENU
-    menu_options = result.get("menu_options", [])
-    if isinstance(menu_options, dict):
-        steps = list(menu_options.keys())
-    else:
-        steps = list(menu_options)
-    assert "manage_pool" not in steps, (
-        "Pool management should not be available for serial/USB primary"
-    )
+    # Should show the form with an error — not navigate to MQTT sub-step
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {"base": "pool_mqtt_requires_mqtt_primary"}
 
 
 async def test_options_flow_manage_pool_mqtt_form_display(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5239,6 +5239,96 @@ async def test_options_flow_manage_pool_readd_removed_hgi(
     assert config_entry.options.get(CONF_MQTT_HGI_ID) == "18:001111"
 
 
+async def test_options_flow_manage_pool_mqtt_url_errors(
+    hass: HomeAssistant,
+) -> None:
+    """Test manage_pool_mqtt_url validation errors (issue 1171)."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt_ha"},
+            CONF_MQTT_USE_HA: True,
+            CONF_SCHEMA: {SZ_OWNER: "me"},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        # Select "MQTT Broker (full URL)..."
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "add_new_port": "__mqtt_full_url__",
+            },
+        )
+        assert result.get("step_id") == "manage_pool_mqtt_url"
+
+        # Empty URL
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"mqtt_url": ""}
+        )
+        assert result.get("errors") == {"base": "mqtt_url_required"}
+
+        # Invalid URL (not mqtt://)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"mqtt_url": "http://broker:1883"}
+        )
+        assert result.get("errors") == {"base": "mqtt_url_invalid"}
+
+        # Valid mqtt:// but no HGI ID in path
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"mqtt_url": "mqtt://broker:1883/RAMSES/GATEWAY"},
+        )
+        assert result.get("errors") == {"base": "mqtt_url_no_hgi_id"}
+
+
+async def test_options_flow_manage_pool_mqtt_full_url_serial_blocked(
+    hass: HomeAssistant,
+) -> None:
+    """Test full URL add blocked when primary is serial (issue 1171)."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyACM0"},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "add_new_port": "__mqtt_full_url__",
+            },
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {"base": "pool_mqtt_requires_mqtt_primary"}
+
+
 async def test_options_flow_manage_pool_mqtt_form_display(
     hass: HomeAssistant,
 ) -> None:
@@ -5275,6 +5365,84 @@ async def test_options_flow_manage_pool_mqtt_form_display(
     # Should show the form (no user_input → just display)
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "manage_pool_mqtt"
+
+
+async def test_options_flow_manage_pool_primary_label_display(
+    hass: HomeAssistant,
+) -> None:
+    """Test pool member label display with credential masking and topic (issue 1171).
+
+    Covers the _mask_mqtt_url and _pool_member_label helpers for:
+    - Primary with mqtt:// URL with credentials and no path
+    - Primary with mqtt:// URL with credentials and path
+    - Secondary with explicit URL construction
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {
+                SZ_PORT_NAME: "mqtt://user:pass@broker.local:1883"
+            },
+            CONF_MQTT_HGI_ID: "18:001111",
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+                "18:002222": {"_class": "HGI", SZ_TR_OWNER: "me"},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    # Form should be displayed with pool members
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool"
+
+
+async def test_options_flow_manage_pool_additional_port_labels(
+    hass: HomeAssistant,
+) -> None:
+    """Test pool form labels for mqtt/zigbee/other additional ports (issue 1171)."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt_ha"},
+            CONF_MQTT_USE_HA: True,
+            CONF_ADDITIONAL_PORTS: [
+                "mqtt://broker:1883/RAMSES/GATEWAY/18:003333",
+                "zigbee://ttyUSB0",
+                "/dev/ttyACM0",
+            ],
+            CONF_SCHEMA: {SZ_OWNER: "me"},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool"
 
 
 async def test_options_flow_manage_pool_remove_schema_member(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5169,15 +5169,14 @@ async def test_options_flow_manage_pool_remove_schema_member(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={"next_step_id": "manage_pool"}
         )
-        # Uncheck 18:002222 (keep only 18:001111 which is primary).
-        # The primary HGI is excluded from the removable list, so only
-        # 18:002222 appears in schema_pool_members.  Unchecking it
-        # (by submitting an empty list) demotes it.
+        # Uncheck 18:002222 (keep 18:001111 which is primary).
+        # Both HGIs are in the removable list now.  Keep the primary
+        # checked, uncheck the secondary to demote it.
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "schema_pool_members": [],
+                "schema_pool_members": ["18:001111"],
                 "add_new_port": "__none__",
             },
         )
@@ -5187,6 +5186,62 @@ async def test_options_flow_manage_pool_remove_schema_member(
     # 18:002222 should have _owner removed (demoted)
     schema = config_entry.options.get(CONF_SCHEMA, {})
     assert SZ_TR_OWNER not in schema.get("18:002222", {})
+
+
+async def test_options_flow_manage_pool_remove_last_hgi(
+    hass: HomeAssistant,
+) -> None:
+    """Test manage_pool allows removing the last HGI, clearing port (issue 1171).
+
+    Removing the last HGI clears the primary port config so the user
+    can start fresh via Connection / Port.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {
+                SZ_PORT_NAME: "mqtt://broker:1883/RAMSES/GATEWAY/18:001111"
+            },
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:001111": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        # Uncheck the only HGI (the primary) — should clear the port
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "schema_pool_members": [],
+                "add_new_port": "__none__",
+            },
+        )
+
+    # Should save successfully
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Primary port should be cleared
+    serial_port = config_entry.options.get(SZ_SERIAL_PORT, {})
+    assert not serial_port.get(SZ_PORT_NAME)
+    # HGI should have _owner removed
+    schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert SZ_TR_OWNER not in schema.get("18:001111", {})
 
 
 async def test_options_flow_manage_pool_zigbee_form_display(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5161,12 +5161,15 @@ async def test_options_flow_manage_pool_remove_schema_member(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={"next_step_id": "manage_pool"}
         )
-        # Uncheck 18:002222 (keep only 18:001111 which is primary)
+        # Uncheck 18:002222 (keep only 18:001111 which is primary).
+        # The primary HGI is excluded from the removable list, so only
+        # 18:002222 appears in schema_pool_members.  Unchecking it
+        # (by submitting an empty list) demotes it.
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
                 CONF_ADDITIONAL_PORTS: [],
-                "schema_pool_members": ["18:001111"],
+                "schema_pool_members": [],
                 "add_new_port": "__none__",
             },
         )

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -849,6 +849,65 @@ async def test_options_flow_manage_pool_visible_for_serial_primary(
     )
 
 
+async def test_options_flow_manage_pool_serial_no_schema_hgis(
+    hass: HomeAssistant,
+) -> None:
+    """Test serial-discovered HGIs are NOT shown as MQTT pool members (issue 1171).
+
+    When the primary is serial/USB, schema HGIs are serial-discovered
+    devices.  They must NOT appear in the MQTT pool member list — they
+    don't have an MQTT topic or broker.  Phase 1 pool is MQTT-only.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                },
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    # The form should be shown
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool"
+
+    # Schema pool members should NOT be listed — they're serial-discovered
+    schema = result.get("data_schema")
+    if schema and hasattr(schema, "schema"):
+        add_field = schema.schema.get("schema_pool_members")
+        if add_field and hasattr(add_field, "config"):
+            options = add_field.config.get("options", [])
+            values = [opt["value"] for opt in options]
+            assert "18:149488" not in values, (
+                "Serial-discovered HGI must not appear as MQTT pool member"
+            )
+            assert "18:130236" not in values, (
+                "Serial-discovered HGI must not appear as MQTT pool member"
+            )
+
+
 async def test_options_flow_schema_save_preserves_serial_port(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5095,6 +5095,51 @@ async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
     assert result.get("errors") == {"base": "pool_mqtt_requires_mqtt_primary"}
 
 
+async def test_options_flow_manage_pool_mqtt_add_when_no_primary(
+    hass: HomeAssistant,
+) -> None:
+    """Test manage_pool allows MQTT add when there is no primary (issue 1171).
+
+    After clearing all HGIs, the primary port is empty.  Adding an MQTT
+    HGI should be allowed — it becomes the new primary.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        # Add MQTT pool member with no primary — should navigate to MQTT sub-step
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_ADDITIONAL_PORTS: [],
+                "add_new_port": CONF_MQTT_PATH,
+            },
+        )
+
+    # Should navigate to the MQTT sub-step (form), not show an error
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool_mqtt"
+    assert not result.get("errors")
+
+
 async def test_options_flow_manage_pool_mqtt_form_display(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes three bugs reported in https://github.com/ramses-rf/ramses_cc/issues/1171:

1. **Primary HGI can't be removed from pool but looks removable** — The primary HGI was shown as a checkbox in the Manage Gateway Pool pane, but unchecking it was silently ignored (the code skips the primary). Now the primary HGI is excluded from the removable checkbox list entirely, so users only see checkboxes for HGIs they can actually remove.

2. **MQTT credentials not masked at top of pane** — The `primary_port` description placeholder showed the raw `mqtt://user:pass@host:port` URL. Now credentials are masked with `***:***@host:port`, matching the checkbox labels.

3. **`Task was destroyed but it is pending`** — `PortProtocol._tx_worker()` task was cancelled but not awaited during `engine.stop()`. Fixed in ramses_rf PR (see below).

#### Test plan
- [x] `tests/tests_new/test_config_flow.py` — 113 passed, 2 skipped
- [x] Full ramses_cc suite — 1748 passed, 15 skipped
- [x] Updated `test_options_flow_manage_pool_remove_schema_member` to match new primary-excluded behavior