### PR TITLE
feat: Phase 2 hybrid serial+MQTT pool with ID_COMMAND signature policy, status entities, and MQTT form redesign

### DIFF
--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -836,7 +836,9 @@ def async_register_domain_services(
     )
 
     # Passive device scan services (only if scan is enabled)
-    if entry.options.get(CONF_ADVANCED_FEATURES, {}).get(CONF_PASSIVE_SCAN):
+    if entry.options.get(CONF_ADVANCED_FEATURES, {}).get(
+        CONF_PASSIVE_SCAN, True
+    ):
         hass.services.async_register(
             DOMAIN,
             SVC_GET_DISCOVERED_DEVICES,

--- a/custom_components/ramses_cc/__init__.py
+++ b/custom_components/ramses_cc/__init__.py
@@ -74,6 +74,8 @@ from homeassistant.helpers.service import verify_domain_control
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
+from ramses_tx.transport.helpers import redact_url
+
 from .const import (
     CONF_ADVANCED_FEATURES,
     CONF_FRESH_START,
@@ -392,16 +394,21 @@ async def async_setup_entry(
     try:
         await coordinator.async_setup()
     except tx_exc.TransportSourceInvalid as err:  # not TransportSerialError
-        _LOGGER.error("Unrecoverable problem with the serial port: %s", err)
+        _LOGGER.error(
+            "Unrecoverable problem with the serial port: %s",
+            redact_url(str(err)),
+        )
         raise ConfigEntryError(
-            f"Unrecoverable serial port error: {err}"
+            f"Unrecoverable serial port error: {redact_url(str(err))}"
         ) from err
     except (tx_exc.TransportError, TimeoutError, ConfigEntryNotReady) as err:
         _LOGGER.warning(
-            "Failed to set up entry %s (will retry): %s", entry.entry_id, err
+            "Failed to set up entry %s (will retry): %s",
+            entry.entry_id,
+            redact_url(str(err)),
         )
         raise ConfigEntryNotReady(
-            f"There is a problem with the serial port: {err}"
+            f"There is a problem with the serial port: {redact_url(str(err))}"
         ) from err
 
     # Start the coordinator after successful setup

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -122,6 +122,11 @@ async def async_setup_entry(
 
     coordinator.async_register_platform(platform, add_devices)
 
+    # Per-HGI pool binary sensors + aggregate pool status sensor
+    # (issue 1119).  These are coordinator-driven (not device-driven)
+    # and report the connectivity/availability of each pool child.
+    _add_pool_status_entities(coordinator, async_add_entities)
+
 
 class RamsesBinarySensor(RamsesEntity, BinarySensorEntity):
     """Representation of a Ramses binary sensor."""
@@ -574,3 +579,220 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
     ),
 )
+
+
+# -- Per-HGI pool status entities (issue 1119) ------------------------------
+
+
+def _add_pool_status_entities(
+    coordinator: RamsesCoordinator,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Create per-HGI binary sensors + aggregate pool status sensor.
+
+    These entities are coordinator-driven (not device-driven) and
+    report the connectivity/availability of each pool child.  They
+    are created once at setup; the coordinator's
+    :meth:`async_update_listeners` triggers state refreshes.
+
+    :param coordinator: The integration coordinator.
+    :param async_add_entities: Callback to add entities.
+    """
+    statuses = coordinator.get_pool_child_status()
+    entities: list[RamsesPoolChildBinarySensor] = []
+    seen_hgis: set[str] = set()
+    for child_status in statuses:
+        hgi_id = child_status.get("hgi_id")
+        child_id = child_status.get("child_id")
+        if not hgi_id or not child_id:
+            continue
+        hgi_key = str(hgi_id)
+        # Deduplicate by HGI ID: when the same HGI appears as both a
+        # serial child and an excluded MQTT callback child, keep only
+        # the first (serial children are listed first in the pool).
+        if hgi_key in seen_hgis:
+            continue
+        seen_hgis.add(hgi_key)
+        entities.append(
+            RamsesPoolChildBinarySensor(
+                coordinator, hgi_key, str(child_id), child_status
+            )
+        )
+    # Aggregate pool status sensor (always created if there's a pool).
+    if statuses:
+        entities.append(RamsesPoolStatusSensor(coordinator))
+    if entities:
+        async_add_entities(entities)
+
+
+class RamsesPoolChildBinarySensor(BinarySensorEntity):
+    """Binary sensor for a single pool child's connectivity.
+
+    ``is_on=True`` means the child is connected and online (packets
+    flowing).  Extra state attributes expose the child's HGI ID,
+    port name, send-readiness, and packet counters.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: RamsesCoordinator,
+        hgi_id: str,
+        child_id: str,
+        initial_status: dict[str, object],
+    ) -> None:
+        """Initialize the per-HGI pool child sensor.
+
+        :param coordinator: The integration coordinator.
+        :param hgi_id: The HGI device ID for this child.
+        :param child_id: The pool child index (string).
+        :param initial_status: Initial status dict.
+        """
+        self._coordinator = coordinator
+        self._hgi_id = hgi_id
+        self._child_id = child_id
+        self._status: dict[str, object] = initial_status
+        self._attr_unique_id = f"pool_child_{hgi_id}_online"
+        self._attr_name = f"HGI {hgi_id} online"
+
+    async def async_added_to_hass(self) -> None:
+        """Register coordinator update listener."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._coordinator.async_add_listener(
+                self._handle_coordinator_update
+            )
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the coordinator and pool are available."""
+        return self._coordinator.last_update_success
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the child is connected and online."""
+        status = self._find_status()
+        if status is None:
+            return None
+        return bool(
+            status.get("connected") and status.get("availability") == "ONLINE"
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return per-child attributes for monitoring."""
+        status = self._find_status() or self._status
+        return {
+            "hgi_id": status.get("hgi_id"),
+            "child_id": status.get("child_id"),
+            "port_name": status.get("port_name"),
+            "connected": status.get("connected"),
+            "availability": status.get("availability"),
+            "accepted": status.get("accepted"),
+            "send_ready": status.get("send_ready"),
+            "callback_driven": status.get("callback_driven"),
+            "pkts_received": status.get("pkts_received"),
+            "consecutive_errors": status.get("consecutive_errors"),
+            "last_pkt_time": status.get("last_pkt_time"),
+        }
+
+    def _find_status(self) -> dict[str, object] | None:
+        """Find this child's status in the current pool status list.
+
+        When multiple children share the same HGI ID (e.g. a serial
+        child and an excluded MQTT callback child), prefer the one
+        that is connected and online.  This ensures the sensor
+        reports the active transport's state after a failover.
+        """
+        first_match: dict[str, object] | None = None
+        for s in self._coordinator.get_pool_child_status():
+            if s.get("hgi_id") != self._hgi_id:
+                continue
+            if first_match is None:
+                first_match = s
+            # Prefer the first connected+online child.
+            if s.get("connected") and s.get("availability") == "ONLINE":
+                return s
+        return first_match
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        status = self._find_status()
+        if status is not None:
+            self._status = status
+        self.async_write_ha_state()
+
+
+class RamsesPoolStatusSensor(BinarySensorEntity):
+    """Aggregate pool status sensor.
+
+    ``is_on=True`` means at least one pool child is connected and
+    online.  Extra state attributes expose aggregate counts.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: RamsesCoordinator) -> None:
+        """Initialize the aggregate pool status sensor.
+
+        :param coordinator: The integration coordinator.
+        """
+        self._coordinator = coordinator
+        self._attr_unique_id = "pool_status_online"
+        self._attr_name = "Pool status"
+
+    async def async_added_to_hass(self) -> None:
+        """Register coordinator update listener."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._coordinator.async_add_listener(
+                self._handle_coordinator_update
+            )
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the coordinator is available."""
+        return self._coordinator.last_update_success
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if at least one child is connected and online."""
+        statuses = self._coordinator.get_pool_child_status()
+        if not statuses:
+            return None
+        return any(
+            bool(s.get("connected") and s.get("availability") == "ONLINE")
+            for s in statuses
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return aggregate pool attributes."""
+        statuses = self._coordinator.get_pool_child_status()
+        connected = sum(1 for s in statuses if s.get("connected"))
+        online = sum(
+            1
+            for s in statuses
+            if s.get("connected") and s.get("availability") == "ONLINE"
+        )
+        send_ready = sum(1 for s in statuses if s.get("send_ready"))
+        return {
+            "children": len(statuses),
+            "connected": connected,
+            "online": online,
+            "send_ready": send_ready,
+            "child_hgis": [s.get("hgi_id") for s in statuses],
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -15,7 +15,11 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_platform
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_platform,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from ramses_rf.const import (
@@ -57,6 +61,7 @@ from .const import (
     ATTR_LATEST_EVENT,
     ATTR_LATEST_FAULT,
     ATTR_WORKING_SCHEMA,
+    DOMAIN,
 )
 from .coordinator import RamsesCoordinator
 from .entity import RamsesEntity, RamsesEntityDescription
@@ -584,6 +589,40 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[RamsesBinarySensorEntityDescription, ...] = (
 # -- Per-HGI pool status entities (issue 1119) ------------------------------
 
 
+def _migrate_old_pool_entities(hass: HomeAssistant, entry_id: str) -> None:
+    """Remove old non-entry-scoped pool entities.
+
+    Before the entry-scoping fix, pool entities had unique IDs like
+    ``pool_child_18:012345_online`` and ``pool_status_online`` (no
+    config-entry prefix).  After the fix, unique IDs include the
+    entry ID (``{entry_id}_pool_child_...``).  The old entities remain
+    in the registry as orphaned duplicates.  Remove them.
+    """
+    ent_reg = er.async_get(hass)
+    for entity in ent_reg.entities.values():
+        uid = entity.unique_id
+        # Old non-entry-scoped pool entity unique IDs:
+        #   pool_child_18:012345_online
+        #   pool_status_online
+        # Skip if the unique ID has the entry_id prefix (current format).
+        if uid.startswith(f"{entry_id}_"):
+            continue
+        if uid.startswith("pool_child_") and uid.endswith("_online"):
+            ent_reg.async_remove(entity.entity_id)
+            _LOGGER.info(
+                "Migrated old pool entity %s (unique_id=%s)",
+                entity.entity_id,
+                uid,
+            )
+        elif uid == "pool_status_online":
+            ent_reg.async_remove(entity.entity_id)
+            _LOGGER.info(
+                "Migrated old pool status entity %s (unique_id=%s)",
+                entity.entity_id,
+                uid,
+            )
+
+
 def _add_pool_status_entities(
     coordinator: RamsesCoordinator,
     async_add_entities: AddEntitiesCallback,
@@ -595,6 +634,9 @@ def _add_pool_status_entities(
     """
     if not coordinator.is_pool_enabled:
         return
+
+    # Migrate old non-entry-scoped pool entities (one-time cleanup).
+    _migrate_old_pool_entities(coordinator.hass, coordinator.entry.entry_id)
 
     seen_hgis: set[str] = set()
 
@@ -660,6 +702,9 @@ class RamsesPoolChildBinarySensor(BinarySensorEntity):
             f"{coordinator.entry.entry_id}_pool_child_{hgi_id}_online"
         )
         self._attr_name = f"HGI {hgi_id} online"
+        # Assign to the HGI device so the entity is grouped in the UI
+        # (not "ungrouped") and appears alongside the Gateway status.
+        self._attr_device_info = dr.DeviceInfo(identifiers={(DOMAIN, hgi_id)})
 
     async def async_added_to_hass(self) -> None:
         """Register coordinator update listener."""

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -591,15 +591,19 @@ def _add_pool_status_entities(
     """Create per-HGI binary sensors + aggregate pool status sensor.
 
     These entities are coordinator-driven (not device-driven) and
-    report the connectivity/availability of each pool child.  They
-    are created once at setup; the coordinator's
-    :meth:`async_update_listeners` triggers state refreshes.
+    report the connectivity/availability of each pool child.
+
+    The aggregate pool status sensor is always created when the
+    coordinator is pool-enabled, even if no children are online yet.
+    Per-HGI child sensors are created for currently-available
+    children; a delayed re-check schedules a second pass to catch
+    HGIs that come online after initial setup (issue 1119).
 
     :param coordinator: The integration coordinator.
     :param async_add_entities: Callback to add entities.
     """
     statuses = coordinator.get_pool_child_status()
-    entities: list[RamsesPoolChildBinarySensor] = []
+    entities: list[RamsesPoolChildBinarySensor | RamsesPoolStatusSensor] = []
     seen_hgis: set[str] = set()
     for child_status in statuses:
         hgi_id = child_status.get("hgi_id")
@@ -618,11 +622,51 @@ def _add_pool_status_entities(
                 coordinator, hgi_key, str(child_id), child_status
             )
         )
-    # Aggregate pool status sensor (always created if there's a pool).
-    if statuses:
+    # Aggregate pool status sensor: always create when pool-enabled,
+    # even if no children are online yet (issue 1119).
+    if coordinator.is_pool_enabled:
         entities.append(RamsesPoolStatusSensor(coordinator))
     if entities:
         async_add_entities(entities)
+
+    # Schedule a delayed re-check to add child sensors for HGIs that
+    # come online after initial setup (e.g. serial reconnect, MQTT
+    # LWT arriving after the binary_sensor platform is set up).
+    if coordinator.is_pool_enabled:
+
+        async def _delayed_pool_check() -> None:
+            """Re-check for pool children after a short delay."""
+            import asyncio
+
+            await asyncio.sleep(10)
+            new_statuses = coordinator.get_pool_child_status()
+            new_entities: list[RamsesPoolChildBinarySensor] = []
+            existing_hgis: set[str] = set()
+            # Collect HGI IDs already tracked by existing entities.
+            for s in new_statuses:
+                hgi = s.get("hgi_id")
+                if hgi:
+                    existing_hgis.add(str(hgi))
+            # We can't easily check which entities already exist, so
+            # only add entities for HGIs not in the original seen set.
+            for s in new_statuses:
+                hgi_id = s.get("hgi_id")
+                child_id = s.get("child_id")
+                if not hgi_id or not child_id:
+                    continue
+                hgi_key = str(hgi_id)
+                if hgi_key in seen_hgis:
+                    continue
+                seen_hgis.add(hgi_key)
+                new_entities.append(
+                    RamsesPoolChildBinarySensor(
+                        coordinator, hgi_key, str(child_id), s
+                    )
+                )
+            if new_entities:
+                async_add_entities(new_entities)
+
+        coordinator.hass.async_create_task(_delayed_pool_check())
 
 
 class RamsesPoolChildBinarySensor(BinarySensorEntity):

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -599,6 +599,10 @@ def _migrate_old_pool_entities(hass: HomeAssistant, entry_id: str) -> None:
     in the registry as orphaned duplicates.  Remove them.
     """
     ent_reg = er.async_get(hass)
+    # Collect entities to remove first — can't modify the registry
+    # while iterating over ent_reg.entities (RuntimeError: dictionary
+    # changed size during iteration).
+    to_remove: list[tuple[str, str]] = []  # (entity_id, unique_id)
     for entity in ent_reg.entities.values():
         uid = entity.unique_id
         # Old non-entry-scoped pool entity unique IDs:
@@ -608,19 +612,14 @@ def _migrate_old_pool_entities(hass: HomeAssistant, entry_id: str) -> None:
         if uid.startswith(f"{entry_id}_"):
             continue
         if uid.startswith("pool_child_") and uid.endswith("_online"):
-            ent_reg.async_remove(entity.entity_id)
-            _LOGGER.info(
-                "Migrated old pool entity %s (unique_id=%s)",
-                entity.entity_id,
-                uid,
-            )
+            to_remove.append((entity.entity_id, uid))
         elif uid == "pool_status_online":
-            ent_reg.async_remove(entity.entity_id)
-            _LOGGER.info(
-                "Migrated old pool status entity %s (unique_id=%s)",
-                entity.entity_id,
-                uid,
-            )
+            to_remove.append((entity.entity_id, uid))
+    for entity_id, uid in to_remove:
+        ent_reg.async_remove(entity_id)
+        _LOGGER.info(
+            "Migrated old pool entity %s (unique_id=%s)", entity_id, uid
+        )
 
 
 def _add_pool_status_entities(

--- a/custom_components/ramses_cc/binary_sensor.py
+++ b/custom_components/ramses_cc/binary_sensor.py
@@ -590,83 +590,40 @@ def _add_pool_status_entities(
 ) -> None:
     """Create per-HGI binary sensors + aggregate pool status sensor.
 
-    These entities are coordinator-driven (not device-driven) and
-    report the connectivity/availability of each pool child.
-
-    The aggregate pool status sensor is always created when the
-    coordinator is pool-enabled, even if no children are online yet.
-    Per-HGI child sensors are created for currently-available
-    children; a delayed re-check schedules a second pass to catch
-    HGIs that come online after initial setup (issue 1119).
-
     :param coordinator: The integration coordinator.
     :param async_add_entities: Callback to add entities.
     """
-    statuses = coordinator.get_pool_child_status()
-    entities: list[RamsesPoolChildBinarySensor | RamsesPoolStatusSensor] = []
+    if not coordinator.is_pool_enabled:
+        return
+
     seen_hgis: set[str] = set()
-    for child_status in statuses:
-        hgi_id = child_status.get("hgi_id")
-        child_id = child_status.get("child_id")
-        if not hgi_id or not child_id:
-            continue
-        hgi_key = str(hgi_id)
-        # Deduplicate by HGI ID: when the same HGI appears as both a
-        # serial child and an excluded MQTT callback child, keep only
-        # the first (serial children are listed first in the pool).
-        if hgi_key in seen_hgis:
-            continue
-        seen_hgis.add(hgi_key)
-        entities.append(
-            RamsesPoolChildBinarySensor(
-                coordinator, hgi_key, str(child_id), child_status
-            )
-        )
-    # Aggregate pool status sensor: always create when pool-enabled,
-    # even if no children are online yet (issue 1119).
-    if coordinator.is_pool_enabled:
-        entities.append(RamsesPoolStatusSensor(coordinator))
-    if entities:
-        async_add_entities(entities)
 
-    # Schedule a delayed re-check to add child sensors for HGIs that
-    # come online after initial setup (e.g. serial reconnect, MQTT
-    # LWT arriving after the binary_sensor platform is set up).
-    if coordinator.is_pool_enabled:
-
-        async def _delayed_pool_check() -> None:
-            """Re-check for pool children after a short delay."""
-            import asyncio
-
-            await asyncio.sleep(10)
-            new_statuses = coordinator.get_pool_child_status()
-            new_entities: list[RamsesPoolChildBinarySensor] = []
-            existing_hgis: set[str] = set()
-            # Collect HGI IDs already tracked by existing entities.
-            for s in new_statuses:
-                hgi = s.get("hgi_id")
-                if hgi:
-                    existing_hgis.add(str(hgi))
-            # We can't easily check which entities already exist, so
-            # only add entities for HGIs not in the original seen set.
-            for s in new_statuses:
-                hgi_id = s.get("hgi_id")
-                child_id = s.get("child_id")
-                if not hgi_id or not child_id:
-                    continue
-                hgi_key = str(hgi_id)
-                if hgi_key in seen_hgis:
-                    continue
-                seen_hgis.add(hgi_key)
-                new_entities.append(
-                    RamsesPoolChildBinarySensor(
-                        coordinator, hgi_key, str(child_id), s
-                    )
+    @callback
+    def add_missing_child_entities() -> None:
+        """Add status entities for newly identified pool children."""
+        entities: list[RamsesPoolChildBinarySensor] = []
+        for child_status in coordinator.get_pool_child_status():
+            hgi_id = child_status.get("hgi_id")
+            child_id = child_status.get("child_id")
+            if not hgi_id or child_id is None:
+                continue
+            hgi_key = str(hgi_id)
+            if hgi_key in seen_hgis:
+                continue
+            seen_hgis.add(hgi_key)
+            entities.append(
+                RamsesPoolChildBinarySensor(
+                    coordinator, hgi_key, str(child_id), child_status
                 )
-            if new_entities:
-                async_add_entities(new_entities)
+            )
+        if entities:
+            async_add_entities(entities)
 
-        coordinator.hass.async_create_task(_delayed_pool_check())
+    async_add_entities([RamsesPoolStatusSensor(coordinator)])
+    add_missing_child_entities()
+    coordinator.entry.async_on_unload(
+        coordinator.async_add_listener(add_missing_child_entities)
+    )
 
 
 class RamsesPoolChildBinarySensor(BinarySensorEntity):
@@ -699,7 +656,9 @@ class RamsesPoolChildBinarySensor(BinarySensorEntity):
         self._hgi_id = hgi_id
         self._child_id = child_id
         self._status: dict[str, object] = initial_status
-        self._attr_unique_id = f"pool_child_{hgi_id}_online"
+        self._attr_unique_id = (
+            f"{coordinator.entry.entry_id}_pool_child_{hgi_id}_online"
+        )
         self._attr_name = f"HGI {hgi_id} online"
 
     async def async_added_to_hass(self) -> None:
@@ -789,7 +748,9 @@ class RamsesPoolStatusSensor(BinarySensorEntity):
         :param coordinator: The integration coordinator.
         """
         self._coordinator = coordinator
-        self._attr_unique_id = "pool_status_online"
+        self._attr_unique_id = (
+            f"{coordinator.entry.entry_id}_pool_status_online"
+        )
         self._attr_name = "Pool status"
 
     async def async_added_to_hass(self) -> None:
@@ -813,7 +774,12 @@ class RamsesPoolStatusSensor(BinarySensorEntity):
         if not statuses:
             return None
         return any(
-            bool(s.get("connected") and s.get("availability") == "ONLINE")
+            bool(
+                s.get("connected")
+                and s.get("availability") == "ONLINE"
+                and s.get("accepted")
+                and s.get("send_ready")
+            )
             for s in statuses
         )
 
@@ -828,11 +794,20 @@ class RamsesPoolStatusSensor(BinarySensorEntity):
             if s.get("connected") and s.get("availability") == "ONLINE"
         )
         send_ready = sum(1 for s in statuses if s.get("send_ready"))
+        eligible = sum(
+            1
+            for s in statuses
+            if s.get("connected")
+            and s.get("availability") == "ONLINE"
+            and s.get("accepted")
+            and s.get("send_ready")
+        )
         return {
             "children": len(statuses),
             "connected": connected,
             "online": online,
             "send_ready": send_ready,
+            "eligible": eligible,
             "child_hgis": [s.get("hgi_id") for s in statuses],
         }
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -88,6 +88,7 @@ from .const import (
     SZ_TR_NAME,
     SZ_TR_OWNER,
     SZ_TR_SKIPPED,
+    build_hgi_comment,
 )
 from .ha_compat import _REAL_VOL, vol_schema
 from .schemas import migrate_known_list_traits, order_schema
@@ -2014,7 +2015,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                             ):
                                                 parts.append("zigbee")
                                             schema_dict[dev_id]["_comment"] = (
-                                                "Supports: " + ", ".join(parts)
+                                                build_hgi_comment(parts)
                                             )
                         self.options[CONF_SCHEMA] = schema_dict
                     self.options[CONF_ADDITIONAL_PORTS] = additional

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -101,7 +101,7 @@ CONF_HA_MQTT_PATH: Final = "Use Home Assistant MQTT - In development!"
 CONF_ZIGBEE_DEVICE: Final = "Zigbee device"
 
 # HGI device ID regex: 18:NNNNNN (class 18, 6 hex digits).
-_HGI_ID_RE: Final = re.compile(r"^18:[0-9]{6}$")
+_HGI_ID_RE: Final = re.compile(r"^18:[0-9A-Fa-f]{6}$")
 
 
 if hasattr(usb, "async_scan_serial_ports"):
@@ -2795,9 +2795,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
             if not hgi_id:
                 errors["base"] = "hgi_id_required"
-            elif not re.match(
-                r"^\d{2}:\d{6}$", hgi_id
-            ) or not hgi_id.startswith(HGI_PREFIX):
+            elif not _HGI_ID_RE.match(hgi_id):
                 errors["base"] = "hgi_id_invalid"
             else:
                 # Phase 1: MQTT pool children share the HA MQTT
@@ -2815,6 +2813,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     schema_dict[hgi_id] = {}
                 schema_dict[hgi_id]["_class"] = "HGI"
                 schema_dict[hgi_id][SZ_TR_OWNER] = root_owner
+                schema_dict[hgi_id]["_preferred_type"] = "mqtt"
                 # Clear the _removed_from_pool trait if it was set
                 # (user is explicitly re-adding this HGI)
                 schema_dict[hgi_id].pop("_removed_from_pool", None)
@@ -2882,7 +2881,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         default_topic = self.options.get(CONF_MQTT_TOPIC, "RAMSES/GATEWAY")
 
         if user_input is not None:
-            hgi_id = (user_input.get("hgi_id") or "").strip()
+            hgi_id = (user_input.get("hgi_id") or "").strip().upper()
             topic_prefix = (user_input.get("topic_prefix") or "").strip()
             if not hgi_id:
                 errors["base"] = "mqtt_hgi_id_required"
@@ -2907,9 +2906,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 self.options[CONF_SCHEMA] = schema_dict
 
                 # Store the optional topic prefix override if it
-                # differs from the configured topic.
+                # differs from the configured topic.  An empty
+                # submission clears any previous override (issue 1171).
                 if topic_prefix and topic_prefix != default_topic:
                     self.options[CONF_MQTT_TOPIC] = topic_prefix
+                elif not topic_prefix and CONF_MQTT_TOPIC in self.options:
+                    self.options.pop(CONF_MQTT_TOPIC, None)
 
                 if switching_primary:
                     # Set as primary MQTT HGI (serial → MQTT switch).
@@ -2934,6 +2936,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             hgi_id,
                         )
                     else:
+                        # Direct add: mark as MQTT-preferred so the
+                        # coordinator recognises it as an MQTT pool
+                        # member (issue 1171).
+                        schema_dict[hgi_id]["_preferred_type"] = "mqtt"
+                        self.options[CONF_SCHEMA] = schema_dict
                         _LOGGER.info(
                             "Added MQTT pool HGI %s (HA broker)",
                             hgi_id,

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -3388,6 +3388,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     "Check the serial port / MQTT broker connection "
                     "and reload the integration."
                 )
+            elif not getattr(coordinator, "client", None):
+                message = (
+                    "The Ramses RF transport failed to start. "
+                    "Check the serial port / MQTT broker connection "
+                    "and reload the integration."
+                )
             else:
                 message = "Passive device scan is not enabled."
             return self.async_show_form(
@@ -4305,11 +4311,23 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         coordinator = getattr(self.config_entry, "runtime_data", None)
 
         if not coordinator or not coordinator.discovery_manager:
+            if coordinator is None:
+                message = (
+                    "The Ramses RF integration is not running. "
+                    "Check the serial port / MQTT broker connection "
+                    "and reload the integration."
+                )
+            elif not getattr(coordinator, "client", None):
+                message = (
+                    "The Ramses RF transport failed to start. "
+                    "Check the serial port / MQTT broker connection "
+                    "and reload the integration."
+                )
+            else:
+                message = "Passive device scan is not enabled."
             return self.async_show_form(
                 step_id="review_device_health",
-                description_placeholders={
-                    "message": "Passive device scan is not enabled."
-                },
+                description_placeholders={"message": message},
                 last_step=True,
             )
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2173,24 +2173,32 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     primary_hgi_id = m.group(1)
         # For serial primary, find the primary HGI from the schema
         # (the accepted HGI with _owner and _class: HGI).
-        # Prefer the HGI with _preferred_type: usb, since that's the
-        # one physically connected to the primary serial port.  If
-        # none has _preferred_type: usb, fall back to the first
-        # accepted HGI (issue 1185).
+        # When the runtime port-to-HGI mapping is available, use it
+        # directly — the primary HGI is the one on the primary serial
+        # port (issue 1185).  Otherwise, prefer the HGI with
+        # _preferred_type: usb, falling back to the first accepted HGI.
         if not primary_hgi_id and isinstance(schema, dict):
+            # Runtime mapping: the HGI on the primary serial port.
+            if (
+                isinstance(primary_port, str)
+                and primary_port in _runtime_port_hgi_map
+            ):
+                primary_hgi_id = _runtime_port_hgi_map[primary_port]
             # First pass: look for _preferred_type: usb.
-            for dev_id, entry in schema.items():
-                if (
-                    dev_id.startswith(HGI_PREFIX)
-                    and dev_id != DEFAULT_HGI_ID
-                    and isinstance(entry, dict)
-                    and entry.get("_class", "").upper() == "HGI"
-                    and entry.get(SZ_TR_OWNER) == root_owner
-                    and not entry.get("_disabled")
-                    and str(entry.get("_preferred_type", "")).lower() == "usb"
-                ):
-                    primary_hgi_id = dev_id
-                    break
+            if not primary_hgi_id:
+                for dev_id, entry in schema.items():
+                    if (
+                        dev_id.startswith(HGI_PREFIX)
+                        and dev_id != DEFAULT_HGI_ID
+                        and isinstance(entry, dict)
+                        and entry.get("_class", "").upper() == "HGI"
+                        and entry.get(SZ_TR_OWNER) == root_owner
+                        and not entry.get("_disabled")
+                        and str(entry.get("_preferred_type", "")).lower()
+                        == "usb"
+                    ):
+                        primary_hgi_id = dev_id
+                        break
             # Fall back: first accepted HGI.
             if not primary_hgi_id:
                 for dev_id, entry in schema.items():

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -4079,6 +4079,72 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     from .coordinator import RamsesCoordinator
 
                     old_schema = new_options.get(CONF_SCHEMA, {})
+
+                    # Clear retained MQTT LWT messages for known HGIs so
+                    # they don't reappear as discovery candidates after the
+                    # schema wipe.  The MQTT broker retains the last
+                    # "online"/"offline" LWT message for each HGI, and the
+                    # MqttPoolBridge re-discovers HGIs from retained
+                    # "online" messages on reload.  Publishing an empty
+                    # retained payload clears the retained message (MQTT
+                    # spec: a zero-length payload with retain=True clears
+                    # the retained message for that topic).
+                    # Only do this for MQTT-primary configs (mqtt_use_ha
+                    # or mqtt:// URL) where the broker is reachable.
+                    is_mqtt_primary = bool(
+                        new_options.get(CONF_MQTT_USE_HA)
+                    ) or (
+                        isinstance(
+                            new_options.get(SZ_SERIAL_PORT, {}).get(
+                                SZ_PORT_NAME
+                            ),
+                            str,
+                        )
+                        and new_options[SZ_SERIAL_PORT][
+                            SZ_PORT_NAME
+                        ].startswith("mqtt://")
+                    )
+                    if is_mqtt_primary:
+                        topic_prefix = new_options.get(
+                            CONF_MQTT_TOPIC, "RAMSES/GATEWAY"
+                        )
+                        hgi_ids_to_clear = [
+                            dev_id
+                            for dev_id, entry in old_schema.items()
+                            if (
+                                dev_id.startswith("18:")
+                                and isinstance(entry, dict)
+                                and entry.get("_class", "").upper() == "HGI"
+                            )
+                        ]
+                        if hgi_ids_to_clear:
+                            try:
+                                from homeassistant.components import (
+                                    mqtt as mqtt_comp,
+                                )
+
+                                for hgi_id in hgi_ids_to_clear:
+                                    topic = f"{topic_prefix}/{hgi_id}"
+                                    await mqtt_comp.async_publish(
+                                        self.hass,
+                                        topic,
+                                        "",
+                                        0,
+                                        True,  # retain=True, empty payload
+                                    )
+                                _LOGGER.info(
+                                    "Clear cache: cleared %d retained "
+                                    "LWT message(s) for HGIs: %s",
+                                    len(hgi_ids_to_clear),
+                                    sorted(hgi_ids_to_clear),
+                                )
+                            except Exception as err:
+                                _LOGGER.warning(
+                                    "Clear cache: failed to clear "
+                                    "retained LWT messages: %s",
+                                    str(err)[:200],
+                                )
+
                     foreign_ids = (
                         RamsesCoordinator._extract_foreign_device_ids(
                             old_schema

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1937,6 +1937,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 elif not errors:
                     # No new port and no errors — just save removals
                     # and _preferred_type updates.
+                    # Capture old _preferred_type values BEFORE
+                    # modifying the schema, so we can detect changes.
+                    old_schema_prefs: dict[str, str] = {}
+                    _old_schema = self.options.get(CONF_SCHEMA, {})
+                    if isinstance(_old_schema, dict):
+                        for _k, _v in _old_schema.items():
+                            if isinstance(_v, dict):
+                                old_schema_prefs[_k] = str(
+                                    _v.get("_preferred_type", "")
+                                )
                     schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
                     if isinstance(schema_dict, dict):
                         for key, val in user_input.items():
@@ -2027,15 +2037,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         # Only trigger a transport switch when the
                         # _preferred_type actually CHANGED — not when
                         # the form just re-submitted the same default.
-                        old_schema = self.options.get(CONF_SCHEMA, {})
-                        old_pref = (
-                            old_schema.get(_primary_hgi_id, {}).get(
-                                "_preferred_type", ""
-                            )
-                            if isinstance(old_schema, dict)
-                            else ""
+                        # Treat "" and "mqtt" as equivalent (both mean
+                        # MQTT) since the selector uses "mqtt" as the
+                        # value for the MQTT option.
+                        old_pref_norm = (
+                            old_schema_prefs.get(_primary_hgi_id, "") or "mqtt"
                         )
-                        if new_pref == old_pref:
+                        new_pref_norm = new_pref or "mqtt"
+                        if new_pref_norm == old_pref_norm:
                             # No change — don't switch transport
                             pass
                         else:
@@ -2139,6 +2148,20 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 m = _re.search(r"(18:[0-9]{6})", primary_port)
                 if m:
                     primary_hgi_id = m.group(1)
+        # For serial primary, find the primary HGI from the schema
+        # (the accepted HGI with _owner and _class: HGI).
+        if not primary_hgi_id and isinstance(schema, dict):
+            for dev_id, entry in schema.items():
+                if (
+                    dev_id.startswith(HGI_PREFIX)
+                    and dev_id != DEFAULT_HGI_ID
+                    and isinstance(entry, dict)
+                    and entry.get("_class", "").upper() == "HGI"
+                    and entry.get(SZ_TR_OWNER) == root_owner
+                    and not entry.get("_disabled")
+                ):
+                    primary_hgi_id = dev_id
+                    break
 
         # Build a label for each pool member showing its broker info.
         # For the primary HGI: the primary_port URL.
@@ -2236,6 +2259,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     comment = str(schema_entry.get("_comment", ""))
                 # Show detected transports in the label.
                 detected_str = f" [{comment}]" if comment else ""
+                # The primary HGI on serial always shows as USB
+                # regardless of _preferred_type — the primary port
+                # IS the transport.  _preferred_type only matters
+                # for non-primary pool members.
+                if dev_id == primary_hgi_id:
+                    return f"HGI: {dev_id} (primary, USB, {primary_port}){detected_str}"
                 if preferred == "usb":
                     return f"HGI: {dev_id} (USB){detected_str}"
                 if preferred == "zigbee":

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -960,7 +960,7 @@ class BaseRamsesFlow:
                     # injected into known_list — now goes to schema as _
                     # traits, the single source of truth.)
                     if self.options.get(CONF_MQTT_USE_HA):
-                        schema = self.options.get(CONF_SCHEMA, {}).copy()
+                        schema = deepcopy(self.options.get(CONF_SCHEMA, {}))
                         if hgi_id not in schema:
                             _LOGGER.debug(
                                 "Config Flow: Inject MQTT HGI %s into schema",
@@ -1855,11 +1855,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         or self.options.get(CONF_MQTT_USE_HA)
                     )
 
-                    # If all owned HGIs are being removed and the
-                    # transport is MQTT, require confirmation.
+                    # If all owned HGIs are being removed, require
+                    # confirmation regardless of transport type.
                     # Don't demote yet — show the error first so the
                     # user can retry without losing the members.
-                    if to_demote and not remaining_hgis and is_mqtt_primary:
+                    if to_demote and not remaining_hgis:
                         if not user_input.get("confirm_clear_last"):
                             errors["base"] = "pool_confirm_clear_last"
                             # Don't demote — fall through to form
@@ -3032,15 +3032,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Don't reload options if we're in a switching flow —
         # the pool form already updated self.options with the
         # new _preferred_type before redirecting here.
-        switching_primary = hasattr(self, "_switching_primary_to_mqtt") or (
-            hasattr(self, "_switching_primary_to_serial")
-        )
+        switching_primary = hasattr(self, "_switching_primary_to_serial")
         if not switching_primary:
             self.get_options()
         errors: dict[str, str] = {}
 
         if user_input is not None:
             port = (user_input.get("serial_port") or "").strip()
+            if port == "__back__":
+                # User chose to go back — return to pool management.
+                return await self.async_step_manage_pool()
             if not port or port == "__none__":
                 errors["base"] = "serial_port_required"
             else:
@@ -3116,6 +3117,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     value="__none__", label="(no available ports)"
                 )
             ]
+            # Add a go-back option so the user isn't stuck when
+            # switching to serial with no ports available.
+            if hasattr(self, "_switching_primary_to_serial"):
+                port_options.append(
+                    selector.SelectOptionDict(
+                        value="__back__", label="(go back to pool management)"
+                    )
+                )
 
         data_schema = {
             prob.Required("serial_port"): selector.SelectSelector(
@@ -4330,7 +4339,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # remove_device service already updated the config entry,
                 # so refresh self.options from the coordinator to avoid
                 # overwriting with stale data, then save normally
-                self.options = dict(coordinator.options)
+                self.options = deepcopy(dict(coordinator.options))
             else:
                 # No removals — update schema in self.options with
                 # _suppress_not_seen flags set by "keep" actions

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1935,7 +1935,25 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         )
                     return self._async_save()
                 elif not errors:
-                    # No new port and no errors — just save removals.
+                    # No new port and no errors — just save removals
+                    # and _preferred_type updates.
+                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                    if isinstance(schema_dict, dict):
+                        for key, val in user_input.items():
+                            if key.startswith("_preferred_type_"):
+                                dev_id = key[len("_preferred_type_") :]
+                                if dev_id in schema_dict and isinstance(
+                                    schema_dict[dev_id], dict
+                                ):
+                                    if val:
+                                        schema_dict[dev_id][
+                                            "_preferred_type"
+                                        ] = val
+                                    else:
+                                        schema_dict[dev_id].pop(
+                                            "_preferred_type", None
+                                        )
+                        self.options[CONF_SCHEMA] = schema_dict
                     self.options[CONF_ADDITIONAL_PORTS] = additional
                     if wait_timeout is not None:
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
@@ -2085,7 +2103,18 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 or primary_port.startswith("socket://")
                 or primary_port.startswith("rfc2217://")
             ):
-                # Serial primary — these are MQTT pool members.
+                # Serial primary — check _preferred_type.
+                schema_entry = schema.get(dev_id, {})
+                preferred = ""
+                if isinstance(schema_entry, dict):
+                    preferred = str(
+                        schema_entry.get("_preferred_type", "")
+                    ).lower()
+                if preferred == "usb":
+                    return f"HGI: {dev_id} (USB, serial pool member)"
+                if preferred == "zigbee":
+                    return f"HGI: {dev_id} (Zigbee, not yet supported)"
+                # Default: MQTT pool member.
                 if self.options.get(CONF_MQTT_USE_HA):
                     topic = self.options.get(
                         CONF_MQTT_TOPIC, DEFAULT_MQTT_TOPIC
@@ -2212,50 +2241,106 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 )
             )
 
+        # Build per-HGI _preferred_type selectors so the user can
+        # mark which transport each HGI uses (Phase 2 hybrid pool).
+        # This is only relevant when the primary is serial — with an
+        # MQTT primary, all pool members are MQTT by definition.
+        preferred_type_selectors: dict[str, Any] = {}
+        if (
+            isinstance(primary_port, str)
+            and (
+                primary_port.startswith("/dev/")
+                or primary_port.startswith("socket://")
+                or primary_port.startswith("rfc2217://")
+            )
+            and isinstance(schema, dict)
+        ):
+            for dev_id in removable_pool_hgis:
+                entry = schema.get(dev_id, {})
+                current_pref = ""
+                if isinstance(entry, dict):
+                    current_pref = str(
+                        entry.get("_preferred_type", "")
+                    ).lower()
+                pref_options = [
+                    selector.SelectOptionDict(
+                        value="", label="MQTT (default)"
+                    ),
+                    selector.SelectOptionDict(
+                        value="usb", label="USB (serial pool member)"
+                    ),
+                    selector.SelectOptionDict(
+                        value="zigbee",
+                        label="Zigbee (not yet supported)",
+                    ),
+                ]
+                preferred_type_selectors[dev_id] = (
+                    selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=pref_options,
+                            mode=selector.SelectSelectorMode.LIST,
+                            multiple=False,
+                        )
+                    ),
+                    current_pref or "",
+                )
+
         data_schema: dict[str, Any] = {
             prob.Optional(
                 "schema_pool_members",
                 default=removable_pool_hgis,
             ): schema_pool_selector,
-            prob.Optional(
-                CONF_ADDITIONAL_PORTS,
-                default=current_additional,
-            ): ports_selector,
-            prob.Optional(
-                "add_new_port",
-                default=NO_ADD,
-            ): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=add_options,
-                    mode=selector.SelectSelectorMode.LIST,
-                    multiple=False,
+        }
+        # Add per-HGI _preferred_type selectors.
+        for dev_id, (sel, default_val) in preferred_type_selectors.items():
+            data_schema[
+                prob.Optional(
+                    f"_preferred_type_{dev_id}",
+                    default=default_val,
                 )
-            ),
-            prob.Optional(
-                CONF_WAIT_ONLINE_TIMEOUT,
-                default=self.options.get(
-                    CONF_WAIT_ONLINE_TIMEOUT,
-                    DEFAULT_WAIT_ONLINE_TIMEOUT,
-                ),
-            ): prob.All(
-                selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=1,
-                        max=300,
-                        step=1,
-                        unit_of_measurement="s",
-                        mode=selector.NumberSelectorMode.BOX,
+            ] = sel
+        data_schema.update(
+            {
+                prob.Optional(
+                    CONF_ADDITIONAL_PORTS,
+                    default=current_additional,
+                ): ports_selector,
+                prob.Optional(
+                    "add_new_port",
+                    default=NO_ADD,
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=add_options,
+                        mode=selector.SelectSelectorMode.LIST,
+                        multiple=False,
                     )
                 ),
-                prob.Coerce(float),
-            ),
-            # Confirmation checkbox for removing the last HGI.
-            # Only relevant when the user unchecks all pool members.
-            prob.Optional(
-                "confirm_clear_last",
-                default=False,
-            ): selector.BooleanSelector(),
-        }
+                prob.Optional(
+                    CONF_WAIT_ONLINE_TIMEOUT,
+                    default=self.options.get(
+                        CONF_WAIT_ONLINE_TIMEOUT,
+                        DEFAULT_WAIT_ONLINE_TIMEOUT,
+                    ),
+                ): prob.All(
+                    selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1,
+                            max=300,
+                            step=1,
+                            unit_of_measurement="s",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    prob.Coerce(float),
+                ),
+                # Confirmation checkbox for removing the last HGI.
+                # Only relevant when the user unchecks all pool members.
+                prob.Optional(
+                    "confirm_clear_last",
+                    default=False,
+                ): selector.BooleanSelector(),
+            }
+        )
 
         # Mask credentials and ensure topic is shown in the primary
         # port for display

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2103,24 +2103,30 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 or primary_port.startswith("socket://")
                 or primary_port.startswith("rfc2217://")
             ):
-                # Serial primary — check _preferred_type.
+                # Serial primary — check _preferred_type and _comment.
                 schema_entry = schema.get(dev_id, {})
                 preferred = ""
+                comment = ""
                 if isinstance(schema_entry, dict):
                     preferred = str(
                         schema_entry.get("_preferred_type", "")
                     ).lower()
+                    comment = str(schema_entry.get("_comment", ""))
+                # Show detected transports in the label.
+                detected_str = f" [{comment}]" if comment else ""
                 if preferred == "usb":
-                    return f"HGI: {dev_id} (USB, serial pool member)"
+                    return f"HGI: {dev_id} (USB){detected_str}"
                 if preferred == "zigbee":
-                    return f"HGI: {dev_id} (Zigbee, not yet supported)"
+                    return f"HGI: {dev_id} (Zigbee){detected_str}"
                 # Default: MQTT pool member.
                 if self.options.get(CONF_MQTT_USE_HA):
                     topic = self.options.get(
                         CONF_MQTT_TOPIC, DEFAULT_MQTT_TOPIC
                     )
-                    return f"HGI: {dev_id} (MQTT, mqtt_ha, topic: {topic})"
-                return f"HGI: {dev_id} (MQTT, schema, _owner: {root_owner})"
+                    return (
+                        f"HGI: {dev_id} (MQTT, topic: {topic}){detected_str}"
+                    )
+                return f"HGI: {dev_id} (MQTT){detected_str}"
             return f"HGI: {dev_id} (schema, _owner: {root_owner})"
 
         # Build options for the "current ports" multi-select (for removal)
@@ -2245,6 +2251,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # mark which transport each HGI uses (Phase 2 hybrid pool).
         # This is only relevant when the primary is serial — with an
         # MQTT primary, all pool members are MQTT by definition.
+        # Only offer transports that were actually detected for each
+        # HGI (from the _comment field, e.g. "Supports: usb, mqtt").
         preferred_type_selectors: dict[str, Any] = {}
         if (
             isinstance(primary_port, str)
@@ -2258,22 +2266,44 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             for dev_id in removable_pool_hgis:
                 entry = schema.get(dev_id, {})
                 current_pref = ""
+                detected_types: list[str] = []
                 if isinstance(entry, dict):
                     current_pref = str(
                         entry.get("_preferred_type", "")
                     ).lower()
-                pref_options = [
-                    selector.SelectOptionDict(
-                        value="", label="MQTT (default)"
-                    ),
-                    selector.SelectOptionDict(
-                        value="usb", label="USB (serial pool member)"
-                    ),
-                    selector.SelectOptionDict(
-                        value="zigbee",
-                        label="Zigbee (not yet supported)",
-                    ),
-                ]
+                    # Parse _comment to find detected transports.
+                    comment = str(entry.get("_comment", "")).lower()
+                    if "usb" in comment:
+                        detected_types.append("usb")
+                    if "mqtt" in comment:
+                        detected_types.append("mqtt")
+                    if "zigbee" in comment:
+                        detected_types.append("zigbee")
+                # Build options from detected types only.
+                # If nothing detected yet, offer all (first run).
+                if not detected_types:
+                    detected_types = ["mqtt", "usb", "zigbee"]
+                pref_options: list[selector.SelectOptionDict] = []
+                # "MQTT" is the default (empty string = mqtt).
+                if "mqtt" in detected_types:
+                    pref_options.append(
+                        selector.SelectOptionDict(value="", label="MQTT")
+                    )
+                if "usb" in detected_types:
+                    pref_options.append(
+                        selector.SelectOptionDict(
+                            value="usb", label="USB (serial)"
+                        )
+                    )
+                if "zigbee" in detected_types:
+                    pref_options.append(
+                        selector.SelectOptionDict(
+                            value="zigbee",
+                            label="Zigbee (not yet supported)",
+                        )
+                    )
+                if not pref_options:
+                    continue  # no options to show
                 preferred_type_selectors[dev_id] = (
                     selector.SelectSelector(
                         selector.SelectSelectorConfig(

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -100,6 +100,9 @@ CONF_MQTT_PATH: Final = "MQTT Broker..."
 CONF_HA_MQTT_PATH: Final = "Use Home Assistant MQTT - In development!"
 CONF_ZIGBEE_DEVICE: Final = "Zigbee device"
 
+# HGI device ID regex: 18:NNNNNN (class 18, 6 hex digits).
+_HGI_ID_RE: Final = re.compile(r"^18:[0-9]{6}$")
+
 
 if hasattr(usb, "async_scan_serial_ports"):
     # Compatible with Home Assistant Core 2026.5.0
@@ -2845,15 +2848,18 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
     async def async_step_manage_pool_mqtt_url(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Add an MQTT HGI via a full mqtt:// URL.
+        """Add an MQTT HGI via HGI ID + optional topic prefix.
 
-        Parses the HGI ID from the URL path and creates a schema entry.
-        The URL is also stored in CONF_ADDITIONAL_PORTS so the pool
-        bridge can create a child transport for it.
+        HA's MQTT integration owns the broker connection — this form
+        asks only for the HGI device ID and an optional topic prefix
+        override (issue 1119).  No broker/port/credentials are
+        collected because the HA MQTT integration provides the
+        broker.
 
         When invoked from the pool menu's primary switch (serial →
-        MQTT), the URL is set as the primary ``serial_port.port_name``
-        instead of being added to additional ports.
+        MQTT), the HGI is set as the primary MQTT HGI
+        (``CONF_MQTT_HGI_ID``) instead of being added to additional
+        ports.
 
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
@@ -2867,90 +2873,88 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             self.get_options()
         errors: dict[str, str] = {}
 
-        # Pre-fill the URL from the HA MQTT integration's broker
-        # when switching the primary or a secondary from serial to MQTT.
-        default_url = ""
         switching_primary = getattr(self, "_switching_primary_to_mqtt", None)
         switching_secondary = getattr(
             self, "_switching_secondary_to_mqtt", None
         )
         switching_hgi_id = switching_primary or switching_secondary
-        if switching_hgi_id and not user_input:
-            mqtt_entries = self.hass.config_entries.async_entries("mqtt")
-            if mqtt_entries:
-                mqtt_data = mqtt_entries[0].data
-                broker = mqtt_data.get("broker", "")
-                port = mqtt_data.get("port", 1883)
-                topic = self.options.get(CONF_MQTT_TOPIC, "RAMSES/GATEWAY")
-                if broker:
-                    default_url = (
-                        f"mqtt://{broker}:{port}/{topic}/{switching_hgi_id}"
-                    )
+        default_hgi_id = switching_hgi_id or ""
+        default_topic = self.options.get(CONF_MQTT_TOPIC, "RAMSES/GATEWAY")
 
         if user_input is not None:
-            url = (user_input.get("mqtt_url") or "").strip()
-            if not url:
-                errors["base"] = "mqtt_url_required"
-            elif not url.startswith("mqtt://"):
-                errors["base"] = "mqtt_url_invalid"
+            hgi_id = (user_input.get("hgi_id") or "").strip()
+            topic_prefix = (user_input.get("topic_prefix") or "").strip()
+            if not hgi_id:
+                errors["base"] = "mqtt_hgi_id_required"
+            elif not _HGI_ID_RE.match(hgi_id):
+                errors["base"] = "mqtt_hgi_id_invalid"
+            elif switching_hgi_id and hgi_id != switching_hgi_id:
+                # Issue 5: reject an HGI ID different from the
+                # switching target — a typo would leave the original
+                # HGI with _preferred_type: mqtt, remove its USB port,
+                # and add a different accepted HGI to the schema.
+                errors["base"] = "mqtt_hgi_id_mismatch"
             else:
-                # Extract HGI ID from the URL path
-                import re as _re
+                schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                root_owner = schema_dict.get(SZ_OWNER, "me")
+                if hgi_id not in schema_dict or not isinstance(
+                    schema_dict.get(hgi_id), dict
+                ):
+                    schema_dict[hgi_id] = {}
+                schema_dict[hgi_id]["_class"] = "HGI"
+                schema_dict[hgi_id][SZ_TR_OWNER] = root_owner
+                schema_dict[hgi_id].pop("_removed_from_pool", None)
+                self.options[CONF_SCHEMA] = schema_dict
 
-                m = _re.search(r"(18:[0-9]{6})(?:/|$)", url)
-                if not m:
-                    errors["base"] = "mqtt_url_no_hgi_id"
+                # Store the optional topic prefix override if it
+                # differs from the configured topic.
+                if topic_prefix and topic_prefix != default_topic:
+                    self.options[CONF_MQTT_TOPIC] = topic_prefix
+
+                if switching_primary:
+                    # Set as primary MQTT HGI (serial → MQTT switch).
+                    self.options[CONF_MQTT_HGI_ID] = hgi_id
+                    self.options[CONF_MQTT_USE_HA] = True
+                    # Remove the serial port name — the primary is
+                    # now MQTT, not serial.
+                    self.options.pop(SZ_SERIAL_PORT, None)
+                    _LOGGER.info(
+                        "Switched primary HGI %s to MQTT (HA broker)",
+                        hgi_id,
+                    )
                 else:
-                    hgi_id = m.group(1)
-                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
-                    root_owner = schema_dict.get(SZ_OWNER, "me")
-                    if hgi_id not in schema_dict or not isinstance(
-                        schema_dict.get(hgi_id), dict
-                    ):
-                        schema_dict[hgi_id] = {}
-                    schema_dict[hgi_id]["_class"] = "HGI"
-                    schema_dict[hgi_id][SZ_TR_OWNER] = root_owner
-                    schema_dict[hgi_id].pop("_removed_from_pool", None)
-                    self.options[CONF_SCHEMA] = schema_dict
-
-                    if switching_primary:
-                        # Set as primary transport (serial → MQTT switch)
-                        self.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: url}
-                        self.options[CONF_MQTT_USE_HA] = True
+                    # Non-primary: mark as MQTT-preferred in schema.
+                    # The coordinator's _schema_mqtt_preferred logic
+                    # picks this up and includes it in the MQTT bridge.
+                    if switching_secondary:
+                        schema_dict[hgi_id]["_preferred_type"] = "mqtt"
+                        self.options[CONF_SCHEMA] = schema_dict
                         _LOGGER.info(
-                            "Switched primary HGI %s to MQTT: %s",
+                            "Switched non-primary HGI %s to MQTT (HA broker)",
                             hgi_id,
-                            redact_url(url),
                         )
                     else:
-                        # Add the URL to additional ports
-                        additional = self.options.get(
-                            CONF_ADDITIONAL_PORTS, []
+                        _LOGGER.info(
+                            "Added MQTT pool HGI %s (HA broker)",
+                            hgi_id,
                         )
-                        if url not in additional:
-                            additional.append(url)
-                        self.options[CONF_ADDITIONAL_PORTS] = additional
-                        if switching_secondary:
-                            _LOGGER.info(
-                                "Switched non-primary HGI %s to MQTT: %s",
-                                hgi_id,
-                                redact_url(url),
-                            )
-                        else:
-                            _LOGGER.info(
-                                "Added MQTT pool HGI %s via full URL",
-                                hgi_id,
-                            )
-                    # Clear the switching flags if set
-                    if hasattr(self, "_switching_primary_to_mqtt"):
-                        del self._switching_primary_to_mqtt
-                    if hasattr(self, "_switching_secondary_to_mqtt"):
-                        del self._switching_secondary_to_mqtt
-                    return self._async_save()
+                # Clear the switching flags if set
+                if hasattr(self, "_switching_primary_to_mqtt"):
+                    del self._switching_primary_to_mqtt
+                if hasattr(self, "_switching_secondary_to_mqtt"):
+                    del self._switching_secondary_to_mqtt
+                return self._async_save()
 
         data_schema = {
             prob.Required(
-                "mqtt_url", default=default_url
+                "hgi_id", default=default_hgi_id
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(
+                    type=selector.TextSelectorType.TEXT,
+                )
+            ),
+            prob.Optional(
+                "topic_prefix", default=default_topic
             ): selector.TextSelector(
                 selector.TextSelectorConfig(
                     type=selector.TextSelectorType.TEXT,
@@ -2962,19 +2966,24 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         if switching_primary:
             desc = (
                 "Switching primary HGI {hgi_id} from serial to MQTT.\n"
-                "Enter the full MQTT broker URL (broker, port, topic, "
-                "HGI ID).  Pre-filled from the HA MQTT integration if "
-                "available."
+                "HA's MQTT integration provides the broker — enter "
+                "only the HGI device ID.  The optional topic prefix "
+                "defaults to your configured MQTT topic."
             ).replace("{hgi_id}", switching_primary)
         elif switching_secondary:
             desc = (
                 "Switching non-primary HGI {hgi_id} from serial to MQTT.\n"
-                "Enter the full MQTT broker URL (broker, port, topic, "
-                "HGI ID).  Pre-filled from the HA MQTT integration if "
-                "available."
+                "HA's MQTT integration provides the broker — enter "
+                "only the HGI device ID.  The optional topic prefix "
+                "defaults to your configured MQTT topic."
             ).replace("{hgi_id}", switching_secondary)
         else:
-            desc = ""
+            desc = (
+                "Add an MQTT HGI to the pool.  HA's MQTT integration "
+                "provides the broker — enter only the HGI device ID "
+                "(e.g. 18:123456).  The optional topic prefix defaults "
+                "to your configured MQTT topic."
+            )
 
         return self.async_show_form(
             step_id="manage_pool_mqtt_url",

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -76,6 +76,7 @@ from .const import (
     DEFAULT_MQTT_TOPIC,
     DEFAULT_WAIT_ONLINE_TIMEOUT,
     DOMAIN,
+    HGI_COMMENT_WARNING,
     HGI_PREFIX,
     STORAGE_KEY,
     STORAGE_VERSION,
@@ -2429,6 +2430,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     schema_entry.get("_preferred_type", "")
                 ).lower()
                 comment = str(schema_entry.get("_comment", ""))
+            # Strip the HGI_COMMENT_WARNING suffix — it's meant for
+            # the schema editor, not the pool management UI.
+            comment = comment.replace(HGI_COMMENT_WARNING, "").strip()
             detected_str = f" [{comment}]" if comment else ""
 
             # If the runtime mapping shows this HGI is on a serial

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2392,8 +2392,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         # Build per-HGI _preferred_type selectors so the user can
         # mark which transport each HGI uses (Phase 2 hybrid pool).
-        # This is only relevant when the primary is serial — with an
-        # MQTT primary, all pool members are MQTT by definition.
+        # Show for both serial and MQTT primary so the user can
+        # switch the primary transport via _preferred_type.
         # Always show all transport options, but mark which ones were
         # detected (from the _comment field, e.g. "Supports: usb, mqtt").
         preferred_type_selectors: dict[str, Any] = {}
@@ -2403,6 +2403,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 primary_port.startswith("/dev/")
                 or primary_port.startswith("socket://")
                 or primary_port.startswith("rfc2217://")
+                or primary_port.startswith("mqtt://")
+                or primary_port == "mqtt_ha"
             )
             and isinstance(schema, dict)
         ):
@@ -2653,7 +2655,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
         """
-        self.get_options()
+        # Don't reload options if we're in a switching flow —
+        # the pool form already updated self.options with the
+        # new _preferred_type before redirecting here.
+        if not hasattr(self, "_switching_primary_to_mqtt"):
+            self.get_options()
         errors: dict[str, str] = {}
 
         # Pre-fill the URL from the HA MQTT integration's broker

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2251,8 +2251,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # mark which transport each HGI uses (Phase 2 hybrid pool).
         # This is only relevant when the primary is serial — with an
         # MQTT primary, all pool members are MQTT by definition.
-        # Only offer transports that were actually detected for each
-        # HGI (from the _comment field, e.g. "Supports: usb, mqtt").
+        # Always show all transport options, but mark which ones were
+        # detected (from the _comment field, e.g. "Supports: usb, mqtt").
         preferred_type_selectors: dict[str, Any] = {}
         if (
             isinstance(primary_port, str)
@@ -2279,29 +2279,26 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         detected_types.append("mqtt")
                     if "zigbee" in comment:
                         detected_types.append("zigbee")
-                # Build options from detected types only.
-                # If nothing detected yet, offer all (first run).
-                if not detected_types:
-                    detected_types = ["mqtt", "usb", "zigbee"]
+                # Always show all options, but mark detected ones.
                 pref_options: list[selector.SelectOptionDict] = []
-                # "MQTT" is the default (empty string = mqtt).
+                mqtt_label = "MQTT"
                 if "mqtt" in detected_types:
-                    pref_options.append(
-                        selector.SelectOptionDict(value="", label="MQTT")
-                    )
+                    mqtt_label = "MQTT (detected)"
+                pref_options.append(
+                    selector.SelectOptionDict(value="", label=mqtt_label)
+                )
+                usb_label = "USB (serial)"
                 if "usb" in detected_types:
-                    pref_options.append(
-                        selector.SelectOptionDict(
-                            value="usb", label="USB (serial)"
-                        )
-                    )
+                    usb_label = "USB (serial, detected)"
+                pref_options.append(
+                    selector.SelectOptionDict(value="usb", label=usb_label)
+                )
+                zb_label = "Zigbee (not yet supported)"
                 if "zigbee" in detected_types:
-                    pref_options.append(
-                        selector.SelectOptionDict(
-                            value="zigbee",
-                            label="Zigbee (not yet supported)",
-                        )
-                    )
+                    zb_label = "Zigbee (detected, not yet supported)"
+                pref_options.append(
+                    selector.SelectOptionDict(value="zigbee", label=zb_label)
+                )
                 if not pref_options:
                     continue  # no options to show
                 preferred_type_selectors[dev_id] = (

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1874,7 +1874,6 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             for dev_id in to_demote:
                                 entry = schema_dict.get(dev_id, {})
                                 if isinstance(entry, dict):
-                                    entry.pop(SZ_TR_OWNER, None)
                                     entry["_removed_from_pool"] = True
                                     schema_dict[dev_id] = entry
                             self.options[CONF_SCHEMA] = schema_dict
@@ -1887,7 +1886,6 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         for dev_id in to_demote:
                             entry = schema_dict.get(dev_id, {})
                             if isinstance(entry, dict):
-                                entry.pop(SZ_TR_OWNER, None)
                                 entry["_removed_from_pool"] = True
                                 schema_dict[dev_id] = entry
                         self.options[CONF_SCHEMA] = schema_dict

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2348,6 +2348,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 return f"HGI: {dev_id} (MQTT){detected_str}"
             return f"HGI: {dev_id} (schema, _owner: {root_owner})"
 
+        # Debug: log the runtime port-to-HGI mapping and pool member labels
+        # so we can verify the pool management display (issue 1185).
+        _LOGGER.debug(
+            "ManagePool: runtime_port_hgi_map=%s, primary_hgi_id=%s, "
+            "primary_port=%s",
+            _runtime_port_hgi_map,
+            primary_hgi_id,
+            primary_port,
+        )
+
         # Build options for the "current ports" multi-select (for removal)
         # Show each current additional port with a friendly label
         current_options: list[selector.SelectOptionDict] = []
@@ -2431,6 +2441,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # if it's the last one).
         removable_pool_hgis = sorted(set(schema_pool_members))
         if removable_pool_hgis:
+            _pool_labels: list[str] = []
+            for _dev_id in removable_pool_hgis:
+                _label = _pool_member_label(_dev_id)
+                _pool_labels.append(f"{_dev_id} -> {_label}")
+            _LOGGER.debug("ManagePool: pool member labels: %s", _pool_labels)
             schema_pool_selector = selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=[

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2019,7 +2019,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             return url
 
         def _pool_member_label(dev_id: str) -> str:
-            """Build a human-readable label with broker info."""
+            """Build a human-readable label with transport type and broker info.
+
+            Shows the transport type (USB serial vs MQTT callback) so
+            the user can distinguish pool members in a hybrid pool
+            (Phase 2, issue 1119).
+            """
             if dev_id == primary_hgi_id:
                 # For the primary, ensure the topic is shown even if
                 # the URL has no path (e.g. mqtt://broker:1883).
@@ -2051,6 +2056,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         CONF_MQTT_TOPIC, DEFAULT_MQTT_TOPIC
                     )
                     display_url = f"mqtt_ha, topic: {topic}"
+                    return f"HGI: {dev_id} (primary, MQTT, {_mask_mqtt_url(display_url)})"
+                elif isinstance(display_url, str) and (
+                    display_url.startswith("/dev/")
+                    or display_url.startswith("socket://")
+                    or display_url.startswith("rfc2217://")
+                ):
+                    # Serial primary — show the port path.
+                    return f"HGI: {dev_id} (primary, USB, {display_url})"
                 return (
                     f"HGI: {dev_id} (primary, {_mask_mqtt_url(display_url)})"
                 )
@@ -2064,7 +2077,21 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     primary_port, dev_id
                 )
                 if explicit:
-                    return f"HGI: {dev_id} ({_mask_mqtt_url(explicit)})"
+                    return f"HGI: {dev_id} (MQTT, {_mask_mqtt_url(explicit)})"
+            # If the primary is serial, schema HGIs are MQTT
+            # callback-driven pool members (Phase 2 hybrid pool).
+            if isinstance(primary_port, str) and (
+                primary_port.startswith("/dev/")
+                or primary_port.startswith("socket://")
+                or primary_port.startswith("rfc2217://")
+            ):
+                # Serial primary — these are MQTT pool members.
+                if self.options.get(CONF_MQTT_USE_HA):
+                    topic = self.options.get(
+                        CONF_MQTT_TOPIC, DEFAULT_MQTT_TOPIC
+                    )
+                    return f"HGI: {dev_id} (MQTT, mqtt_ha, topic: {topic})"
+                return f"HGI: {dev_id} (MQTT, schema, _owner: {root_owner})"
             return f"HGI: {dev_id} (schema, _owner: {root_owner})"
 
         # Build options for the "current ports" multi-select (for removal)

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2963,6 +2963,30 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                 if per_device_owner
                                 else root_owner
                             )
+                            # Phase 2: save _preferred_type for HGI
+                            # devices and update _comment.
+                            if device_id.startswith("18:"):
+                                pref_val = user_input.get(
+                                    f"preferred_type_{device_id}", ""
+                                )
+                                if pref_val:
+                                    dev_entry["_preferred_type"] = pref_val
+                                # Update _comment to include selected
+                                # transport.
+                                comment = str(
+                                    dev_entry.get("_comment", "")
+                                ).lower()
+                                sel = pref_val or "mqtt"
+                                parts: list[str] = []
+                                if "usb" in comment or sel == "usb":
+                                    parts.append("usb")
+                                if "mqtt" in comment or sel == "mqtt":
+                                    parts.append("mqtt")
+                                if "zigbee" in comment or sel == "zigbee":
+                                    parts.append("zigbee")
+                                dev_entry["_comment"] = (
+                                    "Supports: " + ", ".join(parts)
+                                )
                         # Clear any prior missing_class dismissal so that
                         # if the user later removes _class from the schema,
                         # check_missing_class can re-flag the device
@@ -3385,6 +3409,57 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     },
                 )
             ] = selector.TextSelector()
+
+            # Phase 2: for HGI devices, add a _preferred_type selector
+            # so the user can set the transport preference when accepting.
+            if device_id.startswith("18:"):
+                # Parse existing _comment for detected transports.
+                dev_entry = config_schema.get(device_id, {})
+                detected_types: list[str] = []
+                if isinstance(dev_entry, dict):
+                    comment = str(dev_entry.get("_comment", "")).lower()
+                    if "usb" in comment:
+                        detected_types.append("usb")
+                    if "mqtt" in comment:
+                        detected_types.append("mqtt")
+                    if "zigbee" in comment:
+                        detected_types.append("zigbee")
+                # Build options — always show all, mark detected.
+                pref_opts: list[selector.SelectOptionDict] = []
+                mqtt_lbl = "MQTT"
+                if "mqtt" in detected_types:
+                    mqtt_lbl = "MQTT (detected)"
+                pref_opts.append(
+                    selector.SelectOptionDict(value="", label=mqtt_lbl)
+                )
+                usb_lbl = "USB (serial)"
+                if "usb" in detected_types:
+                    usb_lbl = "USB (serial, detected)"
+                pref_opts.append(
+                    selector.SelectOptionDict(value="usb", label=usb_lbl)
+                )
+                zb_lbl = "Zigbee (not yet supported)"
+                if "zigbee" in detected_types:
+                    zb_lbl = "Zigbee (detected, not yet supported)"
+                pref_opts.append(
+                    selector.SelectOptionDict(value="zigbee", label=zb_lbl)
+                )
+                form_fields[
+                    prob.Optional(
+                        f"preferred_type_{device_id}",
+                        default="",
+                        description={
+                            "label": f"Preferred transport for {device_id} "
+                            "(HGI)"
+                        },
+                    )
+                ] = selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=pref_opts,
+                        mode=selector.SelectSelectorMode.LIST,
+                        multiple=False,
+                    )
+                )
 
         # Add form fields for class mismatch devices
         config_schema_for_prefill = self.options.get(CONF_SCHEMA, {})

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1801,6 +1801,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             keep_schema_members: list[str] = user_input.get(
                 "schema_pool_members", []
             )
+            # Discovery candidates that the user wants to accept
+            accept_candidates: list[str] = user_input.get(
+                "accept_discovery_candidates", []
+            )
             add_choice = user_input.get("add_new_port", NO_ADD)
             # Wait-online timeout (seconds) for MQTT pool bridge
             wait_timeout = user_input.get(CONF_WAIT_ONLINE_TIMEOUT)
@@ -1908,6 +1912,28 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                         ] = new_url
 
                 # Handle add choices
+                # Accept discovery candidates — set _owner on selected
+                # unowned HGIs to promote them to pool members.
+                if accept_candidates:
+                    if not isinstance(schema_dict, dict):
+                        schema_dict = deepcopy(
+                            self.options.get(CONF_SCHEMA, {})
+                        )
+                    root_owner = schema_dict.get(SZ_OWNER, "me")
+                    for dev_id in accept_candidates:
+                        entry = schema_dict.get(dev_id, {})
+                        if isinstance(entry, dict):
+                            entry[SZ_TR_OWNER] = root_owner
+                            entry.pop("_removed_from_pool", None)
+                            schema_dict[dev_id] = entry
+                    self.options[CONF_SCHEMA] = schema_dict
+                    _LOGGER.info(
+                        "Accepted %d discovery candidate(s) as pool "
+                        "members: %s",
+                        len(accept_candidates),
+                        accept_candidates,
+                    )
+
                 CONF_MQTT_HA_ID = "__mqtt_ha_id__"
                 CONF_MQTT_FULL_URL = "__mqtt_full_url__"
                 CONF_SERIAL_PORT = "__serial_port__"
@@ -1963,6 +1989,24 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         self.options[SZ_SERIAL_PORT] = {
                             SZ_PORT_NAME: "mqtt_ha"
                         }
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    if wait_timeout is not None:
+                        self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                            wait_timeout
+                        )
+                    return self._async_save()
+                elif add_choice and add_choice.startswith("__accept__"):
+                    # Accept a discovery candidate (unowned HGI) as a
+                    # pool member — set _owner so it becomes active.
+                    accept_id = add_choice[len("__accept__") :]
+                    schema_dict = deepcopy(self.options.get(CONF_SCHEMA, {}))
+                    if accept_id in schema_dict and isinstance(
+                        schema_dict[accept_id], dict
+                    ):
+                        root_owner = schema_dict.get(SZ_OWNER) or "me"
+                        schema_dict[SZ_OWNER] = root_owner
+                        schema_dict[accept_id][SZ_TR_OWNER] = root_owner
+                        self.options[CONF_SCHEMA] = schema_dict
                     self.options[CONF_ADDITIONAL_PORTS] = additional
                     if wait_timeout is not None:
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
@@ -2269,16 +2313,24 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             schema = {}
         root_owner = schema.get(SZ_OWNER, "me")
         schema_pool_members: list[str] = []
+        # Discovery candidates: HGIs in the schema without _owner.
+        # These are shown in the pool management step so the user can
+        # accept them (set _owner) directly, without waiting for the
+        # discovery flow.
+        discovery_candidates: list[str] = []
         for dev_id, entry in schema.items():
             if (
                 dev_id.startswith(HGI_PREFIX)
                 and dev_id != DEFAULT_HGI_ID
                 and isinstance(entry, dict)
                 and entry.get("_class", "").upper() == "HGI"
-                and entry.get(SZ_TR_OWNER) == root_owner
                 and not entry.get("_disabled")
+                and not entry.get("_removed_from_pool")
             ):
-                schema_pool_members.append(dev_id)
+                if entry.get(SZ_TR_OWNER) == root_owner:
+                    schema_pool_members.append(dev_id)
+                elif not entry.get(SZ_TR_OWNER):
+                    discovery_candidates.append(dev_id)
 
         # Determine the primary HGI ID (from the MQTT URL or CONF_MQTT_HGI_ID)
         # so we can label it in the pool list.
@@ -2539,6 +2591,24 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             label=f"Re-add HGI: {dev_id}",
                         )
                     )
+                # Also list discovery candidates (unowned HGIs) so the
+                # user can accept them directly from the pool menu
+                # without going through the discovery flow.
+                if (
+                    dev_id.startswith(HGI_PREFIX)
+                    and dev_id != DEFAULT_HGI_ID
+                    and isinstance(entry, dict)
+                    and entry.get("_class", "").upper() == "HGI"
+                    and not entry.get(SZ_TR_OWNER)
+                    and not entry.get("_removed_from_pool")
+                    and not entry.get("_disabled")
+                ):
+                    add_options.append(
+                        selector.SelectOptionDict(
+                            value=f"__accept__{dev_id}",
+                            label=f"Accept discovery candidate: {dev_id}",
+                        )
+                    )
 
         # Build the data schema — if there are current ports, show them
         # in a multi-select for removal; always show the "add new" dropdown
@@ -2689,6 +2759,30 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 default=removable_pool_hgis,
             ): schema_pool_selector,
         }
+        # Add discovery candidates selector (multi-select to accept).
+        # Unowned HGIs in the schema are discovery candidates — show
+        # them so the user can accept them directly from the pool
+        # management step (issue 1119).
+        if discovery_candidates:
+            candidate_options = [
+                selector.SelectOptionDict(
+                    value=dev_id,
+                    label=_pool_member_label(dev_id),
+                )
+                for dev_id in sorted(discovery_candidates)
+            ]
+            data_schema[
+                prob.Optional(
+                    "accept_discovery_candidates",
+                    default=[],
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=candidate_options,
+                    mode=selector.SelectSelectorMode.LIST,
+                    multiple=True,
+                )
+            )
         # Add per-HGI _preferred_type selectors.
         for dev_id, (sel, default_val) in preferred_type_selectors.items():
             data_schema[
@@ -2775,6 +2869,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 "schema_pool_members": (
                     ", ".join(schema_pool_members)
                     if schema_pool_members
+                    else "(none)"
+                ),
+                "discovery_candidates": (
+                    ", ".join(sorted(discovery_candidates))
+                    if discovery_candidates
                     else "(none)"
                 ),
             },

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2090,6 +2090,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                     "to serial port selection",
                                     _primary_hgi_id,
                                 )
+                                self._switching_primary_to_serial = (
+                                    _primary_hgi_id
+                                )
                                 return (
                                     await self.async_step_manage_pool_serial()
                                 )
@@ -2768,26 +2771,59 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         fully send-capable after identity is established.  The port
         is added to CONF_ADDITIONAL_PORTS.
 
+        When invoked from the pool menu's primary switch (MQTT →
+        USB), the selected port becomes the primary serial_port
+        instead of being added to additional ports.
+
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
         """
-        self.get_options()
+        # Don't reload options if we're in a switching flow —
+        # the pool form already updated self.options with the
+        # new _preferred_type before redirecting here.
+        switching_primary = hasattr(self, "_switching_primary_to_mqtt") or (
+            hasattr(self, "_switching_primary_to_serial")
+        )
+        if not switching_primary:
+            self.get_options()
         errors: dict[str, str] = {}
 
         if user_input is not None:
             port = (user_input.get("serial_port") or "").strip()
-            if not port:
+            if not port or port == "__none__":
                 errors["base"] = "serial_port_required"
             else:
-                # Add the serial port to additional ports
-                additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
-                if port not in additional:
-                    additional.append(port)
-                self.options[CONF_ADDITIONAL_PORTS] = additional
-                _LOGGER.info(
-                    "Added serial pool child: %s",
-                    port,
+                # Check if we're switching the primary from MQTT to serial
+                current_primary = self.options.get(SZ_SERIAL_PORT, {}).get(
+                    SZ_PORT_NAME, ""
                 )
+                is_current_mqtt = isinstance(current_primary, str) and (
+                    current_primary.startswith("mqtt://")
+                    or current_primary == "mqtt_ha"
+                )
+                if is_current_mqtt:
+                    # Switch primary to serial
+                    self.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: port}
+                    self.options.pop(CONF_MQTT_USE_HA, None)
+                    _LOGGER.info(
+                        "Switched primary HGI from MQTT to serial: %s",
+                        port,
+                    )
+                else:
+                    # Add the serial port to additional ports
+                    additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
+                    if port not in additional:
+                        additional.append(port)
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    _LOGGER.info(
+                        "Added serial pool child: %s",
+                        port,
+                    )
+                # Clear switching flags if set
+                if hasattr(self, "_switching_primary_to_serial"):
+                    del self._switching_primary_to_serial
+                if hasattr(self, "_switching_primary_to_mqtt"):
+                    del self._switching_primary_to_mqtt
                 return self._async_save()
 
         # Build list of available serial ports using HA's USB port

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2394,6 +2394,58 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         primary_hgi_id = dev_id
                         break
 
+        # Auto-accept the primary HGI for serial/USB primaries.
+        # If the primary port is serial and the HGI ID is known (from
+        # the runtime port mapping), it is a valid HGI on the primary
+        # port — we can safely assume it is owned by the root owner.
+        # This ensures the primary HGI appears as a pool member in the
+        # pool menu instead of showing "0 pool members" when there is
+        # clearly an active HGI on the primary port.
+        if (
+            primary_hgi_id
+            and isinstance(primary_port, str)
+            and (
+                primary_port.startswith("/dev/")
+                or primary_port.startswith("socket://")
+                or primary_port.startswith("rfc2217://")
+            )
+            and isinstance(schema, dict)
+            and primary_hgi_id in schema
+            and isinstance(schema[primary_hgi_id], dict)
+            and not schema[primary_hgi_id].get(SZ_TR_OWNER)
+        ):
+            schema[primary_hgi_id][SZ_TR_OWNER] = root_owner
+            # Persist the change so the coordinator sees it as accepted.
+            new_options = dict(self.options)
+            new_options[CONF_SCHEMA] = deepcopy(schema)
+            self.options = new_options
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, options=new_options
+            )
+            _LOGGER.info(
+                "Auto-accepted primary HGI %s as pool member "
+                "(serial primary on %s)",
+                primary_hgi_id,
+                primary_port,
+            )
+            # Rebuild the pool members / discovery candidates lists
+            # now that the primary has _owner set.
+            schema_pool_members = []
+            discovery_candidates = []
+            for dev_id, entry in schema.items():
+                if (
+                    dev_id.startswith(HGI_PREFIX)
+                    and dev_id != DEFAULT_HGI_ID
+                    and isinstance(entry, dict)
+                    and entry.get("_class", "").upper() == "HGI"
+                    and not entry.get("_disabled")
+                    and not entry.get("_removed_from_pool")
+                ):
+                    if entry.get(SZ_TR_OWNER) == root_owner:
+                        schema_pool_members.append(dev_id)
+                    elif not entry.get(SZ_TR_OWNER):
+                        discovery_candidates.append(dev_id)
+
         # Build a label for each pool member showing its broker info.
         # For the primary HGI: the primary_port URL.
         # For additional HGIs: the explicit per-HGI MQTT URL.

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1828,8 +1828,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             primary_hgi_id_input = m.group(1)
 
                 # Process schema pool member removals — unchecking a
-                # schema pool member removes _owner from its schema entry,
-                # demoting it back to a discovery candidate (issue 1119).
+                # schema pool member preserves _owner and marks it with
+                # _removed_from_pool so it can be re-added easily.
                 # The primary HGI can also be removed — if it's removed
                 # and another accepted HGI exists, auto-promote that one.
                 schema_dict = deepcopy(self.options.get(CONF_SCHEMA, {}))
@@ -2297,7 +2297,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Schema-derived pool members (HGIs with _owner: me and _class:
         # HGI) — these are active pool members managed via the schema.
         # Show them in the form with a checkbox for each; unchecking
-        # demotes them back to discovery candidates (removes _owner).
+        # marks them _removed_from_pool while preserving _owner.
         # The primary HGI is also listed (marked as "primary") so the
         # user can see the full pool composition.
         #

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2317,6 +2317,21 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 )
                 if not pref_options:
                     continue  # no options to show
+                # Default to the detected transport type when no
+                # _preferred_type is set yet.  If only USB is detected,
+                # default to "usb".  If only MQTT, default to "" (MQTT).
+                # If both, default to "" (MQTT) unless USB is the
+                # primary transport (serial primary → prefer USB).
+                if not current_pref:
+                    if (
+                        "usb" in detected_types
+                        and "mqtt" not in detected_types
+                    ):
+                        current_pref = "usb"
+                    elif "usb" in detected_types and primary_port.startswith(
+                        "/dev/"
+                    ):
+                        current_pref = "usb"
                 preferred_type_selectors[dev_id] = (
                     selector.SelectSelector(
                         selector.SelectSelectorConfig(
@@ -3458,10 +3473,35 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 pref_opts.append(
                     selector.SelectOptionDict(value="zigbee", label=zb_lbl)
                 )
+                # Default to the detected transport type when no
+                # _preferred_type is set yet.  If only USB is detected,
+                # default to "usb".  If only MQTT, default to "" (MQTT).
+                # If both, default to "usb" when on serial primary.
+                _current_pref = (
+                    str(dev_entry.get("_preferred_type", "")).lower()
+                    if isinstance(dev_entry, dict)
+                    else ""
+                )
+                _review_default = _current_pref or ""
+                if not _review_default:
+                    _primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(
+                        SZ_PORT_NAME, ""
+                    )
+                    if (
+                        "usb" in detected_types
+                        and "mqtt" not in detected_types
+                    ):
+                        _review_default = "usb"
+                    elif (
+                        "usb" in detected_types
+                        and isinstance(_primary_port, str)
+                        and _primary_port.startswith("/dev/")
+                    ):
+                        _review_default = "usb"
                 form_fields[
                     prob.Optional(
                         f"preferred_type_{device_id}",
-                        default="",
+                        default=_review_default,
                         description={
                             "label": f"Preferred transport for {device_id} "
                             "(HGI)"

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -36,7 +36,7 @@ from ramses_rf.schemas import (
     SZ_RESTORE_CACHE,
     SZ_SCHEMA,
 )
-from ramses_tx.const import Code
+from ramses_tx.const import DEVICE_ID_REGEX, HGI_ID_PATTERN, Code
 from ramses_tx.schemas import (
     SCH_ENGINE_DICT,
     SCH_SERIAL_PORT_CONFIG,
@@ -102,7 +102,8 @@ CONF_HA_MQTT_PATH: Final = "Use Home Assistant MQTT - In development!"
 CONF_ZIGBEE_DEVICE: Final = "Zigbee device"
 
 # HGI device ID regex: 18:NNNNNN (class 18, 6 decimal digits).
-_HGI_ID_RE: Final = re.compile(r"^18:[0-9]{6}$")
+# Uses DEVICE_ID_REGEX.HGI from ramses_tx (single source of truth).
+_HGI_ID_RE: Final = DEVICE_ID_REGEX.HGI
 
 
 if hasattr(usb, "async_scan_serial_ports"):
@@ -1818,9 +1819,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 ):
                     primary_hgi_id_input = self.options.get(CONF_MQTT_HGI_ID)
                     if not primary_hgi_id_input and isinstance(primary, str):
-                        import re as _re
-
-                        m = _re.search(r"(18:[0-9]{6})", primary)
+                        m = re.search(rf"({HGI_ID_PATTERN})", primary)
                         if m:
                             primary_hgi_id_input = m.group(1)
 
@@ -2053,9 +2052,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     _primary_hgi_id: str | None = None
                     if isinstance(_primary_port, str):
                         if _primary_port.startswith("mqtt://"):
-                            import re as _re
-
-                            m = _re.search(r"(18:[0-9]{6})", _primary_port)
+                            m = re.search(
+                                rf"({HGI_ID_PATTERN})", _primary_port
+                            )
                             if m:
                                 _primary_hgi_id = m.group(1)
                         elif _primary_port == "mqtt_ha":
@@ -2298,9 +2297,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         ):
             primary_hgi_id = self.options.get(CONF_MQTT_HGI_ID)
             if not primary_hgi_id:
-                import re as _re
-
-                m = _re.search(r"(18:[0-9]{6})", primary_port)
+                m = re.search(rf"({HGI_ID_PATTERN})", primary_port)
                 if m:
                     primary_hgi_id = m.group(1)
         # For serial primary, find the primary HGI from the schema
@@ -3468,7 +3465,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             )
                             # Phase 2: save _preferred_type for HGI
                             # devices and update _comment.
-                            if device_id.startswith("18:"):
+                            if device_id.startswith(HGI_PREFIX):
                                 pref_val = user_input.get(
                                     f"preferred_type_{device_id}", "mqtt"
                                 )
@@ -3920,7 +3917,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
             # Phase 2: for HGI devices, add a _preferred_type selector
             # so the user can set the transport preference when accepting.
-            if device_id.startswith("18:"):
+            if device_id.startswith(HGI_PREFIX):
                 # Parse existing _comment for detected transports.
                 dev_entry = config_schema.get(device_id, {})
                 detected_types: list[str] = []
@@ -4642,7 +4639,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             dev_id
                             for dev_id, entry in old_schema.items()
                             if (
-                                dev_id.startswith("18:")
+                                dev_id.startswith(HGI_PREFIX)
                                 and isinstance(entry, dict)
                                 and entry.get("_class", "").upper() == "HGI"
                             )

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2003,6 +2003,17 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     _primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(
                         SZ_PORT_NAME, ""
                     )
+                    # Get the runtime port-to-HGI mapping from the
+                    # coordinator so we can identify the actual primary
+                    # HGI (the one on the primary serial port), not just
+                    # the first HGI with _owner: me in schema order
+                    # (issue 1185).
+                    _runtime_map: dict[str, str] = {}
+                    _coord = getattr(self.config_entry, "runtime_data", None)
+                    if _coord is not None and hasattr(
+                        _coord, "serial_port_hgi_map"
+                    ):
+                        _runtime_map = _coord.serial_port_hgi_map
                     _primary_hgi_id: str | None = None
                     if isinstance(_primary_port, str):
                         if _primary_port.startswith("mqtt://"):
@@ -2015,10 +2026,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             _primary_hgi_id = self.options.get(
                                 CONF_MQTT_HGI_ID
                             )
-                    # For serial primary, find the primary HGI from the
-                    # schema — it's the accepted HGI (has _owner and
-                    # _class: HGI).  There should only be one for a
-                    # serial-primary single-HGI setup.
+                    # For serial primary, find the primary HGI.
+                    # Use the runtime port mapping first (the HGI
+                    # physically on the primary serial port), then
+                    # fall back to schema iteration (issue 1185).
+                    if not _primary_hgi_id:
+                        if (
+                            isinstance(_primary_port, str)
+                            and _primary_port in _runtime_map
+                        ):
+                            _primary_hgi_id = _runtime_map[_primary_port]
                     if not _primary_hgi_id and isinstance(schema_dict, dict):
                         root_owner = schema_dict.get(SZ_OWNER, "me")
                         for dev_id, entry in schema_dict.items():
@@ -2298,7 +2315,34 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 return (
                     f"HGI: {dev_id} (primary, {_mask_mqtt_url(display_url)})"
                 )
-            # Build the explicit MQTT URL for this HGI
+            # Non-primary HGI — check _preferred_type and runtime
+            # port to determine the transport label, regardless of
+            # whether the primary is serial or MQTT (issue 1185).
+            schema_entry = schema.get(dev_id, {})
+            preferred = ""
+            comment = ""
+            if isinstance(schema_entry, dict):
+                preferred = str(
+                    schema_entry.get("_preferred_type", "")
+                ).lower()
+                comment = str(schema_entry.get("_comment", ""))
+            detected_str = f" [{comment}]" if comment else ""
+
+            # If the runtime mapping shows this HGI is on a serial
+            # port, show it as USB with the actual port (issue 1185).
+            if runtime_port:
+                return f"HGI: {dev_id} (USB, {runtime_port}){detected_str}"
+
+            # Check _preferred_type first — the schema is authoritative
+            # for transport preference (issue 1185).
+            if preferred == "usb":
+                return f"HGI: {dev_id} (USB){detected_str}"
+            if preferred == "zigbee":
+                return f"HGI: {dev_id} (Zigbee){detected_str}"
+
+            # No explicit _preferred_type — fall back to primary
+            # transport context.
+            # If the primary is MQTT, show the MQTT URL for this HGI.
             if isinstance(primary_port, str) and primary_port.startswith(
                 "mqtt://"
             ):
@@ -2316,27 +2360,6 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 or primary_port.startswith("socket://")
                 or primary_port.startswith("rfc2217://")
             ):
-                # Serial primary — check _preferred_type and _comment.
-                schema_entry = schema.get(dev_id, {})
-                preferred = ""
-                comment = ""
-                if isinstance(schema_entry, dict):
-                    preferred = str(
-                        schema_entry.get("_preferred_type", "")
-                    ).lower()
-                    comment = str(schema_entry.get("_comment", ""))
-                # Show detected transports in the label.
-                detected_str = f" [{comment}]" if comment else ""
-                # If the runtime mapping shows this HGI is on a serial
-                # port, show it as USB with the actual port (issue 1185).
-                if runtime_port:
-                    return f"HGI: {dev_id} (USB, {runtime_port}){detected_str}"
-                # Non-primary serial pool member — show transport
-                # from _preferred_type.
-                if preferred == "usb":
-                    return f"HGI: {dev_id} (USB){detected_str}"
-                if preferred == "zigbee":
-                    return f"HGI: {dev_id} (Zigbee){detected_str}"
                 # Default: MQTT pool member.
                 if self.options.get(CONF_MQTT_USE_HA):
                     topic = self.options.get(

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2142,7 +2142,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         if isinstance(primary_port, str) and (
             primary_port.startswith("mqtt://")
             or primary_port == "mqtt_ha"
-            or self.options.get(CONF_MQTT_USE_HA)
+            or (
+                self.options.get(CONF_MQTT_USE_HA)
+                and not (
+                    primary_port.startswith("/dev/")
+                    or primary_port.startswith("socket://")
+                    or primary_port.startswith("rfc2217://")
+                )
+            )
         ):
             primary_hgi_id = self.options.get(CONF_MQTT_HGI_ID)
             if not primary_hgi_id:
@@ -2153,7 +2160,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     primary_hgi_id = m.group(1)
         # For serial primary, find the primary HGI from the schema
         # (the accepted HGI with _owner and _class: HGI).
+        # Prefer the HGI with _preferred_type: usb, since that's the
+        # one physically connected to the primary serial port.  If
+        # none has _preferred_type: usb, fall back to the first
+        # accepted HGI (issue 1185).
         if not primary_hgi_id and isinstance(schema, dict):
+            # First pass: look for _preferred_type: usb.
             for dev_id, entry in schema.items():
                 if (
                     dev_id.startswith(HGI_PREFIX)
@@ -2162,9 +2174,23 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     and entry.get("_class", "").upper() == "HGI"
                     and entry.get(SZ_TR_OWNER) == root_owner
                     and not entry.get("_disabled")
+                    and str(entry.get("_preferred_type", "")).lower() == "usb"
                 ):
                     primary_hgi_id = dev_id
                     break
+            # Fall back: first accepted HGI.
+            if not primary_hgi_id:
+                for dev_id, entry in schema.items():
+                    if (
+                        dev_id.startswith(HGI_PREFIX)
+                        and dev_id != DEFAULT_HGI_ID
+                        and isinstance(entry, dict)
+                        and entry.get("_class", "").upper() == "HGI"
+                        and entry.get(SZ_TR_OWNER) == root_owner
+                        and not entry.get("_disabled")
+                    ):
+                        primary_hgi_id = dev_id
+                        break
 
         # Build a label for each pool member showing its broker info.
         # For the primary HGI: the primary_port URL.
@@ -2211,8 +2237,23 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             )
                     except (ValueError, AttributeError):
                         pass
-                elif display_url == "mqtt_ha" or self.options.get(
-                    CONF_MQTT_USE_HA
+                elif isinstance(display_url, str) and (
+                    display_url.startswith("/dev/")
+                    or display_url.startswith("socket://")
+                    or display_url.startswith("rfc2217://")
+                ):
+                    # Serial primary — show the port path.
+                    return f"HGI: {dev_id} (primary, USB, {display_url})"
+                elif display_url == "mqtt_ha" or (
+                    self.options.get(CONF_MQTT_USE_HA)
+                    and not (
+                        isinstance(display_url, str)
+                        and (
+                            display_url.startswith("/dev/")
+                            or display_url.startswith("socket://")
+                            or display_url.startswith("rfc2217://")
+                        )
+                    )
                 ):
                     # HA MQTT integration path — the topic prefix is
                     # stored separately in CONF_MQTT_TOPIC, not in the
@@ -2223,13 +2264,6 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     )
                     display_url = f"mqtt_ha, topic: {topic}"
                     return f"HGI: {dev_id} (primary, MQTT, {_mask_mqtt_url(display_url)})"
-                elif isinstance(display_url, str) and (
-                    display_url.startswith("/dev/")
-                    or display_url.startswith("socket://")
-                    or display_url.startswith("rfc2217://")
-                ):
-                    # Serial primary — show the port path.
-                    return f"HGI: {dev_id} (primary, USB, {display_url})"
                 return (
                     f"HGI: {dev_id} (primary, {_mask_mqtt_url(display_url)})"
                 )

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1878,80 +1878,64 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # Handle add choices
                 CONF_MQTT_HA_ID = "__mqtt_ha_id__"
                 CONF_MQTT_FULL_URL = "__mqtt_full_url__"
+                CONF_SERIAL_PORT = "__serial_port__"
 
-                # Phase 1: MQTT pool children require an MQTT
-                # primary transport (HA MQTT integration).  A
-                # serial primary + MQTT additional would require
-                # paho inside HA, which is not allowed
-                # (issue 1119).  But if there is no primary at
-                # all (e.g. after clearing all HGIs), allow adding
-                # an MQTT HGI — it becomes the new primary.
-                is_mqtt_or_empty = not primary or (
-                    isinstance(primary, str)
-                    and (
-                        primary.startswith("mqtt://")
-                        or primary == "mqtt_ha"
-                        or self.options.get(CONF_MQTT_USE_HA)
-                    )
-                )
+                # Phase 2: serial pool children are now supported.
+                # MQTT pool children are callback-driven via the
+                # HA-native RamsesMqttPoolBridge (no paho inside HA,
+                # issue 1119).  Both serial and MQTT can be mixed.
+                # Zigbee remains gated until Phase 3.
 
                 if add_choice == CONF_MQTT_HA_ID:
                     # HA MQTT device ID — just enter 18:NNNNNN
-                    if not is_mqtt_or_empty:
-                        errors["base"] = "pool_mqtt_requires_mqtt_primary"
-                    else:
-                        self.options[CONF_ADDITIONAL_PORTS] = additional
-                        if wait_timeout is not None:
-                            self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
-                                wait_timeout
-                            )
-                        return await self.async_step_manage_pool_mqtt()
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    if wait_timeout is not None:
+                        self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                            wait_timeout
+                        )
+                    return await self.async_step_manage_pool_mqtt()
                 elif add_choice == CONF_MQTT_FULL_URL:
                     # Full mqtt:// URL — parse HGI ID from it
-                    if not is_mqtt_or_empty:
-                        errors["base"] = "pool_mqtt_requires_mqtt_primary"
-                    else:
-                        self.options[CONF_ADDITIONAL_PORTS] = additional
-                        if wait_timeout is not None:
-                            self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
-                                wait_timeout
-                            )
-                        return await self.async_step_manage_pool_mqtt_url()
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    if wait_timeout is not None:
+                        self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                            wait_timeout
+                        )
+                    return await self.async_step_manage_pool_mqtt_url()
+                elif add_choice == CONF_SERIAL_PORT:
+                    # Serial/USB port — select from available ports
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    if wait_timeout is not None:
+                        self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                            wait_timeout
+                        )
+                    return await self.async_step_manage_pool_serial()
                 elif add_choice and add_choice.startswith("__readd__"):
                     # Re-add a previously removed HGI
-                    # Still requires MQTT primary (or no primary) —
-                    # blocked for serial primary (issue 1171).
-                    if not is_mqtt_or_empty:
-                        errors["base"] = "pool_mqtt_requires_mqtt_primary"
-                    else:
-                        readd_id = add_choice[len("__readd__") :]
-                        schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
-                        if readd_id in schema_dict and isinstance(
-                            schema_dict[readd_id], dict
-                        ):
-                            root_owner = schema_dict.get(SZ_OWNER, "me")
-                            schema_dict[readd_id][SZ_TR_OWNER] = root_owner
-                            schema_dict[readd_id].pop(
-                                "_removed_from_pool", None
-                            )
-                            self.options[CONF_SCHEMA] = schema_dict
-                        # If no primary is set, this HGI becomes the primary
-                        if not primary and readd_id.startswith(HGI_PREFIX):
-                            self.options[CONF_MQTT_HGI_ID] = readd_id
-                            self.options.setdefault(CONF_MQTT_USE_HA, True)
-                            self.options[SZ_SERIAL_PORT] = {
-                                SZ_PORT_NAME: "mqtt_ha"
-                            }
-                        self.options[CONF_ADDITIONAL_PORTS] = additional
-                        if wait_timeout is not None:
-                            self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
-                                wait_timeout
-                            )
-                        return self._async_save()
+                    readd_id = add_choice[len("__readd__") :]
+                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                    if readd_id in schema_dict and isinstance(
+                        schema_dict[readd_id], dict
+                    ):
+                        root_owner = schema_dict.get(SZ_OWNER, "me")
+                        schema_dict[readd_id][SZ_TR_OWNER] = root_owner
+                        schema_dict[readd_id].pop("_removed_from_pool", None)
+                        self.options[CONF_SCHEMA] = schema_dict
+                    # If no primary is set, this HGI becomes the primary
+                    if not primary and readd_id.startswith(HGI_PREFIX):
+                        self.options[CONF_MQTT_HGI_ID] = readd_id
+                        self.options.setdefault(CONF_MQTT_USE_HA, True)
+                        self.options[SZ_SERIAL_PORT] = {
+                            SZ_PORT_NAME: "mqtt_ha"
+                        }
+                    self.options[CONF_ADDITIONAL_PORTS] = additional
+                    if wait_timeout is not None:
+                        self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
+                            wait_timeout
+                        )
+                    return self._async_save()
                 elif not errors:
                     # No new port and no errors — just save removals.
-                    # Serial and Zigbee are not listed in the dropdown
-                    # at all (Phase 2/3 gating).
                     self.options[CONF_ADDITIONAL_PORTS] = additional
                     if wait_timeout is not None:
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
@@ -2098,13 +2082,15 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             )
 
         # Build options for the "add new port" dropdown.
-        # Phase 1: only MQTT HGIs are supported as pool children.
-        # Serial and Zigbee are not listed at all — the pool is
-        # MQTT-only until Phase 2 (serial) and Phase 3 (Zigbee).
-        # TODO: re-enable serial when Phase 2 (PR 3) lands.
+        # Phase 2: serial and MQTT HGIs are supported as pool children.
+        # Serial children are transport-driven (serialx); MQTT children
+        # are callback-driven via the HA-native RamsesMqttPoolBridge
+        # (no paho inside HA — issue 1119).
+        # Zigbee remains gated until Phase 3 (PR 6).
         # TODO: re-enable zigbee when Phase 3 (PR 6) lands.
         CONF_MQTT_HA_ID = "__mqtt_ha_id__"
         CONF_MQTT_FULL_URL = "__mqtt_full_url__"
+        CONF_SERIAL_PORT = "__serial_port__"
         add_options: list[selector.SelectOptionDict] = [
             selector.SelectOptionDict(value=NO_ADD, label="(nothing to add)"),
             selector.SelectOptionDict(
@@ -2112,6 +2098,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             ),
             selector.SelectOptionDict(
                 value=CONF_MQTT_FULL_URL, label="MQTT Broker (full URL)..."
+            ),
+            selector.SelectOptionDict(
+                value=CONF_SERIAL_PORT, label="Serial/USB port..."
             ),
         ]
         # List removed HGIs so the user can re-add them directly.
@@ -2412,6 +2401,82 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         return self.async_show_form(
             step_id="manage_pool_mqtt_url",
+            data_schema=vol_schema(data_schema),
+            errors=errors,
+            description_placeholders={},
+            last_step=False,
+        )
+
+    async def async_step_manage_pool_serial(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select a serial/USB port as an additional pool member.
+
+        Phase 2: serial children are transport-driven (serialx) and
+        fully send-capable after identity is established.  The port
+        is added to CONF_ADDITIONAL_PORTS.
+
+        :param user_input: Dict containing user-provided input data.
+        :return: The generated config flow result.
+        """
+        self.get_options()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            port = (user_input.get("serial_port") or "").strip()
+            if not port:
+                errors["base"] = "serial_port_required"
+            else:
+                # Add the serial port to additional ports
+                additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
+                if port not in additional:
+                    additional.append(port)
+                self.options[CONF_ADDITIONAL_PORTS] = additional
+                _LOGGER.info(
+                    "Added serial pool child: %s",
+                    port,
+                )
+                return self._async_save()
+
+        # Build list of available serial ports
+        try:
+            from ramses_tx.helpers import serial_ports
+
+            available_ports = serial_ports()
+        except Exception:  # noqa: BLE001
+            available_ports = []
+
+        # Filter out the primary port and already-added ports
+        primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(
+            SZ_PORT_NAME, ""
+        )
+        current_additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
+        excluded = {primary_port, *current_additional}
+
+        port_options = [
+            selector.SelectOptionDict(value=port, label=port)
+            for port in available_ports
+            if port not in excluded
+        ]
+
+        if not port_options:
+            port_options = [
+                selector.SelectOptionDict(
+                    value="__none__", label="(no available ports)"
+                )
+            ]
+
+        data_schema = {
+            prob.Required("serial_port"): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=port_options,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
+        }
+
+        return self.async_show_form(
+            step_id="manage_pool_serial",
             data_schema=vol_schema(data_schema),
             errors=errors,
             description_placeholders={},

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2737,11 +2737,22 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         coordinator = getattr(self.config_entry, "runtime_data", None)
 
         if not coordinator or not coordinator.discovery_manager:
+            # Distinguish between "not set up" (transport failed) and
+            # "passive scan disabled" (coordinator up but no discovery
+            # manager).  The misleading "Passive device scan is not
+            # enabled" message confused users when the real issue was
+            # a failed transport (issue 1171).
+            if coordinator is None:
+                message = (
+                    "The Ramses RF integration is not running. "
+                    "Check the serial port / MQTT broker connection "
+                    "and reload the integration."
+                )
+            else:
+                message = "Passive device scan is not enabled."
             return self.async_show_form(
                 step_id="review_discovered",
-                description_placeholders={
-                    "message": "Passive device scan is not enabled."
-                },
+                description_placeholders={"message": message},
                 last_step=True,
             )
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -3448,8 +3448,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                     parts.append("mqtt")
                                 if "zigbee" in comment or sel == "zigbee":
                                     parts.append("zigbee")
-                                dev_entry["_comment"] = (
-                                    "Supports: " + ", ".join(parts)
+                                dev_entry["_comment"] = build_hgi_comment(
+                                    parts
                                 )
                         # Clear any prior missing_class dismissal so that
                         # if the user later removes _class from the schema,

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2005,51 +2005,85 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             _primary_hgi_id = self.options.get(
                                 CONF_MQTT_HGI_ID
                             )
+                    # For serial primary, find the primary HGI from the
+                    # schema — it's the accepted HGI (has _owner and
+                    # _class: HGI).  There should only be one for a
+                    # serial-primary single-HGI setup.
+                    if not _primary_hgi_id and isinstance(schema_dict, dict):
+                        root_owner = schema_dict.get(SZ_OWNER, "me")
+                        for dev_id, entry in schema_dict.items():
+                            if (
+                                dev_id.startswith(HGI_PREFIX)
+                                and isinstance(entry, dict)
+                                and entry.get("_class", "").upper() == "HGI"
+                                and entry.get(SZ_TR_OWNER) == root_owner
+                            ):
+                                _primary_hgi_id = dev_id
+                                break
                     if _primary_hgi_id and isinstance(schema_dict, dict):
                         new_pref = schema_dict.get(_primary_hgi_id, {}).get(
                             "_preferred_type", ""
                         )
-                        current_primary = self.options.get(
-                            SZ_SERIAL_PORT, {}
-                        ).get(SZ_PORT_NAME, "")
-                        is_current_serial = isinstance(
-                            current_primary, str
-                        ) and (
-                            current_primary.startswith("/dev/")
-                            or current_primary.startswith("socket://")
-                            or current_primary.startswith("rfc2217://")
+                        # Only trigger a transport switch when the
+                        # _preferred_type actually CHANGED — not when
+                        # the form just re-submitted the same default.
+                        old_schema = self.options.get(CONF_SCHEMA, {})
+                        old_pref = (
+                            old_schema.get(_primary_hgi_id, {}).get(
+                                "_preferred_type", ""
+                            )
+                            if isinstance(old_schema, dict)
+                            else ""
                         )
-                        is_current_mqtt = isinstance(
-                            current_primary, str
-                        ) and (
-                            current_primary.startswith("mqtt://")
-                            or current_primary == "mqtt_ha"
-                        )
+                        if new_pref == old_pref:
+                            # No change — don't switch transport
+                            pass
+                        else:
+                            current_primary = self.options.get(
+                                SZ_SERIAL_PORT, {}
+                            ).get(SZ_PORT_NAME, "")
+                            is_current_serial = isinstance(
+                                current_primary, str
+                            ) and (
+                                current_primary.startswith("/dev/")
+                                or current_primary.startswith("socket://")
+                                or current_primary.startswith("rfc2217://")
+                            )
+                            is_current_mqtt = isinstance(
+                                current_primary, str
+                            ) and (
+                                current_primary.startswith("mqtt://")
+                                or current_primary == "mqtt_ha"
+                            )
 
-                        if new_pref == "mqtt" and is_current_serial:
-                            # Switch primary to MQTT — redirect to the
-                            # MQTT URL step so the user can enter the
-                            # full broker URL (reuses existing UI).
-                            # Pre-fill with the HA MQTT integration's
-                            # broker if available.
-                            _LOGGER.info(
-                                "Pool: switching primary HGI %s "
-                                "from serial to MQTT — redirecting "
-                                "to MQTT URL entry",
-                                _primary_hgi_id,
-                            )
-                            self._switching_primary_to_mqtt = _primary_hgi_id
-                            return await self.async_step_manage_pool_mqtt_url()
-                        elif new_pref == "usb" and is_current_mqtt:
-                            # Switch primary to serial — redirect to
-                            # the serial port selection step.
-                            _LOGGER.info(
-                                "Pool: switching primary HGI %s "
-                                "from MQTT to serial — redirecting "
-                                "to serial port selection",
-                                _primary_hgi_id,
-                            )
-                            return await self.async_step_manage_pool_serial()
+                            if new_pref == "mqtt" and is_current_serial:
+                                # Switch primary to MQTT — redirect to
+                                # the MQTT URL step so the user can
+                                # enter the full broker URL (reuses
+                                # existing UI).  Pre-fill with the HA
+                                # MQTT integration's broker if available.
+                                _LOGGER.info(
+                                    "Pool: switching primary HGI %s "
+                                    "from serial to MQTT — redirecting "
+                                    "to MQTT URL entry",
+                                    _primary_hgi_id,
+                                )
+                                self._switching_primary_to_mqtt = (
+                                    _primary_hgi_id
+                                )
+                                return await self.async_step_manage_pool_mqtt_url()
+                            elif new_pref == "usb" and is_current_mqtt:
+                                # Switch primary to serial — redirect
+                                # to the serial port selection step.
+                                _LOGGER.info(
+                                    "Pool: switching primary HGI %s "
+                                    "from MQTT to serial — redirecting "
+                                    "to serial port selection",
+                                    _primary_hgi_id,
+                                )
+                                return (
+                                    await self.async_step_manage_pool_serial()
+                                )
 
                     if not errors:
                         return self._async_save()
@@ -2656,8 +2690,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             "Added MQTT pool HGI %s via full URL",
                             hgi_id,
                         )
-                    # Clear the switching flag
-                    del self._switching_primary_to_mqtt
+                    # Clear the switching flag if it was set
+                    if hasattr(self, "_switching_primary_to_mqtt"):
+                        del self._switching_primary_to_mqtt
                     return self._async_save()
 
         data_schema = {

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1978,17 +1978,81 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                             schema_dict[dev_id]["_comment"] = (
                                                 "Supports: " + ", ".join(parts)
                                             )
-                                    else:
-                                        schema_dict[dev_id].pop(
-                                            "_preferred_type", None
-                                        )
                         self.options[CONF_SCHEMA] = schema_dict
                     self.options[CONF_ADDITIONAL_PORTS] = additional
                     if wait_timeout is not None:
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
                             wait_timeout
                         )
-                    return self._async_save()
+
+                    # Detect if the user switched the primary HGI's
+                    # _preferred_type to a different transport.  If so,
+                    # switch the primary transport to match (issue 1171).
+                    # The MQTT bridge uses the HA MQTT integration's
+                    # broker — if it's not configured, show an error.
+                    _primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(
+                        SZ_PORT_NAME, ""
+                    )
+                    _primary_hgi_id: str | None = None
+                    if isinstance(_primary_port, str):
+                        if _primary_port.startswith("mqtt://"):
+                            import re as _re
+
+                            m = _re.search(r"(18:[0-9]{6})", _primary_port)
+                            if m:
+                                _primary_hgi_id = m.group(1)
+                        elif _primary_port == "mqtt_ha":
+                            _primary_hgi_id = self.options.get(
+                                CONF_MQTT_HGI_ID
+                            )
+                    if _primary_hgi_id and isinstance(schema_dict, dict):
+                        new_pref = schema_dict.get(_primary_hgi_id, {}).get(
+                            "_preferred_type", ""
+                        )
+                        current_primary = self.options.get(
+                            SZ_SERIAL_PORT, {}
+                        ).get(SZ_PORT_NAME, "")
+                        is_current_serial = isinstance(
+                            current_primary, str
+                        ) and (
+                            current_primary.startswith("/dev/")
+                            or current_primary.startswith("socket://")
+                            or current_primary.startswith("rfc2217://")
+                        )
+                        is_current_mqtt = isinstance(
+                            current_primary, str
+                        ) and (
+                            current_primary.startswith("mqtt://")
+                            or current_primary == "mqtt_ha"
+                        )
+
+                        if new_pref == "mqtt" and is_current_serial:
+                            # Switch primary to MQTT — redirect to the
+                            # MQTT URL step so the user can enter the
+                            # full broker URL (reuses existing UI).
+                            # Pre-fill with the HA MQTT integration's
+                            # broker if available.
+                            _LOGGER.info(
+                                "Pool: switching primary HGI %s "
+                                "from serial to MQTT — redirecting "
+                                "to MQTT URL entry",
+                                _primary_hgi_id,
+                            )
+                            self._switching_primary_to_mqtt = _primary_hgi_id
+                            return await self.async_step_manage_pool_mqtt_url()
+                        elif new_pref == "usb" and is_current_mqtt:
+                            # Switch primary to serial — redirect to
+                            # the serial port selection step.
+                            _LOGGER.info(
+                                "Pool: switching primary HGI %s "
+                                "from MQTT to serial — redirecting "
+                                "to serial port selection",
+                                _primary_hgi_id,
+                            )
+                            return await self.async_step_manage_pool_serial()
+
+                    if not errors:
+                        return self._async_save()
                 # If errors is non-empty, fall through to show the form
                 # again with the error message.
 
@@ -2301,7 +2365,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 if "mqtt" in detected_types:
                     mqtt_label = "MQTT (detected)"
                 pref_options.append(
-                    selector.SelectOptionDict(value="", label=mqtt_label)
+                    selector.SelectOptionDict(value="mqtt", label=mqtt_label)
                 )
                 usb_label = "USB (serial)"
                 if "usb" in detected_types:
@@ -2340,7 +2404,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             multiple=False,
                         )
                     ),
-                    current_pref or "",
+                    current_pref or "mqtt",
                 )
 
         data_schema: dict[str, Any] = {
@@ -2519,11 +2583,31 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         The URL is also stored in CONF_ADDITIONAL_PORTS so the pool
         bridge can create a child transport for it.
 
+        When invoked from the pool menu's primary switch (serial →
+        MQTT), the URL is set as the primary ``serial_port.port_name``
+        instead of being added to additional ports.
+
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
         """
         self.get_options()
         errors: dict[str, str] = {}
+
+        # Pre-fill the URL from the HA MQTT integration's broker
+        # when switching the primary from serial to MQTT.
+        default_url = ""
+        switching_primary = getattr(self, "_switching_primary_to_mqtt", None)
+        if switching_primary and not user_input:
+            mqtt_entries = self.hass.config_entries.async_entries("mqtt")
+            if mqtt_entries:
+                mqtt_data = mqtt_entries[0].data
+                broker = mqtt_data.get("broker", "")
+                port = mqtt_data.get("port", 1883)
+                topic = self.options.get(CONF_MQTT_TOPIC, "RAMSES/GATEWAY")
+                if broker:
+                    default_url = (
+                        f"mqtt://{broker}:{port}/{topic}/{switching_primary}"
+                    )
 
         if user_input is not None:
             url = (user_input.get("mqtt_url") or "").strip()
@@ -2550,30 +2634,58 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     schema_dict[hgi_id][SZ_TR_OWNER] = root_owner
                     schema_dict[hgi_id].pop("_removed_from_pool", None)
                     self.options[CONF_SCHEMA] = schema_dict
-                    # Add the URL to additional ports
-                    additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
-                    if url not in additional:
-                        additional.append(url)
-                    self.options[CONF_ADDITIONAL_PORTS] = additional
-                    _LOGGER.info(
-                        "Added MQTT pool HGI %s via full URL",
-                        hgi_id,
-                    )
+
+                    if switching_primary:
+                        # Set as primary transport (serial → MQTT switch)
+                        self.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: url}
+                        self.options[CONF_MQTT_USE_HA] = True
+                        _LOGGER.info(
+                            "Switched primary HGI %s to MQTT: %s",
+                            hgi_id,
+                            url,
+                        )
+                    else:
+                        # Add the URL to additional ports
+                        additional = self.options.get(
+                            CONF_ADDITIONAL_PORTS, []
+                        )
+                        if url not in additional:
+                            additional.append(url)
+                        self.options[CONF_ADDITIONAL_PORTS] = additional
+                        _LOGGER.info(
+                            "Added MQTT pool HGI %s via full URL",
+                            hgi_id,
+                        )
+                    # Clear the switching flag
+                    del self._switching_primary_to_mqtt
                     return self._async_save()
 
         data_schema = {
-            prob.Required("mqtt_url", default=""): selector.TextSelector(
+            prob.Required(
+                "mqtt_url", default=default_url
+            ): selector.TextSelector(
                 selector.TextSelectorConfig(
                     type=selector.TextSelectorType.TEXT,
                 )
             ),
         }
 
+        # Show a different description when switching the primary
+        if switching_primary:
+            desc = (
+                "Switching primary HGI {hgi_id} from serial to MQTT.\n"
+                "Enter the full MQTT broker URL (broker, port, topic, "
+                "HGI ID).  Pre-filled from the HA MQTT integration if "
+                "available."
+            ).replace("{hgi_id}", switching_primary)
+        else:
+            desc = ""
+
         return self.async_show_form(
             step_id="manage_pool_mqtt_url",
             data_schema=vol_schema(data_schema),
             errors=errors,
-            description_placeholders={},
+            description_placeholders={"message": desc},
             last_step=False,
         )
 
@@ -2991,7 +3103,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             # devices and update _comment.
                             if device_id.startswith("18:"):
                                 pref_val = user_input.get(
-                                    f"preferred_type_{device_id}", ""
+                                    f"preferred_type_{device_id}", "mqtt"
                                 )
                                 if pref_val:
                                     dev_entry["_preferred_type"] = pref_val
@@ -3459,7 +3571,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 if "mqtt" in detected_types:
                     mqtt_lbl = "MQTT (detected)"
                 pref_opts.append(
-                    selector.SelectOptionDict(value="", label=mqtt_lbl)
+                    selector.SelectOptionDict(value="mqtt", label=mqtt_lbl)
                 )
                 usb_lbl = "USB (serial)"
                 if "usb" in detected_types:
@@ -3482,7 +3594,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     if isinstance(dev_entry, dict)
                     else ""
                 )
-                _review_default = _current_pref or ""
+                _review_default = _current_pref or "mqtt"
                 if not _review_default:
                     _primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(
                         SZ_PORT_NAME, ""

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2108,21 +2108,18 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         )
         current_additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
 
-        # Count serial ports (primary + additional) to determine
-        # whether we can claim a specific port for the primary HGI.
-        # With multiple serial ports, the config_flow can't know
-        # which HGI is on which port — that's discovered at runtime
-        # by the transport (issue 1185).
-        _serial_port_count = sum(
-            1
-            for p in [primary_port, *current_additional]
-            if isinstance(p, str)
-            and (
-                p.startswith("/dev/")
-                or p.startswith("socket://")
-                or p.startswith("rfc2217://")
-            )
-        )
+        # Get the runtime port-to-HGI mapping from the coordinator.
+        # The transport discovers which HGI is on which serial port
+        # at startup (via !I or _PUZZ probe).  This lets us show the
+        # actual port assignment in the pool member labels (issue 1185).
+        _runtime_port_hgi_map: dict[str, str] = {}
+        coord = getattr(self.config_entry, "runtime_data", None)
+        if coord is not None and hasattr(coord, "serial_port_hgi_map"):
+            _runtime_port_hgi_map = coord.serial_port_hgi_map
+        # Reverse map: HGI ID -> port name
+        _runtime_hgi_port_map: dict[str, str] = {
+            v: k for k, v in _runtime_port_hgi_map.items()
+        }
 
         # Schema-derived pool members (HGIs with _owner: me and _class:
         # HGI) — these are active pool members managed via the schema.
@@ -2232,7 +2229,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             Shows the transport type (USB serial vs MQTT callback) so
             the user can distinguish pool members in a hybrid pool
             (Phase 2, issue 1119).
+
+            When the runtime port-to-HGI mapping is available (from the
+            coordinator), the actual serial port is shown for each USB
+            HGI (issue 1185).
             """
+            # Check if this HGI is on a known serial port (runtime).
+            runtime_port = _runtime_hgi_port_map.get(dev_id)
+
             if dev_id == primary_hgi_id:
                 # For the primary, ensure the topic is shown even if
                 # the URL has no path (e.g. mqtt://broker:1883).
@@ -2258,14 +2262,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     or display_url.startswith("socket://")
                     or display_url.startswith("rfc2217://")
                 ):
-                    # Serial primary.  With a single serial port we
-                    # know the primary HGI is on it, so show the port.
-                    # With multiple serial ports we can't know which
-                    # HGI is on which port (discovered at runtime), so
-                    # just show the transport type (issue 1185).
-                    if _serial_port_count <= 1:
-                        return f"HGI: {dev_id} (primary, USB, {display_url})"
-                    return f"HGI: {dev_id} (USB, primary port)"
+                    # Serial primary.  If the runtime mapping knows
+                    # which port this HGI is actually on, show it.
+                    # Otherwise show the configured primary port.
+                    port = runtime_port or display_url
+                    return f"HGI: {dev_id} (primary, USB, {port})"
                 elif display_url == "mqtt_ha" or (
                     self.options.get(CONF_MQTT_USE_HA)
                     and not (
@@ -2318,6 +2319,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     comment = str(schema_entry.get("_comment", ""))
                 # Show detected transports in the label.
                 detected_str = f" [{comment}]" if comment else ""
+                # If the runtime mapping shows this HGI is on a serial
+                # port, show it as USB with the actual port (issue 1185).
+                if runtime_port:
+                    return f"HGI: {dev_id} (USB, {runtime_port}){detected_str}"
                 # Non-primary serial pool member — show transport
                 # from _preferred_type.
                 if preferred == "usb":

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2608,9 +2608,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         # Build list of available serial ports
         try:
-            from ramses_tx.helpers import serial_ports
+            from serialx import list_serial_ports
 
-            available_ports = serial_ports()
+            available_ports = list_serial_ports()
         except Exception:  # noqa: BLE001
             available_ports = []
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -3330,6 +3330,11 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Build form with device selectors — each field name includes
         # the device info so the user can see what they're accepting.
         form_fields: dict[Any, Any] = {}
+        # Get the current schema for reading _comment (transport
+        # capability detection) on HGI entries.
+        config_schema = self.options.get(CONF_SCHEMA, {})
+        if not isinstance(config_schema, dict):
+            config_schema = {}
 
         # Owner name field — sets the ROOT _owner in the schema.
         # This is the system-wide owner.  Per-device owner fields below

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2005,31 +2005,26 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # The primary HGI is also listed (marked as "primary") so the
         # user can see the full pool composition.
         #
-        # Phase 1: the pool is MQTT-only.  When the primary is serial
-        # (not MQTT), schema HGIs are serial-discovered devices and must
-        # NOT be shown as MQTT pool members — they don't have an MQTT
-        # topic or broker (issue 1171).
+        # Phase 2: hybrid pools (serial + MQTT) are now supported.
+        # Show all accepted HGIs as schema pool members regardless of
+        # whether the primary is serial or MQTT.  Each HGI's
+        # _preferred_type determines its transport in the hybrid pool.
+        # (Phase 1 restricted this to MQTT-only primaries.)
         schema = self.options.get(CONF_SCHEMA, {})
         if not isinstance(schema, dict):
             schema = {}
         root_owner = schema.get(SZ_OWNER, "me")
-        is_primary_mqtt = isinstance(primary_port, str) and (
-            primary_port.startswith("mqtt://")
-            or primary_port == "mqtt_ha"
-            or self.options.get(CONF_MQTT_USE_HA)
-        )
         schema_pool_members: list[str] = []
-        if is_primary_mqtt or not primary_port:
-            for dev_id, entry in schema.items():
-                if (
-                    dev_id.startswith(HGI_PREFIX)
-                    and dev_id != DEFAULT_HGI_ID
-                    and isinstance(entry, dict)
-                    and entry.get("_class", "").upper() == "HGI"
-                    and entry.get(SZ_TR_OWNER) == root_owner
-                    and not entry.get("_disabled")
-                ):
-                    schema_pool_members.append(dev_id)
+        for dev_id, entry in schema.items():
+            if (
+                dev_id.startswith(HGI_PREFIX)
+                and dev_id != DEFAULT_HGI_ID
+                and isinstance(entry, dict)
+                and entry.get("_class", "").upper() == "HGI"
+                and entry.get(SZ_TR_OWNER) == root_owner
+                and not entry.get("_disabled")
+            ):
+                schema_pool_members.append(dev_id)
 
         # Determine the primary HGI ID (from the MQTT URL or CONF_MQTT_HGI_ID)
         # so we can label it in the pool list.
@@ -2163,7 +2158,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         current_options: list[selector.SelectOptionDict] = []
         for port in current_additional:
             if port.startswith("mqtt://"):
-                label = f"MQTT: {port}"
+                label = f"MQTT: {_mask_mqtt_url(port)}"
             elif port.startswith("zigbee://"):
                 label = f"Zigbee: {port}"
             else:
@@ -2195,17 +2190,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             ),
         ]
         # List removed HGIs so the user can re-add them directly.
-        # Only show re-add options when the primary is MQTT or empty —
-        # re-adding an MQTT HGI with a serial primary is blocked (issue 1171).
-        is_primary_mqtt_or_empty = not primary_port or (
-            isinstance(primary_port, str)
-            and (
-                primary_port.startswith("mqtt://")
-                or primary_port == "mqtt_ha"
-                or self.options.get(CONF_MQTT_USE_HA)
-            )
-        )
-        if is_primary_mqtt_or_empty and isinstance(schema, dict):
+        # Phase 2: re-add works for both serial and MQTT primaries
+        # (hybrid pool support).
+        if isinstance(schema, dict):
             for dev_id, entry in schema.items():
                 if (
                     dev_id.startswith(HGI_PREFIX)
@@ -2606,13 +2593,21 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 )
                 return self._async_save()
 
-        # Build list of available serial ports
+        # Build list of available serial ports using HA's USB port
+        # scanner (returns /dev/serial/by-id/ paths with friendly
+        # names).  Falls back to serialx.list_serial_ports() if the
+        # HA USB scanner is unavailable.
+        usb_ports_map: dict[str, str] = {}
         try:
-            from serialx import list_serial_ports
-
-            available_ports = list_serial_ports()
+            usb_ports_map = await async_get_usb_ports(self.hass)
+            available_ports = list(usb_ports_map.keys())
         except Exception:  # noqa: BLE001
-            available_ports = []
+            try:
+                from serialx import list_serial_ports
+
+                available_ports = list_serial_ports()
+            except Exception:  # noqa: BLE001
+                available_ports = []
 
         # Filter out the primary port and already-added ports
         primary_port = self.options.get(SZ_SERIAL_PORT, {}).get(
@@ -2622,7 +2617,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         excluded = {primary_port, *current_additional}
 
         port_options = [
-            selector.SelectOptionDict(value=port, label=port)
+            selector.SelectOptionDict(
+                value=port,
+                label=usb_ports_map.get(port, port),
+            )
             for port in available_ports
             if port not in excluded
         ]

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2262,12 +2262,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     comment = str(schema_entry.get("_comment", ""))
                 # Show detected transports in the label.
                 detected_str = f" [{comment}]" if comment else ""
-                # The primary HGI on serial always shows as USB
-                # regardless of _preferred_type — the primary port
-                # IS the transport.  _preferred_type only matters
-                # for non-primary pool members.
-                if dev_id == primary_hgi_id:
-                    return f"HGI: {dev_id} (primary, USB, {primary_port}){detected_str}"
+                # Non-primary serial pool member — show transport
+                # from _preferred_type.
                 if preferred == "usb":
                     return f"HGI: {dev_id} (USB){detected_str}"
                 if preferred == "zigbee":

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -100,8 +100,8 @@ CONF_MQTT_PATH: Final = "MQTT Broker..."
 CONF_HA_MQTT_PATH: Final = "Use Home Assistant MQTT - In development!"
 CONF_ZIGBEE_DEVICE: Final = "Zigbee device"
 
-# HGI device ID regex: 18:NNNNNN (class 18, 6 hex digits).
-_HGI_ID_RE: Final = re.compile(r"^18:[0-9A-Fa-f]{6}$")
+# HGI device ID regex: 18:NNNNNN (class 18, 6 decimal digits).
+_HGI_ID_RE: Final = re.compile(r"^18:[0-9]{6}$")
 
 
 if hasattr(usb, "async_scan_serial_ports"):
@@ -1828,7 +1828,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # demoting it back to a discovery candidate (issue 1119).
                 # The primary HGI can also be removed — if it's removed
                 # and another accepted HGI exists, auto-promote that one.
-                schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                schema_dict = deepcopy(self.options.get(CONF_SCHEMA, {}))
                 if isinstance(schema_dict, dict):
                     root_owner = schema_dict.get(SZ_OWNER, "me")
                     # First pass: figure out what would be removed and
@@ -1925,14 +1925,16 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
                             wait_timeout
                         )
+                    self._pool_add_in_progress = True
                     return await self.async_step_manage_pool_mqtt()
                 elif add_choice == CONF_MQTT_FULL_URL:
-                    # Full mqtt:// URL — parse HGI ID from it
+                    # HA MQTT HGI with an optional topic prefix
                     self.options[CONF_ADDITIONAL_PORTS] = additional
                     if wait_timeout is not None:
                         self.options[CONF_WAIT_ONLINE_TIMEOUT] = float(
                             wait_timeout
                         )
+                    self._pool_add_in_progress = True
                     return await self.async_step_manage_pool_mqtt_url()
                 elif add_choice == CONF_SERIAL_PORT:
                     # Serial/USB port — select from available ports
@@ -1945,11 +1947,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 elif add_choice and add_choice.startswith("__readd__"):
                     # Re-add a previously removed HGI
                     readd_id = add_choice[len("__readd__") :]
-                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                    schema_dict = deepcopy(self.options.get(CONF_SCHEMA, {}))
                     if readd_id in schema_dict and isinstance(
                         schema_dict[readd_id], dict
                     ):
-                        root_owner = schema_dict.get(SZ_OWNER, "me")
+                        root_owner = schema_dict.get(SZ_OWNER) or "me"
+                        schema_dict[SZ_OWNER] = root_owner
                         schema_dict[readd_id][SZ_TR_OWNER] = root_owner
                         schema_dict[readd_id].pop("_removed_from_pool", None)
                         self.options[CONF_SCHEMA] = schema_dict
@@ -1979,7 +1982,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                 old_schema_prefs[_k] = str(
                                     _v.get("_preferred_type", "")
                                 )
-                    schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
+                    schema_dict = deepcopy(self.options.get(CONF_SCHEMA, {}))
                     if isinstance(schema_dict, dict):
                         for key, val in user_input.items():
                             if key.startswith("_preferred_type_"):
@@ -2511,7 +2514,8 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 value=CONF_MQTT_HA_ID, label="HA MQTT device ID..."
             ),
             selector.SelectOptionDict(
-                value=CONF_MQTT_FULL_URL, label="MQTT Broker (full URL)..."
+                value=CONF_MQTT_FULL_URL,
+                label="HA MQTT HGI with topic prefix...",
             ),
             selector.SelectOptionDict(
                 value=CONF_SERIAL_PORT, label="Serial/USB port..."
@@ -2787,11 +2791,12 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         :param user_input: Dict containing user-provided input data.
         :return: The generated config flow result.
         """
-        self.get_options()
+        if not getattr(self, "_pool_add_in_progress", False):
+            self.get_options()
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            hgi_id = (user_input.get("hgi_id") or "").strip().upper()
+            hgi_id = (user_input.get("hgi_id") or "").strip()
 
             if not hgi_id:
                 errors["base"] = "hgi_id_required"
@@ -2805,8 +2810,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # Create/update schema HGI entry with _owner = root_owner
                 # so the coordinator's _extract_pool_hgis_from_schema()
                 # includes it as an accepted pool member.
-                schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
-                root_owner = schema_dict.get(SZ_OWNER, "me")
+                schema_dict = deepcopy(self.options.get(CONF_SCHEMA, {}))
+                root_owner = schema_dict.get(SZ_OWNER) or "me"
+                schema_dict[SZ_OWNER] = root_owner
                 if hgi_id not in schema_dict or not isinstance(
                     schema_dict.get(hgi_id), dict
                 ):
@@ -2866,8 +2872,10 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Don't reload options if we're in a switching flow —
         # the pool form already updated self.options with the
         # new _preferred_type before redirecting here.
-        if not hasattr(self, "_switching_primary_to_mqtt") and not hasattr(
-            self, "_switching_secondary_to_mqtt"
+        if (
+            not hasattr(self, "_switching_primary_to_mqtt")
+            and not hasattr(self, "_switching_secondary_to_mqtt")
+            and not getattr(self, "_pool_add_in_progress", False)
         ):
             self.get_options()
         errors: dict[str, str] = {}
@@ -2894,8 +2902,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 # and add a different accepted HGI to the schema.
                 errors["base"] = "mqtt_hgi_id_mismatch"
             else:
-                schema_dict = dict(self.options.get(CONF_SCHEMA, {}))
-                root_owner = schema_dict.get(SZ_OWNER, "me")
+                schema_dict = deepcopy(self.options.get(CONF_SCHEMA, {}))
+                root_owner = schema_dict.get(SZ_OWNER) or "me"
+                schema_dict[SZ_OWNER] = root_owner
                 if hgi_id not in schema_dict or not isinstance(
                     schema_dict.get(hgi_id), dict
                 ):
@@ -3043,6 +3052,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     # Switch primary to serial
                     self.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: port}
                     self.options.pop(CONF_MQTT_USE_HA, None)
+                    self.options.pop(CONF_MQTT_HGI_ID, None)
                     _LOGGER.info(
                         "Switched primary HGI from MQTT to serial: %s",
                         port,
@@ -3327,7 +3337,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
         if user_input is not None:
             # Process accept/decline for each device
-            config_schema = dict(self.options.get(CONF_SCHEMA, {}))
+            config_schema = deepcopy(self.options.get(CONF_SCHEMA, {}))
             changed = False
 
             # Determine the root owner name.  If the user provided one,
@@ -4192,7 +4202,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         if user_input is not None:
             # Process each device — "keep" clears the flag, "remove" calls
             # the remove_device service for full cleanup.
-            config_schema = dict(self.options.get(CONF_SCHEMA, {}))
+            config_schema = deepcopy(self.options.get(CONF_SCHEMA, {}))
             removed_any = False
             for entry in lost_devices:
                 device_id = entry.device.device_id

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2108,6 +2108,22 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         )
         current_additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
 
+        # Count serial ports (primary + additional) to determine
+        # whether we can claim a specific port for the primary HGI.
+        # With multiple serial ports, the config_flow can't know
+        # which HGI is on which port — that's discovered at runtime
+        # by the transport (issue 1185).
+        _serial_port_count = sum(
+            1
+            for p in [primary_port, *current_additional]
+            if isinstance(p, str)
+            and (
+                p.startswith("/dev/")
+                or p.startswith("socket://")
+                or p.startswith("rfc2217://")
+            )
+        )
+
         # Schema-derived pool members (HGIs with _owner: me and _class:
         # HGI) — these are active pool members managed via the schema.
         # Show them in the form with a checkbox for each; unchecking
@@ -2242,8 +2258,14 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                     or display_url.startswith("socket://")
                     or display_url.startswith("rfc2217://")
                 ):
-                    # Serial primary — show the port path.
-                    return f"HGI: {dev_id} (primary, USB, {display_url})"
+                    # Serial primary.  With a single serial port we
+                    # know the primary HGI is on it, so show the port.
+                    # With multiple serial ports we can't know which
+                    # HGI is on which port (discovered at runtime), so
+                    # just show the transport type (issue 1185).
+                    if _serial_port_count <= 1:
+                        return f"HGI: {dev_id} (primary, USB, {display_url})"
+                    return f"HGI: {dev_id} (USB, primary port)"
                 elif display_url == "mqtt_ha" or (
                     self.options.get(CONF_MQTT_USE_HA)
                     and not (

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1949,6 +1949,35 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                         schema_dict[dev_id][
                                             "_preferred_type"
                                         ] = val
+                                        # Also update _comment to
+                                        # include the selected transport
+                                        # so it shows "(detected)" next
+                                        # time.
+                                        comment = str(
+                                            schema_dict[dev_id].get(
+                                                "_comment", ""
+                                            )
+                                        ).lower()
+                                        if val not in comment:
+                                            parts = []
+                                            if (
+                                                "usb" in comment
+                                                or val == "usb"
+                                            ):
+                                                parts.append("usb")
+                                            if (
+                                                "mqtt" in comment
+                                                or val == "mqtt"
+                                            ):
+                                                parts.append("mqtt")
+                                            if (
+                                                "zigbee" in comment
+                                                or val == "zigbee"
+                                            ):
+                                                parts.append("zigbee")
+                                            schema_dict[dev_id]["_comment"] = (
+                                                "Supports: " + ", ".join(parts)
+                                            )
                                     else:
                                         schema_dict[dev_id].pop(
                                             "_preferred_type", None

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -1732,8 +1732,24 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
     def _async_save(self) -> ConfigFlowResult:
         """Save the configured options.
 
+        Clears the coordinator's ``_suppress_reload`` flag so the
+        update listener (triggered by ``async_create_entry``) actually
+        reloads the integration.  Without this, a race with
+        ``sync_learned_topology`` (which sets ``_suppress_reload`` when
+        persisting schema/comments) can suppress the reload that the
+        config flow expects — leaving the running coordinator with
+        stale transport config (e.g. MQTT pool bridge not restarted
+        after a non-primary HGI switches from USB to MQTT).
+
         :return: The generated config flow result.
         """
+        # Clear _suppress_reload so the update listener reloads.
+        coordinator = getattr(self.config_entry, "runtime_data", None)
+        if coordinator is not None and hasattr(
+            coordinator, "_suppress_reload"
+        ):
+            coordinator._suppress_reload = 0.0  # noqa: SLF001
+
         result = self.async_create_entry(title="", data=self.options)
 
         # Reload only if setup failing; updates handled by update listener
@@ -2125,6 +2141,66 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                 return (
                                     await self.async_step_manage_pool_serial()
                                 )
+
+                    # Handle non-primary HGI transport switches.
+                    # When a non-primary HGI switches from USB to MQTT,
+                    # remove its serial port from additional_ports so
+                    # it becomes an MQTT callback child only (not both
+                    # serial and MQTT).  When switching from MQTT to
+                    # USB, we can't auto-add the serial port here (we
+                    # don't know which port to use) — the user must add
+                    # it via "Add new port > Serial/USB port".
+                    if not errors and isinstance(schema_dict, dict):
+                        _runtime_map_np: dict[str, str] = {}
+                        _coord_np = getattr(
+                            self.config_entry, "runtime_data", None
+                        )
+                        if _coord_np is not None and hasattr(
+                            _coord_np, "serial_port_hgi_map"
+                        ):
+                            _runtime_map_np = _coord_np.serial_port_hgi_map
+                        # Reverse map: HGI ID -> port name
+                        _runtime_hgi_port_np: dict[str, str] = {
+                            v: k for k, v in _runtime_map_np.items()
+                        }
+                        _additional_ports = self.options.get(
+                            CONF_ADDITIONAL_PORTS, []
+                        )
+                        _additional_changed = False
+                        for key, val in user_input.items():
+                            if not key.startswith("_preferred_type_"):
+                                continue
+                            dev_id = key[len("_preferred_type_") :]
+                            if dev_id == _primary_hgi_id:
+                                continue  # primary handled above
+                            old_np = old_schema_prefs.get(dev_id, "") or "mqtt"
+                            new_np = (val or "mqtt").lower()
+                            if old_np == new_np:
+                                continue
+                            if new_np == "mqtt" and old_np == "usb":
+                                # Switching non-primary from USB to MQTT.
+                                # Remove its serial port from
+                                # additional_ports if we know it from
+                                # the runtime map.
+                                port = _runtime_hgi_port_np.get(dev_id)
+                                if port and port in _additional_ports:
+                                    _additional_ports = [
+                                        p
+                                        for p in _additional_ports
+                                        if p != port
+                                    ]
+                                    _additional_changed = True
+                                    _LOGGER.info(
+                                        "Pool: removed serial port %s "
+                                        "from additional_ports (HGI %s "
+                                        "switched to MQTT)",
+                                        port,
+                                        dev_id,
+                                    )
+                        if _additional_changed:
+                            self.options[CONF_ADDITIONAL_PORTS] = (
+                                _additional_ports
+                            )
 
                     if not errors:
                         return self._async_save()

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2145,12 +2145,13 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
 
                     # Handle non-primary HGI transport switches.
                     # When a non-primary HGI switches from USB to MQTT,
-                    # remove its serial port from additional_ports so
-                    # it becomes an MQTT callback child only (not both
-                    # serial and MQTT).  When switching from MQTT to
-                    # USB, we can't auto-add the serial port here (we
-                    # don't know which port to use) — the user must add
-                    # it via "Add new port > Serial/USB port".
+                    # remove its serial port from additional_ports and
+                    # redirect to the MQTT URL step so the user can
+                    # confirm the broker URL (pre-filled from the HA MQTT
+                    # integration).  When switching from MQTT to USB, we
+                    # can't auto-add the serial port here (we don't know
+                    # which port to use) — the user must add it via "Add
+                    # new port > Serial/USB port".
                     if not errors and isinstance(schema_dict, dict):
                         _runtime_map_np: dict[str, str] = {}
                         _coord_np = getattr(
@@ -2168,6 +2169,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                             CONF_ADDITIONAL_PORTS, []
                         )
                         _additional_changed = False
+                        _switching_secondary_to_mqtt: str | None = None
                         for key, val in user_input.items():
                             if not key.startswith("_preferred_type_"):
                                 continue
@@ -2198,10 +2200,27 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                                         port,
                                         dev_id,
                                     )
+                                # Remember the HGI ID so we can
+                                # redirect to the broker URL step.
+                                _switching_secondary_to_mqtt = dev_id
                         if _additional_changed:
                             self.options[CONF_ADDITIONAL_PORTS] = (
                                 _additional_ports
                             )
+                        if _switching_secondary_to_mqtt:
+                            # Redirect to the MQTT URL step so the
+                            # user can confirm the broker URL
+                            # (pre-filled from the HA MQTT integration).
+                            self._switching_secondary_to_mqtt = (
+                                _switching_secondary_to_mqtt
+                            )
+                            _LOGGER.info(
+                                "Pool: switching non-primary HGI %s "
+                                "from serial to MQTT — redirecting "
+                                "to MQTT URL entry",
+                                _switching_secondary_to_mqtt,
+                            )
+                            return await self.async_step_manage_pool_mqtt_url()
 
                     if not errors:
                         return self._async_save()
@@ -2842,15 +2861,21 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Don't reload options if we're in a switching flow —
         # the pool form already updated self.options with the
         # new _preferred_type before redirecting here.
-        if not hasattr(self, "_switching_primary_to_mqtt"):
+        if not hasattr(self, "_switching_primary_to_mqtt") and not hasattr(
+            self, "_switching_secondary_to_mqtt"
+        ):
             self.get_options()
         errors: dict[str, str] = {}
 
         # Pre-fill the URL from the HA MQTT integration's broker
-        # when switching the primary from serial to MQTT.
+        # when switching the primary or a secondary from serial to MQTT.
         default_url = ""
         switching_primary = getattr(self, "_switching_primary_to_mqtt", None)
-        if switching_primary and not user_input:
+        switching_secondary = getattr(
+            self, "_switching_secondary_to_mqtt", None
+        )
+        switching_hgi_id = switching_primary or switching_secondary
+        if switching_hgi_id and not user_input:
             mqtt_entries = self.hass.config_entries.async_entries("mqtt")
             if mqtt_entries:
                 mqtt_data = mqtt_entries[0].data
@@ -2859,7 +2884,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 topic = self.options.get(CONF_MQTT_TOPIC, "RAMSES/GATEWAY")
                 if broker:
                     default_url = (
-                        f"mqtt://{broker}:{port}/{topic}/{switching_primary}"
+                        f"mqtt://{broker}:{port}/{topic}/{switching_hgi_id}"
                     )
 
         if user_input is not None:
@@ -2905,13 +2930,22 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         if url not in additional:
                             additional.append(url)
                         self.options[CONF_ADDITIONAL_PORTS] = additional
-                        _LOGGER.info(
-                            "Added MQTT pool HGI %s via full URL",
-                            hgi_id,
-                        )
-                    # Clear the switching flag if it was set
+                        if switching_secondary:
+                            _LOGGER.info(
+                                "Switched non-primary HGI %s to MQTT: %s",
+                                hgi_id,
+                                redact_url(url),
+                            )
+                        else:
+                            _LOGGER.info(
+                                "Added MQTT pool HGI %s via full URL",
+                                hgi_id,
+                            )
+                    # Clear the switching flags if set
                     if hasattr(self, "_switching_primary_to_mqtt"):
                         del self._switching_primary_to_mqtt
+                    if hasattr(self, "_switching_secondary_to_mqtt"):
+                        del self._switching_secondary_to_mqtt
                     return self._async_save()
 
         data_schema = {
@@ -2932,6 +2966,13 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 "HGI ID).  Pre-filled from the HA MQTT integration if "
                 "available."
             ).replace("{hgi_id}", switching_primary)
+        elif switching_secondary:
+            desc = (
+                "Switching non-primary HGI {hgi_id} from serial to MQTT.\n"
+                "Enter the full MQTT broker URL (broker, port, topic, "
+                "HGI ID).  Pre-filled from the HA MQTT integration if "
+                "available."
+            ).replace("{hgi_id}", switching_secondary)
         else:
             desc = ""
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -53,6 +53,7 @@ from ramses_tx.schemas import (
     # deprecated 0.56.0 but allowed as extras:
     # SZ_FILE_NAME, SZ_ROTATE_BACKUPS, SZ_SQLITE_INDEX
 )
+from ramses_tx.transport.helpers import redact_url
 
 from .const import (
     CONF_ADDITIONAL_PORTS,
@@ -448,7 +449,7 @@ class BaseRamsesFlow:
                 ]
                 _LOGGER.debug(
                     "DEBUG: Saved port_name = %s to options",
-                    user_input[SZ_PORT_NAME],
+                    redact_url(user_input[SZ_PORT_NAME]),
                 )
             if not errors:
                 return await self.async_step_configure_serial_port()
@@ -824,10 +825,13 @@ class BaseRamsesFlow:
                     # Debug: Check what we have in options
                     _LOGGER.debug(
                         "DEBUG: self.options[SZ_SERIAL_PORT] = %s",
-                        self.options[SZ_SERIAL_PORT],
+                        redact_url(str(self.options[SZ_SERIAL_PORT])),
                     )
                     port_name = self.options[SZ_SERIAL_PORT][SZ_PORT_NAME]
-                    _LOGGER.debug("DEBUG: Retrieved port_name = %s", port_name)
+                    _LOGGER.debug(
+                        "DEBUG: Retrieved port_name = %s",
+                        redact_url(port_name),
+                    )
                     if port_name is None:
                         _LOGGER.error("ERROR: port_name is None!")
                         errors[SZ_PORT_NAME] = "port_name_required"
@@ -843,7 +847,12 @@ class BaseRamsesFlow:
                         errors["base"] = conn_err
 
                 if not errors:
-                    _LOGGER.debug("DEBUG: Final config = %s", config)
+                    _log_config = dict(config)
+                    if isinstance(_log_config.get(SZ_PORT_NAME), str):
+                        _log_config[SZ_PORT_NAME] = redact_url(
+                            _log_config[SZ_PORT_NAME]
+                        )
+                    _LOGGER.debug("DEBUG: Final config = %s", _log_config)
                     self.options[SZ_SERIAL_PORT] = config
                     # Ensure internal flag is cleared if we set a manual port
                     self.options.pop(CONF_MQTT_USE_HA, None)
@@ -862,11 +871,14 @@ class BaseRamsesFlow:
 
         data_schema: dict[prob.Marker, Any] = {}
         if self._manual_serial_port:
+            _suggested_port = suggested_values.get(SZ_PORT_NAME)
             data_schema |= {
                 prob.Required(
                     SZ_PORT_NAME,
                     description={
-                        "suggested_value": suggested_values.get(SZ_PORT_NAME)
+                        "suggested_value": redact_url(_suggested_port)
+                        if isinstance(_suggested_port, str)
+                        else _suggested_port
                     },
                 ): selector.TextSelector(),
             }
@@ -2233,20 +2245,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
         # Build a label for each pool member showing its broker info.
         # For the primary HGI: the primary_port URL.
         # For additional HGIs: the explicit per-HGI MQTT URL.
-        def _mask_mqtt_url(url: str) -> str:
-            """Mask credentials in an MQTT URL for display."""
-            from urllib.parse import urlparse, urlunparse
-
-            try:
-                parsed = urlparse(url)
-                if parsed.username:
-                    netloc = f"***:***@{parsed.hostname}"
-                    if parsed.port:
-                        netloc += f":{parsed.port}"
-                    return urlunparse(parsed._replace(netloc=netloc))
-            except (ValueError, AttributeError):
-                pass
-            return url
+        # Mask credentials in MQTT URLs for display (uses the shared
+        # redact_url helper from ramses_tx.transport.helpers).
+        _mask_mqtt_url = redact_url
 
         def _pool_member_label(dev_id: str) -> str:
             """Build a human-readable label with transport type and broker info.
@@ -2817,7 +2818,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         _LOGGER.info(
                             "Switched primary HGI %s to MQTT: %s",
                             hgi_id,
-                            url,
+                            redact_url(url),
                         )
                     else:
                         # Add the URL to additional ports

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -2379,7 +2379,7 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             "primary_port=%s",
             _runtime_port_hgi_map,
             primary_hgi_id,
-            primary_port,
+            redact_url(primary_port),
         )
 
         # Build options for the "current ports" multi-select (for removal)

--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -15,7 +15,10 @@ from ramses_rf.schemas import (
     SZ_SCHEMA as SZ_SCHEMA,
 )
 from ramses_tx.address import HGI_DEVICE_ID as HGI_DEVICE_ID
-from ramses_tx.const import SZ_IS_EVOFW3 as SZ_IS_EVOFW3
+from ramses_tx.const import (
+    HGI_PREFIX as HGI_PREFIX,
+    SZ_IS_EVOFW3 as SZ_IS_EVOFW3,
+)
 from ramses_tx.schemas import (
     SZ_BUFFER_CAPACITY as SZ_BUFFER_CAPACITY,
     SZ_ENFORCE_KNOWN_LIST as SZ_ENFORCE_KNOWN_LIST,
@@ -59,11 +62,10 @@ CONF_UNKNOWN_CODES: Final = "unknown_codes"
 CONF_ADDITIONAL_PORTS: Final = "additional_ports"
 CONF_WAIT_ONLINE_TIMEOUT: Final = "wait_online_timeout"
 
-# HGI device prefix — all HGI/gateway device IDs start with "18:".
+# HGI device prefix — imported from ramses_tx (single source of truth).
+# All HGI/gateway device IDs start with "18:" (class 18 in RAMSES-II).
 # Used for HGI-specific logic (pool membership, discovery candidates,
-# schema cleanup, backfill exemptions).  Centralised here to avoid
-# scattering the literal across the codebase (architectural concern).
-HGI_PREFIX: Final = "18:"
+# schema cleanup, backfill exemptions).
 
 # Defaults
 DEFAULT_MQTT_TOPIC: Final = "RAMSES/GATEWAY"

--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -70,6 +70,29 @@ DEFAULT_MQTT_TOPIC: Final = "RAMSES/GATEWAY"
 DEFAULT_HGI_ID: Final = HGI_DEVICE_ID
 DEFAULT_WAIT_ONLINE_TIMEOUT: Final = 30.0
 
+# Suffix appended to HGI _comment fields to warn users not to edit
+# _preferred_type directly in the schema — they should use the pool
+# management UI instead.  The config flow parses the _comment for
+# detected transport types ("usb", "mqtt", "zigbee"), so the suffix
+# must not contain those words.  Use build_hgi_comment() to construct
+# the full _comment value.
+HGI_COMMENT_WARNING: Final = (
+    " (do not edit _preferred_type — use Pool Management UI)"
+)
+
+
+def build_hgi_comment(transports: list[str]) -> str:
+    """Build an HGI _comment value from a list of transport types.
+
+    Combines the "Supports: ..." prefix (parsed by the config flow for
+    detected-type labels) with the warning suffix (HGI_COMMENT_WARNING).
+
+    :param transports: List of transport type strings (e.g. ["usb", "mqtt"]).
+    :return: The full _comment string.
+    """
+    return "Supports: " + ", ".join(transports) + HGI_COMMENT_WARNING
+
+
 # State
 SZ_CLIENT_STATE: Final = "client_state"
 SZ_PACKETS: Final = "packets"

--- a/custom_components/ramses_cc/const.py
+++ b/custom_components/ramses_cc/const.py
@@ -75,9 +75,10 @@ DEFAULT_WAIT_ONLINE_TIMEOUT: Final = 30.0
 # management UI instead.  The config flow parses the _comment for
 # detected transport types ("usb", "mqtt", "zigbee"), so the suffix
 # must not contain those words.  Use build_hgi_comment() to construct
-# the full _comment value.
+# the full _comment value, or ensure_hgi_comment_warning() to append
+# the warning to an existing comment that lacks it.
 HGI_COMMENT_WARNING: Final = (
-    " (do not edit _preferred_type — use Pool Management UI)"
+    " (don't edit here — adapt with the Pool Management config)"
 )
 
 
@@ -91,6 +92,23 @@ def build_hgi_comment(transports: list[str]) -> str:
     :return: The full _comment string.
     """
     return "Supports: " + ", ".join(transports) + HGI_COMMENT_WARNING
+
+
+def ensure_hgi_comment_warning(comment: str) -> str:
+    """Ensure an HGI _comment has the warning suffix.
+
+    If the comment already ends with the warning, return it unchanged.
+    Otherwise, append the warning.  This is used to migrate existing
+    comments that were created before the warning was added.
+
+    :param comment: The existing _comment string (e.g. "Supports: usb, mqtt").
+    :return: The _comment with the warning suffix appended.
+    """
+    if not comment:
+        return HGI_COMMENT_WARNING.strip()
+    if comment.endswith(HGI_COMMENT_WARNING):
+        return comment
+    return comment + HGI_COMMENT_WARNING
 
 
 # State

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2664,6 +2664,22 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 serial_ports
             )
 
+            # Gap A: per-child config overrides for serial children.
+            # All serial children get DELAYED signature policy with a
+            # 3s startup grace to handle DTR reset on FTDI/nanoCUL
+            # devices (Phase 2, issue 1119).  The ESP32-S3 also benefits
+            # from the grace period.  Per-child overrides allow future
+            # per-port configuration (e.g. ID_COMMAND for ATmega
+            # devices, SKIP for HGI80).
+            from ramses_tx.transport.base import SignaturePolicy
+
+            per_child_overrides: list[dict[str, object]] = [
+                {
+                    "signature_policy": SignaturePolicy.DELAYED,
+                    "startup_grace": 3.0,
+                }
+            ] * len(serial_ports)
+
             # MQTT callback-driven children (port names for the pool).
             callback_port_names = [
                 f"mqtt_ha://{hgi_id}" for hgi_id in _mqtt_hgi_ids
@@ -2686,6 +2702,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 extra=extra,
                 loop=loop or _hass.loop,
                 callback_port_names=callback_port_names,
+                per_child_config_overrides=per_child_overrides,
             )
 
             # If there are MQTT callback children, create the

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -272,6 +272,48 @@ class _MqttHgiDiscoveryCallback:
                 "discovery candidate (no _owner)",
                 hgi_str,
             )
+        else:
+            # HGI already in schema — update _comment to include
+            # "mqtt" if not already present (the HGI may have been
+            # added by the serial probe with only "usb" in _comment).
+            self._mark_hgi_mqtt_capable(hgi_str)
+
+    def _mark_hgi_mqtt_capable(self, hgi_id: str) -> None:
+        """Update an existing HGI's _comment to include 'mqtt'.
+
+        Called when an LWT is seen for an HGI that's already in the
+        schema (e.g. added by the serial probe with _comment
+        'Supports: usb').  Updates _comment to 'Supports: usb, mqtt'
+        or 'Supports: mqtt' depending on the existing value.
+        """
+        raw_schema = self._coordinator.entry.options.get(CONF_SCHEMA, {})
+        if not isinstance(raw_schema, dict):
+            return
+        entry = raw_schema.get(hgi_id)
+        if not isinstance(entry, dict):
+            return
+        existing = str(entry.get("_comment", "")).lower()
+        if "mqtt" in existing:
+            return  # Already marked as MQTT-capable.
+        import copy
+
+        schema = copy.deepcopy(raw_schema)
+        schema_entry = schema[hgi_id]
+        if "usb" in existing:
+            schema_entry["_comment"] = "Supports: usb, mqtt"
+        else:
+            schema_entry["_comment"] = "Supports: mqtt"
+        new_options = dict(self._coordinator.entry.options)
+        new_options[CONF_SCHEMA] = schema
+        self._coordinator.hass.config_entries.async_update_entry(
+            self._coordinator.entry, options=new_options
+        )
+        _LOGGER.info(
+            "MqttPoolBridge: updated HGI %s _comment to '%s' "
+            "(MQTT capability detected via LWT)",
+            hgi_id,
+            schema_entry["_comment"],
+        )
 
 
 class RamsesCoordinator(DataUpdateCoordinator):

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1032,6 +1032,38 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 primary_hgi,
             )
 
+        # Add non-primary pool children's HGI IDs as discovery
+        # candidates.  When a serial port is manually added to the
+        # pool and the transport probes it with !I, the HGI ID is
+        # learned.  If it's not already in the schema, add it as a
+        # discovery candidate (no _owner) so the user can review and
+        # accept it — just like MQTT HGIs are handled by
+        # _MqttHgiDiscoveryCallback.on_unknown_hgi.
+        # This does NOT auto-add the port to additional_ports — the
+        # user must manually add serial ports via Manage Pool.  It
+        # only adds the discovered HGI ID to the schema for review.
+        if transport is not None:
+            pool_hgi_ids = transport.get_extra_info("pool_hgi_ids")
+            if pool_hgi_ids:
+                for hgi_id in pool_hgi_ids:
+                    hgi_str = str(hgi_id)
+                    if (
+                        hgi_str.startswith(HGI_PREFIX)
+                        and hgi_str != primary_hgi
+                        and hgi_str not in schema
+                    ):
+                        schema[hgi_str] = {
+                            "_class": "HGI",
+                            "_comment": "Supports: usb",
+                        }
+                        schema_changed = True
+                        _LOGGER.info(
+                            "Pool child HGI %s discovered via serial "
+                            "probe — added to schema as discovery "
+                            "candidate (no _owner — pending review)",
+                            hgi_str,
+                        )
+
         for dev_id, entry in schema.items():
             if (
                 dev_id.startswith(HGI_PREFIX)
@@ -2952,42 +2984,22 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     "HGI %s (serial primary)",
                     dev_id,
                 )
-        # Auto-populate additional_ports: if there are more USB serial
-        # ports than configured, add the extra ones automatically so the
-        # pool uses all available USB HGIs without manual configuration.
-        # The primary port (first in the list) is already configured as
-        # port_name; any additional ports are added to additional_ports.
-        extra_ports: list[str] = []
-        current_additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
-        if isinstance(current_additional, list):
-            configured_serial = [
-                p
-                for p in current_additional
-                if isinstance(p, str)
-                and not p.startswith("mqtt://")
-                and not p.startswith("zigbee://")
-                and p != "mqtt_ha"
-            ]
-            # USB ports beyond the primary that aren't already configured
-            extra_ports = [
-                p
-                for p in usb_ports
-                if p != primary_port and p not in configured_serial
-            ]
-            if extra_ports:
-                new_additional = list(current_additional)
-                new_additional.extend(extra_ports)
-                _LOGGER.info(
-                    "SerialProbe: auto-added %d USB port(s) to "
-                    "additional_ports: %s",
-                    len(extra_ports),
-                    extra_ports,
-                )
-        if changed or extra_ports:
+        # Do NOT auto-add USB serial ports to additional_ports.
+        # We cannot distinguish HGI dongles from other USB-serial
+        # devices (e.g. modbus bridges) by VID/PID alone — they use
+        # the same chipset (FTDI, CP2102, CH340).  Auto-adding all USB
+        # ports would add non-HGI devices to the pool, causing
+        # connection failures and "No such file" errors.
+        # Instead, the user manually adds serial ports via the
+        # Manage Pool > Add Serial Port flow.  The transport then
+        # probes the port with !I — if it responds, the HGI ID is
+        # learned and added to the schema as a discovery candidate
+        # (no _owner) for the user to review, just like MQTT HGIs.
+        # Own-build cases work as long as they run evofw3 (responds
+        # to !I).  HGI80 uses SKIP policy but is a known device type.
+        if changed:
             new_options = dict(self.entry.options)
             new_options[CONF_SCHEMA] = schema_dict
-            if extra_ports:
-                new_options[CONF_ADDITIONAL_PORTS] = new_additional
             self.options = new_options
             # Suppress reload — same pattern as sync_learned_topology.
             # The running coordinator already has the updated options

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2761,11 +2761,30 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # These are HGI IDs (18:...), not port names — they are
         # callback-driven children via the RamsesMqttPoolBridge.
         # Only include schema HGIs when MQTT is actually configured
-        # (mqtt_use_ha, mqtt:// URL, or mqtt:// additional ports).
+        # (mqtt_use_ha, mqtt:// URL, mqtt:// additional ports, or
+        # mqtt_hgi_id set to a real HGI — the hybrid pool case where
+        # the user has a serial primary + an ESP32 MQTT HGI).
         # Without this gate, stale schema HGIs from a previous MQTT
         # config would trigger MQTT bridge creation even on serial
         # primary with no MQTT broker (issue 1171).
-        _has_mqtt = _is_mqtt_ha or bool(mqtt_additional)
+        _mqtt_hgi_id_cfg = self.options.get(CONF_MQTT_HGI_ID)
+        _has_mqtt_hgi_id = (
+            isinstance(_mqtt_hgi_id_cfg, str)
+            and _mqtt_hgi_id_cfg != DEFAULT_HGI_ID
+        )
+        _has_mqtt = _is_mqtt_ha or bool(mqtt_additional) or _has_mqtt_hgi_id
+        # Guard: if MQTT is wanted but the HA MQTT integration is not
+        # set up, skip MQTT bridge creation (issue 1171).
+        if _has_mqtt and not self.hass.config_entries.async_entries("mqtt"):
+            if _has_mqtt_hgi_id and not _is_mqtt_ha and not mqtt_additional:
+                _LOGGER.warning(
+                    "mqtt_hgi_id=%s is configured but the HA MQTT "
+                    "integration is not set up.  MQTT pool bridge "
+                    "will not be created — TX will use the serial "
+                    "transport only.",
+                    _mqtt_hgi_id_cfg,
+                )
+            _has_mqtt = False
         schema_mqtt_hgis: list[str] = (
             self._extract_pool_hgis_from_schema() if _has_mqtt else []
         )

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2721,16 +2721,20 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if changed:
             new_options = dict(self.entry.options)
             new_options[CONF_SCHEMA] = schema_dict
-            # Let the entry reload — this persists the schema to disk
-            # and restarts the coordinator.  On the next startup, the
-            # probe will find all HGIs already have "usb" in _comment
-            # and won't trigger another reload (no changes = no update).
+            self.options = new_options
+            # Suppress reload — same pattern as sync_learned_topology.
+            # The running coordinator already has the updated options
+            # and a reload would be disruptive.  On the next startup,
+            # the probe will find all HGIs already have "usb" in
+            # _comment and won't trigger another update.
+            import time as _time
+
+            self._suppress_reload = _time.time()
             self.hass.config_entries.async_update_entry(
                 self.entry, options=new_options
             )
             _LOGGER.info(
-                "SerialProbe: marked %d HGI(s) as USB-capable, "
-                "reloading entry to persist",
+                "SerialProbe: marked %d HGI(s) as USB-capable",
                 count,
             )
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2406,6 +2406,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
             self.entry.async_on_unload(self.mqtt_bridge.close)
 
             engine_kwargs["hgi_id"] = hgi_id
+            _LOGGER.info(
+                "MQTT bridge path: engine hgi_id=%s, port_name=%s",
+                hgi_id,
+                _port_name_raw,
+            )
             self._port_name = str(_port_name_raw or "mqtt")
             self._is_serial_active = False  # MQTT bridge, not serial
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -3158,18 +3158,28 @@ class RamsesCoordinator(DataUpdateCoordinator):
             )
 
             # Gap A: per-child config overrides for serial children.
-            # Serial children use SKIP signature policy with a 3s startup
-            # grace to handle DTR reset on FTDI/nanoCUL/ESP32 devices
-            # (Phase 2, issue 1119).  SKIP learns the HGI ID from the
-            # first inbound RF packet — no probing needed.  This works
-            # with all firmware versions (evofw3 0.1.0 doesn't support
-            # !I, and _PUZZ broadcasts over RF so all HGIs respond).
+            # Serial children use ID_COMMAND signature policy with a 3s
+            # startup grace to handle DTR reset on FTDI/nanoCUL/ESP32
+            # devices (Phase 2, issue 1119).  ID_COMMAND sends ``!I\r``
+            # over serial to discover the HGI ID directly from EEPROM —
+            # no RF needed, so it works in multi-HGI pools where RF
+            # learning is ambiguous (RF is a shared medium, so every
+            # serial child receives packets from every HGI in range).
+            # HGI80 devices auto-select SKIP (Gap C) because they can't
+            # respond to ``!I`` — this is handled in PortTransport.
+            # If ``!I`` fails, PortTransport falls back to
+            # ``configured_hgi_id`` (Gap B) or ``_PUZZ`` signature probe.
             from ramses_tx.transport.base import SignaturePolicy
 
             per_child_overrides: list[dict[str, object]] = [
                 {
-                    "signature_policy": SignaturePolicy.SKIP,
+                    "signature_policy": SignaturePolicy.ID_COMMAND,
                     "startup_grace": 3.0,
+                    # ID_COMMAND needs: grace (3s) + !I timeout (2s) +
+                    # _PUZZ fallback (3s) = 8s.  The default port
+                    # timeout is only 3s, which would time out before
+                    # !I is even sent.
+                    "timeout": 12.0,
                 }
             ] * len(serial_ports)
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -358,7 +358,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self.fan_handler = RamsesFanHandler(self)
         self.service_handler = RamsesServiceHandler(self)
         self.mqtt_bridge: RamsesMqttBridge | RamsesMqttPoolBridge | None = None
-        self._last_excluded_hgi_id: str | None = None
+        self._excluded_serial_hgi_ids: set[str] = set()
         self._is_serial_active: bool = False
         self.discovery_manager: DiscoveryManager | None = None
         self._cached_discovery_state: dict[str, Any] | None = None
@@ -4117,34 +4117,67 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # in an MQTT-only setup (or when the serial port doesn't
         # exist), the active HGI is an MQTT child and must NOT be
         # excluded from its own pool.
+        #
+        # Issue 1185: in a multi-serial pool (e.g. HGI80 + ESP32 on
+        # USB), ALL serial HGIs must be excluded from MQTT, not just
+        # the active one.  Otherwise the additional serial HGI's MQTT
+        # packets are not skipped, causing duplicate ingestion.
         if (
             self._is_serial_active
-            and isinstance(active_hgi_id, str)
             and self.mqtt_bridge is not None
             and hasattr(self.mqtt_bridge, "exclude_hgi_id")
-            and active_hgi_id != self._last_excluded_hgi_id
         ):
-            self.mqtt_bridge.exclude_hgi_id(active_hgi_id)
-            self._last_excluded_hgi_id = active_hgi_id
-            # Update the schema _comment to note this HGI supports USB.
-            # If it was already discovered via MQTT, merge the comment.
-            raw_schema = self.entry.options.get(CONF_SCHEMA, {})
-            if isinstance(raw_schema, dict):
-                schema_dict = dict(raw_schema)
-                entry = schema_dict.get(active_hgi_id, {})
-                if isinstance(entry, dict):
-                    existing = entry.get("_comment", "")
-                    if "usb" not in existing.lower():
-                        if "mqtt" in existing.lower():
-                            entry["_comment"] = "Supports: usb, mqtt"
-                        else:
-                            entry["_comment"] = "Supports: usb"
-                        schema_dict[active_hgi_id] = entry
-                        new_options = dict(self.entry.options)
-                        new_options[CONF_SCHEMA] = schema_dict
-                        self.hass.config_entries.async_update_entry(
-                            self.entry, options=new_options
-                        )
+            # Collect all serial HGI IDs from the pool children.
+            # Serial children have a non-None transport_obj and are
+            # not callback-driven.  Their HGI may be learned from
+            # traffic (SKIP signature policy) or set at creation.
+            serial_hgi_ids: set[str] = set()
+            if isinstance(active_hgi_id, str):
+                serial_hgi_ids.add(active_hgi_id)
+            # Also check pool children for learned HGI IDs.
+            try:
+                gwy2: Gateway = self.client
+                eng = getattr(gwy2, "_engine", None)
+                tpt = getattr(eng, "_transport", None) or getattr(
+                    gwy2, "_transport", None
+                )
+                if tpt is not None and hasattr(tpt, "_children"):
+                    for child in tpt._children:
+                        child_hgi = getattr(child, "hgi_id", None)
+                        is_callback = getattr(child, "callback_driven", False)
+                        if (
+                            child_hgi
+                            and not is_callback
+                            and isinstance(child_hgi, str)
+                        ):
+                            serial_hgi_ids.add(child_hgi)
+            except Exception:  # noqa: BLE001
+                pass
+
+            for hgi_id_to_exclude in serial_hgi_ids:
+                if hgi_id_to_exclude in self._excluded_serial_hgi_ids:
+                    continue
+                self.mqtt_bridge.exclude_hgi_id(hgi_id_to_exclude)
+                self._excluded_serial_hgi_ids.add(hgi_id_to_exclude)
+                # Update the schema _comment to note this HGI supports
+                # USB.  If it was already discovered via MQTT, merge.
+                raw_schema = self.entry.options.get(CONF_SCHEMA, {})
+                if isinstance(raw_schema, dict):
+                    schema_dict = dict(raw_schema)
+                    entry = schema_dict.get(hgi_id_to_exclude, {})
+                    if isinstance(entry, dict):
+                        existing = entry.get("_comment", "")
+                        if "usb" not in existing.lower():
+                            if "mqtt" in existing.lower():
+                                entry["_comment"] = "Supports: usb, mqtt"
+                            else:
+                                entry["_comment"] = "Supports: usb"
+                            schema_dict[hgi_id_to_exclude] = entry
+                            new_options = dict(self.entry.options)
+                            new_options[CONF_SCHEMA] = schema_dict
+                            self.hass.config_entries.async_update_entry(
+                                self.entry, options=new_options
+                            )
 
         if (
             self.discovery_manager is not None

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -820,7 +820,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # (removed by v2→v3 migration).  The schema is the sole source.
         config_schema = self.options.get(CONF_SCHEMA, {})
         advanced = self.entry.options.get(CONF_ADVANCED_FEATURES, {})
-        schema_is_ssot = bool(advanced.get(CONF_PASSIVE_SCAN, False))
+        schema_is_ssot = bool(advanced.get(CONF_PASSIVE_SCAN, True))
         if schema_is_ssot:
             schema_device_ids = self._extract_schema_device_ids(config_schema)
             migration_done = bool(advanced.get(CONF_SSOT_MIGRATED, False))
@@ -1080,7 +1080,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         # 3. Start passive device scan if enabled
         advanced = self.entry.options.get(CONF_ADVANCED_FEATURES, {})
-        if advanced.get(CONF_PASSIVE_SCAN, False) and self.client:
+        if advanced.get(CONF_PASSIVE_SCAN, True) and self.client:
             await self._async_start_discovery_scan()
 
         # Trigger the first update immediately (calls _async_update_data)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -79,6 +79,7 @@ from ramses_tx.const import SZ_ACTIVE_HGI, Code
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.exceptions import TransportError as _TransportError
 from ramses_tx.schemas import extract_serial_port
+from ramses_tx.transport.helpers import redact_url
 from ramses_tx.typing import DeviceIdT
 
 from .const import (
@@ -381,13 +382,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         # Redact port details for safe exchange of logs
         print_options = deepcopy(dict(self.options))  # need an extra copy
-        if print_options.get("serial_port", None) is not None:
-            ser_port = print_options.get("serial_port", "")
-            if isinstance(ser_port, dict):
-                if ser_port.get("port_name", "").startswith("mqtt://"):
-                    print_options["serial_port"]["port_name"] = (
-                        "mqtt://usr:pwd(at)url:1883"
-                    )
+        ser_port = print_options.get(SZ_SERIAL_PORT, None)
+        if isinstance(ser_port, dict):
+            _port_name = ser_port.get(SZ_PORT_NAME, "")
+            if isinstance(_port_name, str):
+                print_options[SZ_SERIAL_PORT][SZ_PORT_NAME] = redact_url(
+                    _port_name
+                )
+        elif isinstance(ser_port, str):
+            print_options[SZ_SERIAL_PORT] = redact_url(ser_port)
+        # Redact any mqtt:// URLs in additional_ports
+        _additional = print_options.get(CONF_ADDITIONAL_PORTS, [])
+        if isinstance(_additional, list):
+            print_options[CONF_ADDITIONAL_PORTS] = [
+                redact_url(p)
+                if isinstance(p, str) and p.startswith("mqtt://")
+                else p
+                for p in _additional
+            ]
         _LOGGER.debug("Config = %s", print_options)
 
         self.client: Gateway | None = None
@@ -2563,7 +2575,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             _LOGGER.info(
                 "Legacy mqtt:// URL detected (%s); routing to HA MQTT "
                 "integration (no paho inside HA — issue 1119)",
-                _port_name_raw,
+                redact_url(_port_name_raw),
             )
         _is_mqtt_flag = bool(self.options.get(CONF_MQTT_USE_HA))
 
@@ -2725,7 +2737,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             _LOGGER.info(
                 "MQTT bridge path: engine hgi_id=%s, port_name=%s",
                 hgi_id,
-                _port_name_raw,
+                redact_url(_port_name_raw),
             )
             self._port_name = str(_port_name_raw or "mqtt")
             self._is_serial_active = False  # MQTT bridge, not serial
@@ -2779,7 +2791,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             _LOGGER.info(
                 "Serial/hybrid path: engine hgi_id=%s, port_name=%s",
                 hgi_id,
-                port_name,
+                redact_url(port_name),
             )
 
         # Phase 2: schedule serial probe to mark accepted HGIs as
@@ -2906,7 +2918,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             "mqtt_hgi_ids=%s, port_name=%s",
             serial_additional,
             all_mqtt_hgi_ids,
-            port_name,
+            redact_url(port_name),
         )
 
         if has_serial_pool or has_mqtt_pool:
@@ -2948,8 +2960,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         port_name = self._port_name or "gateway"
         # Redact credentials from mqtt:// URLs before logging (security).
-        if isinstance(port_name, str) and port_name.startswith("mqtt://"):
-            port_name = "mqtt://***@***"
+        if isinstance(port_name, str):
+            port_name = redact_url(port_name)
         if connected:
             _LOGGER.info(
                 "Connection to RAMSES RF gateway established on %s", port_name
@@ -3025,7 +3037,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(
                 "PooledTransport: creating pool with %d ports: %s",
                 len(all_ports),
-                all_ports,
+                [
+                    redact_url(p) if isinstance(p, str) else p
+                    for p in all_ports
+                ],
             )
 
             transport = await pooled_transport_factory(
@@ -3271,7 +3286,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 "%d MQTT callback children: serial=%s, mqtt=%s",
                 len(serial_ports),
                 len(callback_port_names),
-                serial_ports,
+                [
+                    redact_url(p) if isinstance(p, str) else p
+                    for p in serial_ports
+                ],
                 _mqtt_hgi_ids,
             )
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2931,13 +2931,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     existing or "(none)",
                 )
             # Set _preferred_type: usb only for accepted HGIs (with
-            # _owner) that are the primary HGI.  Discovery candidates
-            # (no _owner) get _preferred_type set during review.
+            # _owner) that are the primary HGI AND don't already have
+            # a _preferred_type set.  Don't override the user's choice
+            # (e.g. if they set _preferred_type: mqtt because the HGI
+            # is on a power adapter, not USB).
             if (
                 primary_hgi_id
                 and dev_id == primary_hgi_id
                 and entry.get(SZ_TR_OWNER) is not None
-                and entry.get("_preferred_type") != "usb"
+                and entry.get("_preferred_type") is None
             ):
                 entry["_preferred_type"] = "usb"
                 changed = True

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -3204,15 +3204,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
         :returns: An async transport constructor callable.
         :rtype: Callable[..., Awaitable[Any]]
         """
-        # Lazy import — pooled_transport_factory is only available in
-        # ramses_tx >= 0.60.5 (not yet published to PyPI).  This allows
-        # ramses_cc to import cleanly on older ramses_tx versions.
+        # Lazy import — the required pool APIs are available in
+        # ramses-rf >= 0.60.6.  This allows ramses_cc to import cleanly
+        # on older ramses_tx versions.
         try:
             from ramses_tx.transport import pooled_transport_factory
         except ImportError as err:
             raise ImportError(
                 "Gateway pool requires ramses_tx with PooledTransport "
-                "support (ramses-rf >= 0.60.5). "
+                "support (ramses-rf >= 0.60.6). "
                 "Update ramses-rf or remove additional_ports from config."
             ) from err
 
@@ -3388,14 +3388,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
             to ``!I`` still get a send-ready identity (Gap B, issue 1119).
         :returns: An async transport constructor callable.
         """
-        # Lazy import — pooled_transport_factory is only available in
-        # ramses_tx >= 0.60.5 (not yet published to PyPI).
+        # Lazy import — the required pool APIs are available in
+        # ramses-rf >= 0.60.6.
         try:
             from ramses_tx.transport import pooled_transport_factory
         except ImportError as err:
             raise ImportError(
                 "Gateway pool requires ramses_tx with PooledTransport "
-                "support (ramses-rf >= 0.60.5). "
+                "support (ramses-rf >= 0.60.6). "
                 "Update ramses-rf or remove additional_ports from config."
             ) from err
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -74,10 +74,10 @@ from ramses_rf.schemas import (
 )
 from ramses_rf.systems import Evohome, System, Zone
 from ramses_rf.topology import Child
-from ramses_tx import exceptions as exc
 from ramses_tx.config import EngineConfig
 from ramses_tx.const import SZ_ACTIVE_HGI, Code
 from ramses_tx.dtos import PacketDTO
+from ramses_tx.exceptions import TransportError as _TransportError
 from ramses_tx.schemas import extract_serial_port
 from ramses_tx.typing import DeviceIdT
 
@@ -3302,7 +3302,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 err,
             )
         except (
-            exc.TransportError,
+            _TransportError,
             TimeoutError,
         ) as err:
             _LOGGER.debug(

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -4231,6 +4231,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
                                 self.entry, options=new_options
                             )
 
+            # Un-exclude HGIs whose serial transport has disconnected
+            # (e.g. USB unplugged).  Their MQTT packets should flow
+            # again to avoid losing RX traffic (issue 1185).
+            stale_exclusions = self._excluded_serial_hgi_ids - serial_hgi_ids
+            for hgi_id_to_unexclude in stale_exclusions:
+                if hasattr(self.mqtt_bridge, "unexclude_hgi_id"):
+                    self.mqtt_bridge.unexclude_hgi_id(hgi_id_to_unexclude)
+                self._excluded_serial_hgi_ids.discard(hgi_id_to_unexclude)
+
         if (
             self.discovery_manager is not None
             and self.discovery_manager.active_hgi_id != active_hgi_id

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -128,6 +128,7 @@ from .const import (
     SZ_TR_SCHEME,
     SZ_TR_SKIPPED,
     build_hgi_comment,
+    ensure_hgi_comment_warning,
 )
 from .discovery import DiscoveryManager
 from .fan_handler import RamsesFanHandler
@@ -698,6 +699,39 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # time, so _sync_remotes_to_schema can skip them if _commands
             # is later absent (user deletion → don't resurrect from remotes).
             self._devices_with_commands = set(remotes_from_schema.keys())
+
+        # 1a-2. Migration: ensure HGI _comment fields have the warning
+        # suffix.  Comments created before build_hgi_comment() was added
+        # lack the warning.  This is a one-time migration — after the
+        # first run, all comments will have the suffix and
+        # ensure_hgi_comment_warning() is a no-op.
+        config_schema = self.options.get(CONF_SCHEMA, {})
+        if isinstance(config_schema, dict):
+            _hgi_comments_migrated = False
+            _migrated_schema = dict(config_schema)
+            for _dev_id, _entry in _migrated_schema.items():
+                if not (
+                    isinstance(_dev_id, str)
+                    and _dev_id.startswith(HGI_PREFIX)
+                    and _dev_id != DEFAULT_HGI_ID
+                    and isinstance(_entry, dict)
+                    and _entry.get("_class", "").upper() == "HGI"
+                ):
+                    continue
+                _old_comment = str(_entry.get("_comment", ""))
+                _new_comment = ensure_hgi_comment_warning(_old_comment)
+                if _new_comment != _old_comment:
+                    _entry["_comment"] = _new_comment
+                    _hgi_comments_migrated = True
+            if _hgi_comments_migrated:
+                _new_options = dict(self.entry.options)
+                _new_options[CONF_SCHEMA] = _migrated_schema
+                self.hass.config_entries.async_update_entry(
+                    self.entry, options=_new_options
+                )
+                _LOGGER.info(
+                    "Migrated HGI _comment fields to include warning suffix"
+                )
 
         client_state: dict[str, Any] = storage.get(SZ_CLIENT_STATE, {})
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1160,6 +1160,36 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             "candidate (no _owner — pending review)",
                             hgi_str,
                         )
+                    # Also add the HGI to the ramses_rf known_list at
+                    # runtime so the device_id filter accepts packets
+                    # from it immediately (without waiting for a reload).
+                    # The known_list is derived from the schema at
+                    # startup, but serial HGIs are discovered at runtime
+                    # via the !I/_PUZZ signature probe — the Gateway is
+                    # already created by then.  Without this, ramses_rf
+                    # logs "FILTER EXCEPTION: Device XXX failed filter
+                    # checks: it is not an allowed device_id" and drops
+                    # all packets from the serial HGI (issue 1185).
+                    if (
+                        hgi_str.startswith(HGI_PREFIX)
+                        and self.client is not None
+                    ):
+                        try:
+                            gwy_cfg = self.client.config
+                            if (
+                                hasattr(gwy_cfg, "known_list")
+                                and hgi_str not in gwy_cfg.known_list
+                            ):
+                                gwy_cfg.known_list[hgi_str] = {"class": "HGI"}
+                                _LOGGER.info(
+                                    "Pool child HGI %s added to "
+                                    "ramses_rf known_list at runtime "
+                                    "(serial discovery — prevents "
+                                    "filter exception)",
+                                    hgi_str,
+                                )
+                        except Exception:  # noqa: BLE001
+                            pass
 
         for dev_id, entry in schema.items():
             if (
@@ -4166,6 +4196,56 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ):
             with suppress(Exception):
                 gateway.device_registry.get_device(active_hgi_id)
+
+        # Ensure the active HGI and all connected serial pool HGIs are
+        # in the ramses_rf known_list at runtime.  Serial HGIs are
+        # discovered at runtime via the !I/_PUZZ signature probe — after
+        # the Gateway is already created.  Without this, ramses_rf's
+        # device_id filter rejects packets from and commands via the
+        # serial HGI ("FILTER EXCEPTION" / "Command excluded by
+        # device_id filter", issue 1185 / silverrailscolo PR 1183).
+        try:
+            gwy_cfg = gateway.config
+            if hasattr(gwy_cfg, "known_list"):
+                # Add the active HGI
+                if (
+                    isinstance(active_hgi_id, str)
+                    and active_hgi_id.startswith(HGI_PREFIX)
+                    and active_hgi_id != DEFAULT_HGI_ID
+                    and active_hgi_id not in gwy_cfg.known_list
+                ):
+                    gwy_cfg.known_list[active_hgi_id] = {"class": "HGI"}
+                    _LOGGER.info(
+                        "Active HGI %s added to ramses_rf known_list "
+                        "at runtime (prevents filter exception)",
+                        active_hgi_id,
+                    )
+                # Add all connected serial pool child HGIs
+                eng = getattr(gateway, "_engine", None)
+                tpt = getattr(eng, "_transport", None) or getattr(
+                    gateway, "_transport", None
+                )
+                if tpt is not None and hasattr(tpt, "_children"):
+                    for child in tpt._children:
+                        child_hgi = getattr(child, "hgi_id", None)
+                        is_callback = getattr(child, "callback_driven", False)
+                        if (
+                            child_hgi
+                            and not is_callback
+                            and isinstance(child_hgi, str)
+                            and child_hgi.startswith(HGI_PREFIX)
+                            and child_hgi != DEFAULT_HGI_ID
+                            and child_hgi not in gwy_cfg.known_list
+                        ):
+                            gwy_cfg.known_list[child_hgi] = {"class": "HGI"}
+                            _LOGGER.info(
+                                "Pool child HGI %s added to "
+                                "ramses_rf known_list at runtime "
+                                "(prevents filter exception)",
+                                child_hgi,
+                            )
+        except Exception:  # noqa: BLE001
+            pass
 
         # Phase 2: if the serial primary discovered its HGI ID and
         # that HGI is also in the MQTT pool, exclude it from the MQTT

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2655,159 +2655,74 @@ class RamsesCoordinator(DataUpdateCoordinator):
     async def _async_probe_serial_ports(
         self, primary_port: str, primary_hgi_id: str | None = None
     ) -> None:
-        """Probe serial ports to detect HGI IDs and update _comment.
+        """Mark accepted HGIs as USB-capable when primary port is serial.
 
-        The primary port's HGI ID is known from the config — mark it
-        as USB-capable directly.  For additional ports, try to detect
-        the HGI ID by listening for RF traffic (evofw3) or polling
-        with '?' (ramses_esp).
+        When the MQTT bridge path is taken but the primary port is
+        serial, the serial ports are not opened by the transport.
+        This method marks all accepted HGIs as USB-capable so the
+        review form and pool management show "(detected)" for USB.
 
-        This runs in the background when the MQTT bridge path is taken
-        but the primary port is serial — the serial ports are not
-        otherwise opened in that path.
+        Rationale: if the user has a serial port configured as
+        primary, they likely have HGIs connected via USB.  RF probing
+        is unreliable (ramses_esp firmware has sparse RF output, and
+        ESPs may be out of RF range of each other or the devices).
+        Instead, we mark all accepted HGIs as USB-capable and let the
+        user control which are in the USB pool vs MQTT pool via
+        ``_preferred_type``.
         """
         import glob
-        import re
 
-        # The primary HGI is always on the primary port — mark it
-        # as USB-capable without needing to probe.
-        detected: dict[str, str] = {}  # port -> hgi_id
-        if primary_hgi_id and primary_hgi_id.startswith("18:"):
-            detected[primary_port] = primary_hgi_id
-            _LOGGER.info(
-                "SerialProbe: primary HGI %s on %s (from config)",
-                primary_hgi_id,
-                primary_port,
-            )
-
-        # Build list of additional ports to probe: any /dev/ttyACM*
-        # ports that aren't the primary.
-        ports_to_probe: list[str] = []
+        # Count available USB serial ports.
+        usb_ports = []
         if primary_port.startswith("/dev/"):
-            for p in sorted(glob.glob("/dev/ttyACM*")):
-                if p != primary_port and p not in detected:
-                    ports_to_probe.append(p)
+            usb_ports = sorted(glob.glob("/dev/ttyACM*"))
 
-        if ports_to_probe:
-            _LOGGER.info(
-                "SerialProbe: probing %d additional port(s): %s",
-                len(ports_to_probe),
-                ports_to_probe,
-            )
-
-        hgi_id_re = re.compile(r"\b(18:[0-9]{6})\b")
-
-        for port in ports_to_probe:
-            try:
-                import serial as pyserial  # type: ignore[import-untyped]
-
-                s = pyserial.Serial(port, baudrate=115200, timeout=2)
-                try:
-                    # Strategy 1: passive listen for 60 seconds.
-                    # ramses_esp firmware outputs RF packets on serial
-                    # but the HGI's own packets (with 18: source) may
-                    # only appear every ~20s.  evofw3 streams more
-                    # frequently so it will be detected faster.
-                    import time
-
-                    deadline = time.monotonic() + 60.0
-                    while time.monotonic() < deadline:
-                        line = s.readline()
-                        if not line:
-                            continue
-                        text = line.decode("ascii", errors="ignore")
-                        m = hgi_id_re.search(text)
-                        if m:
-                            hgi_id = m.group(1)
-                            detected[port] = hgi_id
-                            _LOGGER.info(
-                                "SerialProbe: detected HGI %s on %s "
-                                "(passive, %.0fs)",
-                                hgi_id,
-                                port,
-                                60.0 - (deadline - time.monotonic()),
-                            )
-                            break
-
-                    # Strategy 2: active poll with '?' command.
-                    # If passive listen didn't find an 18: packet,
-                    # try querying the firmware for the last received
-                    # packet.  Send '?' every 1s for up to 60s.
-                    if port not in detected:
-                        s.reset_input_buffer()
-                        deadline = time.monotonic() + 60.0
-                        while time.monotonic() < deadline:
-                            s.write(b"?\r")
-                            await asyncio.sleep(1.0)
-                            while True:
-                                line = s.readline()
-                                if not line:
-                                    break
-                                text = line.decode("ascii", errors="ignore")
-                                # Skip command echoes (lines starting
-                                # with '#')
-                                if text.lstrip().startswith("#"):
-                                    continue
-                                m = hgi_id_re.search(text)
-                                if m:
-                                    hgi_id = m.group(1)
-                                    detected[port] = hgi_id
-                                    _LOGGER.info(
-                                        "SerialProbe: detected HGI %s "
-                                        "on %s (active poll)",
-                                        hgi_id,
-                                        port,
-                                    )
-                                    break
-                            if port in detected:
-                                break
-                    if port not in detected:
-                        _LOGGER.info(
-                            "SerialProbe: no HGI ID found on %s "
-                            "after 120s (RF traffic may be sparse)",
-                            port,
-                        )
-                finally:
-                    s.close()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("SerialProbe: could not probe %s: %s", port, err)
-
-        if not detected:
-            _LOGGER.info(
-                "SerialProbe: no HGIs detected on serial ports "
-                "(primary HGI may not start with 18:)"
-            )
+        if not usb_ports:
             return
 
-        # Update schema _comment for each detected HGI.
+        _LOGGER.info(
+            "SerialProbe: %d USB serial port(s) found: %s — marking "
+            "accepted HGIs as USB-capable",
+            len(usb_ports),
+            usb_ports,
+        )
+
+        # Mark ALL accepted HGIs (18: devices with _class: HGI and
+        # _owner: root_owner) as USB-capable.
         raw_schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(raw_schema, dict):
             return
         schema_dict = dict(raw_schema)
+        root_owner = schema_dict.get(SZ_OWNER, "me")
         changed = False
-        for _port, hgi_id in detected.items():
-            entry = schema_dict.get(hgi_id, {})
-            if isinstance(entry, dict):
-                existing = str(entry.get("_comment", "")).lower()
-                if "usb" not in existing:
-                    if "mqtt" in existing:
-                        entry["_comment"] = "Supports: usb, mqtt"
-                    else:
-                        entry["_comment"] = "Supports: usb"
-                    schema_dict[hgi_id] = entry
-                    changed = True
-                    _LOGGER.info(
-                        "SerialProbe: updated _comment for %s to '%s'",
-                        hgi_id,
-                        entry["_comment"],
-                    )
+        count = 0
+        for dev_id, entry in schema_dict.items():
+            if not isinstance(entry, dict):
+                continue
+            if not dev_id.startswith("18:"):
+                continue
+            if entry.get("_class", "").upper() != "HGI":
+                continue
+            if entry.get(SZ_TR_OWNER, root_owner) != root_owner:
+                continue
+            existing = str(entry.get("_comment", "")).lower()
+            if "usb" not in existing:
+                if "mqtt" in existing:
+                    entry["_comment"] = "Supports: usb, mqtt"
+                else:
+                    entry["_comment"] = "Supports: usb"
+                changed = True
+                count += 1
+                _LOGGER.info(
+                    "SerialProbe: marked %s as USB-capable (was: '%s')",
+                    dev_id,
+                    existing or "(none)",
+                )
         if changed:
             new_options = dict(self.entry.options)
             new_options[CONF_SCHEMA] = schema_dict
             # Suppress reload — we only updated _comment metadata,
-            # not anything that requires re-initialisation.  The flag
-            # is checked by the update listener (scheduled as an async
-            # task by async_update_entry) to skip the reload.
+            # not anything that requires re-initialisation.
             import time as _time
 
             self._suppress_reload = _time.time()
@@ -2815,8 +2730,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 self.entry, options=new_options
             )
             _LOGGER.info(
-                "SerialProbe: schema updated with USB detection for %d HGI(s)",
-                sum(1 for _ in detected),
+                "SerialProbe: marked %d HGI(s) as USB-capable",
+                count,
             )
 
     def _create_hybrid_pool_transport_constructor(

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -250,12 +250,6 @@ class _MqttHgiDiscoveryCallback:
         entry reloads.
         """
         hgi_str = str(hgi_id)
-        _LOGGER.info(
-            "MqttPoolBridge: unknown HGI %s observed on topic %s "
-            "(adding as discovery candidate, not added to pool)",
-            hgi_str,
-            topic,
-        )
         # Insert into schema as a discovery candidate (no _owner).
         # This makes sync_with_schema → check_for_new_devices flag
         # it for review on the next checkpoint cycle.
@@ -266,6 +260,12 @@ class _MqttHgiDiscoveryCallback:
         # Only add if not already present (don't overwrite existing
         # entries — the user may have already rejected it).
         if hgi_str not in schema:
+            _LOGGER.info(
+                "MqttPoolBridge: unknown HGI %s observed on topic %s "
+                "(adding as discovery candidate, not added to pool)",
+                hgi_str,
+                topic,
+            )
             schema[hgi_str] = {
                 "_class": "HGI",
                 "_comment": build_hgi_comment(["mqtt"]),

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2872,9 +2872,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
         import glob
 
         # Count available USB serial ports.
+        # Use asyncio.to_thread to avoid blocking HA's event loop
+        # (glob.glob is a synchronous filesystem call).
         usb_ports = []
         if primary_port.startswith("/dev/"):
-            usb_ports = sorted(glob.glob("/dev/ttyACM*"))
+            usb_ports = sorted(
+                await asyncio.to_thread(glob.glob, "/dev/ttyACM*")
+            )
 
         if not usb_ports:
             return
@@ -2948,9 +2952,42 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     "HGI %s (serial primary)",
                     dev_id,
                 )
-        if changed:
+        # Auto-populate additional_ports: if there are more USB serial
+        # ports than configured, add the extra ones automatically so the
+        # pool uses all available USB HGIs without manual configuration.
+        # The primary port (first in the list) is already configured as
+        # port_name; any additional ports are added to additional_ports.
+        extra_ports: list[str] = []
+        current_additional = self.options.get(CONF_ADDITIONAL_PORTS, [])
+        if isinstance(current_additional, list):
+            configured_serial = [
+                p
+                for p in current_additional
+                if isinstance(p, str)
+                and not p.startswith("mqtt://")
+                and not p.startswith("zigbee://")
+                and p != "mqtt_ha"
+            ]
+            # USB ports beyond the primary that aren't already configured
+            extra_ports = [
+                p
+                for p in usb_ports
+                if p != primary_port and p not in configured_serial
+            ]
+            if extra_ports:
+                new_additional = list(current_additional)
+                new_additional.extend(extra_ports)
+                _LOGGER.info(
+                    "SerialProbe: auto-added %d USB port(s) to "
+                    "additional_ports: %s",
+                    len(extra_ports),
+                    extra_ports,
+                )
+        if changed or extra_ports:
             new_options = dict(self.entry.options)
             new_options[CONF_SCHEMA] = schema_dict
+            if extra_ports:
+                new_options[CONF_ADDITIONAL_PORTS] = new_additional
             self.options = new_options
             # Suppress reload — same pattern as sync_learned_topology.
             # The running coordinator already has the updated options

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -471,6 +471,48 @@ class RamsesCoordinator(DataUpdateCoordinator):
             active_hgi_id = gwy.hgi.id
         return active_hgi_id
 
+    @property
+    def serial_port_hgi_map(self) -> dict[str, str]:
+        """Return a mapping of serial port names to discovered HGI IDs.
+
+        Built at runtime from the pool's serial (non-callback) children.
+        Each serial child knows its port_name and, after identity
+        discovery (``!I`` or ``_PUZZ``), its hgi_id.  This lets the
+        config_flow show which HGI is physically on which port —
+        information that's only available after the transport
+        connects and probes the device (issue 1185).
+
+        :return: Dict mapping port names (e.g. ``/dev/ttyACM0``) to
+            HGI IDs (e.g. ``18:149488``).  Empty if no serial children
+            or no HGI IDs discovered yet.
+        :rtype: dict[str, str]
+        """
+        result: dict[str, str] = {}
+        if not self.client:
+            return result
+        try:
+            gwy: Gateway = self.client
+            eng = getattr(gwy, "_engine", None)
+            tpt = getattr(eng, "_transport", None) or getattr(
+                gwy, "_transport", None
+            )
+            if tpt is not None and hasattr(tpt, "_children"):
+                for child in tpt._children:
+                    child_hgi = getattr(child, "hgi_id", None)
+                    is_callback = getattr(child, "callback_driven", False)
+                    port_name = getattr(child, "port_name", None)
+                    if (
+                        child_hgi
+                        and not is_callback
+                        and isinstance(child_hgi, str)
+                        and isinstance(port_name, str)
+                        and port_name.startswith("/dev/")
+                    ):
+                        result[port_name] = child_hgi
+        except Exception:  # noqa: BLE001
+            pass
+        return result
+
     def _get_saved_packets(
         self, client_state: dict[str, Any]
     ) -> dict[str, dict[str, Any] | str]:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -285,6 +285,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self.fan_handler = RamsesFanHandler(self)
         self.service_handler = RamsesServiceHandler(self)
         self.mqtt_bridge: RamsesMqttBridge | RamsesMqttPoolBridge | None = None
+        self._last_excluded_hgi_id: str | None = None
         self.discovery_manager: DiscoveryManager | None = None
         self._cached_discovery_state: dict[str, Any] | None = None
         self._suppress_reload: float = 0.0  # timestamp; >0 means suppressed
@@ -3616,6 +3617,18 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ):
             with suppress(Exception):
                 gateway.device_registry.get_device(active_hgi_id)
+
+        # Phase 2: if the serial primary discovered its HGI ID and
+        # that HGI is also in the MQTT pool, exclude it from the MQTT
+        # bridge to avoid duplicate packet ingestion (hybrid pool).
+        if (
+            isinstance(active_hgi_id, str)
+            and self.mqtt_bridge is not None
+            and hasattr(self.mqtt_bridge, "exclude_hgi_id")
+            and active_hgi_id != self._last_excluded_hgi_id
+        ):
+            self.mqtt_bridge.exclude_hgi_id(active_hgi_id)
+            self._last_excluded_hgi_id = active_hgi_id
 
         if (
             self.discovery_manager is not None

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -289,6 +289,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self.service_handler = RamsesServiceHandler(self)
         self.mqtt_bridge: RamsesMqttBridge | RamsesMqttPoolBridge | None = None
         self._last_excluded_hgi_id: str | None = None
+        self._is_serial_active: bool = False
         self.discovery_manager: DiscoveryManager | None = None
         self._cached_discovery_state: dict[str, Any] | None = None
         self._suppress_reload: float = 0.0  # timestamp; >0 means suppressed
@@ -2406,6 +2407,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
             engine_kwargs["hgi_id"] = hgi_id
             self._port_name = str(_port_name_raw or "mqtt")
+            self._is_serial_active = False  # MQTT bridge, not serial
 
             engine_config = EngineConfig(**engine_kwargs)
             gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
@@ -2423,6 +2425,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             self.options[SZ_SERIAL_PORT]
         )
         self._port_name = str(port_name)
+        self._is_serial_active = True  # Serial transport is actually used
         engine_kwargs["port_config"] = port_config
 
         # Gateway pool (multi-HGI) — issue 1119.
@@ -3650,17 +3653,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Phase 2: if the serial primary discovered its HGI ID and
         # that HGI is also in the MQTT pool, exclude it from the MQTT
         # bridge to avoid duplicate packet ingestion (hybrid pool).
-        # Only do this when the primary is actually serial — in an
-        # MQTT-only setup, the active HGI is an MQTT child and must
-        # NOT be excluded from its own pool.
-        _port_name = self._port_name or ""
-        _is_serial_primary = (
-            _port_name.startswith("/dev/")
-            or _port_name.startswith("socket://")
-            or _port_name.startswith("rfc2217://")
-        )
+        # Only do this when the serial transport is actually active —
+        # in an MQTT-only setup (or when the serial port doesn't
+        # exist), the active HGI is an MQTT child and must NOT be
+        # excluded from its own pool.
         if (
-            _is_serial_primary
+            self._is_serial_active
             and isinstance(active_hgi_id, str)
             and self.mqtt_bridge is not None
             and hasattr(self.mqtt_bridge, "exclude_hgi_id")

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2410,17 +2410,23 @@ class RamsesCoordinator(DataUpdateCoordinator):
             self._is_serial_active = False  # MQTT bridge, not serial
 
             # Phase 2: if the primary port is serial but we took the
-            # MQTT bridge path, probe available serial ports in the
-            # background to detect HGI IDs and update _comment with
-            # "usb" for detected HGIs.  This ensures the review form
-            # and pool management show "(detected)" for USB.
+            # MQTT bridge path, mark accepted HGIs as USB-capable.
+            # Delay slightly to ensure the config entry store is ready.
             if isinstance(_port_name_raw, str) and (
                 _port_name_raw.startswith("/dev/")
                 or _port_name_raw.startswith("socket://")
                 or _port_name_raw.startswith("rfc2217://")
             ):
+                _LOGGER.info("Scheduling serial probe for USB detection in 5s")
+
+                async def _delayed_probe() -> None:
+                    await asyncio.sleep(5.0)
+                    await self._async_probe_serial_ports(
+                        _port_name_raw, hgi_id
+                    )
+
                 self.hass.async_create_background_task(
-                    self._async_probe_serial_ports(_port_name_raw, hgi_id),
+                    _delayed_probe(),
                     "ramses_serial_probe",
                 )
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -559,6 +559,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 and k.startswith(HGI_PREFIX)
                 and v.get(SZ_TR_OWNER) == root_owner
                 and v.get("_class") == "HGI"
+                and not v.get("_removed_from_pool")
             ]
             if len(accepted_hgis) > 1:
                 return True
@@ -1819,7 +1820,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 and not entry.get("_disabled")
             ):
                 continue
-            if entry.get(SZ_TR_OWNER) == root_owner:
+            if entry.get(SZ_TR_OWNER) == root_owner and not entry.get(
+                "_removed_from_pool"
+            ):
                 accepted.add(dev_id)
         return accepted
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2721,16 +2721,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if changed:
             new_options = dict(self.entry.options)
             new_options[CONF_SCHEMA] = schema_dict
-            # Suppress reload — we only updated _comment metadata,
-            # not anything that requires re-initialisation.
-            import time as _time
-
-            self._suppress_reload = _time.time()
+            # Let the entry reload — this persists the schema to disk
+            # and restarts the coordinator.  On the next startup, the
+            # probe will find all HGIs already have "usb" in _comment
+            # and won't trigger another reload (no changes = no update).
             self.hass.config_entries.async_update_entry(
                 self.entry, options=new_options
             )
             _LOGGER.info(
-                "SerialProbe: marked %d HGI(s) as USB-capable",
+                "SerialProbe: marked %d HGI(s) as USB-capable, "
+                "reloading entry to persist",
                 count,
             )
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2478,6 +2478,26 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 port_name,
             )
 
+        # Phase 2: schedule serial probe to mark accepted HGIs as
+        # USB-capable and set _preferred_type for the primary HGI.
+        # This runs in both the serial-only and hybrid paths.
+        # Delay slightly to ensure the config entry store is ready.
+        _primary_port_for_probe = str(port_name)
+        _primary_hgi_for_probe = (
+            hgi_id if hgi_id and hgi_id != DEFAULT_HGI_ID else None
+        )
+
+        async def _delayed_serial_probe() -> None:
+            await asyncio.sleep(5.0)
+            await self._async_probe_serial_ports(
+                _primary_port_for_probe, _primary_hgi_for_probe
+            )
+
+        self.hass.async_create_background_task(
+            _delayed_serial_probe(),
+            "ramses_serial_probe",
+        )
+
         # Gateway pool (multi-HGI) — issue 1119.
         # When additional_ports is set, OR when the schema has multiple
         # accepted HGIs (18: devices with _owner == root_owner and
@@ -2724,6 +2744,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         # Mark ALL accepted HGIs (18: devices with _class: HGI and
         # _owner: root_owner) as USB-capable.
+        # Also set _preferred_type: usb for the primary HGI since we
+        # know it's connected via serial (the user chose a /dev/ port).
         raw_schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(raw_schema, dict):
             return
@@ -2734,6 +2756,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         schema_dict = copy.deepcopy(raw_schema)
         root_owner = schema_dict.get(SZ_OWNER, "me")
+        primary_hgi_id = self._get_primary_hgi_id()
         changed = False
         count = 0
         for dev_id, entry in schema_dict.items():
@@ -2757,6 +2780,23 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     "SerialProbe: marked %s as USB-capable (was: '%s')",
                     dev_id,
                     existing or "(none)",
+                )
+            # Set _preferred_type: usb for the primary HGI — we know
+            # it's connected via serial because the user configured a
+            # /dev/ port as primary.  This ensures the pool UI shows
+            # it as "(USB)" instead of "(MQTT)" and _extract_pool_hgis
+            # excludes it from MQTT callback children.
+            if (
+                primary_hgi_id
+                and dev_id == primary_hgi_id
+                and entry.get("_preferred_type") != "usb"
+            ):
+                entry["_preferred_type"] = "usb"
+                changed = True
+                _LOGGER.info(
+                    "SerialProbe: set _preferred_type=usb for primary "
+                    "HGI %s (serial primary)",
+                    dev_id,
                 )
         if changed:
             new_options = dict(self.entry.options)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2409,6 +2409,21 @@ class RamsesCoordinator(DataUpdateCoordinator):
             self._port_name = str(_port_name_raw or "mqtt")
             self._is_serial_active = False  # MQTT bridge, not serial
 
+            # Phase 2: if the primary port is serial but we took the
+            # MQTT bridge path, probe available serial ports in the
+            # background to detect HGI IDs and update _comment with
+            # "usb" for detected HGIs.  This ensures the review form
+            # and pool management show "(detected)" for USB.
+            if isinstance(_port_name_raw, str) and (
+                _port_name_raw.startswith("/dev/")
+                or _port_name_raw.startswith("socket://")
+                or _port_name_raw.startswith("rfc2217://")
+            ):
+                self.hass.async_create_background_task(
+                    self._async_probe_serial_ports(_port_name_raw),
+                    "ramses_serial_probe",
+                )
+
             engine_config = EngineConfig(**engine_kwargs)
             gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
             return Gateway(
@@ -2636,6 +2651,101 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return transport
 
         return _pool_constructor
+
+    async def _async_probe_serial_ports(self, primary_port: str) -> None:
+        """Probe serial ports to detect HGI IDs and update _comment.
+
+        Opens each available serial port briefly, reads a few packets,
+        and extracts the HGI ID from the first packet with an ``18:``
+        source address.  Updates the schema ``_comment`` to include
+        ``usb`` for each detected HGI.
+
+        This runs in the background when the MQTT bridge path is taken
+        but the primary port is serial — the serial ports are not
+        otherwise opened in that path.
+        """
+        import glob
+        import re
+
+        # Build list of ports to probe: the primary port + any
+        # /dev/ttyACM* ports that aren't the primary.
+        ports_to_probe: list[str] = [primary_port]
+        if primary_port.startswith("/dev/"):
+            for p in sorted(glob.glob("/dev/ttyACM*")):
+                if p != primary_port and p not in ports_to_probe:
+                    ports_to_probe.append(p)
+
+        _LOGGER.info(
+            "SerialProbe: probing %d port(s): %s",
+            len(ports_to_probe),
+            ports_to_probe,
+        )
+
+        hgi_id_re = re.compile(r"\b(18:[0-9]{6})\b")
+        detected: dict[str, str] = {}  # port -> hgi_id
+
+        for port in ports_to_probe:
+            try:
+                import serial as pyserial  # type: ignore[import-untyped]
+
+                s = pyserial.Serial(port, baudrate=115200, timeout=1)
+                try:
+                    # Read for up to 5 seconds, looking for 18:NNNNNN.
+                    import time
+
+                    deadline = time.monotonic() + 5.0
+                    while time.monotonic() < deadline:
+                        line = s.readline()
+                        if not line:
+                            continue
+                        text = line.decode("ascii", errors="ignore")
+                        m = hgi_id_re.search(text)
+                        if m:
+                            hgi_id = m.group(1)
+                            detected[port] = hgi_id
+                            _LOGGER.info(
+                                "SerialProbe: detected HGI %s on %s",
+                                hgi_id,
+                                port,
+                            )
+                            break
+                finally:
+                    s.close()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("SerialProbe: could not probe %s: %s", port, err)
+
+        if not detected:
+            _LOGGER.info("SerialProbe: no HGIs detected on serial ports")
+            return
+
+        # Update schema _comment for each detected HGI.
+        raw_schema = self.entry.options.get(CONF_SCHEMA, {})
+        if not isinstance(raw_schema, dict):
+            return
+        schema_dict = dict(raw_schema)
+        changed = False
+        for _port, hgi_id in detected.items():
+            entry = schema_dict.get(hgi_id, {})
+            if isinstance(entry, dict):
+                existing = str(entry.get("_comment", "")).lower()
+                if "usb" not in existing:
+                    if "mqtt" in existing:
+                        entry["_comment"] = "Supports: usb, mqtt"
+                    else:
+                        entry["_comment"] = "Supports: usb"
+                    schema_dict[hgi_id] = entry
+                    changed = True
+                    _LOGGER.info(
+                        "SerialProbe: updated _comment for %s to '%s'",
+                        hgi_id,
+                        entry["_comment"],
+                    )
+        if changed:
+            new_options = dict(self.entry.options)
+            new_options[CONF_SCHEMA] = schema_dict
+            self.hass.config_entries.async_update_entry(
+                self.entry, options=new_options
+            )
 
     def _create_hybrid_pool_transport_constructor(
         self,

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -500,10 +500,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 for child in tpt._children:
                     child_hgi = getattr(child, "hgi_id", None)
                     is_callback = getattr(child, "callback_driven", False)
+                    is_connected = getattr(child, "is_connected", False)
                     port_name = getattr(child, "port_name", None)
                     if (
                         child_hgi
                         and not is_callback
+                        and is_connected
                         and isinstance(child_hgi, str)
                         and isinstance(port_name, str)
                         and port_name.startswith("/dev/")
@@ -4187,6 +4189,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
             if isinstance(active_hgi_id, str):
                 serial_hgi_ids.add(active_hgi_id)
             # Also check pool children for learned HGI IDs.
+            # Only include *connected* serial children — a disconnected
+            # child's HGI should be un-excluded from MQTT so its
+            # packets can flow via MQTT again (issue 1185).
             try:
                 gwy2: Gateway = self.client
                 eng = getattr(gwy2, "_engine", None)
@@ -4197,10 +4202,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     for child in tpt._children:
                         child_hgi = getattr(child, "hgi_id", None)
                         is_callback = getattr(child, "callback_driven", False)
+                        is_connected = getattr(child, "is_connected", False)
                         if (
                             child_hgi
                             and not is_callback
                             and isinstance(child_hgi, str)
+                            and is_connected
                         ):
                             serial_hgi_ids.add(child_hgi)
             except Exception:  # noqa: BLE001

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -3188,60 +3188,28 @@ class RamsesCoordinator(DataUpdateCoordinator):
     async def _async_probe_serial_ports(
         self, primary_port: str, primary_hgi_id: str | None = None
     ) -> None:
-        """Mark accepted HGIs as USB-capable when primary port is serial.
+        """Mark the identified primary HGI as serial-capable.
 
-        When the MQTT bridge path is taken but the primary port is
-        serial, the serial ports are not opened by the transport.
-        This method marks all accepted HGIs as USB-capable so the
-        review form and pool management show "(detected)" for USB.
-
-        Rationale: if the user has a serial port configured as
-        primary, they likely have HGIs connected via USB.  RF probing
-        is unreliable (ramses_esp firmware has sparse RF output, and
-        ESPs may be out of RF range of each other or the devices).
-        Instead, we mark all accepted HGIs as USB-capable and let the
-        user control which are in the USB pool vs MQTT pool via
-        ``_preferred_type``.
+        :param primary_port: Configured primary serial port.
+        :param primary_hgi_id: Identity associated with the primary port.
         """
-        import glob
-
-        # Count available USB serial ports.
-        # Use asyncio.to_thread to avoid blocking HA's event loop
-        # (glob.glob is a synchronous filesystem call).
-        usb_ports = []
-        if primary_port.startswith("/dev/"):
-            usb_ports = sorted(
-                await asyncio.to_thread(glob.glob, "/dev/ttyACM*")
-            )
-
-        if not usb_ports:
+        if not primary_port or primary_port.startswith("mqtt"):
+            return
+        primary_hgi_id = primary_hgi_id or self._get_primary_hgi_id()
+        if not primary_hgi_id:
             return
 
-        _LOGGER.info(
-            "SerialProbe: %d USB serial port(s) found: %s — marking "
-            "accepted HGIs as USB-capable",
-            len(usb_ports),
-            usb_ports,
-        )
-
-        # Mark ALL HGIs (18: devices with _class: HGI) as USB-capable.
-        # This includes both accepted HGIs (with _owner) and discovery
-        # candidates (without _owner).  The serial probe detects USB
-        # ports — any HGI in the schema that's an HGI gets "usb" in
-        # _comment.  _preferred_type is only set for accepted HGIs
-        # (with _owner), not discovery candidates — the user sets
-        # _preferred_type during review.
+        # Mark only the HGI identified on the configured primary port.
+        # Other schema HGIs may be remote MQTT nodes and must not be
+        # labelled USB-capable merely because a serial primary exists.
         raw_schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(raw_schema, dict):
             return
         # Deep copy the schema so that async_update_entry detects the
         # changes (shallow copy would modify the original in place,
         # making the new options identical to the old ones).
-        import copy
-
-        schema_dict = copy.deepcopy(raw_schema)
+        schema_dict = deepcopy(raw_schema)
         root_owner = schema_dict.get(SZ_OWNER, "me")
-        primary_hgi_id = self._get_primary_hgi_id()
         changed = False
         count = 0
         for dev_id, entry in schema_dict.items():
@@ -3250,6 +3218,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
             if not dev_id.startswith("18:"):
                 continue
             if entry.get("_class", "").upper() != "HGI":
+                continue
+            if dev_id != primary_hgi_id:
                 continue
             # Skip foreign-owned HGIs (different _owner than root).
             hgi_owner = entry.get(SZ_TR_OWNER)
@@ -3308,9 +3278,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # and a reload would be disruptive.  On the next startup,
             # the probe will find all HGIs already have "usb" in
             # _comment and won't trigger another update.
-            import time as _time
-
-            self._suppress_reload = _time.time()
+            self._suppress_reload = time.time()
             self.hass.config_entries.async_update_entry(
                 self.entry, options=new_options
             )
@@ -3453,6 +3421,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 loop=loop or _hass.loop,
                 callback_port_names=callback_port_names,
                 per_child_config_overrides=per_child_overrides,
+                accepted_hgis=_self._get_accepted_hgi_ids(),
             )
 
             # If there are MQTT callback children, create the

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -213,13 +213,19 @@ _T_Entity = TypeVar("_T_Entity", bound=RamsesRFEntity)
 
 
 class _MqttHgiDiscoveryCallback:
-    """Receive unknown-HGI notifications from the MQTT pool bridge.
+    """Receive HGI discovery notifications from the MQTT pool bridge.
 
     Implements the ``MqttDiscoveryCallback`` protocol from
-    ``ramses_tx.transport.callbacks``.  An unknown HGI observed on the
-    wildcard topic is logged and flagged for review by the discovery
-    manager; it does **not** create a ``PoolChild`` or become routable
-    until the user accepts it and the config entry reloads.
+    ``ramses_tx.transport.callbacks``.
+
+    - ``on_unknown_hgi``: an *unknown* HGI observed on the wildcard
+      topic is logged and flagged for review by the discovery
+      manager; it does **not** create a ``PoolChild`` or become
+      routable until the user accepts it and the config entry reloads.
+    - ``on_mqtt_capable``: a *configured* HGI observed online via LWT
+      has its ``_comment`` updated to include ``mqtt`` in its
+      supported transports (e.g. ``"Supports: usb, mqtt"``).  The HGI
+      is already a pool member — no discovery candidate is created.
     """
 
     def __init__(self, coordinator: RamsesCoordinator) -> None:
@@ -277,6 +283,28 @@ class _MqttHgiDiscoveryCallback:
             # "mqtt" if not already present (the HGI may have been
             # added by the serial probe with only "usb" in _comment).
             self._mark_hgi_mqtt_capable(hgi_str)
+
+    def on_mqtt_capable(
+        self,
+        hgi_id: DeviceIdT,
+        *,
+        topic: str | None = None,
+    ) -> None:
+        """Report that a configured HGI is online via MQTT LWT.
+
+        Updates the HGI's ``_comment`` to include ``mqtt`` in its
+        supported transports.  Unlike :meth:`on_unknown_hgi`, this
+        does **not** add the HGI to the schema as a discovery
+        candidate — the HGI is already a pool member.
+        """
+        hgi_str = str(hgi_id)
+        _LOGGER.debug(
+            "MqttPoolBridge: configured HGI %s online via MQTT "
+            "(topic %s) — marking as MQTT-capable",
+            hgi_str,
+            topic,
+        )
+        self._mark_hgi_mqtt_capable(hgi_str)
 
     def _mark_hgi_mqtt_capable(self, hgi_id: str) -> None:
         """Update an existing HGI's _comment to include 'mqtt'.

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -529,6 +529,31 @@ class RamsesCoordinator(DataUpdateCoordinator):
             pass
         return result
 
+    def get_pool_child_status(self) -> list[dict[str, object]]:
+        """Return per-child pool status for monitoring (issue 1119).
+
+        Used by the per-HGI binary sensors and the aggregate pool
+        status sensor to report connectivity, availability, and
+        send-readiness of each pool child.
+
+        :return: List of per-child status dicts (see
+            :meth:`PooledTransport.get_pool_child_status`).  Empty
+            if no pool transport is active.
+        """
+        if not self.client:
+            return []
+        try:
+            gwy: Gateway = self.client
+            eng = getattr(gwy, "_engine", None)
+            tpt = getattr(eng, "_transport", None) or getattr(
+                gwy, "_transport", None
+            )
+            if tpt is not None and hasattr(tpt, "get_pool_child_status"):
+                return tpt.get_pool_child_status()
+        except Exception:  # noqa: BLE001
+            pass
+        return []
+
     def _get_saved_packets(
         self, client_state: dict[str, Any]
     ) -> dict[str, dict[str, Any] | str]:
@@ -708,7 +733,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         config_schema = self.options.get(CONF_SCHEMA, {})
         if isinstance(config_schema, dict):
             _hgi_comments_migrated = False
-            _migrated_schema = dict(config_schema)
+            # Deep copy so mutating _entry["_comment"] doesn't
+            # mutate the live options dict (issue 1119 — shallow
+            # copy left _entry as a reference into the original).
+            _migrated_schema = deepcopy(config_schema)
             for _dev_id, _entry in _migrated_schema.items():
                 if not (
                     isinstance(_dev_id, str)
@@ -2990,6 +3018,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 port_config=port_config,
                 serial_additional=serial_additional,
                 mqtt_hgi_ids=all_mqtt_hgi_ids,
+                primary_hgi_id=(
+                    hgi_id if hgi_id and hgi_id != DEFAULT_HGI_ID else None
+                ),
             )
             engine_config = EngineConfig(**engine_kwargs)
             gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
@@ -3260,6 +3291,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         port_config: dict[str, Any],
         serial_additional: list[str],
         mqtt_hgi_ids: list[str],
+        primary_hgi_id: str | None = None,
     ) -> Callable[..., Awaitable[Any]]:
         """Create a transport_constructor for a hybrid serial+MQTT pool.
 
@@ -3277,6 +3309,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         :param port_config: The primary port configuration dict.
         :param serial_additional: Additional serial port names.
         :param mqtt_hgi_ids: MQTT HGI IDs for callback-driven children.
+        :param primary_hgi_id: The primary port's HGI ID if known
+            (from config/URL extraction).  Passed as
+            ``configured_hgi_id`` so HGI80 devices that can't respond
+            to ``!I`` still get a send-ready identity (Gap B, issue 1119).
         :returns: An async transport constructor callable.
         """
         # Lazy import — pooled_transport_factory is only available in
@@ -3295,6 +3331,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         _port_config = port_config
         _serial_additional = serial_additional
         _mqtt_hgi_ids = mqtt_hgi_ids
+        _primary_hgi_id = primary_hgi_id
         _hass = self.hass
         _self = self
 
@@ -3325,19 +3362,32 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # respond to ``!I`` — this is handled in PortTransport.
             # If ``!I`` fails, PortTransport falls back to
             # ``configured_hgi_id`` (Gap B) or ``_PUZZ`` signature probe.
+            #
+            # enable_reconnect=True allows USB unplugs to recover
+            # transparently without a config-entry reload (issue 1119).
+            # configured_hgi_id is set for the primary port when the
+            # HGI ID is known from config — this makes HGI80 devices
+            # send-ready immediately (Gap B, issue 1119).
             from ramses_tx.transport.base import SignaturePolicy
 
+            _base_override: dict[str, object] = {
+                "signature_policy": SignaturePolicy.ID_COMMAND,
+                "startup_grace": 3.0,
+                # ID_COMMAND needs: grace (3s) + !I timeout (2s) +
+                # _PUZZ fallback (3s) = 8s.  The default port
+                # timeout is only 3s, which would time out before
+                # !I is even sent.
+                "timeout": 12.0,
+                "enable_reconnect": True,
+            }
             per_child_overrides: list[dict[str, object]] = [
-                {
-                    "signature_policy": SignaturePolicy.ID_COMMAND,
-                    "startup_grace": 3.0,
-                    # ID_COMMAND needs: grace (3s) + !I timeout (2s) +
-                    # _PUZZ fallback (3s) = 8s.  The default port
-                    # timeout is only 3s, which would time out before
-                    # !I is even sent.
-                    "timeout": 12.0,
-                }
-            ] * len(serial_ports)
+                dict(_base_override) for _ in range(len(serial_ports))
+            ]
+            # Pass configured_hgi_id for the primary port (index 0)
+            # when the HGI ID is known from config.  This makes HGI80
+            # devices send-ready without !I or _PUZZ (Gap B).
+            if _primary_hgi_id and _primary_hgi_id != DEFAULT_HGI_ID:
+                per_child_overrides[0]["configured_hgi_id"] = _primary_hgi_id
 
             # MQTT callback-driven children (port names for the pool).
             callback_port_names = [

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2420,7 +2420,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 or _port_name_raw.startswith("rfc2217://")
             ):
                 self.hass.async_create_background_task(
-                    self._async_probe_serial_ports(_port_name_raw),
+                    self._async_probe_serial_ports(_port_name_raw, hgi_id),
                     "ramses_serial_probe",
                 )
 
@@ -2652,13 +2652,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         return _pool_constructor
 
-    async def _async_probe_serial_ports(self, primary_port: str) -> None:
+    async def _async_probe_serial_ports(
+        self, primary_port: str, primary_hgi_id: str | None = None
+    ) -> None:
         """Probe serial ports to detect HGI IDs and update _comment.
 
-        Opens each available serial port briefly, reads a few packets,
-        and extracts the HGI ID from the first packet with an ``18:``
-        source address.  Updates the schema ``_comment`` to include
-        ``usb`` for each detected HGI.
+        The primary port's HGI ID is known from the config — mark it
+        as USB-capable directly.  For additional ports, try to detect
+        the HGI ID by listening for RF traffic (evofw3) or polling
+        with '?' (ramses_esp).
 
         This runs in the background when the MQTT bridge path is taken
         but the primary port is serial — the serial ports are not
@@ -2667,22 +2669,33 @@ class RamsesCoordinator(DataUpdateCoordinator):
         import glob
         import re
 
-        # Build list of ports to probe: the primary port + any
-        # /dev/ttyACM* ports that aren't the primary.
-        ports_to_probe: list[str] = [primary_port]
+        # The primary HGI is always on the primary port — mark it
+        # as USB-capable without needing to probe.
+        detected: dict[str, str] = {}  # port -> hgi_id
+        if primary_hgi_id and primary_hgi_id.startswith("18:"):
+            detected[primary_port] = primary_hgi_id
+            _LOGGER.info(
+                "SerialProbe: primary HGI %s on %s (from config)",
+                primary_hgi_id,
+                primary_port,
+            )
+
+        # Build list of additional ports to probe: any /dev/ttyACM*
+        # ports that aren't the primary.
+        ports_to_probe: list[str] = []
         if primary_port.startswith("/dev/"):
             for p in sorted(glob.glob("/dev/ttyACM*")):
-                if p != primary_port and p not in ports_to_probe:
+                if p != primary_port and p not in detected:
                     ports_to_probe.append(p)
 
-        _LOGGER.info(
-            "SerialProbe: probing %d port(s): %s",
-            len(ports_to_probe),
-            ports_to_probe,
-        )
+        if ports_to_probe:
+            _LOGGER.info(
+                "SerialProbe: probing %d additional port(s): %s",
+                len(ports_to_probe),
+                ports_to_probe,
+            )
 
         hgi_id_re = re.compile(r"\b(18:[0-9]{6})\b")
-        detected: dict[str, str] = {}  # port -> hgi_id
 
         for port in ports_to_probe:
             try:
@@ -2749,7 +2762,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("SerialProbe: could not probe %s: %s", port, err)
 
         if not detected:
-            _LOGGER.info("SerialProbe: no HGIs detected on serial ports")
+            _LOGGER.info(
+                "SerialProbe: no HGIs detected on serial ports "
+                "(primary HGI may not start with 18:)"
+            )
             return
 
         # Update schema _comment for each detected HGI.

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2365,10 +2365,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # HGI, the pool bridge subscribes to the wildcard topic and
             # can discover unknown HGIs via the discovery callback.
             schema_pool_hgis = self._extract_pool_hgis_from_schema()
-            all_hgi_ids = [hgi_id]
-            for extra_hgi in schema_pool_hgis:
-                if extra_hgi not in all_hgi_ids:
-                    all_hgi_ids.append(extra_hgi)
+
+            # Phase 2: when the primary is serial (not MQTT), the
+            # primary HGI ID is NOT an MQTT pool member — it's the
+            # serial primary.  Only add schema pool HGIs to the MQTT
+            # bridge's configured list.  The serial primary is
+            # handled by the serial transport constructor.
+            is_primary_serial = isinstance(_port_name_raw, str) and (
+                _port_name_raw.startswith("/dev/")
+                or _port_name_raw.startswith("socket://")
+                or _port_name_raw.startswith("rfc2217://")
+            )
+            if is_primary_serial:
+                all_hgi_ids = list(schema_pool_hgis)
+            else:
+                all_hgi_ids = [hgi_id] if hgi_id else []
+                for extra_hgi in schema_pool_hgis:
+                    if extra_hgi not in all_hgi_ids:
+                        all_hgi_ids.append(extra_hgi)
 
             _LOGGER.info(
                 "MqttPoolBridge: %d configured HGI(s): %s",

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2798,8 +2798,19 @@ class RamsesCoordinator(DataUpdateCoordinator):
         if changed:
             new_options = dict(self.entry.options)
             new_options[CONF_SCHEMA] = schema_dict
+            # Suppress reload — we only updated _comment metadata,
+            # not anything that requires re-initialisation.  The flag
+            # is checked by the update listener (scheduled as an async
+            # task by async_update_entry) to skip the reload.
+            import time as _time
+
+            self._suppress_reload = _time.time()
             self.hass.config_entries.async_update_entry(
                 self.entry, options=new_options
+            )
+            _LOGGER.info(
+                "SerialProbe: schema updated with USB detection for %d HGI(s)",
+                sum(1 for _ in detected),
             )
 
     def _create_hybrid_pool_transport_constructor(

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -75,7 +75,7 @@ from ramses_rf.schemas import (
 from ramses_rf.systems import Evohome, System, Zone
 from ramses_rf.topology import Child
 from ramses_tx.config import EngineConfig
-from ramses_tx.const import SZ_ACTIVE_HGI, Code
+from ramses_tx.const import HGI_ID_PATTERN, SZ_ACTIVE_HGI, Code
 from ramses_tx.dtos import PacketDTO
 from ramses_tx.exceptions import TransportError as _TransportError
 from ramses_tx.schemas import extract_serial_port
@@ -638,7 +638,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 addr = packet.get("addr1") or packet.get("src")
                 if (
                     isinstance(addr, str)
-                    and addr.startswith("18:")
+                    and addr.startswith(HGI_PREFIX)
                     and addr != DEFAULT_HGI_ID
                 ):
                     last_hgi_id = addr
@@ -939,7 +939,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             or _primary_port_name.startswith("rfc2217://")
         )
         if _is_serial_primary and not any(
-            k.startswith("18:")
+            k.startswith(HGI_PREFIX)
             and isinstance(v, dict)
             and v.get("_class", "").upper() == "HGI"
             for k, v in config_schema.items()
@@ -952,7 +952,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 addr = packet.get("addr1") or packet.get("src")
                 if (
                     isinstance(addr, str)
-                    and addr.startswith("18:")
+                    and addr.startswith(HGI_PREFIX)
                     and addr != DEFAULT_HGI_ID
                 ):
                     last_hgi_id = addr
@@ -1847,7 +1847,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # Extract from URL path
                 import re as _re
 
-                m = _re.search(r"(18:[0-9]{6})(?:/|$)", port_name)
+                m = _re.search(rf"({HGI_ID_PATTERN})(?:/|$)", port_name)
                 if m and m.group(1) != DEFAULT_HGI_ID:
                     return m.group(1)
                 # Wildcard MQTT — fall back to the first accepted HGI
@@ -1922,7 +1922,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
             path = path.rstrip("/")
             # If the path already ends with an HGI ID (18:NNNNNN),
             # replace it with the new one
-            path = _re.sub(r"/18:[0-9]{6}$", "", path)
+            path = _re.sub(rf"/{HGI_ID_PATTERN}$", "", path)
             if not path:
                 path = "/RAMSES/GATEWAY"
             # Append the new HGI ID
@@ -2712,7 +2712,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # (e.g. mqtt://user:pass@host:1883/topic/18:001234)
                 import re as _re
 
-                m = _re.search(r"(18:[0-9]{6})(?:/|$)", _port_name_raw)
+                m = _re.search(rf"({HGI_ID_PATTERN})(?:/|$)", _port_name_raw)
                 if m and m.group(1) != DEFAULT_HGI_ID:
                     hgi_id = m.group(1)
             if not hgi_id:
@@ -2732,7 +2732,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # Topic is the path after the host:port, before the HGI ID
                 # e.g. mqtt://host:1883/RAMSES/GATEWAY/18:001234 -> RAMSES/GATEWAY
                 m = _re.search(
-                    r"mqtt://[^/]+/(.+?)/18:[0-9]{6}(?:/|$)",
+                    rf"mqtt://[^/]+/(.+?)/{HGI_ID_PATTERN}(?:/|$)",
                     _port_name_raw,
                 )
                 if m:
@@ -3024,7 +3024,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         for mqtt_url in mqtt_additional:
             import re as _re
 
-            m = _re.search(r"(18:[0-9]{6})(?:/|$)", mqtt_url)
+            m = _re.search(rf"({HGI_ID_PATTERN})(?:/|$)", mqtt_url)
             if m:
                 hgi_id = m.group(1)
                 if hgi_id not in mqtt_hgi_ids_from_urls:
@@ -3215,7 +3215,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         for dev_id, entry in schema_dict.items():
             if not isinstance(entry, dict):
                 continue
-            if not dev_id.startswith("18:"):
+            if not dev_id.startswith(HGI_PREFIX):
                 continue
             if entry.get("_class", "").upper() != "HGI":
                 continue

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1823,6 +1823,69 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 accepted.add(dev_id)
         return accepted
 
+    def _auto_accept_primary_hgi(self) -> None:
+        """Auto-accept the primary serial HGI as a pool member.
+
+        If the primary port is serial/USB and the HGI ID is known from
+        the runtime port mapping, set ``_owner`` on the HGI in the
+        schema so it appears as an accepted pool member.  This ensures
+        the pool menu reflects the active primary HGI instead of
+        showing "0 pool members" when there is clearly a working HGI
+        on the primary port (issue 1171).
+
+        Safe to call repeatedly — does nothing if the HGI is already
+        accepted or the primary is not serial.
+        """
+        if getattr(self, "_primary_auto_accepted", False):
+            return
+        serial_port_cfg = self.options.get(SZ_SERIAL_PORT, {})
+        if not isinstance(serial_port_cfg, dict):
+            return
+        port_name = serial_port_cfg.get(SZ_PORT_NAME, "")
+        if not (
+            isinstance(port_name, str)
+            and (
+                port_name.startswith("/dev/")
+                or port_name.startswith("socket://")
+                or port_name.startswith("rfc2217://")
+            )
+        ):
+            return
+        # Get the HGI ID from the runtime port mapping.
+        port_hgi_map = self.serial_port_hgi_map
+        primary_hgi = port_hgi_map.get(port_name)
+        if not primary_hgi:
+            return
+        # Check if the HGI is in the schema without _owner.
+        schema = self.entry.options.get(CONF_SCHEMA, {})
+        if not isinstance(schema, dict):
+            return
+        entry = schema.get(primary_hgi)
+        if not isinstance(entry, dict):
+            return
+        if entry.get(SZ_TR_OWNER):
+            # Already accepted — mark as done.
+            self._primary_auto_accepted = True
+            return
+        # Set _owner to accept the primary HGI.
+        root_owner = schema.get(SZ_OWNER) or "me"
+        new_schema = deepcopy(schema)
+        new_schema[primary_hgi][SZ_TR_OWNER] = root_owner
+        if SZ_OWNER not in new_schema:
+            new_schema[SZ_OWNER] = root_owner
+        new_options = dict(self.entry.options)
+        new_options[CONF_SCHEMA] = new_schema
+        self.hass.config_entries.async_update_entry(
+            self.entry, options=new_options
+        )
+        self._primary_auto_accepted = True
+        _LOGGER.info(
+            "Auto-accepted primary HGI %s as pool member "
+            "(serial primary on %s)",
+            primary_hgi,
+            port_name,
+        )
+
     def _get_primary_hgi_id(self) -> str | None:
         """Return the primary HGI ID from the transport config.
 
@@ -4229,6 +4292,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 "Coordinator: (_async_update_data) Client None, skip update"
             )
             return None
+
+        # Auto-accept the primary serial HGI as a pool member.
+        # The primary HGI is discovered at runtime via the serial probe
+        # (!I or _PUZZ).  If it's in the schema without _owner, set
+        # _owner so it appears as an accepted pool member (issue 1171).
+        self._auto_accept_primary_hgi()
 
         # Gateway health check: use ramses_rf's Gateway.is_active (SSOT)
         # to detect if the gateway has stopped receiving messages.

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1041,6 +1041,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # it as a discovery candidate.  The user must accept it via
             # "Review Discovered Devices" to set _owner and
             # _preferred_type.  Do NOT auto-enrich with _owner.
+            #
+            # NOTE: the primary HGI is still used as the active gateway
+            # for packet reception and device discovery even before the
+            # user accepts it.  This is by design — the primary
+            # transport (serial port) always receives packets.  The
+            # _owner controls whether the HGI is an accepted pool
+            # member (can send commands), not whether it receives
+            # packets.  For a single-HGI serial setup, the primary
+            # HGI IS the transport — you can't "decline" it without
+            # removing the serial port from the config.
             _LOGGER.info(
                 "Primary HGI %s is in schema without _owner "
                 "(discovery candidate — pending review)",

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2695,18 +2695,17 @@ class RamsesCoordinator(DataUpdateCoordinator):
             )
 
             # Gap A: per-child config overrides for serial children.
-            # Serial children use ID_COMMAND (!I) signature policy with
-            # a 3s startup grace to handle DTR reset on FTDI/nanoCUL/ESP32
-            # devices (Phase 2, issue 1119).  ID_COMMAND is serial-only —
-            # only the USB-connected ESP responds to !I over its serial
-            # port, so identity discovery is deterministic even when
-            # multiple HGIs are on the same RF network.  _PUZZ would
-            # broadcast over RF and get responses from all HGIs.
+            # Serial children use SKIP signature policy with a 3s startup
+            # grace to handle DTR reset on FTDI/nanoCUL/ESP32 devices
+            # (Phase 2, issue 1119).  SKIP learns the HGI ID from the
+            # first inbound RF packet — no probing needed.  This works
+            # with all firmware versions (evofw3 0.1.0 doesn't support
+            # !I, and _PUZZ broadcasts over RF so all HGIs respond).
             from ramses_tx.transport.base import SignaturePolicy
 
             per_child_overrides: list[dict[str, object]] = [
                 {
-                    "signature_policy": SignaturePolicy.ID_COMMAND,
+                    "signature_policy": SignaturePolicy.SKIP,
                     "startup_grace": 3.0,
                 }
             ] * len(serial_ports)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2916,6 +2916,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return
 
         port_name = self._port_name or "gateway"
+        # Redact credentials from mqtt:// URLs before logging (security).
+        if isinstance(port_name, str) and port_name.startswith("mqtt://"):
+            port_name = "mqtt://***@***"
         if connected:
             _LOGGER.info(
                 "Connection to RAMSES RF gateway established on %s", port_name

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -262,7 +262,7 @@ class _MqttHgiDiscoveryCallback:
         raw_schema = self._coordinator.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(raw_schema, dict):
             return
-        schema = dict(raw_schema)
+        schema = deepcopy(raw_schema)
         # Only add if not already present (don't overwrite existing
         # entries — the user may have already rejected it).
         if hgi_str not in schema:
@@ -273,6 +273,8 @@ class _MqttHgiDiscoveryCallback:
             # No _owner — this is a discovery candidate.
             new_options = dict(self._coordinator.entry.options)
             new_options[CONF_SCHEMA] = schema
+            self._coordinator.options = new_options
+            self._coordinator._suppress_reload = time.time()
             self._coordinator.hass.config_entries.async_update_entry(
                 self._coordinator.entry, options=new_options
             )
@@ -326,9 +328,7 @@ class _MqttHgiDiscoveryCallback:
         existing = str(entry.get("_comment", "")).lower()
         if "mqtt" in existing:
             return  # Already marked as MQTT-capable.
-        import copy
-
-        schema = copy.deepcopy(raw_schema)
+        schema = deepcopy(raw_schema)
         schema_entry = schema[hgi_id]
         if "usb" in existing:
             schema_entry["_comment"] = build_hgi_comment(["usb", "mqtt"])
@@ -336,6 +336,8 @@ class _MqttHgiDiscoveryCallback:
             schema_entry["_comment"] = build_hgi_comment(["mqtt"])
         new_options = dict(self._coordinator.entry.options)
         new_options[CONF_SCHEMA] = schema
+        self._coordinator.options = new_options
+        self._coordinator._suppress_reload = time.time()
         self._coordinator.hass.config_entries.async_update_entry(
             self._coordinator.entry, options=new_options
         )
@@ -528,6 +530,39 @@ class RamsesCoordinator(DataUpdateCoordinator):
         except Exception:  # noqa: BLE001
             pass
         return result
+
+    @property
+    def is_pool_enabled(self) -> bool:
+        """Return True if the coordinator is configured for multi-HGI pooling.
+
+        Checks for additional serial ports, MQTT additional ports, or
+        MQTT HGI IDs in the options (issue 1119).
+        """
+        additional_ports: list[str] = self.options.get(
+            CONF_ADDITIONAL_PORTS, []
+        )
+        if additional_ports:
+            return True
+        # MQTT primary or MQTT HGI ID configured.
+        if self.options.get(CONF_MQTT_HGI_ID) or self.options.get(
+            CONF_MQTT_USE_HA
+        ):
+            return True
+        # Check schema for multiple accepted HGIs.
+        schema = self.options.get(CONF_SCHEMA, {})
+        if isinstance(schema, dict):
+            root_owner = schema.get(SZ_OWNER, "me")
+            accepted_hgis = [
+                k
+                for k, v in schema.items()
+                if isinstance(v, dict)
+                and k.startswith(HGI_PREFIX)
+                and v.get(SZ_TR_OWNER) == root_owner
+                and v.get("_class") == "HGI"
+            ]
+            if len(accepted_hgis) > 1:
+                return True
+        return False
 
     def get_pool_child_status(self) -> list[dict[str, object]]:
         """Return per-child pool status for monitoring (issue 1119).
@@ -3345,10 +3380,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ) -> Any:
             """Create a hybrid PooledTransport (serial + MQTT callback)."""
             # Serial children: primary + serial additional.
+            # Use deepcopy per child so the factory can mutate each
+            # config independently (e.g. injecting port_name) without
+            # sharing state across children (issue 1171).
             serial_ports = [_port_name, *_serial_additional]
-            all_serial_configs: list[dict[str, Any]] = [_port_config] * len(
-                serial_ports
-            )
+            all_serial_configs: list[dict[str, Any]] = [
+                deepcopy(_port_config) for _ in serial_ports
+            ]
 
             # Gap A: per-child config overrides for serial children.
             # Serial children use ID_COMMAND signature policy with a 3s
@@ -4428,6 +4466,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
             except Exception:  # noqa: BLE001
                 pass
 
+            # Build schema updates in a single deepcopy pass, then
+            # call async_update_entry once after the loop (issue 1171).
+            raw_schema = self.entry.options.get(CONF_SCHEMA, {})
+            schema_needs_update = False
+            if isinstance(raw_schema, dict):
+                schema_dict = deepcopy(raw_schema)
+            else:
+                schema_dict = {}
             for hgi_id_to_exclude in serial_hgi_ids:
                 if hgi_id_to_exclude in self._excluded_serial_hgi_ids:
                     continue
@@ -4437,25 +4483,27 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # USB.  If it was already discovered via MQTT, merge.
                 # Note: _preferred_type is NOT auto-corrected — the
                 # schema is user-controlled and leading (issue 1185).
-                raw_schema = self.entry.options.get(CONF_SCHEMA, {})
-                if isinstance(raw_schema, dict):
-                    schema_dict = dict(raw_schema)
-                    entry = schema_dict.get(hgi_id_to_exclude, {})
-                    if isinstance(entry, dict):
-                        existing = entry.get("_comment", "")
-                        if "usb" not in existing.lower():
-                            if "mqtt" in existing.lower():
-                                entry["_comment"] = build_hgi_comment(
-                                    ["usb", "mqtt"]
-                                )
-                            else:
-                                entry["_comment"] = build_hgi_comment(["usb"])
-                            schema_dict[hgi_id_to_exclude] = entry
-                            new_options = dict(self.entry.options)
-                            new_options[CONF_SCHEMA] = schema_dict
-                            self.hass.config_entries.async_update_entry(
-                                self.entry, options=new_options
+                entry = schema_dict.get(hgi_id_to_exclude, {})
+                if isinstance(entry, dict):
+                    existing = entry.get("_comment", "")
+                    if "usb" not in existing.lower():
+                        if "mqtt" in existing.lower():
+                            entry["_comment"] = build_hgi_comment(
+                                ["usb", "mqtt"]
                             )
+                        else:
+                            entry["_comment"] = build_hgi_comment(["usb"])
+                        schema_dict[hgi_id_to_exclude] = entry
+                        schema_needs_update = True
+
+            if schema_needs_update:
+                new_options = dict(self.entry.options)
+                new_options[CONF_SCHEMA] = schema_dict
+                self.options = new_options
+                self._suppress_reload = time.time()
+                self.hass.config_entries.async_update_entry(
+                    self.entry, options=new_options
+                )
 
             # Un-exclude HGIs whose serial transport has disconnected
             # (e.g. USB unplugged).  Their MQTT packets should flow

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2859,7 +2859,35 @@ class RamsesCoordinator(DataUpdateCoordinator):
             isinstance(_mqtt_hgi_id_cfg, str)
             and _mqtt_hgi_id_cfg != DEFAULT_HGI_ID
         )
-        _has_mqtt = _is_mqtt_ha or bool(mqtt_additional) or _has_mqtt_hgi_id
+        # Also check if any schema HGI has _preferred_type: "mqtt".
+        # When a non-primary HGI switches from USB to MQTT via the
+        # pool management UI, its _preferred_type changes to "mqtt"
+        # but no mqtt:// URL is added to additional_ports (the MQTT
+        # bridge uses the HA MQTT integration's broker).  Without
+        # this check, the MQTT bridge would not be created for that
+        # HGI (issue 1171).
+        _schema_mqtt_preferred: list[str] = []
+        _schema = self.entry.options.get(CONF_SCHEMA, {})
+        if isinstance(_schema, dict):
+            _root_owner = _schema.get(SZ_OWNER)
+            for _dev_id, _entry in _schema.items():
+                if (
+                    _dev_id.startswith(HGI_PREFIX)
+                    and _dev_id != DEFAULT_HGI_ID
+                    and isinstance(_entry, dict)
+                    and _entry.get("_class", "").upper() == "HGI"
+                    and not _entry.get("_disabled")
+                    and not _entry.get("_removed_from_pool")
+                    and str(_entry.get("_preferred_type", "")).lower()
+                    == "mqtt"
+                ):
+                    _schema_mqtt_preferred.append(_dev_id)
+        _has_mqtt = (
+            _is_mqtt_ha
+            or bool(mqtt_additional)
+            or _has_mqtt_hgi_id
+            or bool(_schema_mqtt_preferred)
+        )
         # Guard: if MQTT is wanted but the HA MQTT integration is not
         # set up, skip MQTT bridge creation (issue 1171).
         if _has_mqtt and not self.hass.config_entries.async_entries("mqtt"):

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2348,12 +2348,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 loop=self.hass.loop,
             )
 
-        if _is_mqtt_ha:
-            # RamsesMqttBridge path — uses HA MQTT
-            if not self.hass.config_entries.async_entries("mqtt"):
-                raise ConfigEntryNotReady(
-                    "Home Assistant MQTT integration is not set up"
-                )
+        # Determine if the primary port is a real serial port (not
+        # mqtt_ha or mqtt://).  When mqtt_use_ha is True AND the
+        # primary is serial, we need a hybrid pool (serial + MQTT).
+        _is_primary_serial = isinstance(_port_name_raw, str) and (
+            _port_name_raw.startswith("/dev/")
+            or _port_name_raw.startswith("socket://")
+            or _port_name_raw.startswith("rfc2217://")
+        )
+
+        # When mqtt_use_ha is True (either MQTT-only or hybrid), the
+        # HA MQTT integration must be available.
+        if _is_mqtt_ha and not self.hass.config_entries.async_entries("mqtt"):
+            raise ConfigEntryNotReady(
+                "Home Assistant MQTT integration is not set up"
+            )
+
+        if _is_mqtt_ha and not _is_primary_serial:
+            # RamsesMqttBridge path — uses HA MQTT (MQTT-only pool)
 
             # Retrieve config options
             mqtt_topic = self.options.get(CONF_MQTT_TOPIC, DEFAULT_MQTT_TOPIC)
@@ -2453,6 +2465,18 @@ class RamsesCoordinator(DataUpdateCoordinator):
         self._port_name = str(port_name)
         self._is_serial_active = True  # Serial transport is actually used
         engine_kwargs["port_config"] = port_config
+
+        # Phase 2: when mqtt_use_ha is True and primary is serial, we
+        # fell through from the MQTT bridge path.  Set the engine
+        # hgi_id so the protocol layer can patch outbound packets
+        # correctly (18:000730 <-> real HGI ID).
+        if hgi_id and hgi_id != DEFAULT_HGI_ID:
+            engine_kwargs["hgi_id"] = hgi_id
+            _LOGGER.info(
+                "Serial/hybrid path: engine hgi_id=%s, port_name=%s",
+                hgi_id,
+                port_name,
+            )
 
         # Gateway pool (multi-HGI) — issue 1119.
         # When additional_ports is set, OR when the schema has multiple

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2761,6 +2761,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
                                     break
                             if port in detected:
                                 break
+                    if port not in detected:
+                        _LOGGER.info(
+                            "SerialProbe: no HGI ID found on %s "
+                            "after 60s (RF traffic may be sparse)",
+                            port,
+                        )
                 finally:
                     s.close()
             except Exception as err:  # noqa: BLE001

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -477,6 +477,34 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 primary_hgi_for_known_list,
             )
 
+        # For serial/USB, the HGI ID isn't known until the first packet
+        # (returns None above).  Extract it from stored packets — the
+        # last packet's addr1/src starting with 18: is the real HGI ID.
+        # This prevents ramses_rf from using the 18:000730 sentinel
+        # when the real HGI is 18:130236 (issue: sentinel shows up
+        # instead of real HGI after clean schema).
+        if not primary_hgi_for_known_list:
+            stored_packets = client_state.get(SZ_PACKETS, {})
+            last_hgi_id: str | None = None
+            for _dtm, packet in stored_packets.items():
+                if not isinstance(packet, dict):
+                    continue
+                addr = packet.get("addr1") or packet.get("src")
+                if (
+                    isinstance(addr, str)
+                    and addr.startswith("18:")
+                    and addr != DEFAULT_HGI_ID
+                ):
+                    last_hgi_id = addr
+            if last_hgi_id and last_hgi_id not in known_list:
+                known_list[last_hgi_id] = {"class": "HGI"}
+                _LOGGER.info(
+                    "Added last-known HGI %s to known_list "
+                    "(extracted from stored packets — serial HGI "
+                    "discovery candidate pending review)",
+                    last_hgi_id,
+                )
+
         packets: dict[str, dict[str, Any] | str] = {}
         now = dt_util.now()
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2701,13 +2701,16 @@ class RamsesCoordinator(DataUpdateCoordinator):
             try:
                 import serial as pyserial  # type: ignore[import-untyped]
 
-                s = pyserial.Serial(port, baudrate=115200, timeout=1)
+                s = pyserial.Serial(port, baudrate=115200, timeout=2)
                 try:
-                    # Strategy 1: passive listen for 5 seconds.
-                    # Works for evofw3 which streams RF on serial.
+                    # Strategy 1: passive listen for 30 seconds.
+                    # ramses_esp firmware outputs RF packets on serial
+                    # but the HGI's own packets (with 18: source) may
+                    # only appear every ~20s.  evofw3 streams more
+                    # frequently so it will be detected faster.
                     import time
 
-                    deadline = time.monotonic() + 5.0
+                    deadline = time.monotonic() + 30.0
                     while time.monotonic() < deadline:
                         line = s.readline()
                         if not line:
@@ -2718,22 +2721,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             hgi_id = m.group(1)
                             detected[port] = hgi_id
                             _LOGGER.info(
-                                "SerialProbe: detected HGI %s on %s (passive)",
+                                "SerialProbe: detected HGI %s on %s "
+                                "(passive, %.0fs)",
                                 hgi_id,
                                 port,
+                                30.0 - (deadline - time.monotonic()),
                             )
                             break
 
                     # Strategy 2: active poll with '?' command.
-                    # Some firmware (ramses_esp) only outputs the last
-                    # RF packet when queried.  Send '?' every 0.5s for
-                    # up to 10s and look for 18:NNNNNN in responses.
+                    # If passive listen didn't find an 18: packet,
+                    # try querying the firmware for the last received
+                    # packet.  Send '?' every 1s for up to 30s.
                     if port not in detected:
                         s.reset_input_buffer()
-                        deadline = time.monotonic() + 10.0
+                        deadline = time.monotonic() + 30.0
                         while time.monotonic() < deadline:
                             s.write(b"?\r")
-                            await asyncio.sleep(0.3)
+                            await asyncio.sleep(1.0)
                             while True:
                                 line = s.readline()
                                 if not line:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -459,6 +459,24 @@ class RamsesCoordinator(DataUpdateCoordinator):
         known_list = self._derive_known_list_from_schema(config_schema)
         enforce_known_list = True  # Phase 4: always-on
 
+        # Ensure the primary HGI is in the known_list even if it's not
+        # in the schema yet (e.g. clean schema, discovery candidate
+        # pending review).  The primary HGI is the one configured in
+        # serial_port — it must be in the known_list for packets to
+        # work.  It's added without _owner (discovery candidate) so
+        # it appears in "Review Discovered Devices".
+        primary_hgi_for_known_list = self._get_primary_hgi_id()
+        if (
+            primary_hgi_for_known_list
+            and primary_hgi_for_known_list not in known_list
+        ):
+            known_list[primary_hgi_for_known_list] = {"class": "HGI"}
+            _LOGGER.info(
+                "Added primary HGI %s to known_list (not in schema yet "
+                "— discovery candidate pending review)",
+                primary_hgi_for_known_list,
+            )
+
         packets: dict[str, dict[str, Any] | str] = {}
         now = dt_util.now()
 
@@ -1463,7 +1481,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
         falls back to the first accepted HGI in the schema.  For serial/
         USB, it's unknown until the first packet (returns None).
         """
-        port_name = self.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME, "")
+        serial_port_cfg = self.options.get(SZ_SERIAL_PORT, {})
+        if not isinstance(serial_port_cfg, dict):
+            serial_port_cfg = {}
+        port_name = serial_port_cfg.get(SZ_PORT_NAME, "")
         is_mqtt_ha = (
             isinstance(port_name, str) and port_name == "mqtt_ha"
         ) or self.options.get(CONF_MQTT_USE_HA)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1198,6 +1198,20 @@ class RamsesCoordinator(DataUpdateCoordinator):
         )
         await self.async_save_client_state()
 
+        # Re-check for new devices after async_save_client_state, which
+        # runs sync_learned_topology and may add the HGI to the schema
+        # (e.g. on the first checkpoint after a clean start).  Without
+        # this, the HGI wouldn't be flagged for review until the next
+        # 5-minute checkpoint cycle.
+        new_schema = self.entry.options.get(CONF_SCHEMA, {})
+        if isinstance(new_schema, dict) and new_schema != schema:
+            new_schema_device_ids = self._extract_schema_device_ids(new_schema)
+            new_foreign_ids = self._extract_foreign_device_ids(new_schema)
+            self.discovery_manager.sync_with_schema(
+                new_schema_device_ids, new_foreign_ids, new_schema
+            )
+            self.discovery_manager.check_for_new_devices()
+
     async def _async_stop_discovery_scan(self) -> None:
         """Stop the discovery scan engine.
 
@@ -1455,15 +1469,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
         the scan engine can discover them, but they cannot send
         commands until the user accepts them (sets _owner).
 
-        Phase 2: HGIs with ``_preferred_type: "usb"`` are excluded
-        from the MQTT pool — they are serial-discovered devices, not
-        MQTT callback children.  This avoids duplicate packet
-        ingestion when an ESP is connected via USB and also publishes
-        on MQTT.
+        Phase 2: HGIs with ``_preferred_type: "usb"`` are included in
+        the MQTT bridge so their MQTT capability can be detected via
+        LWT.  The pool's deduplication filter handles any duplicate
+        packets that arrive from both USB and MQTT transports.
 
         :return: List of HGI device IDs for MQTT pool membership
             (accepted members + discovery candidates), excluding the
-            primary HGI and USB-preferred HGIs.
+            primary HGI.
         """
         schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(schema, dict):
@@ -1485,11 +1498,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 and dev_id != primary_hgi
             ):
                 continue
-            # Phase 2: skip HGIs explicitly marked as USB-preferred.
-            # These are serial-discovered devices, not MQTT children.
-            preferred = entry.get("_preferred_type", "")
-            if isinstance(preferred, str) and preferred.lower() == "usb":
-                continue
+            # Phase 2: USB-preferred HGIs are included in the MQTT
+            # bridge's LWT tracking so their MQTT capability can be
+            # detected (the ESP publishes on both USB and MQTT).
+            # The pool's deduplication filter handles any duplicate
+            # packets that arrive from both transports.
             owner = entry.get(SZ_TR_OWNER)
             if owner is not None and owner == root_owner:
                 # Accepted pool member — full send + receive.
@@ -4014,10 +4027,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
         # Snapshot lists to avoid RuntimeError if ramses_rf updates
         # continuously (fixes silent failure when list size changes).
+        # Filter out the ramses_rf sentinel HGI (18:000730) — it's a
+        # placeholder used when no real HGI is in the known_list, not
+        # a real device.  The real HGI is identified from the _PUZZ
+        # signature echo and should not be confused with this sentinel.
         current_devices = [
             d
             for d in gateway.device_registry.devices
-            if d.id not in self._disabled_device_ids
+            if d.id not in self._disabled_device_ids and d.id != DEFAULT_HGI_ID
         ]
         current_systems = list(gateway.device_registry.systems)
 

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -742,7 +742,21 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # ramses_rf includes it in the known_list.  This prevents
         # ramses_rf from using the 18:000730 sentinel when the real
         # HGI is 18:130236.
-        if not any(
+        # Skip this for MQTT primary — the HGI ID is in the URL and
+        # will be added by the primary HGI logic.  Extracting from
+        # stored packets would re-add stale HGIs from old sessions
+        # after a schema clear.
+        _serial_port_opt = self.options.get(SZ_SERIAL_PORT, {})
+        if isinstance(_serial_port_opt, dict):
+            _primary_port_name = _serial_port_opt.get(SZ_PORT_NAME, "")
+        else:
+            _primary_port_name = str(_serial_port_opt)
+        _is_serial_primary = isinstance(_primary_port_name, str) and (
+            _primary_port_name.startswith("/dev/")
+            or _primary_port_name.startswith("socket://")
+            or _primary_port_name.startswith("rfc2217://")
+        )
+        if _is_serial_primary and not any(
             k.startswith("18:")
             and isinstance(v, dict)
             and v.get("_class", "").upper() == "HGI"
@@ -1002,17 +1016,18 @@ class RamsesCoordinator(DataUpdateCoordinator):
             and primary_hgi.startswith(HGI_PREFIX)
             and primary_hgi not in schema
         ):
-            # Add the primary HGI to the schema as a discovery
-            # candidate (no _owner) so it appears in "Review Discovered
-            # Devices" for the user to accept.  It's still in the
-            # known_list (devices without _owner are not foreign), so
-            # commands work.  The user sets _owner and _preferred_type
-            # via the review flow.
-            schema[primary_hgi] = {"_class": "HGI"}
-            schema_changed = True
+            # Don't add the primary HGI to the schema at startup —
+            # it will be added by the LWT callback (MQTT) or the
+            # pool_hgi_ids path (serial) when the HGI actually
+            # comes online.  The known_list already includes it
+            # (from the URL extraction in _load_client_state), so
+            # packets are accepted.  This prevents stale HGIs from
+            # appearing in "Review Discovered Devices" when nothing
+            # is plugged in (issue 1171).
             _LOGGER.info(
-                "Registered primary HGI %s in schema as discovery "
-                "candidate (no _owner — pending review)",
+                "Primary HGI %s not yet in schema — will be added "
+                "when it comes online (no premature discovery "
+                "candidate)",
                 primary_hgi,
             )
         elif (
@@ -2707,7 +2722,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Schema-derived HGI IDs for the MQTT bridge (HA-native).
         # These are HGI IDs (18:...), not port names — they are
         # callback-driven children via the RamsesMqttPoolBridge.
-        schema_mqtt_hgis: list[str] = self._extract_pool_hgis_from_schema()
+        # Only include schema HGIs when MQTT is actually configured
+        # (mqtt_use_ha, mqtt:// URL, or mqtt:// additional ports).
+        # Without this gate, stale schema HGIs from a previous MQTT
+        # config would trigger MQTT bridge creation even on serial
+        # primary with no MQTT broker (issue 1171).
+        _has_mqtt = _is_mqtt_ha or bool(mqtt_additional)
+        schema_mqtt_hgis: list[str] = (
+            self._extract_pool_hgis_from_schema() if _has_mqtt else []
+        )
 
         # Filter out zigbee ports (Phase 3, not yet supported).
         zigbee_additional = [

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2406,62 +2406,81 @@ class RamsesCoordinator(DataUpdateCoordinator):
             CONF_ADDITIONAL_PORTS, []
         )
 
-        # For MQTT transports, also check the schema for accepted HGIs
-        # that share the same broker.  Each accepted HGI gets its own
-        # child transport with an explicit per-HGI MQTT URL (issue 1119).
-        # For hybrid setups (serial primary + MQTT additional), the
-        # MQTT broker URL is added to additional_ports via the config
-        # flow (manage_pool_mqtt step).
-        schema_accepted_hgis: list[str] = []
-        if isinstance(port_name, str) and port_name.startswith("mqtt://"):
-            schema_accepted_hgis = self._extract_pool_hgis_from_schema()
-
-        # Merge additional_ports and schema-derived HGI ports.
-        # Phase 1: only MQTT pool children are supported, and only
-        # when the primary transport is also MQTT (via the HA-native
-        # RamsesMqttPoolBridge).  When the primary is serial/USB,
-        # MQTT additional ports would require paho-mqtt inside HA,
-        # which is not allowed — ramses_cc must use HA's MQTT
-        # integration exclusively (issue 1119).
-        # TODO: re-enable serial pool when Phase 2 (PR 3) lands.
-        # TODO: re-enable zigbee when Phase 3 (PR 6) lands.
-        all_additional_ports: list[str] = []
-        mqtt_additional = [
+        # Phase 2: hybrid pool support (serial + MQTT via HA-native bridge).
+        # Serial additional ports are transport-driven (serialx).
+        # MQTT additional ports are callback-driven via the HA-native
+        # RamsesMqttPoolBridge (homeassistant.components.mqtt) — never
+        # paho inside HA (issue 1119).
+        # Zigbee remains gated until Phase 3 (PR 6).
+        serial_additional: list[str] = [
+            p
+            for p in additional_ports
+            if isinstance(p, str)
+            and not p.startswith("mqtt://")
+            and not p.startswith("zigbee://")
+            and p != "mqtt_ha"
+        ]
+        mqtt_additional: list[str] = [
             p
             for p in additional_ports
             if isinstance(p, str) and p.startswith("mqtt://")
         ]
-        if mqtt_additional:
+        # Schema-derived HGI IDs for the MQTT bridge (HA-native).
+        # These are HGI IDs (18:...), not port names — they are
+        # callback-driven children via the RamsesMqttPoolBridge.
+        schema_mqtt_hgis: list[str] = self._extract_pool_hgis_from_schema()
+
+        # Filter out zigbee ports (Phase 3, not yet supported).
+        zigbee_additional = [
+            p
+            for p in additional_ports
+            if isinstance(p, str) and p.startswith("zigbee://")
+        ]
+        if zigbee_additional:
             _LOGGER.warning(
-                "Serial primary + MQTT additional ports is not "
-                "supported in Phase 1 (ramses_cc must not use paho). "
-                "Ignoring MQTT additional ports: %s",
-                mqtt_additional,
-            )
-        # Schema-derived HGI ports are only valid when the primary
-        # is MQTT — they share the same broker/topic.  When the
-        # primary is serial, schema HGIs are handled via the
-        # discovery callback on the HA MQTT integration, not via
-        # paho transports.
-        if schema_accepted_hgis:
-            _LOGGER.debug(
-                "Schema HGI ports ignored for serial primary: %s",
-                schema_accepted_hgis,
+                "Zigbee pool children are not yet supported (Phase 3). "
+                "Ignoring Zigbee additional ports: %s",
+                zigbee_additional,
             )
 
+        # MQTT additional ports (mqtt:// URLs) are not used directly
+        # inside HA — they would create paho transports.  Instead, the
+        # HGI IDs embedded in those URLs are extracted and routed
+        # through the HA-native RamsesMqttPoolBridge as callback-driven
+        # children.  This is the no-paho invariant (issue 1119).
+        mqtt_hgi_ids_from_urls: list[str] = []
+        for mqtt_url in mqtt_additional:
+            import re as _re
+
+            m = _re.search(r"(18:[0-9]{6})(?:/|$)", mqtt_url)
+            if m:
+                hgi_id = m.group(1)
+                if hgi_id not in mqtt_hgi_ids_from_urls:
+                    mqtt_hgi_ids_from_urls.append(hgi_id)
+
+        # Combine all MQTT HGI IDs (from schema and from mqtt:// URLs).
+        all_mqtt_hgi_ids: list[str] = list(schema_mqtt_hgis)
+        for hgi_id in mqtt_hgi_ids_from_urls:
+            if hgi_id not in all_mqtt_hgi_ids:
+                all_mqtt_hgi_ids.append(hgi_id)
+
+        has_serial_pool = bool(serial_additional)
+        has_mqtt_pool = bool(all_mqtt_hgi_ids)
+
         _LOGGER.debug(
-            "Gateway pool check: additional_ports=%s, schema_hgis=%s, "
-            "all_additional=%s, port_name=%s",
-            additional_ports,
-            schema_accepted_hgis,
-            all_additional_ports,
+            "Gateway pool check: serial_additional=%s, "
+            "mqtt_hgi_ids=%s, port_name=%s",
+            serial_additional,
+            all_mqtt_hgi_ids,
             port_name,
         )
-        if all_additional_ports:
-            pool_constructor = self._create_pool_transport_constructor(
+
+        if has_serial_pool or has_mqtt_pool:
+            pool_constructor = self._create_hybrid_pool_transport_constructor(
                 port_name=port_name,
                 port_config=port_config,
-                additional_ports=all_additional_ports,
+                serial_additional=serial_additional,
+                mqtt_hgi_ids=all_mqtt_hgi_ids,
             )
             engine_config = EngineConfig(**engine_kwargs)
             gwy_config = GatewayConfig(engine=engine_config, **gateway_kwargs)
@@ -2584,6 +2603,124 @@ class RamsesCoordinator(DataUpdateCoordinator):
             return transport
 
         return _pool_constructor
+
+    def _create_hybrid_pool_transport_constructor(
+        self,
+        *,
+        port_name: str,
+        port_config: dict[str, Any],
+        serial_additional: list[str],
+        mqtt_hgi_ids: list[str],
+    ) -> Callable[..., Awaitable[Any]]:
+        """Create a transport_constructor for a hybrid serial+MQTT pool.
+
+        Serial children (primary + serial additional) are transport-driven
+        via ``pooled_transport_factory`` (serialx).  MQTT children are
+        callback-driven via the HA-native ``RamsesMqttPoolBridge``
+        (``homeassistant.components.mqtt``) — never paho inside HA
+        (issue 1119).
+
+        The resulting ``PooledTransport`` has:
+        - indices 0..N-1: transport-driven serial children
+        - indices N..N+M-1: callback-driven MQTT children (transport=None)
+
+        :param port_name: The primary serial port name.
+        :param port_config: The primary port configuration dict.
+        :param serial_additional: Additional serial port names.
+        :param mqtt_hgi_ids: MQTT HGI IDs for callback-driven children.
+        :returns: An async transport constructor callable.
+        """
+        # Lazy import — pooled_transport_factory is only available in
+        # ramses_tx >= 0.60.5 (not yet published to PyPI).
+        try:
+            from ramses_tx.transport import pooled_transport_factory
+        except ImportError as err:
+            raise ImportError(
+                "Gateway pool requires ramses_tx with PooledTransport "
+                "support (ramses-rf >= 0.60.5). "
+                "Update ramses-rf or remove additional_ports from config."
+            ) from err
+
+        # Capture for closure.
+        _port_name = port_name
+        _port_config = port_config
+        _serial_additional = serial_additional
+        _mqtt_hgi_ids = mqtt_hgi_ids
+        _hass = self.hass
+        _self = self
+
+        async def _hybrid_pool_constructor(
+            protocol: Any,
+            *,
+            config: Any,
+            extra: dict[str, object] | None = None,
+            loop: asyncio.AbstractEventLoop | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            """Create a hybrid PooledTransport (serial + MQTT callback)."""
+            # Serial children: primary + serial additional.
+            serial_ports = [_port_name, *_serial_additional]
+            all_serial_configs: list[dict[str, Any]] = [_port_config] * len(
+                serial_ports
+            )
+
+            # MQTT callback-driven children (port names for the pool).
+            callback_port_names = [
+                f"mqtt_ha://{hgi_id}" for hgi_id in _mqtt_hgi_ids
+            ]
+
+            _LOGGER.info(
+                "HybridPool: creating pool with %d serial children + "
+                "%d MQTT callback children: serial=%s, mqtt=%s",
+                len(serial_ports),
+                len(callback_port_names),
+                serial_ports,
+                _mqtt_hgi_ids,
+            )
+
+            transport = await pooled_transport_factory(
+                protocol,
+                config=config,
+                port_names=serial_ports,
+                port_configs=all_serial_configs,
+                extra=extra,
+                loop=loop or _hass.loop,
+                callback_port_names=callback_port_names,
+            )
+
+            # If there are MQTT callback children, create the
+            # RamsesMqttPoolBridge and attach it to the pool.
+            if _mqtt_hgi_ids:
+                from .mqtt_pool_bridge import RamsesMqttPoolBridge
+
+                mqtt_topic = _self.options.get(
+                    CONF_MQTT_TOPIC, DEFAULT_MQTT_TOPIC
+                )
+                _self.mqtt_bridge = RamsesMqttPoolBridge(
+                    _hass,
+                    mqtt_topic,
+                    _mqtt_hgi_ids,
+                    discovery_callback=_MqttHgiDiscoveryCallback(_self),
+                    wait_online_timeout=float(
+                        _self.options.get(
+                            CONF_WAIT_ONLINE_TIMEOUT,
+                            DEFAULT_WAIT_ONLINE_TIMEOUT,
+                        )
+                    ),
+                    accepted_hgi_ids=_self._get_accepted_hgi_ids(),
+                )
+                _self.entry.async_on_unload(_self.mqtt_bridge.close)
+
+                # Attach the bridge to the existing pool's
+                # callback-driven children (after serial children).
+                await _self.mqtt_bridge.async_attach_to_pool(
+                    transport,
+                    callback_child_start_index=len(serial_ports),
+                )
+
+            return transport
+
+        return _hybrid_pool_constructor
 
     async def _async_stop_client(self) -> None:
         """Safely stop RAMSES client, catching transport exceptions."""

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -913,12 +913,17 @@ class RamsesCoordinator(DataUpdateCoordinator):
             and primary_hgi.startswith(HGI_PREFIX)
             and primary_hgi not in schema
         ):
-            root_owner = schema.get(SZ_OWNER, "me")
+            # Add the primary HGI to the schema as a discovery
+            # candidate (no _owner) so it appears in "Review Discovered
+            # Devices" for the user to accept.  It's still in the
+            # known_list (devices without _owner are not foreign), so
+            # commands work.  The user sets _owner and _preferred_type
+            # via the review flow.
             schema[primary_hgi] = {"_class": "HGI"}
-            schema[primary_hgi][SZ_TR_OWNER] = root_owner
             schema_changed = True
             _LOGGER.info(
-                "Registered primary HGI %s in schema (was missing)",
+                "Registered primary HGI %s in schema as discovery "
+                "candidate (no _owner — pending review)",
                 primary_hgi,
             )
         elif (
@@ -928,18 +933,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
             and schema[primary_hgi].get("_class", "").upper() == "HGI"
             and SZ_TR_OWNER not in schema[primary_hgi]
         ):
-            # Primary HGI is in the schema but missing _owner — enrich
-            # it so it's treated as an accepted pool member (issue 1119).
-            # Default to "me" when the schema root has no _owner (e.g.
-            # after clear_cached_state in ha_sim_test).
-            root_owner = schema.get(SZ_OWNER, "me")
-            schema[primary_hgi][SZ_TR_OWNER] = root_owner
-            schema_changed = True
+            # Primary HGI is in the schema but missing _owner — leave
+            # it as a discovery candidate.  The user must accept it via
+            # "Review Discovered Devices" to set _owner and
+            # _preferred_type.  Do NOT auto-enrich with _owner.
             _LOGGER.info(
-                "Enriched primary HGI %s with _owner=%s "
-                "(was in schema without _owner)",
+                "Primary HGI %s is in schema without _owner "
+                "(discovery candidate — pending review)",
                 primary_hgi,
-                root_owner,
             )
 
         for dev_id, entry in schema.items():
@@ -2784,10 +2785,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
             usb_ports,
         )
 
-        # Mark ALL accepted HGIs (18: devices with _class: HGI and
-        # _owner: root_owner) as USB-capable.
-        # Also set _preferred_type: usb for the primary HGI since we
-        # know it's connected via serial (the user chose a /dev/ port).
+        # Mark ALL HGIs (18: devices with _class: HGI) as USB-capable.
+        # This includes both accepted HGIs (with _owner) and discovery
+        # candidates (without _owner).  The serial probe detects USB
+        # ports — any HGI in the schema that's an HGI gets "usb" in
+        # _comment.  _preferred_type is only set for accepted HGIs
+        # (with _owner), not discovery candidates — the user sets
+        # _preferred_type during review.
         raw_schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(raw_schema, dict):
             return
@@ -2808,7 +2812,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 continue
             if entry.get("_class", "").upper() != "HGI":
                 continue
-            if entry.get(SZ_TR_OWNER, root_owner) != root_owner:
+            # Skip foreign-owned HGIs (different _owner than root).
+            hgi_owner = entry.get(SZ_TR_OWNER)
+            if hgi_owner is not None and hgi_owner != root_owner:
                 continue
             existing = str(entry.get("_comment", "")).lower()
             if "usb" not in existing:
@@ -2823,14 +2829,13 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     dev_id,
                     existing or "(none)",
                 )
-            # Set _preferred_type: usb for the primary HGI — we know
-            # it's connected via serial because the user configured a
-            # /dev/ port as primary.  This ensures the pool UI shows
-            # it as "(USB)" instead of "(MQTT)" and _extract_pool_hgis
-            # excludes it from MQTT callback children.
+            # Set _preferred_type: usb only for accepted HGIs (with
+            # _owner) that are the primary HGI.  Discovery candidates
+            # (no _owner) get _preferred_type set during review.
             if (
                 primary_hgi_id
                 and dev_id == primary_hgi_id
+                and entry.get(SZ_TR_OWNER) is not None
                 and entry.get("_preferred_type") != "usb"
             ):
                 entry["_preferred_type"] = "usb"

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1475,8 +1475,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         packets that arrive from both USB and MQTT transports.
 
         :return: List of HGI device IDs for MQTT pool membership
-            (accepted members + discovery candidates), excluding the
-            primary HGI.
+            (accepted members + discovery candidates).
         """
         schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(schema, dict):
@@ -1484,8 +1483,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
         root_owner = schema.get(SZ_OWNER)
         if not root_owner:
             return []
-        # Get the primary HGI ID to exclude it from additional children
-        primary_hgi = self._get_primary_hgi_id()
         pool_hgis: list[str] = []
         for dev_id, entry in schema.items():
             if not (
@@ -1495,7 +1492,6 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 and entry.get("_class", "").upper() == "HGI"
                 and not entry.get("_disabled")
                 and not entry.get("_removed_from_pool")
-                and dev_id != primary_hgi
             ):
                 continue
             # Phase 2: USB-preferred HGIs are included in the MQTT

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1870,6 +1870,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
             # Already accepted — mark as done.
             self._primary_auto_accepted = True
             return
+        if entry.get("_removed_from_pool"):
+            # Explicitly removed — don't re-add (issue 1183).
+            self._primary_auto_accepted = True
+            return
         # Set _owner to accept the primary HGI.
         root_owner = schema.get(SZ_OWNER) or "me"
         new_schema = deepcopy(schema)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2690,7 +2690,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
                 s = pyserial.Serial(port, baudrate=115200, timeout=1)
                 try:
-                    # Read for up to 5 seconds, looking for 18:NNNNNN.
+                    # Strategy 1: passive listen for 5 seconds.
+                    # Works for evofw3 which streams RF on serial.
                     import time
 
                     deadline = time.monotonic() + 5.0
@@ -2704,11 +2705,44 @@ class RamsesCoordinator(DataUpdateCoordinator):
                             hgi_id = m.group(1)
                             detected[port] = hgi_id
                             _LOGGER.info(
-                                "SerialProbe: detected HGI %s on %s",
+                                "SerialProbe: detected HGI %s on %s (passive)",
                                 hgi_id,
                                 port,
                             )
                             break
+
+                    # Strategy 2: active poll with '?' command.
+                    # Some firmware (ramses_esp) only outputs the last
+                    # RF packet when queried.  Send '?' every 0.5s for
+                    # up to 10s and look for 18:NNNNNN in responses.
+                    if port not in detected:
+                        s.reset_input_buffer()
+                        deadline = time.monotonic() + 10.0
+                        while time.monotonic() < deadline:
+                            s.write(b"?\r")
+                            await asyncio.sleep(0.3)
+                            while True:
+                                line = s.readline()
+                                if not line:
+                                    break
+                                text = line.decode("ascii", errors="ignore")
+                                # Skip command echoes (lines starting
+                                # with '#')
+                                if text.lstrip().startswith("#"):
+                                    continue
+                                m = hgi_id_re.search(text)
+                                if m:
+                                    hgi_id = m.group(1)
+                                    detected[port] = hgi_id
+                                    _LOGGER.info(
+                                        "SerialProbe: detected HGI %s "
+                                        "on %s (active poll)",
+                                        hgi_id,
+                                        port,
+                                    )
+                                    break
+                            if port in detected:
+                                break
                 finally:
                     s.close()
             except Exception as err:  # noqa: BLE001

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -127,6 +127,7 @@ from .const import (
     SZ_TR_OWNER,
     SZ_TR_SCHEME,
     SZ_TR_SKIPPED,
+    build_hgi_comment,
 )
 from .discovery import DiscoveryManager
 from .fan_handler import RamsesFanHandler
@@ -266,7 +267,7 @@ class _MqttHgiDiscoveryCallback:
         if hgi_str not in schema:
             schema[hgi_str] = {
                 "_class": "HGI",
-                "_comment": "Supports: mqtt",
+                "_comment": build_hgi_comment(["mqtt"]),
             }
             # No _owner — this is a discovery candidate.
             new_options = dict(self._coordinator.entry.options)
@@ -329,9 +330,9 @@ class _MqttHgiDiscoveryCallback:
         schema = copy.deepcopy(raw_schema)
         schema_entry = schema[hgi_id]
         if "usb" in existing:
-            schema_entry["_comment"] = "Supports: usb, mqtt"
+            schema_entry["_comment"] = build_hgi_comment(["usb", "mqtt"])
         else:
-            schema_entry["_comment"] = "Supports: mqtt"
+            schema_entry["_comment"] = build_hgi_comment(["mqtt"])
         new_options = dict(self._coordinator.entry.options)
         new_options[CONF_SCHEMA] = schema
         self._coordinator.hass.config_entries.async_update_entry(
@@ -1164,7 +1165,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     ):
                         schema[hgi_str] = {
                             "_class": "HGI",
-                            "_comment": "Supports: usb",
+                            "_comment": build_hgi_comment(["usb"]),
                         }
                         schema_changed = True
                         _LOGGER.info(
@@ -3157,9 +3158,9 @@ class RamsesCoordinator(DataUpdateCoordinator):
             existing = str(entry.get("_comment", "")).lower()
             if "usb" not in existing:
                 if "mqtt" in existing:
-                    entry["_comment"] = "Supports: usb, mqtt"
+                    entry["_comment"] = build_hgi_comment(["usb", "mqtt"])
                 else:
-                    entry["_comment"] = "Supports: usb"
+                    entry["_comment"] = build_hgi_comment(["usb"])
                 changed = True
                 count += 1
                 _LOGGER.info(
@@ -4360,9 +4361,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
                         existing = entry.get("_comment", "")
                         if "usb" not in existing.lower():
                             if "mqtt" in existing.lower():
-                                entry["_comment"] = "Supports: usb, mqtt"
+                                entry["_comment"] = build_hgi_comment(
+                                    ["usb", "mqtt"]
+                                )
                             else:
-                                entry["_comment"] = "Supports: usb"
+                                entry["_comment"] = build_hgi_comment(["usb"])
                             schema_dict[hgi_id_to_exclude] = entry
                             new_options = dict(self.entry.options)
                             new_options[CONF_SCHEMA] = schema_dict

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2703,14 +2703,14 @@ class RamsesCoordinator(DataUpdateCoordinator):
 
                 s = pyserial.Serial(port, baudrate=115200, timeout=2)
                 try:
-                    # Strategy 1: passive listen for 30 seconds.
+                    # Strategy 1: passive listen for 60 seconds.
                     # ramses_esp firmware outputs RF packets on serial
                     # but the HGI's own packets (with 18: source) may
                     # only appear every ~20s.  evofw3 streams more
                     # frequently so it will be detected faster.
                     import time
 
-                    deadline = time.monotonic() + 30.0
+                    deadline = time.monotonic() + 60.0
                     while time.monotonic() < deadline:
                         line = s.readline()
                         if not line:
@@ -2725,17 +2725,17 @@ class RamsesCoordinator(DataUpdateCoordinator):
                                 "(passive, %.0fs)",
                                 hgi_id,
                                 port,
-                                30.0 - (deadline - time.monotonic()),
+                                60.0 - (deadline - time.monotonic()),
                             )
                             break
 
                     # Strategy 2: active poll with '?' command.
                     # If passive listen didn't find an 18: packet,
                     # try querying the firmware for the last received
-                    # packet.  Send '?' every 1s for up to 30s.
+                    # packet.  Send '?' every 1s for up to 60s.
                     if port not in detected:
                         s.reset_input_buffer()
-                        deadline = time.monotonic() + 30.0
+                        deadline = time.monotonic() + 60.0
                         while time.monotonic() < deadline:
                             s.write(b"?\r")
                             await asyncio.sleep(1.0)
@@ -2764,7 +2764,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                     if port not in detected:
                         _LOGGER.info(
                             "SerialProbe: no HGI ID found on %s "
-                            "after 60s (RF traffic may be sparse)",
+                            "after 120s (RF traffic may be sparse)",
                             port,
                         )
                 finally:

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2695,17 +2695,18 @@ class RamsesCoordinator(DataUpdateCoordinator):
             )
 
             # Gap A: per-child config overrides for serial children.
-            # All serial children get DELAYED signature policy with a
-            # 3s startup grace to handle DTR reset on FTDI/nanoCUL
-            # devices (Phase 2, issue 1119).  The ESP32-S3 also benefits
-            # from the grace period.  Per-child overrides allow future
-            # per-port configuration (e.g. ID_COMMAND for ATmega
-            # devices, SKIP for HGI80).
+            # Serial children use ID_COMMAND (!I) signature policy with
+            # a 3s startup grace to handle DTR reset on FTDI/nanoCUL/ESP32
+            # devices (Phase 2, issue 1119).  ID_COMMAND is serial-only —
+            # only the USB-connected ESP responds to !I over its serial
+            # port, so identity discovery is deterministic even when
+            # multiple HGIs are on the same RF network.  _PUZZ would
+            # broadcast over RF and get responses from all HGIs.
             from ramses_tx.transport.base import SignaturePolicy
 
             per_child_overrides: list[dict[str, object]] = [
                 {
-                    "signature_policy": SignaturePolicy.DELAYED,
+                    "signature_policy": SignaturePolicy.ID_COMMAND,
                     "startup_grace": 3.0,
                 }
             ] * len(serial_ports)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -3650,8 +3650,18 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Phase 2: if the serial primary discovered its HGI ID and
         # that HGI is also in the MQTT pool, exclude it from the MQTT
         # bridge to avoid duplicate packet ingestion (hybrid pool).
+        # Only do this when the primary is actually serial — in an
+        # MQTT-only setup, the active HGI is an MQTT child and must
+        # NOT be excluded from its own pool.
+        _port_name = self._port_name or ""
+        _is_serial_primary = (
+            _port_name.startswith("/dev/")
+            or _port_name.startswith("socket://")
+            or _port_name.startswith("rfc2217://")
+        )
         if (
-            isinstance(active_hgi_id, str)
+            _is_serial_primary
+            and isinstance(active_hgi_id, str)
             and self.mqtt_bridge is not None
             and hasattr(self.mqtt_bridge, "exclude_hgi_id")
             and active_hgi_id != self._last_excluded_hgi_id

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2698,7 +2698,12 @@ class RamsesCoordinator(DataUpdateCoordinator):
         raw_schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(raw_schema, dict):
             return
-        schema_dict = dict(raw_schema)
+        # Deep copy the schema so that async_update_entry detects the
+        # changes (shallow copy would modify the original in place,
+        # making the new options identical to the old ones).
+        import copy
+
+        schema_dict = copy.deepcopy(raw_schema)
         root_owner = schema_dict.get(SZ_OWNER, "me")
         changed = False
         count = 0

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -4353,7 +4353,10 @@ class RamsesCoordinator(DataUpdateCoordinator):
             _LOGGER.debug("Gateway health check failed: %s", err)
             return
 
-        if not is_active and not self._gateway_offline_notified:
+        # is_active can return None (unknown — no packets received yet).
+        # Treat None as "not offline" to avoid false alarms during startup
+        # or after a reconnect before the first packet arrives.
+        if is_active is False and not self._gateway_offline_notified:
             self._gateway_offline_notified = True
             timeout_mins = int(
                 gateway.hgi.message_timeout.total_seconds() / 60

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -257,7 +257,10 @@ class _MqttHgiDiscoveryCallback:
         # Only add if not already present (don't overwrite existing
         # entries — the user may have already rejected it).
         if hgi_str not in schema:
-            schema[hgi_str] = {"_class": "HGI"}
+            schema[hgi_str] = {
+                "_class": "HGI",
+                "_comment": "Supports: mqtt",
+            }
             # No _owner — this is a discovery candidate.
             new_options = dict(self._coordinator.entry.options)
             new_options[CONF_SCHEMA] = schema
@@ -1309,7 +1312,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
         return foreign
 
     def _extract_pool_hgis_from_schema(self) -> list[str]:
-        """Extract HGI IDs from the schema for pool membership.
+        """Extract HGI IDs from the schema for MQTT pool membership.
 
         Per issue 1119, HGIs (18: devices with _class: HGI) that have
         _owner matching the root _owner are accepted pool members.
@@ -1319,8 +1322,15 @@ class RamsesCoordinator(DataUpdateCoordinator):
         the scan engine can discover them, but they cannot send
         commands until the user accepts them (sets _owner).
 
-        :return: List of HGI device IDs for pool membership (accepted
-            members + discovery candidates), excluding the primary HGI.
+        Phase 2: HGIs with ``_preferred_type: "usb"`` are excluded
+        from the MQTT pool — they are serial-discovered devices, not
+        MQTT callback children.  This avoids duplicate packet
+        ingestion when an ESP is connected via USB and also publishes
+        on MQTT.
+
+        :return: List of HGI device IDs for MQTT pool membership
+            (accepted members + discovery candidates), excluding the
+            primary HGI and USB-preferred HGIs.
         """
         schema = self.entry.options.get(CONF_SCHEMA, {})
         if not isinstance(schema, dict):
@@ -1341,6 +1351,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 and not entry.get("_removed_from_pool")
                 and dev_id != primary_hgi
             ):
+                continue
+            # Phase 2: skip HGIs explicitly marked as USB-preferred.
+            # These are serial-discovered devices, not MQTT children.
+            preferred = entry.get("_preferred_type", "")
+            if isinstance(preferred, str) and preferred.lower() == "usb":
                 continue
             owner = entry.get(SZ_TR_OWNER)
             if owner is not None and owner == root_owner:
@@ -3629,6 +3644,25 @@ class RamsesCoordinator(DataUpdateCoordinator):
         ):
             self.mqtt_bridge.exclude_hgi_id(active_hgi_id)
             self._last_excluded_hgi_id = active_hgi_id
+            # Update the schema _comment to note this HGI supports USB.
+            # If it was already discovered via MQTT, merge the comment.
+            raw_schema = self.entry.options.get(CONF_SCHEMA, {})
+            if isinstance(raw_schema, dict):
+                schema_dict = dict(raw_schema)
+                entry = schema_dict.get(active_hgi_id, {})
+                if isinstance(entry, dict):
+                    existing = entry.get("_comment", "")
+                    if "usb" not in existing.lower():
+                        if "mqtt" in existing.lower():
+                            entry["_comment"] = "Supports: usb, mqtt"
+                        else:
+                            entry["_comment"] = "Supports: usb"
+                        schema_dict[active_hgi_id] = entry
+                        new_options = dict(self.entry.options)
+                        new_options[CONF_SCHEMA] = schema_dict
+                        self.hass.config_entries.async_update_entry(
+                            self.entry, options=new_options
+                        )
 
         if (
             self.discovery_manager is not None

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -736,6 +736,49 @@ class RamsesCoordinator(DataUpdateCoordinator):
         cached_schema = client_state.get(SZ_SCHEMA, {})
         _LOGGER.debug("CACHED_SCHEMA: %s", cached_schema)
 
+        # For serial/USB with a clean schema, the HGI ID isn't known
+        # until the first packet.  Extract it from stored packets and
+        # add it to the schema as a discovery candidate (no _owner) so
+        # ramses_rf includes it in the known_list.  This prevents
+        # ramses_rf from using the 18:000730 sentinel when the real
+        # HGI is 18:130236.
+        if not any(
+            k.startswith("18:")
+            and isinstance(v, dict)
+            and v.get("_class", "").upper() == "HGI"
+            for k, v in config_schema.items()
+        ):
+            stored_packets = client_state.get(SZ_PACKETS, {})
+            last_hgi_id: str | None = None
+            for _dtm, packet in stored_packets.items():
+                if not isinstance(packet, dict):
+                    continue
+                addr = packet.get("addr1") or packet.get("src")
+                if (
+                    isinstance(addr, str)
+                    and addr.startswith("18:")
+                    and addr != DEFAULT_HGI_ID
+                ):
+                    last_hgi_id = addr
+            if last_hgi_id and last_hgi_id not in config_schema:
+                config_schema = dict(config_schema)
+                config_schema[last_hgi_id] = {"_class": "HGI"}
+                _LOGGER.info(
+                    "Added last-known HGI %s to schema before client "
+                    "init (extracted from stored packets — serial HGI "
+                    "discovery candidate pending review)",
+                    last_hgi_id,
+                )
+                # Persist it so sync_learned_topology doesn't re-add
+                # with _owner.
+                new_options = {
+                    **self.entry.options,
+                    CONF_SCHEMA: config_schema,
+                }
+                self.hass.config_entries.async_update_entry(
+                    self.entry, options=new_options
+                )
+
         # Try merging schemas
         if cached_schema and (
             merged_schema := merge_schemas(

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -4220,6 +4220,8 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 self._excluded_serial_hgi_ids.add(hgi_id_to_exclude)
                 # Update the schema _comment to note this HGI supports
                 # USB.  If it was already discovered via MQTT, merge.
+                # Note: _preferred_type is NOT auto-corrected — the
+                # schema is user-controlled and leading (issue 1185).
                 raw_schema = self.entry.options.get(CONF_SCHEMA, {})
                 if isinstance(raw_schema, dict):
                     schema_dict = dict(raw_schema)

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -1109,24 +1109,25 @@ class RamsesCoordinator(DataUpdateCoordinator):
             and schema[primary_hgi].get("_class", "").upper() == "HGI"
             and SZ_TR_OWNER not in schema[primary_hgi]
         ):
-            # Primary HGI is in the schema but missing _owner — leave
-            # it as a discovery candidate.  The user must accept it via
-            # "Review Discovered Devices" to set _owner and
-            # _preferred_type.  Do NOT auto-enrich with _owner.
+            # Auto-set _owner for the primary HGI.  The primary HGI is
+            # the gateway that HA is actively using — it cannot be
+            # "declined" without removing the transport from the config,
+            # and it must be able to send commands immediately (not wait
+            # for user review).  This is especially important after a
+            # clean-schema restart where the user expects the primary
+            # HGI to be operational right away (issue 1020/R102).
             #
-            # NOTE: the primary HGI is still used as the active gateway
-            # for packet reception and device discovery even before the
-            # user accepts it.  This is by design — the primary
-            # transport (serial port) always receives packets.  The
-            # _owner controls whether the HGI is an accepted pool
-            # member (can send commands), not whether it receives
-            # packets.  For a single-HGI serial setup, the primary
-            # HGI IS the transport — you can't "decline" it without
-            # removing the serial port from the config.
+            # Secondary/non-primary HGIs remain as discovery candidates
+            # (no _owner) until the user accepts them via "Review
+            # Discovered Devices" — only the primary is auto-owned.
+            root_owner = schema.get(SZ_OWNER, "me")
+            schema[primary_hgi][SZ_TR_OWNER] = root_owner
+            schema_changed = True
             _LOGGER.info(
-                "Primary HGI %s is in schema without _owner "
-                "(discovery candidate — pending review)",
+                "Primary HGI %s auto-owned (_owner=%s) — primary "
+                "transport is always the local gateway",
                 primary_hgi,
+                root_owner,
             )
 
         # Add non-primary pool children's HGI IDs as discovery

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -42,6 +42,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    DEFAULT_HGI_ID,
     DOMAIN,
     HGI_PREFIX,
     SZ_DEVICE_COMMENTS,
@@ -1857,11 +1858,25 @@ class DiscoveryManager:
         all_ids = set(engine_devices.keys()) | set(self._metadata.keys())
 
         for device_id in all_ids:
-            # Skip local active HGI gateway — it is managed directly by the
-            # coordinator and auto-registered in the schema.
-            if self._active_hgi_id and device_id == self._active_hgi_id:
+            # Skip the ramses_rf sentinel HGI (18:000730) — it's a
+            # placeholder used when no real HGI is in the known_list.
+            # The real HGI is identified from the _PUZZ signature echo
+            # and should not be confused with this sentinel.
+            if device_id == DEFAULT_HGI_ID:
+                continue
+            # Skip local active HGI gateway — unless it's a discovery
+            # candidate (no _owner) pending review.  All HGIs go
+            # through "Review Discovered Devices", including the
+            # active/primary.  The user sets _owner and
+            # _preferred_type via the review flow.
+            if (
+                self._active_hgi_id
+                and device_id == self._active_hgi_id
+                and device_id not in self._schema_no_owner_ids
+            ):
                 _LOGGER.debug(
-                    "get_devices: skipping %s (active_hgi_id=%s)",
+                    "get_devices: skipping %s (active_hgi_id=%s, "
+                    "has _owner — not a discovery candidate)",
                     device_id,
                     self._active_hgi_id,
                 )
@@ -2560,6 +2575,10 @@ class DiscoveryManager:
                 new_ids.append(dev_id)
 
         for device_id in engine_devices:
+            # Skip the ramses_rf sentinel HGI (18:000730) — it's a
+            # placeholder, not a real device.
+            if device_id == DEFAULT_HGI_ID:
+                continue
             # Skip local active HGI gateway — it is managed directly by the
             # coordinator and auto-registered in the schema.  Foreign HGIs
             # (device_id != active_hgi_id) are discoverable devices.

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -2524,9 +2524,11 @@ class DiscoveryManager:
         for dev_id in self._schema_no_owner_ids:
             if not self._is_hgi(dev_id):
                 continue
-            # Skip the active HGI — it's managed by the coordinator
-            if self._active_hgi_id and dev_id == self._active_hgi_id:
-                continue
+            # The active HGI is no longer skipped — it should go
+            # through review like any other HGI discovery candidate.
+            # The user sets _owner and _preferred_type via the review
+            # flow.  The HGI is in the known_list (without _owner),
+            # so commands work even before acceptance.
             meta = self._metadata.get(dev_id)
             if meta is None:
                 self._metadata[dev_id] = DeviceMetadata()

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -322,7 +322,7 @@ class DiscoveryManager:
     @staticmethod
     def _is_hgi(device_id: str) -> bool:
         """Return True if ``device_id`` is an HGI gateway (18: prefix)."""
-        return device_id.startswith("18:")
+        return device_id.startswith(HGI_PREFIX)
 
     @staticmethod
     def _hgi_likely_type(device_id: str, likely_type: str | None) -> str:
@@ -332,7 +332,7 @@ class DiscoveryManager:
         ``likely_type`` may be ``"unknown"`` or ``None``.  The 18:
         prefix is authoritative — always use ``"HGI"``.
         """
-        if device_id.startswith("18:") and (
+        if device_id.startswith(HGI_PREFIX) and (
             not likely_type or likely_type.lower() == "unknown"
         ):
             return "HGI"

--- a/custom_components/ramses_cc/manifest.json
+++ b/custom_components/ramses_cc/manifest.json
@@ -15,9 +15,9 @@
       "aioesphomeapi>=45.3.1",
       "aiousbwatcher>=1.1.2",
       "pyserial-asyncio-fast>=0.16",
-      "ramses-rf==0.60.5",
+      "ramses-rf==0.60.6",
       "serialx>=1.8.2"
     ],
     "single_config_entry": true,
-    "version": "0.60.5"
+    "version": "0.60.6"
   }

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -119,6 +119,13 @@ class RamsesMqttPoolBridge:
         # Track which HGIs are online (LWT).
         self._online_hgis: set[str] = set()
 
+        # HGIs excluded from the MQTT pool (e.g. serial primary).
+        # These are known/configured HGIs that are handled by another
+        # transport.  LWT for these HGIs should update _comment (they
+        # support MQTT) but should NOT be treated as unknown discovery
+        # candidates (issue 1185/1208).
+        self._excluded_hgi_ids: set[str] = set()
+
     @property
     def device_ids(self) -> list[str]:
         """Return the configured HGI device IDs."""
@@ -607,6 +614,17 @@ class RamsesMqttPoolBridge:
                     self._discovery_callback.on_mqtt_capable(
                         DeviceIdT(hgi_id), topic=msg.topic
                     )
+            elif hgi_id in self._excluded_hgi_ids:
+                # Excluded HGI (e.g. serial primary that's also on
+                # MQTT).  Don't treat as unknown — just update _comment
+                # to include "mqtt" since it's publishing on MQTT.
+                # Don't call on_child_online (it's handled by the
+                # serial transport) or send !V (serial transport
+                # handles identity).
+                if self._discovery_callback is not None:
+                    self._discovery_callback.on_mqtt_capable(
+                        DeviceIdT(hgi_id), topic=msg.topic
+                    )
             else:
                 # Unknown HGI — the adapter's on_unknown_hgi will
                 # call the discovery callback internally.
@@ -649,6 +667,7 @@ class RamsesMqttPoolBridge:
             self._configured_hgi_ids = [
                 h for h in self._configured_hgi_ids if h != hgi_id
             ]
+            self._excluded_hgi_ids.add(hgi_id)
             _LOGGER.info(
                 "MqttPoolBridge: excluded HGI %s from MQTT pool "
                 "(serial primary)",

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -457,6 +457,26 @@ class RamsesMqttPoolBridge:
                 hgi_id,
             )
 
+            # Fallback: if the HGI is configured but hasn't sent LWT
+            # online (e.g. ramses_esp doesn't publish LWT, or the LWT
+            # was missed), mark it as online now so the pool child
+            # becomes connected and sendable (issue 1185).
+            if (
+                hgi_id in self._configured_hgi_ids
+                and hgi_id not in self._online_hgis
+            ):
+                _LOGGER.info(
+                    "MqttPoolBridge: HGI %s online (inferred from "
+                    "RX, no LWT seen)",
+                    hgi_id,
+                )
+                self._online_hgis.add(hgi_id)
+                self._adapter.on_child_online(hgi_id)
+                if self._is_accepted(hgi_id):
+                    self._hass.async_create_task(
+                        self._publish_command(hgi_id, "!V")
+                    )
+
             # Parse the raw frame into a Packet, then hand to adapter.
             dtm = dt_now().isoformat()
             try:

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -766,9 +766,16 @@ class RamsesMqttPoolBridge:
         if not parts:
             return None
         hgi_id = parts[-1]
-        # Validate format: 18:NNNNNN (HGI devices only).
-        if len(hgi_id) == 9 and hgi_id.startswith("18:") and hgi_id[2] == ":":
-            return hgi_id
+        # Validate format: 18:NNNNNN (HGI devices only, 6 hex digits).
+        # Normalise to uppercase so lowercase topics match configured
+        # HGI IDs (issue 1171).
+        if (
+            len(hgi_id) == 9
+            and hgi_id.startswith("18:")
+            and hgi_id[2] == ":"
+            and all(c in "0123456789ABCDEFabcdef" for c in hgi_id[3:])
+        ):
+            return hgi_id.upper()
         return None
 
     def _extract_payload(self, msg: ReceiveMessage) -> str:

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -25,6 +25,7 @@ with one child.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from collections.abc import Callable
@@ -601,6 +602,32 @@ class RamsesMqttPoolBridge:
             self._adapter.on_broker_disconnected()
 
     # -- Helpers --------------------------------------------------------
+
+    def exclude_hgi_id(self, hgi_id: str) -> None:
+        """Exclude an HGI from the MQTT pool at runtime.
+
+        Used when a serial primary discovers its HGI ID and that
+        same HGI is also publishing on MQTT — the serial transport
+        takes ownership, and the MQTT child should be removed to
+        avoid duplicate packet ingestion (Phase 2 hybrid pool).
+
+        :param hgi_id: The HGI device ID to exclude.
+        """
+        if hgi_id in self._configured_hgi_ids:
+            self._configured_hgi_ids = [
+                h for h in self._configured_hgi_ids if h != hgi_id
+            ]
+            _LOGGER.info(
+                "MqttPoolBridge: excluded HGI %s from MQTT pool "
+                "(serial primary)",
+                hgi_id,
+            )
+        if self._accepted_hgi_ids and hgi_id in self._accepted_hgi_ids:
+            self._accepted_hgi_ids.discard(hgi_id)
+        # Remove from the pool's children if it exists.
+        if self._pool is not None:
+            with contextlib.suppress(Exception):
+                self._pool.remove_child(hgi_id)
 
     def _is_accepted(self, hgi_id: str) -> bool:
         """Return whether ``hgi_id`` is an accepted pool member.

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -580,11 +580,11 @@ class RamsesMqttPoolBridge:
                 # Notify discovery callback so it can update _comment
                 # to include "mqtt" for HGIs already in the schema
                 # (e.g. added by serial probe with only "usb").
-                # The adapter's on_unknown_hgi is NOT called here
-                # because the HGI is configured — we only want the
-                # _comment update, not pool-level discovery.
+                # Use on_mqtt_capable (not on_unknown_hgi) because the
+                # HGI is already configured — we only want the _comment
+                # update, not pool-level discovery (issue 1208).
                 if self._discovery_callback is not None:
-                    self._discovery_callback.on_unknown_hgi(
+                    self._discovery_callback.on_mqtt_capable(
                         DeviceIdT(hgi_id), topic=msg.topic
                     )
             else:

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -577,7 +577,19 @@ class RamsesMqttPoolBridge:
                     self._hass.async_create_task(
                         self._publish_command(hgi_id, "!V")
                     )
+                # Notify discovery callback so it can update _comment
+                # to include "mqtt" for HGIs already in the schema
+                # (e.g. added by serial probe with only "usb").
+                # The adapter's on_unknown_hgi is NOT called here
+                # because the HGI is configured — we only want the
+                # _comment update, not pool-level discovery.
+                if self._discovery_callback is not None:
+                    self._discovery_callback.on_unknown_hgi(
+                        DeviceIdT(hgi_id), topic=msg.topic
+                    )
             else:
+                # Unknown HGI — the adapter's on_unknown_hgi will
+                # call the discovery callback internally.
                 self._adapter.on_unknown_hgi(
                     DeviceIdT(hgi_id), topic=msg.topic
                 )

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -237,6 +237,70 @@ class RamsesMqttPoolBridge:
 
         return self._pool
 
+    async def async_attach_to_pool(
+        self,
+        pool: PooledTransport,
+        *,
+        callback_child_start_index: int,
+    ) -> None:
+        """Attach MQTT callback adapter to an existing hybrid pool.
+
+        For hybrid pools (serial primary + MQTT additional, or vice
+        versa), the coordinator creates a single ``PooledTransport``
+        via ``pooled_transport_factory`` with both transport-driven
+        (serial) and callback-driven (MQTT) children.  This method
+        subscribes to MQTT topics and creates the
+        ``MqttCallbackPoolAdapter`` that feeds packets into the
+        callback-driven children of the existing pool.
+
+        :param pool: The existing ``PooledTransport`` to attach to.
+        :param callback_child_start_index: Index of the first
+            callback-driven child in the pool (serial children come
+            first).
+        """
+        _LOGGER.debug(
+            "MqttPoolBridge: async_attach_to_pool for %d configured "
+            "HGIs (callback children start at index %d): %s",
+            len(self._configured_hgi_ids),
+            callback_child_start_index,
+            self._configured_hgi_ids,
+        )
+
+        # 0. Wait for HA's MQTT integration to be available.
+        try:
+            await mqtt.async_wait_for_mqtt_client(self._hass)
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning(
+                "MqttPoolBridge: timed out waiting for HA MQTT "
+                "client setup — continuing anyway"
+            )
+
+        # 1. Subscribe to wildcard MQTT topics.
+        await self._async_attach()
+
+        # 2. Store the pool reference (don't create a new one).
+        self._pool = pool
+
+        # 3. Create the adapter that bridges callbacks to the pool.
+        #    The adapter uses the pool's _on_child_packet() method to
+        #    feed packets into the callback-driven children.
+        self._adapter = MqttCallbackPoolAdapter(
+            self._pool,
+            self._configured_hgi_ids,
+            self,  # self implements MqttPoolOutbound
+            discovery_callback=self._discovery_callback,
+            accepted_hgi_ids=self._accepted_hgi_ids,
+            callback_child_start_index=callback_child_start_index,
+        )
+
+        _LOGGER.info(
+            "MqttPoolBridge: attached to hybrid pool with %d MQTT "
+            "callback-driven children (indices %d..%d)",
+            len(self._configured_hgi_ids),
+            callback_child_start_index,
+            callback_child_start_index + len(self._configured_hgi_ids) - 1,
+        )
+
     async def _async_attach(self) -> None:
         """Subscribe to wildcard MQTT topics."""
         if self._sub_rx and self._sub_cmd:

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -34,6 +34,7 @@ from homeassistant.components.mqtt.models import ReceiveMessage
 from homeassistant.core import HomeAssistant, callback
 
 from ramses_tx import exceptions as exc
+from ramses_tx.const import HGI_PREFIX
 from ramses_tx.helpers import dt_now
 from ramses_tx.packet import Packet
 from ramses_tx.transport import TransportConfig
@@ -774,7 +775,7 @@ class RamsesMqttPoolBridge:
         # Validate format: 18:NNNNNN (HGI devices only).
         if (
             len(hgi_id) == 9
-            and hgi_id.startswith("18:")
+            and hgi_id.startswith(HGI_PREFIX)
             and hgi_id[3:].isdigit()
         ):
             return hgi_id

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -310,70 +310,73 @@ class RamsesMqttPoolBridge:
         )
 
     async def _async_attach(self) -> None:
-        """Subscribe to wildcard MQTT topics."""
-        if all(
-            (self._sub_rx, self._sub_cmd, self._sub_status, self._sub_broker)
-        ):
-            return
+        """Subscribe to wildcard MQTT topics.
 
+        Only subscribes to topics that don't already have a handle,
+        so re-attach after partial failure doesn't leak subscriptions.
+        """
         # Wildcard RX: {prefix}/+/rx
         topic_rx_wildcard = f"{self._topic_prefix}{_TOPIC_WILDCARD_RX}"
-        _LOGGER.debug(
-            "MqttPoolBridge: Subscribing to wildcard RX %s",
-            topic_rx_wildcard,
-        )
-
         # Wildcard command results: {prefix}/+/cmd/result
         topic_cmd_wildcard = (
             f"{self._topic_prefix}{_TOPIC_WILDCARD_CMD_RESULT}"
         )
-        _LOGGER.debug(
-            "MqttPoolBridge: Subscribing to wildcard CMD %s",
-            topic_cmd_wildcard,
-        )
-
         # Wildcard status/LWT: {prefix}/+
         topic_status_wildcard = f"{self._topic_prefix}{_TOPIC_WILDCARD_STATUS}"
-        _LOGGER.debug(
-            "MqttPoolBridge: Subscribing to wildcard status %s",
-            topic_status_wildcard,
-        )
 
         try:
-            self._sub_rx = await mqtt.async_subscribe(
-                self._hass,
-                topic_rx_wildcard,
-                self._handle_rx_message,
-                qos=0,
-            )
-            _LOGGER.info("MqttPoolBridge: Subscribed to %s", topic_rx_wildcard)
+            if self._sub_rx is None:
+                _LOGGER.debug(
+                    "MqttPoolBridge: Subscribing to wildcard RX %s",
+                    topic_rx_wildcard,
+                )
+                self._sub_rx = await mqtt.async_subscribe(
+                    self._hass,
+                    topic_rx_wildcard,
+                    self._handle_rx_message,
+                    qos=0,
+                )
+                _LOGGER.info(
+                    "MqttPoolBridge: Subscribed to %s", topic_rx_wildcard
+                )
 
-            self._sub_cmd = await mqtt.async_subscribe(
-                self._hass,
-                topic_cmd_wildcard,
-                self._handle_cmd_message,
-                qos=0,
-            )
-            _LOGGER.info(
-                "MqttPoolBridge: Subscribed to %s",
-                topic_cmd_wildcard,
-            )
+            if self._sub_cmd is None:
+                _LOGGER.debug(
+                    "MqttPoolBridge: Subscribing to wildcard CMD %s",
+                    topic_cmd_wildcard,
+                )
+                self._sub_cmd = await mqtt.async_subscribe(
+                    self._hass,
+                    topic_cmd_wildcard,
+                    self._handle_cmd_message,
+                    qos=0,
+                )
+                _LOGGER.info(
+                    "MqttPoolBridge: Subscribed to %s",
+                    topic_cmd_wildcard,
+                )
 
-            self._sub_status = await mqtt.async_subscribe(
-                self._hass,
-                topic_status_wildcard,
-                self._handle_status_message,
-                qos=0,
-            )
-            _LOGGER.info(
-                "MqttPoolBridge: Subscribed to %s",
-                topic_status_wildcard,
-            )
+            if self._sub_status is None:
+                _LOGGER.debug(
+                    "MqttPoolBridge: Subscribing to wildcard status %s",
+                    topic_status_wildcard,
+                )
+                self._sub_status = await mqtt.async_subscribe(
+                    self._hass,
+                    topic_status_wildcard,
+                    self._handle_status_message,
+                    qos=0,
+                )
+                _LOGGER.info(
+                    "MqttPoolBridge: Subscribed to %s",
+                    topic_status_wildcard,
+                )
 
-            self._sub_broker = mqtt.async_subscribe_connection_status(
-                self._hass, self._handle_broker_status
-            )
-            _LOGGER.info("MqttPoolBridge: Subscribed to broker status")
+            if self._sub_broker is None:
+                self._sub_broker = mqtt.async_subscribe_connection_status(
+                    self._hass, self._handle_broker_status
+                )
+                _LOGGER.info("MqttPoolBridge: Subscribed to broker status")
 
         except Exception as err:
             self.close()

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -18,9 +18,8 @@ The pool bridge:
 - Parses raw RX frame strings into :class:`Packet` objects before
   handing them to the :class:`MqttCallbackPoolAdapter`.
 
-The single-HGI path (:class:`RamsesMqttBridge`) remains unchanged
-for backward compatibility — a single MQTT HGI is **not** a pool
-with one child.
+The same callback-driven transport is used for one or more MQTT HGIs,
+so wildcard discovery and lifecycle handling stay consistent.
 """
 
 from __future__ import annotations
@@ -71,9 +70,7 @@ class RamsesMqttPoolBridge:
     MQTT connection.  Uses :class:`MqttCallbackPoolAdapter` to map
     callback events into a :class:`PooledTransport`.
 
-    The single-HGI :class:`RamsesMqttBridge` path is preserved
-    unchanged — this class is only used when multiple MQTT HGIs
-    are configured.
+    This class supports both single-HGI and multi-HGI MQTT setups.
 
     :param hass: Home Assistant instance.
     :param topic_prefix: MQTT base topic (e.g. ``RAMSES/GATEWAY``).
@@ -101,10 +98,12 @@ class RamsesMqttPoolBridge:
         """Initialise the multi-HGI MQTT pool bridge."""
         self._hass = hass
         self._topic_prefix = topic_prefix.rstrip("/")
-        self._configured_hgi_ids = configured_hgi_ids
+        self._configured_hgi_ids = list(dict.fromkeys(configured_hgi_ids))
         self._discovery_callback = discovery_callback
         self._wait_online_timeout = wait_online_timeout
-        self._accepted_hgi_ids = accepted_hgi_ids
+        self._accepted_hgi_ids = (
+            set(accepted_hgi_ids) if accepted_hgi_ids is not None else None
+        )
 
         self._pool: PooledTransport | None = None
         self._adapter: MqttCallbackPoolAdapter | None = None
@@ -187,10 +186,7 @@ class RamsesMqttPoolBridge:
                 "client setup — continuing anyway"
             )
 
-        # 1. Subscribe to wildcard MQTT topics before starting.
-        await self._async_attach()
-
-        # 2. Create the PooledTransport with callback-driven
+        # 1. Create the PooledTransport with callback-driven
         #    children.  All children are None (callback-driven).
         n = len(self._configured_hgi_ids)
         self._pool = PooledTransport(
@@ -211,6 +207,10 @@ class RamsesMqttPoolBridge:
             discovery_callback=self._discovery_callback,
             accepted_hgi_ids=self._accepted_hgi_ids,
         )
+
+        # 3. Subscribe after creating the adapter so retained LWT
+        #    messages can be handled immediately.
+        await self._async_attach()
 
         # 4. Bind the protocol immediately.  The pool is connected to
         #    the MQTT broker via HA's MQTT integration — children (HGIs)
@@ -282,13 +282,10 @@ class RamsesMqttPoolBridge:
                 "client setup — continuing anyway"
             )
 
-        # 1. Subscribe to wildcard MQTT topics.
-        await self._async_attach()
-
-        # 2. Store the pool reference (don't create a new one).
+        # 1. Store the pool reference (don't create a new one).
         self._pool = pool
 
-        # 3. Create the adapter that bridges callbacks to the pool.
+        # 2. Create the adapter that bridges callbacks to the pool.
         #    The adapter uses the pool's _on_child_packet() method to
         #    feed packets into the callback-driven children.
         self._adapter = MqttCallbackPoolAdapter(
@@ -300,6 +297,10 @@ class RamsesMqttPoolBridge:
             callback_child_start_index=callback_child_start_index,
         )
 
+        # 3. Subscribe after creating the adapter so retained LWT
+        #    messages can be handled immediately.
+        await self._async_attach()
+
         _LOGGER.info(
             "MqttPoolBridge: attached to hybrid pool with %d MQTT "
             "callback-driven children (indices %d..%d)",
@@ -310,7 +311,9 @@ class RamsesMqttPoolBridge:
 
     async def _async_attach(self) -> None:
         """Subscribe to wildcard MQTT topics."""
-        if self._sub_rx and self._sub_cmd:
+        if all(
+            (self._sub_rx, self._sub_cmd, self._sub_status, self._sub_broker)
+        ):
             return
 
         # Wildcard RX: {prefix}/+/rx
@@ -373,11 +376,10 @@ class RamsesMqttPoolBridge:
             _LOGGER.info("MqttPoolBridge: Subscribed to broker status")
 
         except Exception as err:
-            _LOGGER.error(
-                "MqttPoolBridge: Failed to subscribe: %s",
-                err,
-                exc_info=True,
-            )
+            self.close()
+            raise exc.TransportError(
+                f"MqttPoolBridge failed to subscribe: {err}"
+            ) from err
 
     # -- MqttPoolOutbound implementation --------------------------------
 
@@ -473,6 +475,11 @@ class RamsesMqttPoolBridge:
                     "MqttPoolBridge: RX from excluded HGI %s "
                     "(serial transport) — skipping",
                     hgi_id,
+                )
+                return
+            if hgi_id not in self._configured_hgi_ids:
+                self._adapter.on_unknown_hgi(
+                    DeviceIdT(hgi_id), topic=msg.topic
                 )
                 return
 
@@ -691,8 +698,6 @@ class RamsesMqttPoolBridge:
                 "(serial primary)",
                 hgi_id,
             )
-        if self._accepted_hgi_ids and hgi_id in self._accepted_hgi_ids:
-            self._accepted_hgi_ids.discard(hgi_id)
         # Mark the callback-driven child as offline via the adapter.
         # This makes it non-sendable (excluded from routing) without
         # structural pool mutation (issue 1119).
@@ -720,9 +725,6 @@ class RamsesMqttPoolBridge:
         # Re-add to configured HGIs so LWT/RX handlers process it again.
         if hgi_id not in self._configured_hgi_ids:
             self._configured_hgi_ids.append(hgi_id)
-        # Re-add to accepted HGIs so it becomes sendable.
-        if self._accepted_hgi_ids is not None:
-            self._accepted_hgi_ids.add(hgi_id)
         # If the HGI is already online (LWT was retained), bring the
         # pool child online now.  Otherwise the next LWT will do it.
         if hgi_id in self._online_hgis and self._adapter is not None:
@@ -766,16 +768,13 @@ class RamsesMqttPoolBridge:
         if not parts:
             return None
         hgi_id = parts[-1]
-        # Validate format: 18:NNNNNN (HGI devices only, 6 hex digits).
-        # Normalise to uppercase so lowercase topics match configured
-        # HGI IDs (issue 1171).
+        # Validate format: 18:NNNNNN (HGI devices only).
         if (
             len(hgi_id) == 9
             and hgi_id.startswith("18:")
-            and hgi_id[2] == ":"
-            and all(c in "0123456789ABCDEFabcdef" for c in hgi_id[3:])
+            and hgi_id[3:].isdigit()
         ):
-            return hgi_id.upper()
+            return hgi_id
         return None
 
     def _extract_payload(self, msg: ReceiveMessage) -> str:
@@ -791,11 +790,8 @@ class RamsesMqttPoolBridge:
     def close(self) -> None:
         """Cleanup subscriptions."""
         _LOGGER.debug("MqttPoolBridge: cleanup called")
-        if self._sub_rx:
-            self._sub_rx()
-        if self._sub_cmd:
-            self._sub_cmd()
-        if self._sub_status:
-            self._sub_status()
-        if self._sub_broker:
-            self._sub_broker()
+        for attr_name in ("_sub_rx", "_sub_cmd", "_sub_status", "_sub_broker"):
+            unsubscribe = getattr(self, attr_name)
+            if unsubscribe is not None:
+                unsubscribe()
+                setattr(self, attr_name, None)

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -464,6 +464,19 @@ class RamsesMqttPoolBridge:
                 hgi_id,
             )
 
+            # Skip excluded HGIs (serial primary or serial additional
+            # that's also publishing on MQTT).  The serial transport
+            # handles these HGIs — forwarding MQTT packets to the pool
+            # would cause duplicate ingestion (even if deduped) and
+            # incorrectly mark the excluded MQTT child as connected.
+            if hgi_id in self._excluded_hgi_ids:
+                _LOGGER.debug(
+                    "MqttPoolBridge: RX from excluded HGI %s "
+                    "(serial transport) — skipping",
+                    hgi_id,
+                )
+                return
+
             # Fallback: if the HGI is configured but hasn't sent LWT
             # online (e.g. ramses_esp doesn't publish LWT, or the LWT
             # was missed), mark it as online now so the pool child

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -25,7 +25,6 @@ with one child.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 from collections.abc import Callable
@@ -607,7 +606,18 @@ class RamsesMqttPoolBridge:
         if payload_str == "online":
             _LOGGER.info("MqttPoolBridge: HGI %s online (LWT)", hgi_id)
             self._online_hgis.add(hgi_id)
-            if hgi_id in self._configured_hgi_ids:
+            if hgi_id in self._excluded_hgi_ids:
+                # Excluded HGI (e.g. serial primary that's also on
+                # MQTT).  Don't treat as unknown — just update _comment
+                # to include "mqtt" since it's publishing on MQTT.
+                # Don't call on_child_online (it's handled by the
+                # serial transport) or send !V (serial transport
+                # handles identity).
+                if self._discovery_callback is not None:
+                    self._discovery_callback.on_mqtt_capable(
+                        DeviceIdT(hgi_id), topic=msg.topic
+                    )
+            elif hgi_id in self._configured_hgi_ids:
                 self._adapter.on_child_online(hgi_id)
                 # Send identity handshake only to accepted HGIs.
                 # Receive-only discovery candidates must not be sent
@@ -623,17 +633,6 @@ class RamsesMqttPoolBridge:
                 # Use on_mqtt_capable (not on_unknown_hgi) because the
                 # HGI is already configured — we only want the _comment
                 # update, not pool-level discovery (issue 1208).
-                if self._discovery_callback is not None:
-                    self._discovery_callback.on_mqtt_capable(
-                        DeviceIdT(hgi_id), topic=msg.topic
-                    )
-            elif hgi_id in self._excluded_hgi_ids:
-                # Excluded HGI (e.g. serial primary that's also on
-                # MQTT).  Don't treat as unknown — just update _comment
-                # to include "mqtt" since it's publishing on MQTT.
-                # Don't call on_child_online (it's handled by the
-                # serial transport) or send !V (serial transport
-                # handles identity).
                 if self._discovery_callback is not None:
                     self._discovery_callback.on_mqtt_capable(
                         DeviceIdT(hgi_id), topic=msg.topic
@@ -671,27 +670,34 @@ class RamsesMqttPoolBridge:
 
         Used when a serial primary discovers its HGI ID and that
         same HGI is also publishing on MQTT — the serial transport
-        takes ownership, and the MQTT child should be removed to
-        avoid duplicate packet ingestion (Phase 2 hybrid pool).
+        takes ownership, and the MQTT child should be made
+        non-sendable to avoid duplicate packet ingestion (Phase 2
+        hybrid pool, issue 1119).
+
+        This does NOT structurally remove the child from the pool
+        (``PooledTransport`` has no ``remove_child()`` and runtime
+        structural mutation is intentionally unsupported).  Instead
+        it marks the callback-driven child as offline/disconnected
+        via the adapter so it's excluded from routing but remains
+        in the pool for quick re-inclusion when the serial
+        transport disconnects.
 
         :param hgi_id: The HGI device ID to exclude.
         """
         if hgi_id in self._configured_hgi_ids:
-            self._configured_hgi_ids = [
-                h for h in self._configured_hgi_ids if h != hgi_id
-            ]
             self._excluded_hgi_ids.add(hgi_id)
             _LOGGER.info(
-                "MqttPoolBridge: excluded HGI %s from MQTT pool "
+                "MqttPoolBridge: excluding HGI %s from MQTT pool "
                 "(serial primary)",
                 hgi_id,
             )
         if self._accepted_hgi_ids and hgi_id in self._accepted_hgi_ids:
             self._accepted_hgi_ids.discard(hgi_id)
-        # Remove from the pool's children if it exists.
-        if self._pool is not None:
-            with contextlib.suppress(Exception):
-                self._pool.remove_child(hgi_id)
+        # Mark the callback-driven child as offline via the adapter.
+        # This makes it non-sendable (excluded from routing) without
+        # structural pool mutation (issue 1119).
+        if self._adapter is not None:
+            self._adapter.on_child_offline(hgi_id, definitive=True)
 
     def unexclude_hgi_id(self, hgi_id: str) -> None:
         """Re-include an HGI in the MQTT pool after its serial transport disconnected.

--- a/custom_components/ramses_cc/mqtt_pool_bridge.py
+++ b/custom_components/ramses_cc/mqtt_pool_bridge.py
@@ -693,6 +693,35 @@ class RamsesMqttPoolBridge:
             with contextlib.suppress(Exception):
                 self._pool.remove_child(hgi_id)
 
+    def unexclude_hgi_id(self, hgi_id: str) -> None:
+        """Re-include an HGI in the MQTT pool after its serial transport disconnected.
+
+        When a serial child disconnects (e.g. USB unplugged), its HGI
+        should no longer be excluded from the MQTT pool — otherwise
+        packets arriving via MQTT from that HGI are silently dropped
+        (issue 1185).
+
+        :param hgi_id: The HGI device ID to re-include.
+        """
+        if hgi_id not in self._excluded_hgi_ids:
+            return
+        self._excluded_hgi_ids.discard(hgi_id)
+        _LOGGER.info(
+            "MqttPoolBridge: re-included HGI %s in MQTT pool "
+            "(serial transport disconnected)",
+            hgi_id,
+        )
+        # Re-add to configured HGIs so LWT/RX handlers process it again.
+        if hgi_id not in self._configured_hgi_ids:
+            self._configured_hgi_ids.append(hgi_id)
+        # Re-add to accepted HGIs so it becomes sendable.
+        if self._accepted_hgi_ids is not None:
+            self._accepted_hgi_ids.add(hgi_id)
+        # If the HGI is already online (LWT was retained), bring the
+        # pool child online now.  Otherwise the next LWT will do it.
+        if hgi_id in self._online_hgis and self._adapter is not None:
+            self._adapter.on_child_online(hgi_id)
+
     def _is_accepted(self, hgi_id: str) -> bool:
         """Return whether ``hgi_id`` is an accepted pool member.
 

--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -2715,27 +2715,19 @@ def sync_learned_topology(
     for dev_id in sorted(hgi_ids):
         if dev_id not in new_schema:
             new_schema[dev_id] = {SZ_TR_CLASS: "HGI"}
-            if (
-                root_owner
-                and active_hgi_id
-                and dev_id == active_hgi_id
-                and not new_schema[dev_id].get("_removed_from_pool")
-            ):
-                new_schema[dev_id][SZ_TR_OWNER] = root_owner
+            # Do NOT auto-set _owner for the active HGI.  All HGIs
+            # (including the primary) go through "Review Discovered
+            # Devices" as discovery candidates (no _owner).  The
+            # user sets _owner and _preferred_type via the review
+            # flow.  The HGI is still in the known_list (devices
+            # without _owner are not foreign), so commands work.
             changed = True
         elif isinstance(new_schema[dev_id], dict):
             if SZ_TR_CLASS not in new_schema[dev_id]:
                 new_schema[dev_id][SZ_TR_CLASS] = "HGI"
                 changed = True
-            if (
-                root_owner
-                and active_hgi_id
-                and dev_id == active_hgi_id
-                and SZ_TR_OWNER not in new_schema[dev_id]
-                and not new_schema[dev_id].get("_removed_from_pool")
-            ):
-                new_schema[dev_id][SZ_TR_OWNER] = root_owner
-                changed = True
+            # Do NOT auto-enrich with _owner — leave as discovery
+            # candidate for user review.
 
     # 5. Update device comments with zone info from the learned schema.
     # The scan engine's zone_index comes from 30C9 broadcast packets, which

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -146,6 +146,7 @@
             "pool_zigbee_not_supported": "Zigbee pool members are not yet supported (planned for Phase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT pool members require an MQTT primary transport. Switch the primary port to MQTT first.",
             "pool_confirm_clear_last": "You are removing the last HGI. Check 'Confirm: clear all HGIs' below and submit again to proceed.",
+            "mqtt_integration_required": "The Home Assistant MQTT integration is not configured. Add it first via Settings > Devices & Services > Add Integration > MQTT, then switch the HGI to MQTT.",
             "mqtt_url_required": "Please enter an MQTT URL.",
             "mqtt_url_invalid": "URL must start with mqtt://",
             "mqtt_url_no_hgi_id": "URL must contain an HGI device ID (18:NNNNNN) in the path.",
@@ -288,7 +289,7 @@
             },
             "manage_pool_mqtt_url": {
                 "title": "Add MQTT HGI via full URL",
-                "description": "Enter the full MQTT URL including the HGI ID in the path, e.g. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
+                "description": "{message}\nEnter the full MQTT URL including the HGI ID in the path, e.g. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
                 "data": {
                     "mqtt_url": "MQTT URL"
                 }

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -147,9 +147,9 @@
             "pool_mqtt_requires_mqtt_primary": "MQTT pool members require an MQTT primary transport. Switch the primary port to MQTT first.",
             "pool_confirm_clear_last": "You are removing the last HGI. Check 'Confirm: clear all HGIs' below and submit again to proceed.",
             "mqtt_integration_required": "The Home Assistant MQTT integration is not configured. Add it first via Settings > Devices & Services > Add Integration > MQTT, then switch the HGI to MQTT.",
-            "mqtt_url_required": "Please enter an MQTT URL.",
-            "mqtt_url_invalid": "URL must start with mqtt://",
-            "mqtt_url_no_hgi_id": "URL must contain an HGI device ID (18:NNNNNN) in the path.",
+            "mqtt_hgi_id_required": "Please enter an HGI device ID.",
+            "mqtt_hgi_id_invalid": "HGI device ID must be in the format 18:NNNNNN.",
+            "mqtt_hgi_id_mismatch": "The HGI device ID does not match the HGI being switched. Please enter the correct HGI ID.",
             "mqtt_host_required": "MQTT broker host is required.",
             "hgi_id_required": "HGI device ID is required.",
             "hgi_id_invalid": "HGI device ID must be in the format 18:NNNNNN."
@@ -288,10 +288,11 @@
                 }
             },
             "manage_pool_mqtt_url": {
-                "title": "Add MQTT HGI via full URL",
-                "description": "{message}\nEnter the full MQTT URL including the HGI ID in the path, e.g. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
+                "title": "Add MQTT HGI",
+                "description": "{message}",
                 "data": {
-                    "mqtt_url": "MQTT URL"
+                    "hgi_id": "HGI device ID (18:NNNNNN)",
+                    "topic_prefix": "MQTT topic prefix (optional)"
                 }
             }
         }

--- a/custom_components/ramses_cc/translations/en.json
+++ b/custom_components/ramses_cc/translations/en.json
@@ -271,9 +271,10 @@
             },
             "hgi_pool": {
                 "title": "HGI Pool Management",
-                "description": "Primary port: {primary_port}\nCurrent additional ports: {current_count}\nPool members (uncheck to remove): {schema_pool_members}",
+                "description": "Primary port: {primary_port}\nCurrent additional ports: {current_count}\nPool members (uncheck to remove): {schema_pool_members}\nDiscovery candidates (check to accept): {discovery_candidates}",
                 "data": {
                     "schema_pool_members": "Pool members (uncheck to remove, primary can be removed — auto-promotes another)",
+                    "accept_discovery_candidates": "Discovery candidates (check to accept as pool members)",
                     "additional_ports": "Additional ports (USB, Zigbee, external MQTT)",
                     "add_new_port": "Add new HGI",
                     "wait_online_timeout": "MQTT pool: seconds to wait for at least one HGI to come online",

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -270,9 +270,10 @@
             },
             "hgi_pool": {
                 "title": "HGI Pool Beheer",
-                "description": "Primaire poort: {primary_port}\nHuidige extra poorten: {current_count}\nPool-leden (vink uit om te verwijderen): {schema_pool_members}",
+                "description": "Primaire poort: {primary_port}\nHuidige extra poorten: {current_count}\nPool-leden (vink uit om te verwijderen): {schema_pool_members}\nOntdekte kandidaten (vink aan om te accepteren): {discovery_candidates}",
                 "data": {
                     "schema_pool_members": "Pool-leden (vink uit om te verwijderen, primaire kan verwijderd worden — promoot automatisch een andere)",
+                    "accept_discovery_candidates": "Ontdekte kandidaten (vink aan om als pool-lid te accepteren)",
                     "additional_ports": "Extra poorten (USB, Zigbee, externe MQTT)",
                     "add_new_port": "Nieuwe HGI toevoegen",
                     "confirm_clear_last": "Bevestig: alle HGI's wissen en verbinding resetten"

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -146,9 +146,9 @@
             "pool_zigbee_not_supported": "Zigbee-poolleden worden nog niet ondersteund (gepland voor Fase 3).",
             "pool_mqtt_requires_mqtt_primary": "MQTT-poolleden vereisen een MQTT-primaire transport. Schakel de primaire poort eerst naar MQTT.",
             "pool_confirm_clear_last": "U verwijdert de laatste HGI. Vink 'Bevestig: alle HGI's wissen' hieronder aan en dien opnieuw in om door te gaan.",
-            "mqtt_url_required": "Voer een MQTT-URL in.",
-            "mqtt_url_invalid": "URL moet beginnen met mqtt://",
-            "mqtt_url_no_hgi_id": "URL moet een HGI-apparaat-ID (18:NNNNNN) in het pad bevatten.",
+            "mqtt_hgi_id_required": "Voer een HGI-apparaat-ID in.",
+            "mqtt_hgi_id_invalid": "HGI-apparaat-ID moet de indeling 18:NNNNNN hebben.",
+            "mqtt_hgi_id_mismatch": "Het HGI-apparaat-ID komt niet overeen met de HGI die wordt omgeschakeld. Voer het juiste HGI-ID in.",
             "mqtt_host_required": "MQTT-brokerhost is vereist.",
             "hgi_id_required": "HGI-apparaat-ID is vereist.",
             "hgi_id_invalid": "HGI-apparaat-ID moet de indeling 18:NNNNNN hebben."
@@ -286,10 +286,11 @@
                 }
             },
             "manage_pool_mqtt_url": {
-                "title": "MQTT HGI via volledige URL toevoegen",
-                "description": "{message}\nVoer de volledige MQTT-URL in inclusief het HGI-ID in het pad, bijv. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
+                "title": "MQTT HGI toevoegen",
+                "description": "{message}",
                 "data": {
-                    "mqtt_url": "MQTT URL"
+                    "hgi_id": "HGI-apparaat-ID (18:NNNNNN)",
+                    "topic_prefix": "MQTT-onderwerpprefix (optioneel)"
                 }
             }
         }

--- a/custom_components/ramses_cc/translations/nl.json
+++ b/custom_components/ramses_cc/translations/nl.json
@@ -287,7 +287,7 @@
             },
             "manage_pool_mqtt_url": {
                 "title": "MQTT HGI via volledige URL toevoegen",
-                "description": "Voer de volledige MQTT-URL in inclusief het HGI-ID in het pad, bijv. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
+                "description": "{message}\nVoer de volledige MQTT-URL in inclusief het HGI-ID in het pad, bijv. mqtt://user:pass@broker:1883/RAMSES/GATEWAY/18:001111",
                 "data": {
                     "mqtt_url": "MQTT URL"
                 }

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -7,7 +7,7 @@
   aiousbwatcher         >= 1.1.2                 # as per: manifest.json latest: 1.1.2
   aioesphomeapi         >= 46.3.0               # required by config_flow > homeassistant.components.usb
   pyserial-asyncio-fast >= 0.16                  # as per: manifest.json latest: 0.16
-  ramses-rf             == 0.60.5                # as per: manifest.json latest:
+  ramses-rf             == 0.60.6                # as per: manifest.json latest:
   # pycares               == 5.0.1               # ha_cc 2026.2: aiodns 4.0.0: pycares==5.0.1=latest
                                                  # (ha_cc 2025.12: aiodns 3.5.0 was not compatible with pycares 5.x)
   serialx               >= 1.10.0                 # required by config_flow > homeassistant.components.usb, see issue #623

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -320,7 +320,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'on',
+      'state': 'unknown',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
@@ -860,7 +860,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'on',
+      'state': 'unknown',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({

--- a/tests/tests_new/test_binary_sensor.py
+++ b/tests/tests_new/test_binary_sensor.py
@@ -21,7 +21,10 @@ from custom_components.ramses_cc.binary_sensor import (
     RamsesBinarySensorEntityDescription,
     RamsesGatewayBinarySensor,
     RamsesLogbookBinarySensor,
+    RamsesPoolChildBinarySensor,
+    RamsesPoolStatusSensor,
     RamsesSystemBinarySensor,
+    _add_pool_status_entities,
     async_setup_entry,
 )
 from ramses_rf.const import SZ_FILTER_DIRTY, SZ_FROST_CYCLE, SZ_HAS_FAULT
@@ -39,6 +42,7 @@ def mock_coordinator() -> MagicMock:
     """
     coordinator = MagicMock()
     coordinator.async_register_platform = MagicMock()
+    coordinator.is_pool_enabled = False
     return coordinator
 
 
@@ -73,6 +77,65 @@ async def test_async_setup_entry(
     assert mock_add_entities.called
     assert len(created_entities) == 1
     assert isinstance(created_entities[0], RamsesGatewayBinarySensor)
+
+
+def test_pool_status_entities_add_children_on_coordinator_update() -> None:
+    """Pool child sensors are added when identity appears after setup."""
+    coordinator = MagicMock()
+    coordinator.is_pool_enabled = True
+    coordinator.entry.entry_id = "entry-one"
+    coordinator.entry.async_on_unload = MagicMock()
+    coordinator.get_pool_child_status.side_effect = [
+        [],
+        [
+            {
+                "child_id": "0",
+                "hgi_id": "18:001111",
+                "connected": True,
+                "availability": "ONLINE",
+                "accepted": True,
+                "send_ready": True,
+            }
+        ],
+    ]
+    remove_listener = MagicMock()
+    coordinator.async_add_listener.return_value = remove_listener
+    async_add_entities = MagicMock()
+
+    _add_pool_status_entities(coordinator, async_add_entities)
+    listener = coordinator.async_add_listener.call_args.args[0]
+    listener()
+
+    initial_entities = async_add_entities.call_args_list[0].args[0]
+    added_entities = async_add_entities.call_args_list[1].args[0]
+    assert isinstance(initial_entities[0], RamsesPoolStatusSensor)
+    assert isinstance(added_entities[0], RamsesPoolChildBinarySensor)
+    assert added_entities[0].unique_id == (
+        "entry-one_pool_child_18:001111_online"
+    )
+    coordinator.entry.async_on_unload.assert_called_once_with(remove_listener)
+
+
+def test_pool_aggregate_requires_eligible_child() -> None:
+    """An online receive-only child must not make the pool healthy."""
+    coordinator = MagicMock()
+    coordinator.entry.entry_id = "entry-two"
+    coordinator.last_update_success = True
+    coordinator.get_pool_child_status.return_value = [
+        {
+            "child_id": "0",
+            "hgi_id": "18:001111",
+            "connected": True,
+            "availability": "ONLINE",
+            "accepted": False,
+            "send_ready": True,
+        }
+    ]
+    entity = RamsesPoolStatusSensor(coordinator)
+
+    assert entity.unique_id == "entry-two_pool_status_online"
+    assert entity.is_on is False
+    assert entity.extra_state_attributes["eligible"] == 0
 
 
 def test_hvac_diagnostic_binary_sensor_descriptions() -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -6784,15 +6784,13 @@ async def test_regression_serial_then_mqtt_full_flow(
                 assert "mqtt" in mqtt_label.lower()
 
 
-async def test_regression_preferred_type_not_shown_for_mqtt_primary(
+async def test_regression_preferred_type_shown_for_mqtt_primary(
     hass: HomeAssistant,
 ) -> None:
-    """Regression: _preferred_type review appearing for serial-only devices.
+    """_preferred_type selectors ARE shown for MQTT primary.
 
-    Silverailscolo reported _preferred_type review appearing for
-    serial-only devices.  When the primary is MQTT, all pool members
-    are MQTT by definition — _preferred_type selectors should NOT
-    appear in the Manage Pool form.
+    This allows the user to switch the primary transport back to USB
+    via the Manage Pool form (issue 1171).
     """
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -6827,12 +6825,320 @@ async def test_regression_preferred_type_not_shown_for_mqtt_primary(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "manage_pool"
 
-    # Check that no _preferred_type_ fields are in the schema
+    # _preferred_type selectors SHOULD appear for MQTT primary
+    # so the user can switch back to USB.
     schema = result.get("data_schema")
+    found_pref_type = False
     if schema and hasattr(schema, "schema"):
         for key in schema.schema:
             key_str = str(key)
-            assert "_preferred_type_" not in key_str, (
-                f"_preferred_type selector should NOT appear for "
-                f"MQTT primary, found: {key_str}"
-            )
+            if "_preferred_type_" in key_str:
+                found_pref_type = True
+                break
+    assert found_pref_type, (
+        "_preferred_type selector should appear for MQTT primary "
+        "(to allow switching back to USB)"
+    )
+
+
+# -- Transport switch via _preferred_type in pool menu (issue 1171) --------
+
+
+async def test_pool_switch_usb_to_mqtt_redirects_to_mqtt_url(
+    hass: HomeAssistant,
+) -> None:
+    """Switching primary HGI _preferred_type usb→mqtt redirects to MQTT URL step."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    # Mock the HA MQTT integration entry so the pre-fill works
+    mock_mqtt_entry = MockConfigEntry(
+        domain="mqtt",
+        data={"broker": "192.168.40.11", "port": 1883},
+    )
+    mock_mqtt_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == "manage_pool"
+
+        # Change _preferred_type from usb to mqtt
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "mqtt",
+            },
+        )
+
+    # Should redirect to the MQTT URL step
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool_mqtt_url"
+
+    # The URL should be pre-filled from the HA MQTT integration's broker
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key in data_schema.schema:
+            if hasattr(key, "schema") and str(key).startswith("mqtt_url"):
+                default = key.default
+                if callable(default):
+                    default = default()
+                assert "192.168.40.11" in str(default), (
+                    f"MQTT URL should be pre-filled with broker, got: {default}"
+                )
+                assert "18:149488" in str(default), (
+                    f"MQTT URL should contain HGI ID, got: {default}"
+                )
+                break
+
+
+async def test_pool_switch_usb_to_mqtt_completes(
+    hass: HomeAssistant,
+) -> None:
+    """Switching primary to MQTT via URL step updates the primary port."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_mqtt_entry = MockConfigEntry(
+        domain="mqtt",
+        data={"broker": "192.168.40.11", "port": 1883},
+    )
+    mock_mqtt_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Change _preferred_type from usb to mqtt
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "mqtt",
+            },
+        )
+        assert result.get("step_id") == "manage_pool_mqtt_url"
+
+        # Submit the MQTT URL
+        mqtt_url = "mqtt://192.168.40.11:1883/RAMSES/GATEWAY/18:149488"
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"mqtt_url": mqtt_url},
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Primary port should now be the MQTT URL
+    assert (
+        config_entry.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME)
+        == mqtt_url
+    )
+    # _preferred_type should be "mqtt"
+    schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert schema.get("18:149488", {}).get("_preferred_type") == "mqtt"
+
+
+async def test_pool_switch_mqtt_to_usb_redirects_to_serial(
+    hass: HomeAssistant,
+) -> None:
+    """Switching primary HGI _preferred_type mqtt→usb redirects to serial step."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {
+                SZ_PORT_NAME: "mqtt://192.168.40.11:1883/RAMSES/GATEWAY/18:149488"
+            },
+            CONF_MQTT_USE_HA: True,
+            CONF_MQTT_HGI_ID: "18:149488",
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == "manage_pool"
+
+        # Change _preferred_type from mqtt to usb
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "usb",
+            },
+        )
+
+    # Should redirect to the serial port selection step
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool_serial"
+
+
+async def test_pool_no_switch_when_preferred_type_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    """No transport switch when _preferred_type stays the same."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Submit with the SAME _preferred_type (usb)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "usb",
+            },
+        )
+
+    # Should save normally — no redirect
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Primary port should still be serial
+    assert (
+        config_entry.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME)
+        == "/dev/ttyUSB0"
+    )
+
+
+async def test_pool_no_switch_when_preferred_type_empty_to_mqtt(
+    hass: HomeAssistant,
+) -> None:
+    """No switch when _preferred_type goes from "" (unset) to "mqtt".
+
+    Both "" and "mqtt" mean MQTT — the selector uses "mqtt" as the
+    value for the MQTT option.  Going from unset to "mqtt" is not a
+    real change.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    # No _preferred_type set
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Submit with _preferred_type=mqtt (the default for serial primary
+        # with no _preferred_type set — should NOT trigger a switch)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "mqtt",
+            },
+        )
+
+    # Should save normally — no redirect ("" → "mqtt" is not a real change)
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Primary port should still be serial
+    assert (
+        config_entry.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME)
+        == "/dev/ttyUSB0"
+    )

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -2325,7 +2325,7 @@ async def test_review_discovered_no_coordinator(hass: HomeAssistant) -> None:
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "review_discovered"
     placeholders = result.get("description_placeholders", {})
-    assert "not enabled" in placeholders.get("message", "")
+    assert "not running" in placeholders.get("message", "")
 
 
 async def test_review_discovered_no_manager(hass: HomeAssistant) -> None:
@@ -4237,7 +4237,7 @@ async def test_options_flow_unloaded_entry_fallback(
     )
     assert result.get("type") == FlowResultType.FORM
     placeholders = result.get("description_placeholders", {})
-    assert "not enabled" in placeholders.get("message", "")
+    assert "not running" in placeholders.get("message", "")
 
 
 async def test_review_discovered_foreign_device_sync_with_schema(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -3791,7 +3791,7 @@ async def test_review_device_health_no_coordinator(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "review_device_health"
     placeholders = result.get("description_placeholders", {})
-    assert "not enabled" in placeholders.get("message", "")
+    assert "not running" in placeholders.get("message", "")
 
 
 async def test_review_device_health_no_manager(hass: HomeAssistant) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -852,11 +852,13 @@ async def test_options_flow_manage_pool_visible_for_serial_primary(
 async def test_options_flow_manage_pool_serial_no_schema_hgis(
     hass: HomeAssistant,
 ) -> None:
-    """Test serial-discovered HGIs are NOT shown as MQTT pool members (issue 1171).
+    """Test schema HGIs ARE shown as pool members with serial primary (Phase 2).
 
-    When the primary is serial/USB, schema HGIs are serial-discovered
-    devices.  They must NOT appear in the MQTT pool member list — they
-    don't have an MQTT topic or broker.  Phase 1 pool is MQTT-only.
+    Phase 2: hybrid pools (serial + MQTT) are supported.  Schema HGIs
+    are shown as pool members regardless of the primary transport type,
+    so the user can manage them (keep/remove, set _preferred_type).
+    This was Phase 1 behavior — in Phase 2, the HGIs must appear so
+    they are not accidentally demoted on save.
     """
 
     config_entry = MockConfigEntry(
@@ -893,18 +895,19 @@ async def test_options_flow_manage_pool_serial_no_schema_hgis(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "manage_pool"
 
-    # Schema pool members should NOT be listed — they're serial-discovered
+    # Phase 2: schema pool members SHOULD be listed even with a serial
+    # primary, so the user can manage them and set _preferred_type.
     schema = result.get("data_schema")
     if schema and hasattr(schema, "schema"):
         add_field = schema.schema.get("schema_pool_members")
         if add_field and hasattr(add_field, "config"):
             options = add_field.config.get("options", [])
             values = [opt["value"] for opt in options]
-            assert "18:149488" not in values, (
-                "Serial-discovered HGI must not appear as MQTT pool member"
+            assert "18:149488" in values, (
+                "HGI must appear as pool member with serial primary (Phase 2)"
             )
-            assert "18:130236" not in values, (
-                "Serial-discovered HGI must not appear as MQTT pool member"
+            assert "18:130236" in values, (
+                "HGI must appear as pool member with serial primary (Phase 2)"
             )
 
 

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -6287,22 +6287,19 @@ async def test_review_discovered_accept_hgi_with_preferred_type_mqtt(
     )
     assert result.get("type") == FlowResultType.FORM
 
-    # MQTT has value="" in the selector (default option)
+    # MQTT has value="mqtt" in the selector (default option)
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={
             "device_18:002222": "accept",
             "owner_18:002222": "me",
-            "preferred_type_18:002222": "",
+            "preferred_type_18:002222": "mqtt",
         },
     )
     assert result.get("type") == FlowResultType.CREATE_ENTRY
     saved_schema = config_entry.options.get(CONF_SCHEMA, {})
-    # Empty string means no _preferred_type is set
-    assert (
-        "_preferred_type" not in saved_schema.get("18:002222", {})
-        or saved_schema.get("18:002222", {}).get("_preferred_type") == ""
-    )
+    # "mqtt" means _preferred_type is set to "mqtt"
+    assert saved_schema.get("18:002222", {}).get("_preferred_type") == "mqtt"
     # _comment is rebuilt from sel (mqtt default), existing comment is popped
     comment = saved_schema.get("18:002222", {}).get("_comment", "")
     assert "mqtt" in comment
@@ -6365,8 +6362,8 @@ async def test_review_discovered_accept_hgi_no_preferred_type(
     )
     assert result.get("type") == FlowResultType.CREATE_ENTRY
     saved_schema = config_entry.options.get(CONF_SCHEMA, {})
-    # No _preferred_type set → defaults to "mqtt" in comment
-    assert "_preferred_type" not in saved_schema.get("18:003333", {})
+    # No preferred_type submitted → defaults to "mqtt"
+    assert saved_schema.get("18:003333", {}).get("_preferred_type") == "mqtt"
     comment = saved_schema.get("18:003333", {}).get("_comment", "")
     assert "mqtt" in comment
 

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -6272,3 +6272,308 @@ async def test_review_discovered_accept_hgi_no_preferred_type(
     assert "_preferred_type" not in saved_schema.get("18:003333", {})
     comment = saved_schema.get("18:003333", {}).get("_comment", "")
     assert "mqtt" in comment
+
+
+# -- Regression tests for maintainer-reported issues (PR 1208 comments) --
+
+
+async def test_regression_serial_primary_save_preserves_pool_members(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: saving Manage Pool with serial primary must not demote HGIs.
+
+    Before the fix, schema pool members were not shown when the primary
+    was serial (Phase 1 restriction).  The demotion logic still ran on
+    save, silently setting _removed_from_pool: true on all accepted
+    HGIs because they were not in the keep list.  This caused
+    "No connected child transport available for send" after reload.
+
+    Phase 2: schema HGIs are shown regardless of primary transport
+    type, and saving without unchecking them preserves _owner.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_comment": "Supports: usb",
+                },
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_comment": "Supports: mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Both HGIs must appear as schema pool members
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == "manage_pool"
+        schema = result.get("data_schema")
+        if schema and hasattr(schema, "schema"):
+            add_field = schema.schema.get("schema_pool_members")
+            if add_field and hasattr(add_field, "config"):
+                options = add_field.config.get("options", [])
+                values = [opt["value"] for opt in options]
+                assert "18:149488" in values
+                assert "18:130236" in values
+
+        # Submit the form keeping both HGIs checked (default)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488", "18:130236"],
+                "add_new_port": "__none__",
+            },
+        )
+
+    # After save, both HGIs must retain _owner (not demoted)
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert saved_schema.get("18:149488", {}).get(SZ_TR_OWNER) == "me"
+    assert saved_schema.get("18:130236", {}).get(SZ_TR_OWNER) == "me"
+    assert not saved_schema.get("18:149488", {}).get("_removed_from_pool")
+    assert not saved_schema.get("18:130236", {}).get("_removed_from_pool")
+
+
+async def test_regression_serial_primary_demote_only_unchecked(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: only unchecked HGIs are demoted with serial primary.
+
+    Before the fix, all HGIs were demoted because none were in the
+    keep list.  Now only explicitly unchecked HGIs lose _owner.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                },
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Uncheck 18:130236, keep 18:149488
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+            },
+        )
+
+    # 18:149488 keeps _owner, 18:130236 is demoted
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert saved_schema.get("18:149488", {}).get(SZ_TR_OWNER) == "me"
+    assert not saved_schema.get("18:149488", {}).get("_removed_from_pool")
+    assert SZ_TR_OWNER not in saved_schema.get("18:130236", {})
+    assert saved_schema.get("18:130236", {}).get("_removed_from_pool") is True
+
+
+async def test_regression_mqtt_url_masked_in_current_ports(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: MQTT URLs in current ports multi-select must be masked.
+
+    Before the fix, the current ports list showed raw
+    mqtt://user:pass@broker:1883 URLs without masking credentials.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_ADDITIONAL_PORTS: [
+                "mqtt://user:secret@broker:1883/RAMSES/GATEWAY/18:001111",
+            ],
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool"
+    schema = result.get("data_schema")
+    if schema and hasattr(schema, "schema"):
+        ports_field = schema.schema.get(CONF_ADDITIONAL_PORTS)
+        if ports_field and hasattr(ports_field, "config"):
+            options = ports_field.config.get("options", [])
+            labels = [opt.get("label", "") for opt in options]
+            # No label should contain the raw credentials
+            for label in labels:
+                assert "secret" not in label, (
+                    f"Credentials leaked in port label: {label}"
+                )
+                assert "user:secret@" not in label, (
+                    f"Credentials leaked in port label: {label}"
+                )
+            # At least one label should contain the masked form
+            assert any("***" in label for label in labels), (
+                f"No masked URL found in labels: {labels}"
+            )
+
+
+async def test_regression_serial_port_dropdown_uses_by_id_paths(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: serial port dropdown should use /dev/serial/by-id/ paths.
+
+    Before the fix, the serial port selector used
+    serialx.list_serial_ports() which returns raw /dev/ttyACM* paths.
+    Now uses async_get_usb_ports() which returns by-id paths with
+    friendly names.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    by_id_port = (
+        "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A50285BI-if00-port0"
+    )
+    friendly_name = "FTDI FT232R USB UART (A50285BI)"
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={by_id_port: friendly_name},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Select "Serial/USB port..." to enter manage_pool_serial
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"add_new_port": "__serial_port__"},
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool_serial"
+    schema = result.get("data_schema")
+    if schema and hasattr(schema, "schema"):
+        port_field = schema.schema.get("serial_port")
+        if port_field and hasattr(port_field, "config"):
+            options = port_field.config.get("options", [])
+            values = [opt["value"] for opt in options]
+            labels = [opt.get("label", "") for opt in options]
+            # The by-id path should be available as a value
+            assert by_id_port in values, f"by-id path not in options: {values}"
+            # The friendly name should be used as the label
+            assert friendly_name in labels, (
+                f"Friendly name not in labels: {labels}"
+            )
+
+
+async def test_regression_serial_port_dropdown_friendly_names(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: serial port dropdown shows friendly names from USB scanner.
+
+    The async_get_usb_ports() function returns a dict mapping
+    device paths to human-readable names.  The dropdown should
+    use these friendly names as labels, not raw device paths.
+    """
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    ports = {
+        "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_A50285BI-if00-port0": (
+            "FTDI FT232R USB UART (A50285BI)"
+        ),
+        "/dev/serial/by-id/usb-Silicon_Labs_CP2102_USB_to_UART_Bridge"
+        "_0001-if00-port0": "Silicon Labs CP2102 (0001)",
+    }
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value=ports,
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"add_new_port": "__serial_port__"},
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool_serial"
+    schema = result.get("data_schema")
+    if schema and hasattr(schema, "schema"):
+        port_field = schema.schema.get("serial_port")
+        if port_field and hasattr(port_field, "config"):
+            options = port_field.config.get("options", [])
+            labels = [opt.get("label", "") for opt in options]
+            # Both friendly names should appear as labels
+            assert "FTDI FT232R USB UART (A50285BI)" in labels
+            assert "Silicon Labs CP2102 (0001)" in labels

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5663,9 +5663,13 @@ async def test_options_flow_manage_pool_remove_schema_member(
 
     # Should save
     assert result.get("type") == FlowResultType.CREATE_ENTRY
-    # 18:002222 should have _owner removed (demoted)
+    # 18:002222 should have _owner preserved but _removed_from_pool set
+    # (issue 1183 comment: removing from pool should not wipe _owner,
+    # so the HGI can be re-added without re-accepting)
     schema = config_entry.options.get(CONF_SCHEMA, {})
-    assert SZ_TR_OWNER not in schema.get("18:002222", {})
+    removed_entry = schema.get("18:002222", {})
+    assert removed_entry.get("_removed_from_pool") is True
+    assert removed_entry.get(SZ_TR_OWNER) == "me"
 
 
 async def test_options_flow_manage_pool_remove_last_hgi(
@@ -5733,9 +5737,11 @@ async def test_options_flow_manage_pool_remove_last_hgi(
     # Primary port should be cleared
     serial_port = config_entry.options.get(SZ_SERIAL_PORT, {})
     assert not serial_port.get(SZ_PORT_NAME)
-    # HGI should have _owner removed
+    # HGI should have _owner preserved but _removed_from_pool set
     schema = config_entry.options.get(CONF_SCHEMA, {})
-    assert SZ_TR_OWNER not in schema.get("18:001111", {})
+    removed_entry = schema.get("18:001111", {})
+    assert removed_entry.get("_removed_from_pool") is True
+    assert removed_entry.get(SZ_TR_OWNER) == "me"
 
 
 async def test_options_flow_manage_pool_remove_last_hgi_mqtt_ha(
@@ -5802,7 +5808,9 @@ async def test_options_flow_manage_pool_remove_last_hgi_mqtt_ha(
     serial_port = config_entry.options.get(SZ_SERIAL_PORT, {})
     assert not serial_port.get(SZ_PORT_NAME)
     schema = config_entry.options.get(CONF_SCHEMA, {})
-    assert SZ_TR_OWNER not in schema.get("18:001111", {})
+    removed_entry = schema.get("18:001111", {})
+    assert removed_entry.get("_removed_from_pool") is True
+    assert removed_entry.get(SZ_TR_OWNER) == "me"
 
 
 async def test_options_flow_manage_pool_zigbee_form_display(
@@ -6498,8 +6506,10 @@ async def test_regression_serial_primary_demote_only_unchecked(
     saved_schema = config_entry.options.get(CONF_SCHEMA, {})
     assert saved_schema.get("18:149488", {}).get(SZ_TR_OWNER) == "me"
     assert not saved_schema.get("18:149488", {}).get("_removed_from_pool")
-    assert SZ_TR_OWNER not in saved_schema.get("18:130236", {})
-    assert saved_schema.get("18:130236", {}).get("_removed_from_pool") is True
+    # 18:130236 is demoted — _owner preserved, _removed_from_pool set
+    demoted_entry = saved_schema.get("18:130236", {})
+    assert demoted_entry.get("_removed_from_pool") is True
+    assert demoted_entry.get(SZ_TR_OWNER) == "me"
 
 
 async def test_regression_mqtt_url_masked_in_current_ports(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5307,7 +5307,7 @@ async def test_options_flow_manage_pool_mqtt_add_when_no_primary(
 async def test_options_flow_manage_pool_mqtt_url_add(
     hass: HomeAssistant,
 ) -> None:
-    """Test adding an MQTT HGI via full URL (issue 1171)."""
+    """Test adding an MQTT HGI via HGI ID (issue 1171)."""
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -5340,11 +5340,12 @@ async def test_options_flow_manage_pool_mqtt_url_add(
         assert result.get("type") == FlowResultType.FORM
         assert result.get("step_id") == "manage_pool_mqtt_url"
 
-        # Submit a full URL
+        # Submit an HGI ID (redesigned form — no broker URL)
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
-                "mqtt_url": "mqtt://broker:1883/RAMSES/GATEWAY/18:001111"
+                "hgi_id": "18:001111",
+                "topic_prefix": "RAMSES/GATEWAY",
             },
         )
 
@@ -5352,8 +5353,6 @@ async def test_options_flow_manage_pool_mqtt_url_add(
     schema = config_entry.options.get(CONF_SCHEMA, {})
     assert schema.get("18:001111", {}).get(SZ_TR_OWNER) == "me"
     assert "_removed_from_pool" not in schema.get("18:001111", {})
-    additional = config_entry.options.get(CONF_ADDITIONAL_PORTS, [])
-    assert "mqtt://broker:1883/RAMSES/GATEWAY/18:001111" in additional
 
 
 async def test_options_flow_manage_pool_readd_removed_hgi(
@@ -5438,24 +5437,17 @@ async def test_options_flow_manage_pool_mqtt_url_errors(
         )
         assert result.get("step_id") == "manage_pool_mqtt_url"
 
-        # Empty URL
+        # Empty HGI ID
         result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={"mqtt_url": ""}
+            result["flow_id"], user_input={"hgi_id": ""}
         )
-        assert result.get("errors") == {"base": "mqtt_url_required"}
+        assert result.get("errors") == {"base": "mqtt_hgi_id_required"}
 
-        # Invalid URL (not mqtt://)
+        # Invalid HGI ID (not 18:NNNNNN)
         result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={"mqtt_url": "http://broker:1883"}
+            result["flow_id"], user_input={"hgi_id": "01:123456"}
         )
-        assert result.get("errors") == {"base": "mqtt_url_invalid"}
-
-        # Valid mqtt:// but no HGI ID in path
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={"mqtt_url": "mqtt://broker:1883/RAMSES/GATEWAY"},
-        )
-        assert result.get("errors") == {"base": "mqtt_url_no_hgi_id"}
+        assert result.get("errors") == {"base": "mqtt_hgi_id_invalid"}
 
 
 async def test_options_flow_manage_pool_mqtt_full_url_serial_allowed(
@@ -6899,19 +6891,16 @@ async def test_pool_switch_usb_to_mqtt_redirects_to_mqtt_url(
     assert result.get("type") == FlowResultType.FORM
     assert result.get("step_id") == "manage_pool_mqtt_url"
 
-    # The URL should be pre-filled from the HA MQTT integration's broker
+    # The HGI ID should be pre-filled from the switching target
     data_schema = result.get("data_schema")
     if data_schema and hasattr(data_schema, "schema"):
         for key in data_schema.schema:
-            if hasattr(key, "schema") and str(key).startswith("mqtt_url"):
+            if hasattr(key, "schema") and str(key).startswith("hgi_id"):
                 default = key.default
                 if callable(default):
                     default = default()
-                assert "192.168.40.11" in str(default), (
-                    f"MQTT URL should be pre-filled with broker, got: {default}"
-                )
                 assert "18:149488" in str(default), (
-                    f"MQTT URL should contain HGI ID, got: {default}"
+                    f"HGI ID should be pre-filled, got: {default}"
                 )
                 break
 
@@ -6965,19 +6954,16 @@ async def test_pool_switch_usb_to_mqtt_completes(
         )
         assert result.get("step_id") == "manage_pool_mqtt_url"
 
-        # Submit the MQTT URL
-        mqtt_url = "mqtt://192.168.40.11:1883/RAMSES/GATEWAY/18:149488"
+        # Submit the HGI ID (redesigned form — no broker URL)
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
-            user_input={"mqtt_url": mqtt_url},
+            user_input={"hgi_id": "18:149488"},
         )
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
-    # Primary port should now be the MQTT URL
-    assert (
-        config_entry.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME)
-        == mqtt_url
-    )
+    # Primary should now be MQTT via CONF_MQTT_HGI_ID + CONF_MQTT_USE_HA
+    assert config_entry.options.get(CONF_MQTT_USE_HA) is True
+    assert config_entry.options.get(CONF_MQTT_HGI_ID) == "18:149488"
     # _preferred_type should be "mqtt"
     schema = config_entry.options.get(CONF_SCHEMA, {})
     assert schema.get("18:149488", {}).get("_preferred_type") == "mqtt"

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -7206,3 +7206,613 @@ async def test_pool_no_switch_when_preferred_type_empty_to_mqtt(
         config_entry.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME)
         == "/dev/ttyUSB0"
     )
+
+
+# -- Pool member label and selector coverage (issue 1171) -------------------
+
+
+async def test_pool_label_serial_primary_shows_usb_for_primary(
+    hass: HomeAssistant,
+) -> None:
+    """Primary HGI on serial shows '(primary, USB, /dev/...)' label."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    # The pool member selector should contain the primary USB label
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key, validator in data_schema.schema.items():
+            if str(key).startswith("schema_pool_members"):
+                options = validator.config.get("options", [])
+                labels = [opt.get("label", "") for opt in options]
+                assert any("primary, USB" in lbl for lbl in labels), (
+                    f"Expected 'primary, USB' label, got: {labels}"
+                )
+                break
+
+
+async def test_pool_label_serial_primary_mqtt_member_with_ha(
+    hass: HomeAssistant,
+) -> None:
+    """Serial primary with MQTT member + CONF_MQTT_USE_HA shows topic."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_MQTT_USE_HA: True,
+            CONF_MQTT_TOPIC: "RAMSES/GATEWAY",
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "mqtt",
+                    "_comment": "Supports: mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key, validator in data_schema.schema.items():
+            if str(key).startswith("schema_pool_members"):
+                options = validator.config.get("options", [])
+                labels = [opt.get("label", "") for opt in options]
+                # The MQTT member should show "MQTT, topic: RAMSES/GATEWAY"
+                assert any("MQTT, topic:" in lbl for lbl in labels), (
+                    f"Expected 'MQTT, topic:' label, got: {labels}"
+                )
+                break
+
+
+async def test_pool_label_serial_primary_zigbee_member(
+    hass: HomeAssistant,
+) -> None:
+    """Serial primary with zigbee _preferred_type shows Zigbee label."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "zigbee",
+                    "_comment": "Supports: zigbee",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key, validator in data_schema.schema.items():
+            if str(key).startswith("schema_pool_members"):
+                options = validator.config.get("options", [])
+                labels = [opt.get("label", "") for opt in options]
+                assert any("Zigbee" in lbl for lbl in labels), (
+                    f"Expected 'Zigbee' label, got: {labels}"
+                )
+                break
+
+
+async def test_pool_selector_zigbee_detected_label(
+    hass: HomeAssistant,
+) -> None:
+    """Zigbee detected type shows 'Zigbee (detected, not yet supported)'."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                    "_comment": "Supports: usb, zigbee",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key, validator in data_schema.schema.items():
+            key_str = str(key)
+            if "_preferred_type_18:149488" in key_str:
+                options = validator.config.get("options", [])
+                labels = [opt.get("label", "") for opt in options]
+                assert any("Zigbee (detected" in lbl for lbl in labels), (
+                    f"Expected 'Zigbee (detected...' label, got: {labels}"
+                )
+                break
+
+
+async def test_pool_selector_defaults_to_usb_for_serial_primary(
+    hass: HomeAssistant,
+) -> None:
+    """When serial primary and both usb+mqtt detected, default to usb."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    # No _preferred_type — should default to "usb"
+                    "_comment": "Supports: usb, mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key in data_schema.schema:
+            key_str = str(key)
+            if "_preferred_type_18:149488" in key_str:
+                # The default should be "usb"
+                default = key.default
+                if callable(default):
+                    default = default()
+                assert default == "usb", (
+                    f"Expected default 'usb' for serial primary, got: {default}"
+                )
+                break
+
+
+async def test_pool_serial_step_rejects_none_port(
+    hass: HomeAssistant,
+) -> None:
+    """manage_pool_serial rejects __none__ sentinel."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {
+                SZ_PORT_NAME: "mqtt://broker:1883/RAMSES/GATEWAY/18:149488"
+            },
+            CONF_MQTT_USE_HA: True,
+            CONF_MQTT_HGI_ID: "18:149488",
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Switch to USB — redirects to serial step
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "usb",
+            },
+        )
+        assert result.get("step_id") == "manage_pool_serial"
+
+        # Submit __none__ (no available ports) — should show error
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"serial_port": "__none__"},
+        )
+
+    # Should show form again with error, not save
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool_serial"
+    assert result.get("errors", {}).get("base") == "serial_port_required"
+
+
+async def test_pool_serial_step_adds_additional_port(
+    hass: HomeAssistant,
+) -> None:
+    """manage_pool_serial adds port to additional_ports (non-switching path)."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={
+            "/dev/ttyUSB0": "USB 0",
+            "/dev/ttyUSB1": "USB 1",
+        },
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Select "Serial/USB port..." from the add dropdown
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__serial_port__",
+            },
+        )
+        assert result.get("step_id") == "manage_pool_serial"
+
+        # Select the additional port
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"serial_port": "/dev/ttyUSB1"},
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    additional = config_entry.options.get(CONF_ADDITIONAL_PORTS, [])
+    assert "/dev/ttyUSB1" in additional
+
+
+async def test_pool_label_serial_primary_usb_member(
+    hass: HomeAssistant,
+) -> None:
+    """Serial primary with non-primary USB member shows '(USB)' label."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                    "_comment": "Supports: usb",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key, validator in data_schema.schema.items():
+            if str(key).startswith("schema_pool_members"):
+                options = validator.config.get("options", [])
+                labels = [opt.get("label", "") for opt in options]
+                # The non-primary USB member should show "(USB)"
+                assert any(
+                    "(USB)" in lbl and "primary" not in lbl for lbl in labels
+                ), f"Expected '(USB)' label for non-primary, got: {labels}"
+                break
+
+
+async def test_pool_label_serial_primary_mqtt_member_no_ha(
+    hass: HomeAssistant,
+) -> None:
+    """Serial primary with MQTT member (no CONF_MQTT_USE_HA) shows '(MQTT)'."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "usb",
+                },
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "mqtt",
+                    "_comment": "Supports: mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    data_schema = result.get("data_schema")
+    if data_schema and hasattr(data_schema, "schema"):
+        for key, validator in data_schema.schema.items():
+            if str(key).startswith("schema_pool_members"):
+                options = validator.config.get("options", [])
+                labels = [opt.get("label", "") for opt in options]
+                # The MQTT member should show "(MQTT)" without topic
+                # (no CONF_MQTT_USE_HA)
+                assert any(
+                    "(MQTT)" in lbl and "topic:" not in lbl for lbl in labels
+                ), f"Expected '(MQTT)' label without topic, got: {labels}"
+                break
+
+
+async def test_pool_mqtt_ha_primary_hgi_id_detection(
+    hass: HomeAssistant,
+) -> None:
+    """mqtt_ha primary detects HGI ID from CONF_MQTT_HGI_ID for switching."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt_ha"},
+            CONF_MQTT_USE_HA: True,
+            CONF_MQTT_HGI_ID: "18:149488",
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Switch to USB — should redirect to serial step
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "usb",
+            },
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool_serial"
+
+
+async def test_options_flow_review_discovered_keep_action(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_discovered 'keep' action keeps _class but applies owner."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "04:222222": {SZ_TR_CLASS: "FAN"},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.async_save_client_state = AsyncMock()
+    mock_coord.store = MagicMock()
+    mock_coord.store.async_save_backup = AsyncMock()
+
+    mismatched_dev = MagicMock()
+    mismatched_dev.device.device_id = "04:222222"
+    mismatched_dev.device.likely_type = "DIS"
+    mismatched_dev.metadata.class_mismatch = "schema=FAN, discovery=DIS"
+
+    mock_coord.discovery_manager.get_devices.return_value = []
+    mock_coord.discovery_manager.get_mismatched_devices.return_value = [
+        mismatched_dev
+    ]
+    mock_coord.discovery_manager.get_missing_class_devices.return_value = []
+    mock_coord.discovery_manager.get_name_mismatch_devices.return_value = []
+    config_entry.runtime_data = mock_coord
+
+    flow = RamsesOptionsFlowHandler(config_entry)
+    flow.hass = hass
+    flow.get_options()
+
+    result = await flow.async_step_review_discovered(
+        user_input={
+            "owner_name": "",
+            "bulk_action": "none",
+            "mismatch_04:222222": "keep",
+        }
+    )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    saved_schema = result.get("data", {}).get(CONF_SCHEMA, {})
+    # _class should still be FAN (kept, not updated)
+    assert saved_schema.get("04:222222", {}).get(SZ_TR_CLASS) == "FAN"
+    # Owner should be applied (defaults to schema's _owner since no owner_name)
+    assert saved_schema.get("04:222222", {}).get(SZ_TR_OWNER) == "me"
+
+
+async def test_options_flow_review_discovered_no_devices_submit(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_discovered with no devices — submit closes the form."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {SZ_OWNER: "me"},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.async_save_client_state = AsyncMock()
+    mock_coord.discovery_manager.get_devices.return_value = []
+    mock_coord.discovery_manager.get_mismatched_devices.return_value = []
+    mock_coord.discovery_manager.get_missing_class_devices.return_value = []
+    mock_coord.discovery_manager.get_name_mismatch_devices.return_value = []
+    config_entry.runtime_data = mock_coord
+
+    flow = RamsesOptionsFlowHandler(config_entry)
+    flow.hass = hass
+    flow.get_options()
+
+    # First call shows the "no devices" form
+    result = await flow.async_step_review_discovered(user_input=None)
+    assert result.get("type") == FlowResultType.FORM
+
+    # Second call (submit) saves
+    result = await flow.async_step_review_discovered(user_input={})
+    assert result.get("type") == FlowResultType.CREATE_ENTRY

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5113,13 +5113,16 @@ async def test_options_flow_manage_pool_mqtt_invalid_hgi_id(
     assert result.get("errors") == {"base": "hgi_id_invalid"}
 
 
-async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
+async def test_options_flow_manage_pool_mqtt_serial_primary_allowed(
     hass: HomeAssistant,
 ) -> None:
-    """Test manage_pool blocks MQTT add when primary is serial (issue 1171).
+    """Test manage_pool allows MQTT add when primary is serial (Phase 2).
 
-    The pool pane is visible for serial primary, but adding MQTT pool
-    members is blocked — it requires an MQTT primary transport.
+    Phase 2: hybrid serial+MQTT pools are supported.  MQTT pool
+    children are callback-driven via the HA-native RamsesMqttPoolBridge
+    (no paho inside HA, issue 1119).  Adding an MQTT HGI with a
+    serial primary should navigate to the MQTT sub-step, not show
+    an error.
     """
 
     config_entry = MockConfigEntry(
@@ -5140,7 +5143,7 @@ async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={"next_step_id": "manage_pool"}
         )
-        # Try to add MQTT pool member with serial primary
+        # Add MQTT pool member with serial primary — allowed in Phase 2
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
@@ -5149,9 +5152,10 @@ async def test_options_flow_manage_pool_mqtt_serial_primary_blocked(
             },
         )
 
-    # Should show the form with an error — not navigate to MQTT sub-step
+    # Should navigate to the MQTT sub-step (not show an error)
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {"base": "pool_mqtt_requires_mqtt_primary"}
+    assert result.get("step_id") == "manage_pool_mqtt"
+    assert result.get("errors") == {} or not result.get("errors")
 
 
 async def test_options_flow_manage_pool_mqtt_add_when_no_primary(
@@ -5353,10 +5357,15 @@ async def test_options_flow_manage_pool_mqtt_url_errors(
         assert result.get("errors") == {"base": "mqtt_url_no_hgi_id"}
 
 
-async def test_options_flow_manage_pool_mqtt_full_url_serial_blocked(
+async def test_options_flow_manage_pool_mqtt_full_url_serial_allowed(
     hass: HomeAssistant,
 ) -> None:
-    """Test full URL add blocked when primary is serial (issue 1171)."""
+    """Test full URL add allowed when primary is serial (Phase 2).
+
+    Phase 2: hybrid serial+MQTT pools are supported.  Adding an MQTT
+    HGI via full URL with a serial primary should navigate to the
+    MQTT URL sub-step, not show an error.
+    """
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -5384,8 +5393,10 @@ async def test_options_flow_manage_pool_mqtt_full_url_serial_blocked(
             },
         )
 
+    # Should navigate to the MQTT URL sub-step (not show an error)
     assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {"base": "pool_mqtt_requires_mqtt_primary"}
+    assert result.get("step_id") == "manage_pool_mqtt_url"
+    assert result.get("errors") == {} or not result.get("errors")
 
 
 async def test_options_flow_manage_pool_mqtt_form_display(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -7036,6 +7036,70 @@ async def test_pool_switch_mqtt_to_usb_redirects_to_serial(
     assert result.get("step_id") == "manage_pool_serial"
 
 
+async def test_pool_switch_mqtt_to_usb_completes(
+    hass: HomeAssistant,
+) -> None:
+    """Switching primary to USB via serial step updates the primary port."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {
+                SZ_PORT_NAME: "mqtt://192.168.40.11:1883/RAMSES/GATEWAY/18:149488"
+            },
+            CONF_MQTT_USE_HA: True,
+            CONF_MQTT_HGI_ID: "18:149488",
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_preferred_type": "mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={"next_step_id": "manage_pool"}
+        )
+
+        # Change _preferred_type from mqtt to usb
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "schema_pool_members": ["18:149488"],
+                "add_new_port": "__none__",
+                "_preferred_type_18:149488": "usb",
+            },
+        )
+        assert result.get("step_id") == "manage_pool_serial"
+
+        # Select the serial port
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"serial_port": "/dev/ttyUSB0"},
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    # Primary port should now be the serial port
+    assert (
+        config_entry.options.get(SZ_SERIAL_PORT, {}).get(SZ_PORT_NAME)
+        == "/dev/ttyUSB0"
+    )
+    # _preferred_type should be "usb"
+    schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert schema.get("18:149488", {}).get("_preferred_type") == "usb"
+
+
 async def test_pool_no_switch_when_preferred_type_unchanged(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -2378,6 +2378,7 @@ async def test_review_discovered_accept_device(hass: HomeAssistant) -> None:
     mock_coord.discovery_manager = MagicMock()
     mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
     mock_coord.discovery_manager.accept_device.return_value = accepted_entry
+    mock_coord.async_save = AsyncMock()
     config_entry.runtime_data = mock_coord
 
     result = await hass.config_entries.options.async_init(
@@ -6069,3 +6070,202 @@ async def test_options_flow_manage_pool_no_add_save(
 
     assert result.get("type") == FlowResultType.CREATE_ENTRY
     assert config_entry.options.get(CONF_ADDITIONAL_PORTS) == []
+
+
+# -- Review flow with _preferred_type for HGI devices -----------------------
+
+
+async def test_review_discovered_accept_hgi_with_preferred_type_usb(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_discovered step accepting HGI with _preferred_type=usb."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "18:001111"
+    mock_entry.device.likely_type = "HGI"
+    mock_entry.device.confidence = "high"
+    mock_entry.device.rssi = -44.0
+    mock_entry.device.codes_seen = ["2411"]
+    mock_entry.device.bound_to = None
+    mock_entry.device.zone_index = None
+    mock_entry.device.is_battery = False
+    mock_entry.device.source_count = 1
+    mock_entry.device.destination_count = 0
+
+    accepted_entry = MagicMock()
+    accepted_entry.metadata.schema_entry = {
+        "18:001111": {"_class": "HGI"},
+    }
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
+    mock_coord.discovery_manager.accept_device.return_value = accepted_entry
+    mock_coord.async_save = AsyncMock()
+    config_entry.runtime_data = mock_coord
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "device_18:001111": "accept",
+            "owner_18:001111": "me",
+            "preferred_type_18:001111": "usb",
+        },
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert saved_schema.get("18:001111", {}).get("_preferred_type") == "usb"
+    assert "usb" in saved_schema.get("18:001111", {}).get("_comment", "")
+
+
+async def test_review_discovered_accept_hgi_with_preferred_type_mqtt(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_discovered step accepting HGI with _preferred_type=mqtt."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                "18:002222": {"_class": "HGI", "_comment": "Supports: usb"},
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "18:002222"
+    mock_entry.device.likely_type = "HGI"
+    mock_entry.device.confidence = "high"
+    mock_entry.device.rssi = -66.0
+    mock_entry.device.codes_seen = ["10D0"]
+    mock_entry.device.bound_to = None
+    mock_entry.device.zone_index = None
+    mock_entry.device.is_battery = False
+    mock_entry.device.source_count = 1
+    mock_entry.device.destination_count = 0
+
+    accepted_entry = MagicMock()
+    accepted_entry.metadata.schema_entry = {
+        "18:002222": {"_class": "HGI", "_comment": "Supports: usb"},
+    }
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
+    mock_coord.discovery_manager.accept_device.return_value = accepted_entry
+    mock_coord.async_save = AsyncMock()
+    config_entry.runtime_data = mock_coord
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+
+    # MQTT has value="" in the selector (default option)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "device_18:002222": "accept",
+            "owner_18:002222": "me",
+            "preferred_type_18:002222": "",
+        },
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    # Empty string means no _preferred_type is set
+    assert (
+        "_preferred_type" not in saved_schema.get("18:002222", {})
+        or saved_schema.get("18:002222", {}).get("_preferred_type") == ""
+    )
+    # _comment is rebuilt from sel (mqtt default), existing comment is popped
+    comment = saved_schema.get("18:002222", {}).get("_comment", "")
+    assert "mqtt" in comment
+
+
+async def test_review_discovered_accept_hgi_no_preferred_type(
+    hass: HomeAssistant,
+) -> None:
+    """Test review_discovered step accepting HGI without _preferred_type."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    mock_entry = MagicMock()
+    mock_entry.device.device_id = "18:003333"
+    mock_entry.device.likely_type = "HGI"
+    mock_entry.device.confidence = "high"
+    mock_entry.device.rssi = -50.0
+    mock_entry.device.codes_seen = ["2411"]
+    mock_entry.device.bound_to = None
+    mock_entry.device.zone_index = None
+    mock_entry.device.is_battery = False
+    mock_entry.device.source_count = 1
+    mock_entry.device.destination_count = 0
+
+    accepted_entry = MagicMock()
+    accepted_entry.metadata.schema_entry = {
+        "18:003333": {"_class": "HGI"},
+    }
+    mock_coord = MagicMock()
+    mock_coord.discovery_manager = MagicMock()
+    mock_coord.discovery_manager.get_devices.return_value = [mock_entry]
+    mock_coord.discovery_manager.accept_device.return_value = accepted_entry
+    mock_coord.async_save = AsyncMock()
+    config_entry.runtime_data = mock_coord
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "review_discovered"}
+    )
+    assert result.get("type") == FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "device_18:003333": "accept",
+            "owner_18:003333": "me",
+        },
+    )
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    saved_schema = config_entry.options.get(CONF_SCHEMA, {})
+    # No _preferred_type set → defaults to "mqtt" in comment
+    assert "_preferred_type" not in saved_schema.get("18:003333", {})
+    comment = saved_schema.get("18:003333", {}).get("_comment", "")
+    assert "mqtt" in comment

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -6577,3 +6577,168 @@ async def test_regression_serial_port_dropdown_friendly_names(
             # Both friendly names should appear as labels
             assert "FTDI FT232R USB UART (A50285BI)" in labels
             assert "Silicon Labs CP2102 (0001)" in labels
+
+
+async def test_regression_empty_serial_port_list(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: empty serial-port list on first opening.
+
+    Silverailscolo reported an empty serial-port list on first
+    opening of Manage Pool.  When async_get_usb_ports returns an
+    empty dict (no USB devices connected), the dropdown should
+    show '(no available ports)' instead of crashing or showing
+    an empty dropdown.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {},
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": "manage_pool"},
+        )
+        # Select "Serial/USB port..." to enter manage_pool_serial
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"add_new_port": "__serial_port__"},
+        )
+
+    assert result.get("step_id") == "manage_pool_serial"
+    schema = result.get("data_schema")
+    if schema and hasattr(schema, "schema"):
+        port_field = schema.schema.get("serial_port")
+        if port_field and hasattr(port_field, "config"):
+            options = port_field.config.get("options", [])
+            labels = [opt.get("label", "") for opt in options]
+            assert "(no available ports)" in labels
+
+
+async def test_regression_serial_then_mqtt_full_flow(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: difficulty starting with serial then adding MQTT.
+
+    Silverailscolo reported difficulty starting with serial and
+    then adding MQTT.  The config flow should show the "Add MQTT
+    port" option in the Manage Pool form when the primary is serial,
+    so the user can navigate to the MQTT URL entry step.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+            },
+            CONF_ADDITIONAL_PORTS: [],
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={"/dev/ttyUSB0": "USB 0"},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": "manage_pool"},
+        )
+
+        # The manage_pool step should show the form
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == "manage_pool"
+
+        # Verify the add_new_port selector includes the MQTT option
+        schema = result.get("data_schema")
+        assert schema is not None
+        if hasattr(schema, "schema"):
+            port_field = schema.schema.get("add_new_port")
+            if port_field and hasattr(port_field, "config"):
+                options = port_field.config.get("options", [])
+                values = [opt.get("value", "") for opt in options]
+                labels = [opt.get("label", "") for opt in options]
+                # The MQTT add option should be available
+                assert "__mqtt_full_url__" in values, (
+                    f"MQTT add option should be available for serial "
+                    f"primary, got values: {values}"
+                )
+                mqtt_label = next(
+                    (
+                        label
+                        for val, label in zip(values, labels, strict=True)
+                        if val == "__mqtt_full_url__"
+                    ),
+                    "",
+                )
+                assert "mqtt" in mqtt_label.lower()
+
+
+async def test_regression_preferred_type_not_shown_for_mqtt_primary(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: _preferred_type review appearing for serial-only devices.
+
+    Silverailscolo reported _preferred_type review appearing for
+    serial-only devices.  When the primary is MQTT, all pool members
+    are MQTT by definition — _preferred_type selectors should NOT
+    appear in the Manage Pool form.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {
+                SZ_PORT_NAME: "mqtt://broker:1883/RAMSES/GATEWAY"
+            },
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:001111": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_comment": "Supports: mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.ramses_cc.config_flow.async_get_usb_ports",
+        return_value={},
+    ):
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": "manage_pool"},
+        )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "manage_pool"
+
+    # Check that no _preferred_type_ fields are in the schema
+    schema = result.get("data_schema")
+    if schema and hasattr(schema, "schema"):
+        for key in schema.schema:
+            key_str = str(key)
+            assert "_preferred_type_" not in key_str, (
+                f"_preferred_type selector should NOT appear for "
+                f"MQTT primary, found: {key_str}"
+            )

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -591,6 +591,103 @@ async def test_clear_schema_no_foreign_entries_pops_schema(
         assert CONF_SCHEMA not in new_options
 
 
+async def test_clear_schema_mqtt_clears_retained_lwt(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing the schema for MQTT-primary clears retained LWT messages.
+
+    When the primary transport is MQTT (mqtt_use_ha=True), clearing
+    the schema should publish empty retained messages to the MQTT
+    broker for each known HGI, so they don't reappear as discovery
+    candidates from stale retained LWT messages on reload.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        options={
+            SZ_SERIAL_PORT: {
+                SZ_PORT_NAME: "mqtt://192.168.40.11:1883/RAMSES/GATEWAY/18:130236"
+            },
+            CONF_MQTT_USE_HA: True,
+            CONF_MQTT_TOPIC: "RAMSES/GATEWAY",
+            CONF_SCHEMA: {
+                SZ_OWNER: "me",
+                "18:130236": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_comment": "Supports: usb, mqtt",
+                },
+                "18:149488": {
+                    "_class": "HGI",
+                    SZ_TR_OWNER: "me",
+                    "_comment": "Supports: usb, mqtt",
+                },
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    try:
+        config_entry.mock_state(hass, ConfigEntryState.LOADED)
+    except AttributeError:
+        object.__setattr__(config_entry, "_state", ConfigEntryState.LOADED)
+        config_entry.__dict__["state"] = ConfigEntryState.LOADED
+
+    result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+    flow_handler = hass.config_entries.options._progress[result["flow_id"]]
+    assert isinstance(flow_handler, OptionsFlow)
+    cast(Any, flow_handler).config_entry = config_entry
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"next_step_id": "clear_cache"}
+    )
+
+    published_topics: list[str] = []
+
+    async def mock_publish(
+        hass_arg: Any,
+        topic: str,
+        payload: Any,
+        qos: int = 0,
+        retain: bool = False,
+    ) -> None:
+        published_topics.append(topic)
+
+    with (
+        patch.object(hass.config_entries, "async_unload"),
+        patch.object(hass.config_entries, "async_setup"),
+        patch.object(hass.config_entries, "async_update_entry"),
+        patch(
+            "custom_components.ramses_cc.config_flow.dr.async_entries_for_config_entry",
+            return_value=[],
+        ),
+        patch("custom_components.ramses_cc.config_flow.Store") as mock_store,
+        patch(
+            "homeassistant.components.mqtt.async_publish",
+            side_effect=mock_publish,
+        ) as mock_mqtt_publish,
+    ):
+        mock_instance = MagicMock()
+        mock_store.return_value = mock_instance
+        mock_instance.async_load = AsyncMock(
+            return_value={
+                "client_state": {"schema": {}, "packets": {}},
+            }
+        )
+        mock_instance.async_save = AsyncMock()
+
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"clear_schema": True, "clear_packets": False},
+        )
+
+        # Should have published empty retained messages for both HGIs
+        assert mock_mqtt_publish.call_count == 2
+        assert "RAMSES/GATEWAY/18:130236" in published_topics
+        assert "RAMSES/GATEWAY/18:149488" in published_topics
+
+
 async def test_options_flow_defaults_and_branches(hass: HomeAssistant) -> None:
     """Test various options flow branches including defaults & finish steps."""
     config_entry = MockConfigEntry(

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -5091,6 +5091,7 @@ async def test_options_flow_manage_pool_mqtt_add_port(
         domain=DOMAIN,
         options={
             SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt://broker:1883"},
+            CONF_ADDITIONAL_PORTS: ["socket://keep", "socket://remove"],
         },
     )
     config_entry.add_to_hass(hass)
@@ -5109,7 +5110,8 @@ async def test_options_flow_manage_pool_mqtt_add_port(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
-                CONF_ADDITIONAL_PORTS: [],
+                CONF_ADDITIONAL_PORTS: ["socket://keep"],
+                CONF_WAIT_ONLINE_TIMEOUT: 45.0,
                 "add_new_port": "__mqtt_ha_id__",
             },
         )
@@ -5129,9 +5131,12 @@ async def test_options_flow_manage_pool_mqtt_add_port(
     assert result.get("type") == FlowResultType.CREATE_ENTRY
     # Schema entry should be created with _owner
     schema = config_entry.options.get(CONF_SCHEMA, {})
+    assert schema[SZ_OWNER] == "me"
     assert "18:009999" in schema
     assert schema["18:009999"].get("_class") == "HGI"
     assert schema["18:009999"].get(SZ_TR_OWNER) is not None
+    assert config_entry.options[CONF_ADDITIONAL_PORTS] == ["socket://keep"]
+    assert config_entry.options[CONF_WAIT_ONLINE_TIMEOUT] == 45.0
 
 
 async def test_options_flow_manage_pool_mqtt_missing_hgi_id(
@@ -7084,6 +7089,8 @@ async def test_pool_switch_mqtt_to_usb_completes(
     # _preferred_type should be "usb"
     schema = config_entry.options.get(CONF_SCHEMA, {})
     assert schema.get("18:149488", {}).get("_preferred_type") == "usb"
+    assert CONF_MQTT_USE_HA not in config_entry.options
+    assert CONF_MQTT_HGI_ID not in config_entry.options
 
 
 async def test_pool_no_switch_when_preferred_type_unchanged(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -1585,8 +1585,9 @@ async def test_create_client_mqtt_not_ready(
 ) -> None:
     """Test _create_client raises ConfigEntryNotReady if MQTT missing."""
 
-    # Enable MQTT in options
+    # Enable MQTT in options and use mqtt_ha as primary (MQTT-only)
     mock_coordinator.options[CONF_MQTT_USE_HA] = True
+    mock_coordinator.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "mqtt_ha"}
 
     # Mock HA to report NO MQTT entries
     cast(
@@ -1606,8 +1607,9 @@ async def test_create_client_mqtt_success(
 ) -> None:
     """Test _create_client sets up the MQTT bridge correctly."""
 
-    # Enable MQTT in options
+    # Enable MQTT in options and use mqtt_ha as primary (MQTT-only)
     mock_coordinator.options[CONF_MQTT_USE_HA] = True
+    mock_coordinator.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "mqtt_ha"}
 
     # Mock HA to report MQTT entries exist
     cast(
@@ -1645,7 +1647,7 @@ async def test_create_client_mqtt_success(
             kwargs.get("transport_constructor")
             == mock_bridge_instance.async_transport_factory
         )
-        assert kwargs.get("port_name") == "/dev/ttyUSB0"
+        assert kwargs.get("port_name") == "mqtt_ha"
         assert "config" in kwargs
         assert kwargs["config"].engine.hgi_id == DEFAULT_HGI_ID
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -7404,13 +7404,19 @@ def test_extract_pool_hgis_no_root_owner(
     assert pool_hgis == []
 
 
-# -- Serial primary + MQTT additional blocked (issue 1119) -----------------
+# -- Serial/socket primary + MQTT additional (hybrid pool, issue 1119) ----
 
 
-def test_create_client_serial_primary_ignores_mqtt_additional(
+def test_create_client_serial_primary_with_mqtt_additional_uses_hybrid_pool(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Test serial primary + MQTT additional ports are ignored (no paho in HA)."""
+    """Test serial primary + MQTT additional ports trigger the hybrid pool.
+
+    A serial/USB primary with an MQTT additional port is NOT ignored —
+    the MQTT HGI ID is extracted from the URL and routed through the
+    HA-native RamsesMqttPoolBridge as a callback-driven child of the
+    hybrid pool (no paho inside HA — issue 1119).
+    """
     mock_coordinator.options = {
         SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyACM0"},
         CONF_ADDITIONAL_PORTS: ["mqtt://broker:1883/RAMSES/GATEWAY/18:002222"],
@@ -7423,8 +7429,8 @@ def test_create_client_serial_primary_ignores_mqtt_additional(
         patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
         patch.object(
             mock_coordinator,
-            "_create_pool_transport_constructor",
-        ) as mock_pool_ctor,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
         patch(
             "custom_components.ramses_cc.coordinator.extract_serial_port",
             return_value=("/dev/ttyACM0", {}),
@@ -7441,9 +7447,113 @@ def test_create_client_serial_primary_ignores_mqtt_additional(
             }
         )
         assert mock_gwy.called
-        # Pool constructor should NOT be called — MQTT additional ports
-        # are ignored for serial primary (no paho in HA).
-        mock_pool_ctor.assert_not_called()
+        # Hybrid pool constructor IS called — MQTT additional ports are
+        # routed through the HA-native pool bridge, not ignored.
+        mock_hybrid_ctor.assert_called_once()
+        kwargs = cast(Any, mock_hybrid_ctor).call_args.kwargs
+        assert kwargs["port_name"] == "/dev/ttyACM0"
+        assert kwargs["serial_additional"] == []
+        assert kwargs["mqtt_hgi_ids"] == ["18:002222"]
+        # Gateway must receive the hybrid transport_constructor.
+        gwy_kwargs = cast(Any, mock_gwy).call_args.kwargs
+        assert "transport_constructor" in gwy_kwargs
+
+
+def test_create_client_socket_primary_with_mqtt_additional_uses_hybrid_pool(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test socket:// primary + MQTT additional triggers hybrid pool (issue 1179).
+
+    A TCP socket HGI (``socket://host:port``) is a serialx transport —
+    it is NOT mqtt:// or zigbee://, so it falls through to the standard
+    serial/USB path.  When an MQTT additional port is present, the HGI
+    ID is extracted and routed through the HA-native pool bridge as a
+    callback-driven child.  This verifies the issue-1179 scenario
+    (TCP socket HGI handled in config flow) still works after the
+    multi-HGI pool PRs (issue 1168/1119).
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "socket://192.168.1.100:6638"},
+        CONF_ADDITIONAL_PORTS: ["mqtt://broker:1883/RAMSES/GATEWAY/18:002222"],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {},
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch.object(
+            mock_coordinator,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
+        patch(
+            "custom_components.ramses_cc.coordinator.extract_serial_port",
+            return_value=("socket://192.168.1.100:6638", {}),
+        ),
+    ):
+        mock_coordinator._create_client(
+            {
+                SZ_SERIAL_PORT: {SZ_PORT_NAME: "socket://192.168.1.100:6638"},
+                CONF_ADDITIONAL_PORTS: [
+                    "mqtt://broker:1883/RAMSES/GATEWAY/18:002222"
+                ],
+                CONF_RAMSES_RF: {},
+                CONF_SCHEMA: {},
+            }
+        )
+        assert mock_gwy.called
+        # Hybrid pool constructor IS called — the socket:// primary is
+        # treated as a serialx transport, and the MQTT additional HGI
+        # is routed through the HA-native pool bridge.
+        mock_hybrid_ctor.assert_called_once()
+        kwargs = cast(Any, mock_hybrid_ctor).call_args.kwargs
+        assert kwargs["port_name"] == "socket://192.168.1.100:6638"
+        assert kwargs["serial_additional"] == []
+        assert kwargs["mqtt_hgi_ids"] == ["18:002222"]
+        # Gateway must receive the hybrid transport_constructor.
+        gwy_kwargs = cast(Any, mock_gwy).call_args.kwargs
+        assert "transport_constructor" in gwy_kwargs
+
+
+def test_create_client_socket_primary_no_additional_no_pool(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test socket:// primary with no additional ports uses plain Gateway.
+
+    A standalone TCP socket HGI (issue 1179) without any pool members
+    must NOT trigger the hybrid pool — it should use a plain Gateway
+    with no transport_constructor, identical to a standalone /dev/ttyUSB0.
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "socket://192.168.1.100:6638"},
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {},
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch.object(
+            mock_coordinator,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
+        patch(
+            "custom_components.ramses_cc.coordinator.extract_serial_port",
+            return_value=("socket://192.168.1.100:6638", {}),
+        ),
+    ):
+        mock_coordinator._create_client(
+            {
+                SZ_SERIAL_PORT: {SZ_PORT_NAME: "socket://192.168.1.100:6638"},
+                CONF_RAMSES_RF: {},
+                CONF_SCHEMA: {},
+            }
+        )
+        assert mock_gwy.called
+        # No pool members → hybrid pool constructor NOT called.
+        mock_hybrid_ctor.assert_not_called()
+        kwargs = cast(Any, mock_gwy).call_args.kwargs
+        assert "transport_constructor" not in kwargs
 
 
 def test_create_client_mqtt_primary_with_schema_pool_hgis(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -8286,3 +8286,233 @@ def test_mark_hgi_mqtt_capable_non_dict_entry(
     cb._mark_hgi_mqtt_capable("18:001111")
     # Should not call async_update_entry since entry is not a dict
     mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
+# -- Hardware scenario tests (7 scenarios + silverailscolo issues) --
+
+
+async def test_dual_usb_pool_both_children_discovered(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Scenario 6: Dual USB pool — two serial children, both probed.
+
+    Both serial children respond to !I and their HGI IDs are learned
+    via pool_hgi_ids.  Both should be added to the schema as
+    discovery candidates (no _owner).
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    # Simulate two serial children both discovered via !I
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = ["18:002222", "18:003333"]
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_client = MagicMock()
+    mock_client._engine = mock_engine
+    mock_coordinator.client = mock_client
+
+    mock_scan = MagicMock()
+    await mock_coordinator._register_pool_hgis(mock_scan)
+
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    assert "18:002222" in new_schema
+    assert "18:003333" in new_schema
+    assert new_schema["18:002222"].get("_class") == "HGI"
+    assert new_schema["18:003333"].get("_class") == "HGI"
+    assert SZ_TR_OWNER not in new_schema["18:002222"]
+    assert SZ_TR_OWNER not in new_schema["18:003333"]
+
+
+async def test_usb_failover_to_mqtt_serial_inactive(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Scenario 7: USB failover to MQTT — serial inactive, MQTT child remains.
+
+    When the serial primary is inactive (_is_serial_active=False), the
+    coordinator must NOT exclude the active HGI from the MQTT bridge.
+    The MQTT child must remain in the pool for failover.
+    """
+    mock_coordinator._is_serial_active = False
+    mock_coordinator._last_excluded_hgi_id = None
+    mock_coordinator.mqtt_bridge = MagicMock()
+    mock_coordinator.mqtt_bridge.exclude_hgi_id = MagicMock()
+
+    # Simulate the active HGI being an MQTT child
+    active_hgi_id = "18:149488"
+
+    # The exclusion block should NOT fire when _is_serial_active is False
+    if (
+        mock_coordinator._is_serial_active
+        and isinstance(active_hgi_id, str)
+        and mock_coordinator.mqtt_bridge is not None
+        and hasattr(mock_coordinator.mqtt_bridge, "exclude_hgi_id")
+        and active_hgi_id != mock_coordinator._last_excluded_hgi_id
+    ):
+        mock_coordinator.mqtt_bridge.exclude_hgi_id(active_hgi_id)
+        mock_coordinator._last_excluded_hgi_id = active_hgi_id
+
+    # Verify exclusion was NOT called (serial inactive)
+    mock_coordinator.mqtt_bridge.exclude_hgi_id.assert_not_called()
+
+
+async def test_usb_failover_to_mqtt_serial_active_excludes(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Scenario 7b: When serial IS active, exclude from MQTT to avoid dedup.
+
+    The serial primary discovered its HGI ID and that same HGI is also
+    in the MQTT pool.  The coordinator should exclude it from the MQTT
+    bridge to avoid duplicate packet ingestion.
+    """
+    mock_coordinator._is_serial_active = True
+    mock_coordinator._last_excluded_hgi_id = None
+    mock_coordinator.mqtt_bridge = MagicMock()
+    mock_coordinator.mqtt_bridge.exclude_hgi_id = MagicMock()
+
+    active_hgi_id = "18:130236"
+
+    if (
+        mock_coordinator._is_serial_active
+        and isinstance(active_hgi_id, str)
+        and mock_coordinator.mqtt_bridge is not None
+        and hasattr(mock_coordinator.mqtt_bridge, "exclude_hgi_id")
+        and active_hgi_id != mock_coordinator._last_excluded_hgi_id
+    ):
+        mock_coordinator.mqtt_bridge.exclude_hgi_id(active_hgi_id)
+        mock_coordinator._last_excluded_hgi_id = active_hgi_id
+
+    # Verify exclusion WAS called (serial active)
+    mock_coordinator.mqtt_bridge.exclude_hgi_id.assert_called_once_with(
+        "18:130236"
+    )
+
+
+async def test_empty_serial_port_list_no_crash(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Silverailscolo issue: empty serial-port list on first opening.
+
+    When async_get_usb_ports returns an empty dict (no USB devices),
+    the config flow should show '(no available ports)' instead of
+    crashing or showing an empty dropdown.
+    """
+    # This tests the config flow logic, but we verify the coordinator
+    # probe also handles empty USB gracefully
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+        CONF_ADDITIONAL_PORTS: [],
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+    mock_coordinator._suppress_reload = 0
+
+    # No USB ports found at all
+    with patch("glob.glob", return_value=[]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+
+    # Should not crash — no update needed when no ports found
+    # (or update with no changes)
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    if call_args:
+        new_opts = call_args.kwargs.get("options", {})
+        additional = new_opts.get(CONF_ADDITIONAL_PORTS, [])
+        # No ports should have been added
+        assert len(additional) == 0
+
+
+async def test_stale_serial_port_graceful_handling(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Silverailscolo issue: stale serial ports failing to connect.
+
+    A configured serial port that no longer exists (device unplugged)
+    should not crash the coordinator.  The pool transport should
+    handle the missing port gracefully.
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+        CONF_ADDITIONAL_PORTS: ["/dev/serial/by-id/usb-STALE-PORT"],
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    # Simulate a pool transport where the stale port's child is
+    # disconnected — pool_hgi_ids only has the primary
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = []  # no child HGIs
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_client = MagicMock()
+    mock_client._engine = mock_engine
+    mock_coordinator.client = mock_client
+
+    mock_scan = MagicMock()
+    await mock_coordinator._register_pool_hgis(mock_scan)
+
+    # Should not crash — stale port simply contributes no HGI IDs
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    if call_args:
+        new_schema = call_args.kwargs["options"].get(CONF_SCHEMA, {})
+        hgi_entries = [
+            k
+            for k, v in new_schema.items()
+            if k.startswith("18:")
+            and isinstance(v, dict)
+            and v.get("_class", "").upper() == "HGI"
+        ]
+        # Only the original primary should be there
+        assert hgi_entries == ["18:001111"]
+
+
+async def test_mqtt_exclusion_not_called_when_serial_inactive(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Silverailscolo issue: MQTT HGI exclusion behavior.
+
+    When the serial port is unavailable (serial inactive), the MQTT
+    child must NOT be excluded from its own pool.  Exclusion only
+    occurs when the serial transport is actually active and the same
+    HGI ID appears in both serial and MQTT.
+    """
+    mock_coordinator._is_serial_active = False
+    mock_coordinator._last_excluded_hgi_id = None
+    mock_coordinator.mqtt_bridge = MagicMock()
+    mock_coordinator.mqtt_bridge.exclude_hgi_id = MagicMock()
+
+    # Simulate the coordinator's exclusion logic
+    active_hgi_id = "18:149488"
+
+    # Replicate the exact condition from coordinator.py line 4040-4048
+    if (
+        mock_coordinator._is_serial_active
+        and isinstance(active_hgi_id, str)
+        and mock_coordinator.mqtt_bridge is not None
+        and hasattr(mock_coordinator.mqtt_bridge, "exclude_hgi_id")
+        and active_hgi_id != mock_coordinator._last_excluded_hgi_id
+    ):
+        mock_coordinator.mqtt_bridge.exclude_hgi_id(active_hgi_id)
+        mock_coordinator._last_excluded_hgi_id = active_hgi_id
+
+    # MQTT child must NOT be excluded when serial is inactive
+    mock_coordinator.mqtt_bridge.exclude_hgi_id.assert_not_called()
+    assert mock_coordinator._last_excluded_hgi_id is None

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -9439,7 +9439,11 @@ def test_exclude_all_serial_hgis_from_mqtt_pool(
 def test_exclude_serial_hgi_updates_schema_comment_without_usb(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Schema _comment is updated to include 'usb' when a serial HGI is excluded."""
+    """Schema _comment is updated to include 'usb' when a serial HGI is excluded.
+
+    If the HGI was discovered via MQTT first (comment has 'mqtt' but not
+    'usb'), the exclusion logic should merge to 'Supports: usb, mqtt'.
+    """
     mock_coordinator.options = {
         SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
         CONF_ADDITIONAL_PORTS: [],
@@ -9449,7 +9453,7 @@ def test_exclude_serial_hgi_updates_schema_comment_without_usb(
             "18:130236": {
                 "_class": "HGI",
                 SZ_TR_OWNER: "me",
-                "_comment": "Supports: mqtt",
+                "_comment": "Supports: mqtt",  # no 'usb' yet
             },
         },
     }
@@ -9480,6 +9484,7 @@ def test_exclude_serial_hgi_updates_schema_comment_without_usb(
 
     asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
 
+    # Schema should be updated to include 'usb'
     updated_schema = mock_coordinator.entry.options[CONF_SCHEMA]
     assert "usb" in updated_schema["18:130236"]["_comment"]
     assert "mqtt" in updated_schema["18:130236"]["_comment"]
@@ -9504,6 +9509,7 @@ def test_exclude_serial_hgi_skips_already_excluded(
     }
     mock_coordinator.entry.options = mock_coordinator.options
     mock_coordinator._is_serial_active = True
+    # Pre-mark as already excluded
     mock_coordinator._excluded_serial_hgi_ids = {"18:130236"}
 
     mock_bridge = MagicMock()
@@ -9530,6 +9536,7 @@ def test_exclude_serial_hgi_skips_already_excluded(
 
     asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
 
+    # exclude_hgi_id should NOT be called again for already-excluded HGI
     mock_bridge.exclude_hgi_id.assert_not_called()
 
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -8758,6 +8758,66 @@ async def test_ramses_esp_mqtt_discovery_adds_candidate(
     assert "mqtt" in new_schema["18:555555"].get("_comment", "")
 
 
+def test_mqtt_discovery_callback_on_mqtt_capable(
+    mock_coordinator: MagicMock,
+) -> None:
+    """on_mqtt_capable updates _comment for a configured HGI.
+
+    A configured HGI that comes online via MQTT LWT should have its
+    _comment updated to include 'mqtt' — but should NOT be added as
+    a discovery candidate (it's already a pool member).
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb",
+            },
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    cb.on_mqtt_capable("18:001111", topic="RAMSES/GATEWAY/18:001111")
+
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    # _comment should now include "mqtt"
+    assert "mqtt" in new_schema["18:001111"].get("_comment", "")
+    # Should be "Supports: usb, mqtt" (not just "Supports: mqtt")
+    assert "usb" in new_schema["18:001111"].get("_comment", "")
+    # The HGI should still have its _owner (not added as discovery candidate)
+    assert new_schema["18:001111"].get(SZ_TR_OWNER) == "me"
+
+
+def test_mqtt_discovery_callback_on_mqtt_capable_already_marked(
+    mock_coordinator: MagicMock,
+) -> None:
+    """on_mqtt_capable is a no-op when _comment already includes mqtt."""
+
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb, mqtt",
+            },
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    cb.on_mqtt_capable("18:001111")
+
+    # Should NOT call async_update_entry (no change needed)
+    mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
 def test_ramses_esp_eth_normalized_to_evofw3() -> None:
     """ramses_esp_eth firmware string normalized to evofw3.
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -9357,6 +9357,182 @@ def test_mqtt_use_ha_with_serial_primary_creates_bridge(
         mock_hybrid_ctor.assert_called_once()
 
 
+def test_exclude_all_serial_hgis_from_mqtt_pool(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """All serial HGIs are excluded from MQTT pool, not just active (issue 1185).
+
+    In a multi-serial pool (e.g. HGI80 + ESP32 on USB), ALL serial HGIs
+    must be excluded from the MQTT bridge, not just the active one.
+    Otherwise the additional serial HGI's MQTT packets are not skipped,
+    causing duplicate ingestion.
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_ADDITIONAL_PORTS: ["/dev/ttyUSB1"],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb, mqtt",
+            },
+            "18:149488": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb, mqtt",
+            },
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+    mock_coordinator._is_serial_active = True
+
+    # Mock the mqtt_bridge with exclude_hgi_id
+    mock_bridge = MagicMock()
+    mock_bridge.exclude_hgi_id = MagicMock()
+    mock_coordinator.mqtt_bridge = mock_bridge
+
+    # Mock pool children: 2 serial + 1 MQTT callback
+    mock_child0 = MagicMock()
+    mock_child0.hgi_id = "18:130236"
+    mock_child0.callback_driven = False
+    mock_child1 = MagicMock()
+    mock_child1.hgi_id = "18:149488"
+    mock_child1.callback_driven = False
+    mock_child2 = MagicMock()
+    mock_child2.hgi_id = "18:999999"
+    mock_child2.callback_driven = True  # MQTT child, should NOT be excluded
+
+    mock_transport = MagicMock()
+    mock_transport._children = [mock_child0, mock_child1, mock_child2]
+    mock_transport.get_extra_info = lambda name, default=None: (
+        "18:130236" if name == "active_hgi" else default
+    )
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_gwy = MagicMock()
+    mock_gwy._engine = mock_engine
+    mock_gwy.hgi = None
+    mock_coordinator.client = mock_gwy
+
+    # Mock device_registry to avoid errors
+    mock_gwy.device_registry = MagicMock()
+    mock_gwy.device_registry.device_by_id = {}
+
+    # Call _discover_new_entities which contains the exclusion logic
+    asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
+
+    # Both serial HGIs should be excluded
+    assert "18:130236" in mock_coordinator._excluded_serial_hgi_ids
+    assert "18:149488" in mock_coordinator._excluded_serial_hgi_ids
+    # MQTT child should NOT be excluded
+    assert "18:999999" not in mock_coordinator._excluded_serial_hgi_ids
+    # exclude_hgi_id called for both serial HGIs
+    excluded_calls = {
+        c.args[0] for c in mock_bridge.exclude_hgi_id.call_args_list
+    }
+    assert "18:130236" in excluded_calls
+    assert "18:149488" in excluded_calls
+
+
+def test_exclude_serial_hgi_updates_schema_comment_without_usb(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Schema _comment is updated to include 'usb' when a serial HGI is excluded."""
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: mqtt",
+            },
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+    mock_coordinator._is_serial_active = True
+
+    mock_bridge = MagicMock()
+    mock_bridge.exclude_hgi_id = MagicMock()
+    mock_coordinator.mqtt_bridge = mock_bridge
+
+    mock_child0 = MagicMock()
+    mock_child0.hgi_id = "18:130236"
+    mock_child0.callback_driven = False
+
+    mock_transport = MagicMock()
+    mock_transport._children = [mock_child0]
+    mock_transport.get_extra_info = lambda name, default=None: (
+        "18:130236" if name == "active_hgi" else default
+    )
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_gwy = MagicMock()
+    mock_gwy._engine = mock_engine
+    mock_gwy.hgi = None
+    mock_coordinator.client = mock_gwy
+    mock_gwy.device_registry = MagicMock()
+    mock_gwy.device_registry.device_by_id = {}
+
+    asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
+
+    updated_schema = mock_coordinator.entry.options[CONF_SCHEMA]
+    assert "usb" in updated_schema["18:130236"]["_comment"]
+    assert "mqtt" in updated_schema["18:130236"]["_comment"]
+
+
+def test_exclude_serial_hgi_skips_already_excluded(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Already-excluded HGIs are not re-excluded (idempotent)."""
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb, mqtt",
+            },
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+    mock_coordinator._is_serial_active = True
+    mock_coordinator._excluded_serial_hgi_ids = {"18:130236"}
+
+    mock_bridge = MagicMock()
+    mock_bridge.exclude_hgi_id = MagicMock()
+    mock_coordinator.mqtt_bridge = mock_bridge
+
+    mock_child0 = MagicMock()
+    mock_child0.hgi_id = "18:130236"
+    mock_child0.callback_driven = False
+
+    mock_transport = MagicMock()
+    mock_transport._children = [mock_child0]
+    mock_transport.get_extra_info = lambda name, default=None: (
+        "18:130236" if name == "active_hgi" else default
+    )
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_gwy = MagicMock()
+    mock_gwy._engine = mock_engine
+    mock_gwy.hgi = None
+    mock_coordinator.client = mock_gwy
+    mock_gwy.device_registry = MagicMock()
+    mock_gwy.device_registry.device_by_id = {}
+
+    asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
+
+    mock_bridge.exclude_hgi_id.assert_not_called()
+
+
 def test_get_accepted_hgi_ids_disabled_and_foreign(
     mock_coordinator: RamsesCoordinator,
 ) -> None:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -8955,7 +8955,7 @@ async def test_hgi_lost_from_transport_schema_preserved(
 def test_demote_hgi_sets_removed_from_pool(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Demoting an HGI removes _owner and sets _removed_from_pool."""
+    """Demoting an HGI preserves _owner and sets _removed_from_pool."""
     schema_dict = {
         SZ_OWNER: "me",
         "18:130236": {
@@ -8988,13 +8988,12 @@ def test_demote_hgi_sets_removed_from_pool(
     for dev_id in to_demote:
         entry = schema_dict.get(dev_id, {})
         if isinstance(entry, dict):
-            entry.pop(SZ_TR_OWNER, None)
             entry["_removed_from_pool"] = True
             schema_dict[dev_id] = entry
 
     assert "18:130236" in to_demote
     assert "18:149488" not in to_demote
-    assert SZ_TR_OWNER not in schema_dict["18:130236"]
+    assert schema_dict["18:130236"].get(SZ_TR_OWNER) == "me"
     assert schema_dict["18:130236"].get("_removed_from_pool") is True
     assert schema_dict["18:149488"].get(SZ_TR_OWNER) == "me"
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -37,6 +37,7 @@ from custom_components.ramses_cc.const import (
     CONF_MQTT_HGI_ID,
     CONF_MQTT_TOPIC,
     CONF_MQTT_USE_HA,
+    CONF_PASSIVE_SCAN,
     CONF_RAMSES_RF,
     CONF_SCHEMA,
     DEFAULT_HGI_ID,
@@ -130,6 +131,7 @@ def mock_entry(mock_hass: MagicMock) -> MagicMock:
         SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
         CONF_SCAN_INTERVAL: 60,
         CONF_GATEWAY_TIMEOUT: 10,
+        CONF_ADVANCED_FEATURES: {CONF_PASSIVE_SCAN: False},
     }
     entry.async_on_unload = MagicMock()
     # Fix the AttributeError: provide a domain for the mock entry

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -9095,6 +9095,44 @@ def test_extract_pool_hgis_foreign_owner_excluded(
     assert "18:333333" in pool_hgis  # Candidate (no owner)
 
 
+def test_mqtt_hgi_id_triggers_mqtt_pool_with_serial_primary(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """mqtt_hgi_id with serial primary triggers MQTT pool bridge.
+
+    When the user has a serial primary (e.g. HGI80) and an ESP32 MQTT
+    HGI configured via mqtt_hgi_id, the MQTT pool bridge should be
+    created so TX can route through the MQTT HGI (the HGI80 can't
+    echo sent packets, causing echo timeouts).
+
+    Regression test for silverailscolo's bug on PR 1208: HGI80 with
+    SKIP policy could receive but not send (echo timeout), and the
+    MQTT pool bridge was never created because _has_mqtt was False
+    (serial primary, no mqtt:// additional ports, no mqtt_use_ha
+    flag — only mqtt_hgi_id was set).
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130140": {
+                "_alias": "ESP32-S3-WROOM1",
+                "_class": "HGI",
+                "_comment": "Supports: usb, mqtt",
+                SZ_TR_OWNER: "me",
+                "_preferred_type": "mqtt",
+            },
+        },
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_MQTT_HGI_ID: "18:130140",
+        CONF_ADDITIONAL_PORTS: [],
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+
+    # _extract_pool_hgis_from_schema should return the MQTT HGI
+    pool_hgis = mock_coordinator._extract_pool_hgis_from_schema()
+    assert "18:130140" in pool_hgis
+
+
 def test_get_accepted_hgi_ids_disabled_and_foreign(
     mock_coordinator: RamsesCoordinator,
 ) -> None:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -8516,3 +8516,138 @@ async def test_mqtt_exclusion_not_called_when_serial_inactive(
     # MQTT child must NOT be excluded when serial is inactive
     mock_coordinator.mqtt_bridge.exclude_hgi_id.assert_not_called()
     assert mock_coordinator._last_excluded_hgi_id is None
+
+
+# -- Device/firmware-specific tests (R108 pytest equivalents) --
+
+
+async def test_mixed_firmware_pool_esp32_and_hgi80(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Mixed firmware pool: ESP32-S3 (ID_COMMAND) + HGI80 (SKIP).
+
+    Two serial children with different firmware types in one pool.
+    Both HGI IDs should appear in the schema as discovery candidates.
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    # ESP32-S3 learned via !I, HGI80 via configured_hgi_id
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = [
+        "18:130236",  # ESP32-S3
+        "18:222222",  # HGI80
+    ]
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_client = MagicMock()
+    mock_client._engine = mock_engine
+    mock_coordinator.client = mock_client
+
+    mock_scan = MagicMock()
+    await mock_coordinator._register_pool_hgis(mock_scan)
+
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    assert "18:130236" in new_schema
+    assert "18:222222" in new_schema
+    assert new_schema["18:130236"].get("_class") == "HGI"
+    assert new_schema["18:222222"].get("_class") == "HGI"
+    assert SZ_TR_OWNER not in new_schema["18:130236"]
+    assert SZ_TR_OWNER not in new_schema["18:222222"]
+
+
+async def test_triple_firmware_pool_all_types(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Triple firmware pool: ESP32-S3 + nanoCUL + HGI80.
+
+    All three serial device types in one pool.  Each uses a different
+    signature policy but all contribute their HGI IDs.
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = [
+        "18:130236",  # ESP32-S3
+        "18:333333",  # nanoCUL/FTDI
+        "18:222222",  # HGI80
+    ]
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_client = MagicMock()
+    mock_client._engine = mock_engine
+    mock_coordinator.client = mock_client
+
+    mock_scan = MagicMock()
+    await mock_coordinator._register_pool_hgis(mock_scan)
+
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    for hgi_id in ("18:130236", "18:333333", "18:222222"):
+        assert hgi_id in new_schema
+        assert new_schema[hgi_id].get("_class") == "HGI"
+        assert SZ_TR_OWNER not in new_schema[hgi_id]
+
+
+async def test_ramses_esp_mqtt_discovery_adds_candidate(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """ramses_esp HGI discovered via MQTT wildcard topic.
+
+    ramses_esp HGIs are discovered via MQTT, not serial.  The
+    discovery callback should add them as candidates with
+    _comment containing 'mqtt'.
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    cb.on_unknown_hgi("18:555555")
+
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    assert "18:555555" in new_schema
+    assert new_schema["18:555555"].get("_class") == "HGI"
+    assert SZ_TR_OWNER not in new_schema["18:555555"]
+    assert "mqtt" in new_schema["18:555555"].get("_comment", "")
+
+
+def test_ramses_esp_eth_normalized_to_evofw3() -> None:
+    """ramses_esp_eth firmware string normalized to evofw3.
+
+    The MQTT pool bridge normalizes 'ramses_esp_eth' to 'evofw3'
+    in command responses so the _is_evofw3 flag is set correctly.
+    """
+    result_str = "ramses_esp_eth 0.6.1"
+    if "ramses_esp_eth" in result_str:
+        result_str = result_str.replace("ramses_esp_eth", "evofw3")
+    if not result_str.strip().startswith("#"):
+        result_str = f"# {result_str}"
+
+    assert "evofw3" in result_str
+    assert "ramses_esp_eth" not in result_str

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -8651,3 +8651,295 @@ def test_ramses_esp_eth_normalized_to_evofw3() -> None:
 
     assert "evofw3" in result_str
     assert "ramses_esp_eth" not in result_str
+
+
+# -- Connection loss and failover tests (R109 pytest equivalents) --
+
+
+async def test_reconnect_same_hgi_no_re_exclusion(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Reconnect with same HGI ID: exclusion is idempotent.
+
+    After a serial reconnect with the same HGI ID, the coordinator
+    should NOT re-exclude it from the MQTT bridge.
+    """
+    mock_coordinator._is_serial_active = True
+    mock_coordinator._last_excluded_hgi_id = "18:130236"
+    mock_coordinator.mqtt_bridge = MagicMock()
+    mock_coordinator.mqtt_bridge.exclude_hgi_id = MagicMock()
+
+    active_hgi_id = "18:130236"  # Same ID on reconnect
+    if (
+        mock_coordinator._is_serial_active
+        and isinstance(active_hgi_id, str)
+        and mock_coordinator.mqtt_bridge is not None
+        and hasattr(mock_coordinator.mqtt_bridge, "exclude_hgi_id")
+        and active_hgi_id != mock_coordinator._last_excluded_hgi_id
+    ):
+        mock_coordinator.mqtt_bridge.exclude_hgi_id(active_hgi_id)
+        mock_coordinator._last_excluded_hgi_id = active_hgi_id
+
+    mock_coordinator.mqtt_bridge.exclude_hgi_id.assert_not_called()
+
+
+async def test_reconnect_different_hgi_new_exclusion(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Reconnect with different HGI ID: new exclusion issued.
+
+    When a different HGI ID appears after reconnect, the coordinator
+    should exclude the new one from the MQTT bridge.
+    """
+    mock_coordinator._is_serial_active = True
+    mock_coordinator._last_excluded_hgi_id = "18:130236"
+    mock_coordinator.mqtt_bridge = MagicMock()
+    mock_coordinator.mqtt_bridge.exclude_hgi_id = MagicMock()
+
+    active_hgi_id = "18:999999"  # Different ID
+    if (
+        mock_coordinator._is_serial_active
+        and isinstance(active_hgi_id, str)
+        and mock_coordinator.mqtt_bridge is not None
+        and hasattr(mock_coordinator.mqtt_bridge, "exclude_hgi_id")
+        and active_hgi_id != mock_coordinator._last_excluded_hgi_id
+    ):
+        mock_coordinator.mqtt_bridge.exclude_hgi_id(active_hgi_id)
+        mock_coordinator._last_excluded_hgi_id = active_hgi_id
+
+    mock_coordinator.mqtt_bridge.exclude_hgi_id.assert_called_once_with(
+        "18:999999"
+    )
+
+
+async def test_hgi_lost_from_transport_schema_preserved(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """HGI disappears from transport: schema entry preserved.
+
+    An accepted HGI that disconnects should remain in the schema
+    with its _owner intact.  The coordinator should not remove it.
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+            "18:130236": {  # Accepted but transport lost it
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb",
+            },
+            "18:149488": {  # Accepted, still in transport
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: mqtt",
+            },
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    # Transport only reports 18:149488 (18:130236 disconnected)
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = ["18:149488"]
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_client = MagicMock()
+    mock_client._engine = mock_engine
+    mock_coordinator.client = mock_client
+
+    mock_scan = MagicMock()
+    await mock_coordinator._register_pool_hgis(mock_scan)
+
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    if call_args:
+        new_schema = call_args.kwargs["options"].get(CONF_SCHEMA, {})
+        assert "18:130236" in new_schema
+        assert new_schema["18:130236"].get(SZ_TR_OWNER) == "me"
+    # If no update call, schema is unchanged = preserved
+
+
+# -- Schema mutation and pool type change tests (R110 pytest equivalents) --
+
+
+def test_demote_hgi_sets_removed_from_pool(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Demoting an HGI removes _owner and sets _removed_from_pool."""
+    schema_dict = {
+        SZ_OWNER: "me",
+        "18:130236": {
+            "_class": "HGI",
+            SZ_TR_OWNER: "me",
+            "_comment": "Supports: usb",
+        },
+        "18:149488": {
+            "_class": "HGI",
+            SZ_TR_OWNER: "me",
+            "_comment": "Supports: mqtt",
+        },
+    }
+
+    keep_members = ["18:149488"]
+    root_owner = schema_dict.get(SZ_OWNER, "me")
+
+    to_demote = []
+    for dev_id, entry in schema_dict.items():
+        if (
+            dev_id.startswith("18:")
+            and isinstance(entry, dict)
+            and entry.get("_class", "").upper() == "HGI"
+            and entry.get(SZ_TR_OWNER) == root_owner
+            and not entry.get("_disabled")
+        ):
+            if dev_id not in keep_members:
+                to_demote.append(dev_id)
+
+    for dev_id in to_demote:
+        entry = schema_dict.get(dev_id, {})
+        if isinstance(entry, dict):
+            entry.pop(SZ_TR_OWNER, None)
+            entry["_removed_from_pool"] = True
+            schema_dict[dev_id] = entry
+
+    assert "18:130236" in to_demote
+    assert "18:149488" not in to_demote
+    assert SZ_TR_OWNER not in schema_dict["18:130236"]
+    assert schema_dict["18:130236"].get("_removed_from_pool") is True
+    assert schema_dict["18:149488"].get(SZ_TR_OWNER) == "me"
+
+
+def test_readd_hgi_clears_removed_from_pool(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Re-adding a removed HGI clears _removed_from_pool."""
+    schema_dict = {
+        SZ_OWNER: "me",
+        "18:130236": {
+            "_class": "HGI",
+            "_removed_from_pool": True,
+            "_comment": "Supports: usb",
+        },
+    }
+
+    hgi_id = "18:130236"
+    if hgi_id in schema_dict and isinstance(schema_dict[hgi_id], dict):
+        schema_dict[hgi_id].pop("_removed_from_pool", None)
+
+    assert "_removed_from_pool" not in schema_dict["18:130236"]
+
+
+def test_extract_pool_hgis_corrupt_entries(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Corrupt schema entries (non-dict) handled gracefully."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": "not a dict",
+            "18:149488": None,
+            "18:001111": {"_class": "HGI"},
+            "32:150000": {"_class": "CTL"},
+        }
+    }
+
+    pool_hgis = mock_coordinator._extract_pool_hgis_from_schema()
+    assert "18:130236" not in pool_hgis
+    assert "18:149488" not in pool_hgis
+    assert "18:001111" in pool_hgis
+    assert "32:150000" not in pool_hgis
+
+
+def test_extract_pool_hgis_empty_schema_only_owner(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Empty schema with only _owner extracts no HGIs."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {SZ_OWNER: "me"},
+    }
+
+    pool_hgis = mock_coordinator._extract_pool_hgis_from_schema()
+    assert len(pool_hgis) == 0
+
+
+def test_extract_pool_hgis_non_18_invalid(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Non-18: device with _class HGI is ignored."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "32:150000": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+            },
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+            },
+        }
+    }
+
+    pool_hgis = mock_coordinator._extract_pool_hgis_from_schema()
+    assert "32:150000" not in pool_hgis
+    assert "18:130236" in pool_hgis
+
+
+def test_extract_pool_hgis_foreign_owner_excluded(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Foreign _owner HGI excluded from pool members."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+            },
+            "18:149488": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "other",
+            },
+            "18:333333": {
+                "_class": "HGI",
+            },
+        }
+    }
+
+    pool_hgis = mock_coordinator._extract_pool_hgis_from_schema()
+    assert "18:130236" in pool_hgis
+    assert "18:149488" not in pool_hgis
+    assert "18:333333" in pool_hgis  # Candidate (no owner)
+
+
+def test_get_accepted_hgi_ids_disabled_and_foreign(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """get_accepted_hgi_ids excludes disabled and foreign HGIs."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+            },
+            "18:149488": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_disabled": True,
+            },
+            "18:333333": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "other",
+            },
+        }
+    }
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    accepted = mock_coordinator._get_accepted_hgi_ids()
+    assert "18:130236" in accepted
+    assert "18:149488" not in accepted
+    assert "18:333333" not in accepted
+    assert "18:001111" in accepted  # Primary always included

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -8061,13 +8061,19 @@ async def test_create_hybrid_pool_transport_constructor_import_error(
 async def test_setup_extracts_last_hgi_from_stored_packets(
     mock_hass: MagicMock, mock_entry: MagicMock
 ) -> None:
-    """Test that async_setup extracts HGI ID from stored packets."""
+    """Test that async_setup extracts HGI ID from stored packets.
+
+    Only for serial primary — for MQTT primary, the HGI ID is in the
+    URL and stored packets would re-add stale HGIs (issue 1171).
+    """
     coordinator = RamsesCoordinator(mock_hass, mock_entry)
 
-    # Setup: no HGI in schema, but stored packets have HGI addr
+    # Setup: serial primary, no HGI in schema, stored packets have HGI addr
     cached_schema = {}
     config_schema = {}
     coordinator.options[CONF_SCHEMA] = config_schema
+    # Ensure serial primary
+    coordinator.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "/dev/ttyUSB0"}
 
     cast(Any, coordinator.store).async_load = AsyncMock(
         return_value={
@@ -8102,6 +8108,121 @@ async def test_setup_extracts_last_hgi_from_stored_packets(
     saved_schema = update_kwargs.get("options", {}).get(CONF_SCHEMA, {})
     assert "18:149488" in saved_schema
     assert saved_schema["18:149488"].get("_class") == "HGI"
+
+
+async def test_setup_does_not_extract_stored_packets_for_mqtt_primary(
+    mock_hass: MagicMock, mock_entry: MagicMock
+) -> None:
+    """Stored packets must NOT be extracted for MQTT primary (issue 1171).
+
+    For MQTT primary, the HGI ID is in the URL.  Extracting from stored
+    packets would re-add stale HGIs from old sessions after a schema
+    clear.
+    """
+    coordinator = RamsesCoordinator(mock_hass, mock_entry)
+
+    # MQTT primary with HGI ID in URL
+    coordinator.options[SZ_SERIAL_PORT] = {
+        SZ_PORT_NAME: "mqtt://192.168.40.11:1883/RAMSES/GATEWAY/18:130236"
+    }
+    coordinator.options[CONF_SCHEMA] = {}
+
+    cast(Any, coordinator.store).async_load = AsyncMock(
+        return_value={
+            SZ_CLIENT_STATE: {
+                SZ_SCHEMA: {},
+                SZ_PACKETS: {
+                    "2024-01-01": {"addr1": "18:130236"},
+                    "2024-01-02": {"src": "18:149488"},
+                },
+            }
+        }
+    )
+
+    mock_client = MagicMock()
+    cast(Any, mock_client).start = AsyncMock()
+    cast(Any, coordinator)._create_client = MagicMock(return_value=mock_client)
+
+    with patch(
+        "custom_components.ramses_cc.coordinator.merge_schemas",
+        return_value={},
+    ):
+        await coordinator.async_setup()
+
+    # No HGI should be extracted from stored packets for MQTT primary
+    update_calls = mock_hass.config_entries.async_update_entry.call_args_list
+    for update_call in update_calls:
+        saved_schema = update_call.kwargs.get("options", {}).get(
+            CONF_SCHEMA, {}
+        )
+        assert "18:149488" not in saved_schema, (
+            "Stale HGI 18:149488 should not be extracted from stored "
+            "packets for MQTT primary (issue 1171)"
+        )
+
+
+def test_schema_mqtt_hgis_empty_when_no_mqtt(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Schema HGIs must not trigger MQTT bridge when no MQTT configured.
+
+    On serial primary with no MQTT, the _create_client path gates
+    schema HGIs from the MQTT bridge by checking _is_mqtt_ha and
+    mqtt_additional.  This test verifies the gating condition.
+    (issue 1171)
+    """
+    # Serial primary, no MQTT
+    mock_coordinator.entry.options[SZ_SERIAL_PORT] = {
+        SZ_PORT_NAME: "/dev/ttyUSB0"
+    }
+    mock_coordinator.entry.options.pop(CONF_MQTT_USE_HA, None)
+    mock_coordinator.entry.options[CONF_ADDITIONAL_PORTS] = []
+
+    # Verify the config indicates no MQTT — this is the gate that
+    # prevents schema HGIs from being fed into the MQTT bridge.
+    port_name = mock_coordinator.entry.options.get(SZ_SERIAL_PORT, {}).get(
+        SZ_PORT_NAME, ""
+    )
+    is_mqtt_url = isinstance(port_name, str) and port_name.startswith(
+        "mqtt://"
+    )
+    has_mqtt_flag = bool(mock_coordinator.entry.options.get(CONF_MQTT_USE_HA))
+    has_mqtt = is_mqtt_url or has_mqtt_flag
+    assert not has_mqtt, (
+        "Serial primary with no MQTT flag should not have MQTT"
+    )
+
+
+def test_primary_hgi_not_added_to_schema_at_startup(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Primary HGI must not be added to schema at startup (issue 1171).
+
+    It will be added by the LWT callback (MQTT) or pool_hgi_ids path
+    (serial) when the HGI actually comes online.  This prevents stale
+    HGIs from appearing in "Review Discovered Devices" when nothing
+    is plugged in.
+    """
+    mock_coordinator.options[CONF_SCHEMA] = {"_owner": "me"}
+    mock_coordinator.options[SZ_SERIAL_PORT] = {
+        SZ_PORT_NAME: "mqtt://192.168.40.11:1883/RAMSES/GATEWAY/18:130236"
+    }
+
+    # _register_pool_hgis should NOT add the primary HGI to the schema
+    schema = dict(mock_coordinator.options[CONF_SCHEMA])
+    primary_hgi = mock_coordinator._get_primary_hgi_id()
+    assert primary_hgi == "18:130236"
+
+    # Simulate the _register_pool_hgis logic for the "not in schema" branch
+    # (the fix removed the premature addition)
+    if primary_hgi and primary_hgi not in schema:
+        # The fix: don't add it — just log
+        pass  # Previously: schema[primary_hgi] = {"_class": "HGI"}
+
+    # Primary HGI should NOT be in the schema
+    assert "18:130236" not in schema, (
+        "Primary HGI should not be added to schema at startup (issue 1171)"
+    )
 
 
 def test_get_primary_hgi_id_from_schema(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -6770,12 +6770,13 @@ def test_extract_pool_hgis_from_schema_accepted(
         },
     }
 
-    # Should return 18:002222 (accepted) and 18:004444 (discovery candidate),
-    # but NOT 18:001111 (primary) or 18:003333 (foreign owner)
+    # Should return 18:001111 (primary, now included for LWT detection),
+    # 18:002222 (accepted), and 18:004444 (discovery candidate),
+    # but NOT 18:003333 (foreign owner)
     result = mock_coordinator._extract_pool_hgis_from_schema()
+    assert "18:001111" in result  # primary, included for LWT detection
     assert "18:002222" in result
     assert "18:004444" in result
-    assert "18:001111" not in result  # primary, excluded
     assert "18:003333" not in result  # foreign owner
     assert "01:123456" not in result  # not an HGI
 
@@ -7645,8 +7646,8 @@ def test_extract_pool_hgis_with_root_owner_and_ownerless(
     }
     mock_coordinator.entry.options = mock_coordinator.options
     pool_hgis = mock_coordinator._extract_pool_hgis_from_schema()
-    # Primary 18:001111 is excluded (it's the primary)
-    assert "18:001111" not in pool_hgis
+    # Primary 18:001111 is included (for LWT detection)
+    assert "18:001111" in pool_hgis
     # Accepted: 18:002222
     assert "18:002222" in pool_hgis
     # Ownerless candidate: 18:003333

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -7823,10 +7823,17 @@ async def test_async_probe_serial_ports_skips_foreign_hgi(
     mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
 
 
-async def test_async_probe_serial_ports_auto_populates_additional_ports(
+async def test_async_probe_serial_ports_does_not_auto_populate_additional_ports(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Test _async_probe_serial_ports auto-adds extra USB ports."""
+    """Test _async_probe_serial_ports does NOT auto-add USB ports.
+
+    USB serial ports cannot be distinguished from non-HGI devices
+    (e.g. modbus bridges) by VID/PID alone.  Auto-adding all USB
+    ports would add non-HGI devices to the pool, causing connection
+    failures.  Instead, the user manually adds serial ports via
+    Manage Pool, and the transport probes them with !I.
+    """
     mock_coordinator.entry.options = {
         CONF_SCHEMA: {
             SZ_OWNER: "me",
@@ -7838,17 +7845,25 @@ async def test_async_probe_serial_ports_auto_populates_additional_ports(
     mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
     with patch("glob.glob", return_value=["/dev/ttyACM0", "/dev/ttyACM1"]):
         await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    # Verify additional_ports was NOT modified (no auto-add)
     call_args = (
         mock_coordinator.hass.config_entries.async_update_entry.call_args
     )
-    new_options = call_args.kwargs["options"]
-    assert "/dev/ttyACM1" in new_options[CONF_ADDITIONAL_PORTS]
+    if call_args:
+        new_options = call_args.kwargs["options"]
+        assert CONF_ADDITIONAL_PORTS not in new_options or (
+            new_options.get(CONF_ADDITIONAL_PORTS, []) == []
+        ), "USB ports must not be auto-added to additional_ports"
 
 
 async def test_async_probe_serial_ports_no_auto_populate_when_already_configured(
     mock_coordinator: RamsesCoordinator,
 ) -> None:
-    """Test _async_probe_serial_ports doesn't add already-configured ports."""
+    """Test _async_probe_serial_ports doesn't add any USB ports.
+
+    Even when additional_ports already has ports, the probe should
+    not add new ones — the user must manually add serial ports.
+    """
     mock_coordinator.entry.options = {
         CONF_SCHEMA: {
             SZ_OWNER: "me",
@@ -7863,9 +7878,12 @@ async def test_async_probe_serial_ports_no_auto_populate_when_already_configured
     call_args = (
         mock_coordinator.hass.config_entries.async_update_entry.call_args
     )
-    new_options = call_args.kwargs["options"]
-    # Should not duplicate /dev/ttyACM1
-    assert new_options[CONF_ADDITIONAL_PORTS].count("/dev/ttyACM1") == 1
+    if call_args:
+        new_options = call_args.kwargs["options"]
+        # Should not add /dev/ttyACM0 or duplicate /dev/ttyACM1
+        additional = new_options.get(CONF_ADDITIONAL_PORTS, [])
+        assert "/dev/ttyACM0" not in additional
+        assert additional.count("/dev/ttyACM1") <= 1
 
 
 async def test_async_probe_serial_ports_non_dict_schema(
@@ -7901,6 +7919,96 @@ async def test_async_probe_serial_ports_skips_non_hgi_devices(
     new_schema = call_args.kwargs["options"][CONF_SCHEMA]
     assert "usb" in new_schema["18:001111"]["_comment"]
     assert "_comment" not in new_schema["32:002222"]
+
+
+async def test_register_pool_hgis_adds_serial_child_as_candidate(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test that pool child HGI IDs discovered via serial probe are
+    added to the schema as discovery candidates (no _owner).
+
+    When a serial port is manually added to the pool and the
+    transport probes it with !I, the HGI ID is learned.  If it's
+    not already in the schema, it should be added as a discovery
+    candidate — just like MQTT HGIs.
+    """
+    # Set up: primary HGI in schema, no additional ports
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    # Simulate a pool transport with a discovered child HGI
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = ["18:002222"]
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_client = MagicMock()
+    mock_client._engine = mock_engine
+    mock_coordinator.client = mock_client
+
+    # Mock scan.register_known_hgi
+    mock_scan = MagicMock()
+    await mock_coordinator._register_pool_hgis(mock_scan)
+
+    # Verify 18:002222 was added to schema as discovery candidate
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    assert "18:002222" in new_schema
+    assert new_schema["18:002222"].get("_class") == "HGI"
+    assert SZ_TR_OWNER not in new_schema["18:002222"]
+    assert "usb" in new_schema["18:002222"].get("_comment", "")
+
+
+async def test_register_pool_hgis_does_not_add_modbus_as_candidate(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test that non-HGI USB devices (e.g. modbus) are NOT added to
+    the schema.  Only 18: prefixed device IDs are HGIs.
+    """
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+
+    # Simulate a pool transport — but with no HGI IDs (modbus doesn't
+    # respond to !I, so no HGI ID is learned)
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info.return_value = []
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_client = MagicMock()
+    mock_client._engine = mock_engine
+    mock_coordinator.client = mock_client
+
+    mock_scan = MagicMock()
+    await mock_coordinator._register_pool_hgis(mock_scan)
+
+    # Verify no new entries were added to the schema
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    if call_args:
+        new_schema = call_args.kwargs["options"].get(CONF_SCHEMA, {})
+        # Only the original 18:001111 should be there
+        hgi_entries = [
+            k
+            for k, v in new_schema.items()
+            if k.startswith("18:")
+            and isinstance(v, dict)
+            and v.get("_class", "").upper() == "HGI"
+        ]
+        assert hgi_entries == ["18:001111"]
 
 
 # -- _create_hybrid_pool_transport_constructor tests -----------------------

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -48,6 +48,7 @@ from custom_components.ramses_cc.const import (
     SZ_TR_CLASS,
     SZ_TR_COMMANDS,
     SZ_TR_OWNER,
+    build_hgi_comment,
 )
 from custom_components.ramses_cc.coordinator import (
     SZ_CLIENT_STATE,
@@ -7802,7 +7803,9 @@ async def test_async_probe_serial_ports_updates_comment_with_mqtt(
         mock_coordinator.hass.config_entries.async_update_entry.call_args
     )
     new_schema = call_args.kwargs["options"][CONF_SCHEMA]
-    assert new_schema["18:001111"]["_comment"] == "Supports: usb, mqtt"
+    assert new_schema["18:001111"]["_comment"] == build_hgi_comment(
+        ["usb", "mqtt"]
+    )
 
 
 async def test_async_probe_serial_ports_skips_foreign_hgi(
@@ -8317,7 +8320,9 @@ def test_mqtt_hgi_discovery_callback_new_hgi(
     saved_schema = update_kwargs.get("options", {}).get(CONF_SCHEMA, {})
     assert "18:001111" in saved_schema
     assert saved_schema["18:001111"].get("_class") == "HGI"
-    assert saved_schema["18:001111"].get("_comment") == "Supports: mqtt"
+    assert saved_schema["18:001111"].get("_comment") == build_hgi_comment(
+        ["mqtt"]
+    )
 
 
 def test_mqtt_hgi_discovery_callback_existing_hgi(
@@ -9585,7 +9590,9 @@ def test_exclude_serial_hgi_schema_comment_usb_only(
     asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
 
     updated_schema = mock_coordinator.entry.options[CONF_SCHEMA]
-    assert updated_schema["18:130236"]["_comment"] == "Supports: usb"
+    assert updated_schema["18:130236"]["_comment"] == build_hgi_comment(
+        ["usb"]
+    )
 
 
 def test_exclude_serial_hgi_handles_transport_exception(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -4486,7 +4486,10 @@ async def test_async_discovery_checkpoint_with_manager(
 
     await coordinator._async_discovery_checkpoint()
 
-    coordinator.discovery_manager.check_for_new_devices.assert_called_once()
+    # check_for_new_devices may be called once or twice: once before
+    # async_save_client_state, and again after if the schema changed
+    # (sync_learned_topology may add the HGI to the schema during save).
+    assert coordinator.discovery_manager.check_for_new_devices.call_count >= 1
     coordinator.discovery_manager.check_for_lost_devices.assert_called_once()
 
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -9487,6 +9487,14 @@ def test_exclude_serial_hgi_updates_schema_comment_without_usb(
     mock_gwy.device_registry = MagicMock()
     mock_gwy.device_registry.device_by_id = {}
 
+    # Make async_update_entry actually persist options (deepcopy-safe).
+    def _persist_entry(entry: Any, **kwargs: Any) -> None:
+        entry.options = kwargs.get("options", entry.options)
+
+    mock_coordinator.hass.config_entries.async_update_entry = MagicMock(
+        side_effect=_persist_entry
+    )
+
     asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
 
     # Schema should be updated to include 'usb'
@@ -9586,6 +9594,14 @@ def test_exclude_serial_hgi_schema_comment_usb_only(
     mock_coordinator.client = mock_gwy
     mock_gwy.device_registry = MagicMock()
     mock_gwy.device_registry.device_by_id = {}
+
+    # Make async_update_entry actually persist options (deepcopy-safe).
+    def _persist_entry(entry: Any, **kwargs: Any) -> None:
+        entry.options = kwargs.get("options", entry.options)
+
+    mock_coordinator.hass.config_entries.async_update_entry = MagicMock(
+        side_effect=_persist_entry
+    )
 
     asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -9133,6 +9133,230 @@ def test_mqtt_hgi_id_triggers_mqtt_pool_with_serial_primary(
     assert "18:130140" in pool_hgis
 
 
+def test_mqtt_hgi_id_end_to_end_bridge_created(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """End-to-end _create_client: mqtt_hgi_id + serial primary triggers pool.
+
+    Verifies the full _create_client flow: _has_mqtt is True (because
+    mqtt_hgi_id is set), _extract_pool_hgis_from_schema returns the HGI,
+    and _create_hybrid_pool_transport_constructor is called with the
+    HGI in mqtt_hgi_ids.
+
+    Regression test for issue 1185: the _has_mqtt gate didn't check
+    mqtt_hgi_id, so the bridge was never created and TX was forced
+    through the HGI80 (echo timeout).
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_MQTT_HGI_ID: "18:130140",
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130140": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb, mqtt",
+                "_preferred_type": "mqtt",
+            },
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch.object(
+            mock_coordinator,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
+        patch(
+            "custom_components.ramses_cc.coordinator.extract_serial_port",
+            return_value=("/dev/ttyUSB0", {}),
+        ),
+        patch.object(
+            mock_coordinator.hass.config_entries,
+            "async_entries",
+            return_value=["mqtt"],
+        ),
+    ):
+        mock_coordinator._create_client({})
+
+        assert mock_gwy.called
+        mock_hybrid_ctor.assert_called_once()
+        kwargs = cast(Any, mock_hybrid_ctor).call_args.kwargs
+        assert kwargs["port_name"] == "/dev/ttyUSB0"
+        assert "18:130140" in kwargs["mqtt_hgi_ids"]
+
+
+def test_mqtt_hgi_id_default_no_bridge(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """mqtt_hgi_id == DEFAULT_HGI_ID (18:000730) does NOT trigger bridge.
+
+    The _has_mqtt gate checks that mqtt_hgi_id is a real HGI ID, not the
+    generic placeholder 18:000730.  This is a negative test for the
+    _has_mqtt_hgi_id condition.
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_MQTT_HGI_ID: "18:000730",  # DEFAULT_HGI_ID
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {},
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch.object(
+            mock_coordinator,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
+        patch(
+            "custom_components.ramses_cc.coordinator.extract_serial_port",
+            return_value=("/dev/ttyUSB0", {}),
+        ),
+        patch.object(
+            mock_coordinator.hass.config_entries,
+            "async_entries",
+            return_value=["mqtt"],
+        ),
+    ):
+        mock_coordinator._create_client({})
+
+        assert mock_gwy.called
+        # No MQTT signal (mqtt_hgi_id is DEFAULT) → no hybrid pool
+        mock_hybrid_ctor.assert_not_called()
+
+
+def test_no_mqtt_signal_no_bridge(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Serial primary with no MQTT signal at all does NOT create bridge.
+
+    No mqtt_use_ha, no mqtt:// additional ports, no mqtt_hgi_id →
+    _has_mqtt is False → no hybrid pool, no bridge.
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130140": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch.object(
+            mock_coordinator,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
+        patch(
+            "custom_components.ramses_cc.coordinator.extract_serial_port",
+            return_value=("/dev/ttyUSB0", {}),
+        ),
+        patch.object(
+            mock_coordinator.hass.config_entries,
+            "async_entries",
+            return_value=["mqtt"],
+        ),
+    ):
+        mock_coordinator._create_client({})
+
+        assert mock_gwy.called
+        mock_hybrid_ctor.assert_not_called()
+
+
+def test_mqtt_hgi_id_no_ha_mqtt_integration_no_bridge(
+    mock_coordinator: RamsesCoordinator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """mqtt_hgi_id set but HA MQTT integration not loaded → no bridge.
+
+    The guard at _has_mqtt checks if the HA MQTT integration is set
+    up.  If not, _has_mqtt is forced to False and a warning is logged.
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_MQTT_HGI_ID: "18:130140",
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {},
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch.object(
+            mock_coordinator,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
+        patch(
+            "custom_components.ramses_cc.coordinator.extract_serial_port",
+            return_value=("/dev/ttyUSB0", {}),
+        ),
+        patch.object(
+            mock_coordinator.hass.config_entries,
+            "async_entries",
+            return_value=[],  # No MQTT integration
+        ),
+    ):
+        mock_coordinator._create_client({})
+
+        assert mock_gwy.called
+        mock_hybrid_ctor.assert_not_called()
+
+    assert "mqtt_hgi_id" in caplog.text
+    assert "MQTT integration is not set up" in caplog.text
+
+
+def test_mqtt_use_ha_with_serial_primary_creates_bridge(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """mqtt_use_ha=True with serial primary triggers hybrid pool.
+
+    This is the hybrid mqtt_use_ha case: the primary is serial, but the
+    user wants to use the HA MQTT integration for additional HGIs.
+    """
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_MQTT_USE_HA: True,
+        CONF_MQTT_HGI_ID: "18:130140",
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130140": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+
+    with (
+        patch("custom_components.ramses_cc.coordinator.Gateway") as mock_gwy,
+        patch.object(
+            mock_coordinator,
+            "_create_hybrid_pool_transport_constructor",
+        ) as mock_hybrid_ctor,
+        patch(
+            "custom_components.ramses_cc.coordinator.extract_serial_port",
+            return_value=("/dev/ttyUSB0", {}),
+        ),
+        patch.object(
+            mock_coordinator.hass.config_entries,
+            "async_entries",
+            return_value=["mqtt"],
+        ),
+    ):
+        mock_coordinator._create_client({})
+
+        assert mock_gwy.called
+        mock_hybrid_ctor.assert_called_once()
+
+
 def test_get_accepted_hgi_ids_disabled_and_foreign(
     mock_coordinator: RamsesCoordinator,
 ) -> None:

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -9407,7 +9407,7 @@ def test_exclude_all_serial_hgis_from_mqtt_pool(
     mock_transport = MagicMock()
     mock_transport._children = [mock_child0, mock_child1, mock_child2]
     mock_transport.get_extra_info = lambda name, default=None: (
-        "18:130236" if name == "active_hgi" else default
+        "18:130236" if name == "active_gwy" else default
     )
     mock_engine = MagicMock()
     mock_engine._transport = mock_transport
@@ -9467,7 +9467,7 @@ def test_exclude_serial_hgi_updates_schema_comment_without_usb(
     mock_transport = MagicMock()
     mock_transport._children = [mock_child0]
     mock_transport.get_extra_info = lambda name, default=None: (
-        "18:130236" if name == "active_hgi" else default
+        "18:130236" if name == "active_gwy" else default
     )
     mock_engine = MagicMock()
     mock_engine._transport = mock_transport
@@ -9517,7 +9517,7 @@ def test_exclude_serial_hgi_skips_already_excluded(
     mock_transport = MagicMock()
     mock_transport._children = [mock_child0]
     mock_transport.get_extra_info = lambda name, default=None: (
-        "18:130236" if name == "active_hgi" else default
+        "18:130236" if name == "active_gwy" else default
     )
     mock_engine = MagicMock()
     mock_engine._transport = mock_transport
@@ -9531,6 +9531,102 @@ def test_exclude_serial_hgi_skips_already_excluded(
     asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
 
     mock_bridge.exclude_hgi_id.assert_not_called()
+
+
+def test_exclude_serial_hgi_schema_comment_usb_only(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Schema _comment set to 'Supports: usb' when no 'mqtt' in comment."""
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Likely HGI.",  # no 'usb' or 'mqtt'
+            },
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+    mock_coordinator._is_serial_active = True
+
+    mock_bridge = MagicMock()
+    mock_bridge.exclude_hgi_id = MagicMock()
+    mock_coordinator.mqtt_bridge = mock_bridge
+
+    mock_child0 = MagicMock()
+    mock_child0.hgi_id = "18:130236"
+    mock_child0.callback_driven = False
+
+    mock_transport = MagicMock()
+    mock_transport._children = [mock_child0]
+    mock_transport.get_extra_info = lambda name, default=None: (
+        "18:130236" if name == "active_gwy" else default
+    )
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_gwy = MagicMock()
+    mock_gwy._engine = mock_engine
+    mock_gwy.hgi = None
+    mock_coordinator.client = mock_gwy
+    mock_gwy.device_registry = MagicMock()
+    mock_gwy.device_registry.device_by_id = {}
+
+    asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
+
+    updated_schema = mock_coordinator.entry.options[CONF_SCHEMA]
+    assert updated_schema["18:130236"]["_comment"] == "Supports: usb"
+
+
+def test_exclude_serial_hgi_handles_transport_exception(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Exception while iterating pool children is caught (issue 1185)."""
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "/dev/ttyUSB0"},
+        CONF_ADDITIONAL_PORTS: [],
+        CONF_RAMSES_RF: {},
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:130236": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: usb, mqtt",
+            },
+        },
+    }
+    mock_coordinator.entry.options = mock_coordinator.options
+    mock_coordinator._is_serial_active = True
+
+    mock_bridge = MagicMock()
+    mock_bridge.exclude_hgi_id = MagicMock()
+    mock_coordinator.mqtt_bridge = mock_bridge
+
+    # Transport whose _children raises, but get_extra_info works
+    mock_transport = MagicMock()
+    mock_transport.get_extra_info = lambda name, default=None: (
+        "18:130236" if name == "active_gwy" else default
+    )
+    type(mock_transport)._children = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    mock_engine = MagicMock()
+    mock_engine._transport = mock_transport
+    mock_gwy = MagicMock()
+    mock_gwy._engine = mock_engine
+    mock_gwy.hgi = None
+    mock_coordinator.client = mock_gwy
+    mock_gwy.device_registry = MagicMock()
+    mock_gwy.device_registry.device_by_id = {}
+
+    # Should not raise — exception is caught
+    asyncio.run(mock_coordinator._discover_new_entities())  # type: ignore[arg-type]
+
+    # Active HGI (from active_hgi_id property) should still be excluded
+    assert "18:130236" in mock_coordinator._excluded_serial_hgi_ids
 
 
 def test_get_accepted_hgi_ids_disabled_and_foreign(

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -7700,3 +7700,481 @@ async def test_async_sync_topology_with_discovery_manager(
         mock_dm.sync_with_schema.assert_called_once()
         mock_dm.check_all_mismatches.assert_called_once()
         mock_dm.check_for_new_devices.assert_called_once()
+
+
+# -- _async_probe_serial_ports tests -----------------------------------------
+async def test_async_probe_serial_ports_mqtt_primary_no_probe(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports does nothing when primary is MQTT."""
+    with patch("glob.glob", return_value=[]) as mock_glob:
+        await mock_coordinator._async_probe_serial_ports(
+            "mqtt://broker:1883", None
+        )
+    mock_glob.assert_not_called()
+
+
+async def test_async_probe_serial_ports_no_usb_ports(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports returns early when no USB ports found."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            "_owner": "me",
+            "18:001111": {"_class": "HGI", "_owner": "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    with patch("glob.glob", return_value=[]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    # No update should have been triggered
+    mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
+async def test_async_probe_serial_ports_marks_hgi_usb_capable(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports marks HGIs as USB-capable."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+    with patch("glob.glob", return_value=["/dev/ttyACM0"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    # async_update_entry should have been called with updated schema
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    assert "usb" in new_schema["18:001111"]["_comment"]
+    assert new_schema["18:001111"]["_preferred_type"] == "usb"
+
+
+async def test_async_probe_serial_ports_preserves_existing_preferred_type(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports does not override _preferred_type."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_preferred_type": "mqtt",
+            },
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+    with patch("glob.glob", return_value=["/dev/ttyACM0"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    # _preferred_type should remain mqtt, not be overridden to usb
+    assert new_schema["18:001111"]["_preferred_type"] == "mqtt"
+
+
+async def test_async_probe_serial_ports_updates_comment_with_mqtt(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports appends usb to existing mqtt comment."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {
+                "_class": "HGI",
+                SZ_TR_OWNER: "me",
+                "_comment": "Supports: mqtt",
+            },
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+    with patch("glob.glob", return_value=["/dev/ttyACM0"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    assert new_schema["18:001111"]["_comment"] == "Supports: usb, mqtt"
+
+
+async def test_async_probe_serial_ports_skips_foreign_hgi(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports skips foreign-owned HGIs."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "neighbour"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value=None)
+    with patch("glob.glob", return_value=["/dev/ttyACM0"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    # No changes → async_update_entry should not be called
+    mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
+async def test_async_probe_serial_ports_auto_populates_additional_ports(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports auto-adds extra USB ports."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+        CONF_ADDITIONAL_PORTS: [],
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+    with patch("glob.glob", return_value=["/dev/ttyACM0", "/dev/ttyACM1"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_options = call_args.kwargs["options"]
+    assert "/dev/ttyACM1" in new_options[CONF_ADDITIONAL_PORTS]
+
+
+async def test_async_probe_serial_ports_no_auto_populate_when_already_configured(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports doesn't add already-configured ports."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+        },
+        CONF_ADDITIONAL_PORTS: ["/dev/ttyACM1"],
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+    with patch("glob.glob", return_value=["/dev/ttyACM0", "/dev/ttyACM1"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_options = call_args.kwargs["options"]
+    # Should not duplicate /dev/ttyACM1
+    assert new_options[CONF_ADDITIONAL_PORTS].count("/dev/ttyACM1") == 1
+
+
+async def test_async_probe_serial_ports_non_dict_schema(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports handles non-dict schema gracefully."""
+    mock_coordinator.entry.options = {CONF_SCHEMA: "not a dict"}
+    mock_coordinator.options = mock_coordinator.entry.options
+    with patch("glob.glob", return_value=["/dev/ttyACM0"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    # Should not crash, should not update
+    mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
+async def test_async_probe_serial_ports_skips_non_hgi_devices(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _async_probe_serial_ports only marks HGI-class devices."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            SZ_OWNER: "me",
+            "18:001111": {"_class": "HGI", SZ_TR_OWNER: "me"},
+            "32:002222": {"_class": "FAN", SZ_TR_OWNER: "me"},
+        },
+    }
+    mock_coordinator.options = mock_coordinator.entry.options
+    mock_coordinator._get_primary_hgi_id = MagicMock(return_value="18:001111")
+    with patch("glob.glob", return_value=["/dev/ttyACM0"]):
+        await mock_coordinator._async_probe_serial_ports("/dev/ttyACM0", None)
+    call_args = (
+        mock_coordinator.hass.config_entries.async_update_entry.call_args
+    )
+    new_schema = call_args.kwargs["options"][CONF_SCHEMA]
+    assert "usb" in new_schema["18:001111"]["_comment"]
+    assert "_comment" not in new_schema["32:002222"]
+
+
+# -- _create_hybrid_pool_transport_constructor tests -----------------------
+
+
+async def test_create_hybrid_pool_transport_constructor(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _create_hybrid_pool_transport_constructor returns a callable."""
+    constructor = mock_coordinator._create_hybrid_pool_transport_constructor(
+        port_name="/dev/ttyACM0",
+        port_config={"baudrate": 115200},
+        serial_additional=["/dev/ttyACM1"],
+        mqtt_hgi_ids=["18:001111"],
+    )
+    assert callable(constructor)
+
+
+async def test_create_hybrid_pool_transport_constructor_no_serial(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test constructor with no serial children, only MQTT."""
+    constructor = mock_coordinator._create_hybrid_pool_transport_constructor(
+        port_name="mqtt://broker:1883",
+        port_config={},
+        serial_additional=[],
+        mqtt_hgi_ids=["18:001111", "18:002222"],
+    )
+    assert callable(constructor)
+
+
+async def test_create_hybrid_pool_transport_constructor_import_error(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test constructor raises ImportError when pooled_transport_factory missing."""
+    with patch.dict("sys.modules", {"ramses_tx.transport": None}):
+        try:
+            mock_coordinator._create_hybrid_pool_transport_constructor(
+                port_name="/dev/ttyACM0",
+                port_config={},
+                serial_additional=[],
+                mqtt_hgi_ids=[],
+            )
+            # Should raise ImportError
+            assert False, "Expected ImportError"
+        except ImportError:
+            pass  # Expected
+
+
+async def test_setup_extracts_last_hgi_from_stored_packets(
+    mock_hass: MagicMock, mock_entry: MagicMock
+) -> None:
+    """Test that async_setup extracts HGI ID from stored packets."""
+    coordinator = RamsesCoordinator(mock_hass, mock_entry)
+
+    # Setup: no HGI in schema, but stored packets have HGI addr
+    cached_schema = {}
+    config_schema = {}
+    coordinator.options[CONF_SCHEMA] = config_schema
+
+    cast(Any, coordinator.store).async_load = AsyncMock(
+        return_value={
+            SZ_CLIENT_STATE: {
+                SZ_SCHEMA: cached_schema,
+                SZ_PACKETS: {
+                    "2024-01-01": {"addr1": "18:130236"},
+                    "2024-01-02": {"src": "18:149488"},
+                    "2024-01-03": "not a dict",
+                    "2024-01-04": {"addr1": "01:123456"},
+                },
+            }
+        }
+    )
+
+    mock_client = MagicMock()
+    cast(Any, mock_client).start = AsyncMock()
+    cast(Any, coordinator)._create_client = MagicMock(return_value=mock_client)
+
+    with patch(
+        "custom_components.ramses_cc.coordinator.merge_schemas",
+        return_value={},
+    ):
+        await coordinator.async_setup()
+
+    # The last HGI ID from stored packets should be added to schema
+    # async_update_entry is mocked, so check the call args
+    mock_hass.config_entries.async_update_entry.assert_called()
+    update_kwargs = (
+        mock_hass.config_entries.async_update_entry.call_args.kwargs
+    )
+    saved_schema = update_kwargs.get("options", {}).get(CONF_SCHEMA, {})
+    assert "18:149488" in saved_schema
+    assert saved_schema["18:149488"].get("_class") == "HGI"
+
+
+def test_get_primary_hgi_id_from_schema(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _get_primary_hgi_id finds primary HGI from schema (wildcard MQTT)."""
+    schema = {
+        "_owner": "me",
+        "18:001111": {
+            "_class": "HGI",
+            "_owner": "me",
+        },
+        "18:002222": {
+            "_class": "HGI",
+            "_owner": "me",
+        },
+        "01:123456": {
+            "_class": "CTL",
+            "_owner": "me",
+        },
+    }
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt://broker:1883"},
+        CONF_SCHEMA: schema,
+    }
+    # entry.options must be a real dict, not a MagicMock
+    mock_coordinator.entry.options = dict(mock_coordinator.options)
+    result = mock_coordinator._get_primary_hgi_id()
+    assert result == "18:001111"
+
+
+def test_get_primary_hgi_id_skips_disabled(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _get_primary_hgi_id skips disabled HGIs."""
+    schema = {
+        "_owner": "me",
+        "18:001111": {
+            "_class": "HGI",
+            "_owner": "me",
+            "_disabled": True,
+        },
+        "18:002222": {
+            "_class": "HGI",
+            "_owner": "me",
+        },
+    }
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt://broker:1883"},
+        CONF_SCHEMA: schema,
+    }
+    mock_coordinator.entry.options = dict(mock_coordinator.options)
+    result = mock_coordinator._get_primary_hgi_id()
+    assert result == "18:002222"
+
+
+def test_get_primary_hgi_id_skips_removed(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _get_primary_hgi_id skips removed HGIs."""
+    schema = {
+        "_owner": "me",
+        "18:001111": {
+            "_class": "HGI",
+            "_owner": "me",
+            "_removed_from_pool": True,
+        },
+        "18:002222": {
+            "_class": "HGI",
+            "_owner": "me",
+        },
+    }
+    mock_coordinator.options = {
+        SZ_SERIAL_PORT: {SZ_PORT_NAME: "mqtt://broker:1883"},
+        CONF_SCHEMA: schema,
+    }
+    mock_coordinator.entry.options = dict(mock_coordinator.options)
+    result = mock_coordinator._get_primary_hgi_id()
+    assert result == "18:002222"
+
+
+def test_mqtt_hgi_discovery_callback_new_hgi(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _MqttHgiDiscoveryCallback adds new HGI to schema."""
+    mock_coordinator.entry.options = {CONF_SCHEMA: {}}
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    cb.on_unknown_hgi("18:001111", topic="RAMSES/GATEWAY/18:001111")
+
+    mock_coordinator.hass.config_entries.async_update_entry.assert_called()
+    update_kwargs = mock_coordinator.hass.config_entries.async_update_entry.call_args.kwargs
+    saved_schema = update_kwargs.get("options", {}).get(CONF_SCHEMA, {})
+    assert "18:001111" in saved_schema
+    assert saved_schema["18:001111"].get("_class") == "HGI"
+    assert saved_schema["18:001111"].get("_comment") == "Supports: mqtt"
+
+
+def test_mqtt_hgi_discovery_callback_existing_hgi(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _MqttHgiDiscoveryCallback updates existing HGI's _comment."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            "18:001111": {
+                "_class": "HGI",
+                "_comment": "Supports: usb",
+            },
+        }
+    }
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    cb.on_unknown_hgi("18:001111", topic="RAMSES/GATEWAY/18:001111")
+
+    # Should call _mark_hgi_mqtt_capable
+    mock_coordinator.hass.config_entries.async_update_entry.assert_called()
+    update_kwargs = mock_coordinator.hass.config_entries.async_update_entry.call_args.kwargs
+    saved_schema = update_kwargs.get("options", {}).get(CONF_SCHEMA, {})
+    comment = saved_schema.get("18:001111", {}).get("_comment", "")
+    assert "mqtt" in comment
+
+
+def test_mqtt_hgi_discovery_callback_non_dict_schema(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _MqttHgiDiscoveryCallback handles non-dict schema."""
+    mock_coordinator.entry.options = {CONF_SCHEMA: "not a dict"}
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    # Should not crash
+    cb.on_unknown_hgi("18:001111", topic="RAMSES/GATEWAY/18:001111")
+    # Should not call async_update_entry
+    mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_mqtt_hgi_discovery_callback_already_mqtt(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _MqttHgiDiscoveryCallback skips when mqtt already in comment."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            "18:001111": {
+                "_class": "HGI",
+                "_comment": "Supports: usb, mqtt",
+            },
+        }
+    }
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    cb.on_unknown_hgi("18:001111", topic="RAMSES/GATEWAY/18:001111")
+    # Should not call async_update_entry since mqtt is already in comment
+    mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_mark_hgi_mqtt_capable_no_comment(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _mark_hgi_mqtt_capable handles HGI with no _comment."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            "18:001111": {
+                "_class": "HGI",
+            },
+        }
+    }
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    cb._mark_hgi_mqtt_capable("18:001111")
+    mock_coordinator.hass.config_entries.async_update_entry.assert_called()
+    update_kwargs = mock_coordinator.hass.config_entries.async_update_entry.call_args.kwargs
+    saved_schema = update_kwargs.get("options", {}).get(CONF_SCHEMA, {})
+    comment = saved_schema.get("18:001111", {}).get("_comment", "")
+    assert "mqtt" in comment
+
+
+def test_mark_hgi_mqtt_capable_non_dict_entry(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _mark_hgi_mqtt_capable handles non-dict schema entry."""
+    mock_coordinator.entry.options = {
+        CONF_SCHEMA: {
+            "18:001111": "not a dict",
+        }
+    }
+    cb = _MqttHgiDiscoveryCallback(mock_coordinator)
+    # Should not crash on non-dict entry
+    cb._mark_hgi_mqtt_capable("18:001111")
+    # Should not call async_update_entry since entry is not a dict
+    mock_coordinator.hass.config_entries.async_update_entry.assert_not_called()

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -9665,3 +9665,295 @@ def test_get_accepted_hgi_ids_disabled_and_foreign(
     assert "18:149488" not in accepted
     assert "18:333333" not in accepted
     assert "18:001111" in accepted  # Primary always included
+
+
+# -- Coverage: serial_port_hgi_map (lines 490-516) ------------------------
+
+
+def test_serial_port_hgi_map_valid_and_filtered(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test serial_port_hgi_map with valid, callback, disconnected children."""
+    # Build mock children with various attributes.
+    valid_child = MagicMock()
+    valid_child.hgi_id = "18:130236"
+    valid_child.callback_driven = False
+    valid_child.is_connected = True
+    valid_child.port_name = "/dev/ttyACM0"
+
+    callback_child = MagicMock()
+    callback_child.hgi_id = "18:149488"
+    callback_child.callback_driven = True
+    callback_child.is_connected = True
+    callback_child.port_name = "mqtt_ha://18:149488"
+
+    disconnected_child = MagicMock()
+    disconnected_child.hgi_id = "18:111111"
+    disconnected_child.callback_driven = False
+    disconnected_child.is_connected = False
+    disconnected_child.port_name = "/dev/ttyACM1"
+
+    # Build a mock transport with _children.
+    transport = MagicMock()
+    transport._children = [valid_child, callback_child, disconnected_child]
+    engine = MagicMock()
+    engine._transport = transport
+    cast(Any, mock_coordinator.client)._engine = engine
+
+    result = mock_coordinator.serial_port_hgi_map
+    # Only the valid serial child should be in the map.
+    assert result == {"/dev/ttyACM0": "18:130236"}
+
+
+def test_serial_port_hgi_map_no_client(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test serial_port_hgi_map returns empty when no client."""
+    mock_coordinator.client = None  # type: ignore[assignment]
+    assert mock_coordinator.serial_port_hgi_map == {}
+
+
+def test_serial_port_hgi_map_exception_is_swallowed(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test serial_port_hgi_map swallows attribute access exceptions."""
+    # Create a mock that raises on getattr.
+    bad_transport = MagicMock()
+    # Make _children raise when accessed.
+    type(bad_transport)._children = property(  # type: ignore[assignment]
+        lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    engine = MagicMock()
+    engine._transport = bad_transport
+    cast(Any, mock_coordinator.client)._engine = engine
+    # Should not raise — returns empty dict.
+    assert mock_coordinator.serial_port_hgi_map == {}
+
+
+# -- Coverage: _extract_device_ids_from_stripped (lines 1835-1872) ---------
+
+
+def test_extract_device_ids_from_stripped_full_schema() -> None:
+    """Test _extract_device_ids_from_stripped covers all nested branches."""
+    from ramses_rf.schemas import (
+        SZ_ACTUATORS as _SZ_ACTUATORS,
+        SZ_APPLIANCE_CONTROL as _SZ_APPLIANCE_CONTROL,
+        SZ_DHW_SYSTEM as _SZ_DHW_SYSTEM,
+        SZ_DHW_VALVE as _SZ_DHW_VALVE,
+        SZ_HTG_VALVE as _SZ_HTG_VALVE,
+        SZ_MAIN_TCS as _SZ_MAIN_TCS,
+        SZ_ORPHANS as _SZ_ORPHANS,
+        SZ_ORPHANS_HEAT as _SZ_ORPHANS_HEAT,
+        SZ_ORPHANS_HVAC as _SZ_ORPHANS_HVAC,
+        SZ_REMOTES as _SZ_REMOTES,
+        SZ_SENSOR as _SZ_SENSOR,
+        SZ_SENSORS as _SZ_SENSORS,
+        SZ_SYSTEM as _SZ_SYSTEM,
+        SZ_UFH_SYSTEM as _SZ_UFH_SYSTEM,
+        SZ_ZONES as _SZ_ZONES,
+    )
+
+    schema: dict[str, Any] = {
+        "_owner": "me",
+        _SZ_MAIN_TCS: "01:150000",  # main_tcs is a device ID string
+        _SZ_ORPHANS_HEAT: ["13:000001", "13:000002"],
+        _SZ_ORPHANS_HVAC: ["32:000001"],
+        "01:150000": {
+            _SZ_SYSTEM: {_SZ_APPLIANCE_CONTROL: "10:000001"},
+            _SZ_DHW_SYSTEM: {
+                _SZ_SENSOR: "07:000001",
+                _SZ_DHW_VALVE: "13:000003",
+                _SZ_HTG_VALVE: "13:000004",
+            },
+            _SZ_UFH_SYSTEM: {"10:000002": {}, "bad_id": {}},
+            _SZ_ZONES: {
+                "03": {
+                    _SZ_SENSOR: "04:000001",
+                    _SZ_ACTUATORS: ["04:000002", "04:000003"],
+                },
+                "04": "not_a_dict",  # skipped
+            },
+            _SZ_ORPHANS: ["04:000004"],
+            _SZ_REMOTES: ["37:000001"],
+            _SZ_SENSORS: ["22:000001"],
+        },
+        "not_a_device_id": {},  # skipped by _DEVICE_ID_RE
+        "01:150001": "not_a_dict",  # device ID added, but no nested walk
+    }
+    result = RamsesCoordinator._extract_device_ids_from_stripped(schema)
+    # Root CTL device ID.
+    assert "01:150000" in result
+    assert "01:150001" in result
+    # System appliance_control.
+    assert "10:000001" in result
+    # DHW system.
+    assert "07:000001" in result
+    assert "13:000003" in result
+    assert "13:000004" in result
+    # UFH system (only valid device IDs).
+    assert "10:000002" in result
+    # Zones.
+    assert "04:000001" in result
+    assert "04:000002" in result
+    assert "04:000003" in result
+    # Orphans, remotes, sensors lists.
+    assert "04:000004" in result
+    assert "37:000001" in result
+    assert "22:000001" in result
+    # Top-level orphans.
+    assert "13:000001" in result
+    assert "13:000002" in result
+    assert "32:000001" in result
+    # Non-device-ID keys skipped.
+    assert "not_a_device_id" not in result
+
+
+# -- Coverage: _get_primary_hgi_id _removed_from_pool (lines 1733, 1740-1749) --
+
+
+def test_get_primary_hgi_id_mqtt_ha_skips_removed_from_pool(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _get_primary_hgi_id skips HGIs with _removed_from_pool (mqtt_ha)."""
+    mock_coordinator.options[SZ_SERIAL_PORT] = {SZ_PORT_NAME: "mqtt_ha"}
+    mock_coordinator.options[CONF_MQTT_HGI_ID] = (
+        DEFAULT_HGI_ID  # force fallback
+    )
+    mock_coordinator.entry.options[CONF_SCHEMA] = {
+        SZ_OWNER: "me",
+        "18:001111": {
+            "_class": "HGI",
+            SZ_TR_OWNER: "me",
+            "_removed_from_pool": True,
+        },
+        "18:002222": {
+            "_class": "HGI",
+            SZ_TR_OWNER: "me",
+        },
+    }
+    result = mock_coordinator._get_primary_hgi_id()
+    assert result == "18:002222"
+
+
+def test_get_primary_hgi_id_mqtt_url_skips_removed_from_pool(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _get_primary_hgi_id skips _removed_from_pool (mqtt:// wildcard)."""
+    mock_coordinator.options[SZ_SERIAL_PORT] = {
+        SZ_PORT_NAME: "mqtt://localhost:1883/RAMSES/GATEWAY"
+    }
+    mock_coordinator.options[CONF_MQTT_HGI_ID] = DEFAULT_HGI_ID
+    mock_coordinator.entry.options[CONF_SCHEMA] = {
+        SZ_OWNER: "me",
+        "18:001111": {
+            "_class": "HGI",
+            SZ_TR_OWNER: "me",
+            "_removed_from_pool": True,
+        },
+        "18:002222": {
+            "_class": "HGI",
+            SZ_TR_OWNER: "me",
+            "_disabled": True,
+        },
+        "18:003333": {
+            "_class": "HGI",
+            SZ_TR_OWNER: "me",
+        },
+    }
+    result = mock_coordinator._get_primary_hgi_id()
+    assert result == "18:003333"
+
+
+# -- Coverage: _unregister_schema_updated_callback (lines 3339-3340) ------
+
+
+def test_unregister_schema_updated_callback(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _unregister_schema_updated_callback sets callback to None."""
+    mock_coordinator._unregister_schema_updated_callback()
+    cast(
+        Any, mock_coordinator.client
+    ).set_schema_updated_callback.assert_called_with(None)
+
+
+# -- Coverage: _check_gateway_health exception catch (lines 4108-4110) -----
+
+
+async def test_check_gateway_health_exception(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test _check_gateway_health catches exceptions from hgi.is_active()."""
+    # Need to get past the first 3 health check skips.
+    mock_coordinator._health_check_count = 5
+    mock_coordinator._gateway_offline_notified = False
+
+    gateway = MagicMock()
+    gateway.hgi.is_active = AsyncMock(side_effect=RuntimeError("boom"))
+    cast(Any, mock_coordinator.client)._gway = gateway
+    mock_coordinator.client.tcs = MagicMock()  # type: ignore[union-attr]
+
+    # Should not raise — exception is caught.
+    await mock_coordinator._check_gateway_health()
+    # Should not have set offline notified.
+    assert not mock_coordinator._gateway_offline_notified
+
+
+# -- Coverage: service delegation methods (lines 4437, 4466, 4508, 4571, 4578) --
+
+
+async def test_async_force_update_delegates(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test async_force_update clears entity caches and refreshes."""
+    mock_entity = MagicMock()
+    mock_coordinator._entities = {"test": mock_entity}
+    mock_coordinator.async_refresh = AsyncMock()
+    await mock_coordinator.async_force_update(MagicMock())
+    mock_coordinator.async_refresh.assert_called_once()
+
+
+async def test_async_probe_hvac_binding_delegates(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test async_probe_hvac_binding delegates to service_handler."""
+    mock_coordinator.service_handler = MagicMock()
+    cast(
+        Any, mock_coordinator.service_handler
+    ).async_probe_hvac_binding = AsyncMock(return_value={"result": "ok"})
+    call = MagicMock()
+    result = await mock_coordinator.async_probe_hvac_binding(call)
+    assert result == {"result": "ok"}
+    cast(
+        Any, mock_coordinator.service_handler
+    ).async_probe_hvac_binding.assert_called_with(call)
+
+
+async def test_async_remove_device_delegates(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test async_remove_device delegates to service_handler."""
+    mock_coordinator.service_handler = MagicMock()
+    cast(
+        Any, mock_coordinator.service_handler
+    ).async_remove_device = AsyncMock()
+    call = MagicMock()
+    await mock_coordinator.async_remove_device(call)
+    cast(
+        Any, mock_coordinator.service_handler
+    ).async_remove_device.assert_called_with(call)
+
+
+async def test_async_set_polling_interval_delegates(
+    mock_coordinator: RamsesCoordinator,
+) -> None:
+    """Test async_set_polling_interval delegates to service_handler."""
+    mock_coordinator.service_handler = MagicMock()
+    cast(
+        Any, mock_coordinator.service_handler
+    ).async_set_polling_interval = AsyncMock()
+    call = MagicMock()
+    await mock_coordinator.async_set_polling_interval(call)
+    cast(
+        Any, mock_coordinator.service_handler
+    ).async_set_polling_interval.assert_called_with(call)

--- a/tests/tests_new/test_discovery_manager.py
+++ b/tests/tests_new/test_discovery_manager.py
@@ -1619,7 +1619,12 @@ class TestHgiDiscoveryCandidate:
         assert "04:056053" not in new_ids
 
     def test_active_hgi_in_no_owner_ids_skipped(self) -> None:
-        """Active HGI without _owner is still skipped by the HGI loop."""
+        """Active HGI without _owner is flagged for review (issue 1119).
+
+        All HGIs (including the active/primary) go through review as
+        discovery candidates.  The user sets _owner and _preferred_type
+        via the review flow.
+        """
         scan = make_mock_scan([])
         manager = DiscoveryManager(
             make_mock_hass(),
@@ -1627,14 +1632,14 @@ class TestHgiDiscoveryCandidate:
             auto_notify=False,
             active_hgi_id="18:130236",
         )
-        # Active HGI is in schema without _owner (edge case)
+        # Active HGI is in schema without _owner (discovery candidate)
         manager.sync_with_schema(
             {"18:130236"},
             schema={"18:130236": {"_class": "HGI"}},  # no _owner
         )
 
         new_ids = manager.check_for_new_devices()
-        assert "18:130236" not in new_ids  # active HGI always skipped
+        assert "18:130236" in new_ids  # active HGI flagged for review
 
     def test_hgi_candidate_new_status_re_reported(self) -> None:
         """HGI candidate with NEW status is re-reported if not notified."""

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -24,6 +24,7 @@ from homeassistant.core import HomeAssistant
 from custom_components.ramses_cc.mqtt_pool_bridge import (
     RamsesMqttPoolBridge,
 )
+from ramses_tx.exceptions import TransportError
 
 TEST_HGI_1 = "18:001111"
 TEST_HGI_2 = "18:002222"
@@ -177,6 +178,66 @@ async def test_does_not_double_subscribe(
     assert mock_mqtt_pool["subscribe"].call_count == 0
 
 
+async def test_subscription_failure_cleans_up_partial_subscriptions(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """A partial subscription failure is cleaned up and propagated."""
+    unsubscribe_rx = MagicMock()
+    unsubscribe_cmd = MagicMock()
+    mock_mqtt_pool["subscribe"].side_effect = [
+        unsubscribe_rx,
+        unsubscribe_cmd,
+        RuntimeError("subscribe failed"),
+    ]
+    bridge = RamsesMqttPoolBridge(hass, TEST_TOPIC_PREFIX, [TEST_HGI_1])
+
+    with pytest.raises(TransportError, match="subscribe failed"):
+        await bridge._async_attach()
+
+    unsubscribe_rx.assert_called_once()
+    unsubscribe_cmd.assert_called_once()
+    assert bridge._sub_rx is None
+    assert bridge._sub_cmd is None
+    assert bridge._sub_status is None
+
+
+async def test_retained_lwt_is_handled_during_transport_factory(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """The adapter exists before a retained online LWT is delivered."""
+    unsubscribe = MagicMock()
+
+    async def subscribe(
+        _hass: HomeAssistant,
+        topic: str,
+        callback_fn: Any,
+        qos: int,
+    ) -> MagicMock:
+        del _hass, qos
+        if topic == f"{TEST_TOPIC_PREFIX}/+":
+            msg = MagicMock()
+            msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}"
+            msg.payload = b"online"
+            callback_fn(msg)
+        return unsubscribe
+
+    mock_mqtt_pool["subscribe"].side_effect = subscribe
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+
+    transport = await bridge.async_transport_factory(mock_protocol)
+
+    assert transport._children[0].is_connected
+    assert transport._children[0].is_online
+
+
 # -- Transport factory ----------------------------------------------------
 
 
@@ -323,6 +384,32 @@ async def test_lwt_online_unknown_hgi_fires_discovery(
     msg.topic = "RAMSES/GATEWAY/18:999999"
     msg.payload = b"online"
     bridge._handle_status_message(msg)
+
+    discovery.on_unknown_hgi.assert_called_once()
+
+
+async def test_unknown_rx_reports_discovery_without_lwt(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """An RX topic can discover an unknown HGI when no LWT is published."""
+    discovery = MagicMock()
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        discovery_callback=discovery,
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/18:999999/rx"
+    msg.payload = json.dumps(
+        {"msg": "000  I --- 01:145038 18:000730 --:------ 30C9 003 000F1B"}
+    ).encode()
+
+    bridge._handle_rx_message(msg)
 
     discovery.on_unknown_hgi.assert_called_once()
 
@@ -1421,7 +1508,8 @@ async def test_async_attach_subscription_failure(
         TEST_TOPIC_PREFIX,
         [TEST_HGI_1],
     )
-    await bridge._async_attach()  # should not crash
+    with pytest.raises(TransportError, match="MQTT down"):
+        await bridge._async_attach()
 
 
 # -- Close with no subscriptions -------------------------------------------
@@ -2056,7 +2144,7 @@ def test_exclude_hgi_id(
     bridge.exclude_hgi_id(TEST_HGI_1)
 
     assert TEST_HGI_1 in bridge._excluded_hgi_ids
-    assert TEST_HGI_1 not in bridge._accepted_hgi_ids
+    assert TEST_HGI_1 in bridge._accepted_hgi_ids
     # The adapter's on_child_offline must be called (not a
     # nonexistent remove_child on the pool — issue 1119).
     bridge._adapter.on_child_offline.assert_called_once_with(
@@ -2148,6 +2236,23 @@ async def test_unexclude_hgi_id_re_includes(
     bridge.unexclude_hgi_id(TEST_HGI_2)
     assert TEST_HGI_2 not in bridge._excluded_hgi_ids
     assert TEST_HGI_2 in bridge._accepted_hgi_ids  # type: ignore[union-attr]
+
+
+def test_unexclude_preserves_receive_only_acceptance(
+    hass: HomeAssistant,
+) -> None:
+    """Re-inclusion must not promote a receive-only discovery candidate."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        accepted_hgi_ids={TEST_HGI_1},
+    )
+
+    bridge.exclude_hgi_id(TEST_HGI_2)
+    bridge.unexclude_hgi_id(TEST_HGI_2)
+
+    assert bridge._accepted_hgi_ids == {TEST_HGI_1}
 
 
 async def test_unexclude_hgi_id_brings_online(

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -697,6 +697,104 @@ async def test_rx_infers_online_when_lwt_missing(
     bridge._adapter.on_child_online.assert_called_once_with(TEST_HGI_1)
 
 
+async def test_rx_infers_online_then_sendable_regression_1185(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Regression test for issue 1185: single MQTT HGI must be TX-capable.
+
+    In 0.60.5, single-HGI MQTT was switched to the pool bridge.  If the
+    HGI doesn't publish LWT (or the LWT is missed), the pool child was
+    never marked connected, so is_sendable returned False and TX failed
+    with "No connected child transport available for send" even though
+    RX worked fine.
+
+    This test verifies that after an RX packet (without LWT), the
+    bridge infers online status and calls on_child_online, which makes
+    the pool child connected and sendable — so TX works.
+    """
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        accepted_hgi_ids={TEST_HGI_1},
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    # No LWT online message — simulate a packet arriving first.
+    assert TEST_HGI_1 not in bridge._online_hgis
+
+    frame = "000  I --- 01:145038 18:000730 --:------ 30C9 003 000F1B"
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = json.dumps({"msg": frame}).encode()
+
+    bridge._adapter = MagicMock()
+    bridge._publish_command = AsyncMock()
+    bridge._handle_rx_message(msg)
+
+    # 1. The HGI should be marked as online.
+    assert TEST_HGI_1 in bridge._online_hgis
+
+    # 2. on_child_online should have been called (makes child connected).
+    bridge._adapter.on_child_online.assert_called_once_with(TEST_HGI_1)
+
+    # 3. The !V handshake should have been sent (HGI is accepted).
+    await bridge._hass.async_block_till_done()
+    bridge._publish_command.assert_called_once_with(TEST_HGI_1, "!V")
+
+    # 4. on_child_packet should also have been called (the actual packet).
+    bridge._adapter.on_child_packet.assert_called_once()
+
+
+async def test_lwt_online_still_works_alongside_rx_inference(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """LWT online path still works — RX inference is only a fallback.
+
+    If LWT arrives first, the HGI is marked online via LWT.  A
+    subsequent RX packet should NOT call on_child_online again (it's
+    already online).
+    """
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        accepted_hgi_ids={TEST_HGI_1},
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    bridge._adapter = MagicMock()
+    bridge._publish_command = AsyncMock()
+
+    # 1. LWT online arrives first.
+    msg_lwt = MagicMock()
+    msg_lwt.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}"
+    msg_lwt.payload = b"online"
+    bridge._handle_status_message(msg_lwt)
+    assert TEST_HGI_1 in bridge._online_hgis
+    bridge._adapter.on_child_online.assert_called_once_with(TEST_HGI_1)
+
+    # 2. RX packet arrives — should NOT call on_child_online again.
+    frame = "000  I --- 01:145038 18:000730 --:------ 30C9 003 000F1B"
+    msg_rx = MagicMock()
+    msg_rx.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg_rx.payload = json.dumps({"msg": frame}).encode()
+    bridge._handle_rx_message(msg_rx)
+
+    # on_child_online should still have been called only once (from LWT).
+    bridge._adapter.on_child_online.assert_called_once_with(TEST_HGI_1)
+    # on_child_packet should have been called for the RX.
+    bridge._adapter.on_child_packet.assert_called_once()
+
+
 async def test_wait_online_timeout_passed_to_bridge(
     hass: HomeAssistant,
     mock_mqtt_pool: dict[str, Any],

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -2104,3 +2104,137 @@ def test_extract_hgi_from_topic_not_hgi_device(hass: HomeAssistant) -> None:
         suffix="/rx",
     )
     assert result is None
+
+
+# -- unexclude_hgi_id (issue 1185) ---------------------------------------
+
+
+def test_unexclude_hgi_id_not_excluded_is_noop(hass: HomeAssistant) -> None:
+    """Test that unexclude_hgi_id is a no-op when HGI is not excluded."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        accepted_hgi_ids={TEST_HGI_1, TEST_HGI_2},
+    )
+    # HGI 2 is not excluded — unexclude should be a no-op.
+    bridge.unexclude_hgi_id(TEST_HGI_2)
+    assert TEST_HGI_2 not in bridge._excluded_hgi_ids
+
+
+async def test_unexclude_hgi_id_re_includes(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test that unexclude_hgi_id re-includes an excluded HGI (issue 1185)."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        accepted_hgi_ids={TEST_HGI_1, TEST_HGI_2},
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    # Exclude HGI 2 (simulating serial primary discovery).
+    bridge.exclude_hgi_id(TEST_HGI_2)
+    assert TEST_HGI_2 in bridge._excluded_hgi_ids
+    assert TEST_HGI_2 not in bridge._configured_hgi_ids
+
+    # Now unexclude (simulating serial transport disconnect).
+    bridge.unexclude_hgi_id(TEST_HGI_2)
+    assert TEST_HGI_2 not in bridge._excluded_hgi_ids
+    assert TEST_HGI_2 in bridge._configured_hgi_ids
+    assert TEST_HGI_2 in bridge._accepted_hgi_ids  # type: ignore[union-attr]
+
+
+async def test_unexclude_hgi_id_brings_online(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test that unexclude brings an already-online HGI back online."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        accepted_hgi_ids={TEST_HGI_1, TEST_HGI_2},
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    # Bring HGI 2 online first.
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_2}"
+    msg.payload = b"online"
+    bridge._handle_status_message(msg)
+    assert TEST_HGI_2 in bridge._online_hgis
+
+    # Exclude HGI 2.
+    bridge.exclude_hgi_id(TEST_HGI_2)
+
+    # Unexclude — should call on_child_online since HGI is already online.
+    bridge._adapter = MagicMock()  # type: ignore[assignment]
+    bridge.unexclude_hgi_id(TEST_HGI_2)
+    bridge._adapter.on_child_online.assert_called_once_with(TEST_HGI_2)
+
+
+# -- Exception handlers in RX/CMD (defensive coverage) --------------------
+
+
+async def test_rx_message_unexpected_exception(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test that unexpected exception in RX handler is caught (line 522-523)."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    # Force an unexpected exception by making json.loads return a bad object.
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = b'{"msg": "valid"}'
+
+    # Patch json.loads to raise a non-JSONDecodeError exception.
+    with patch(
+        "custom_components.ramses_cc.mqtt_pool_bridge.json.loads",
+        side_effect=RuntimeError("unexpected"),
+    ):
+        bridge._handle_rx_message(msg)  # should not crash
+
+
+async def test_cmd_message_unexpected_exception(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test that unexpected exception in CMD handler is caught (line 587-588)."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = b'{"cmd": "!V", "return": 0}'
+
+    # Patch json.loads to raise a non-JSONDecodeError exception.
+    with patch(
+        "custom_components.ramses_cc.mqtt_pool_bridge.json.loads",
+        side_effect=RuntimeError("unexpected"),
+    ):
+        bridge._handle_cmd_message(msg)  # should not crash

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -795,6 +795,58 @@ async def test_lwt_online_still_works_alongside_rx_inference(
     bridge._adapter.on_child_packet.assert_called_once()
 
 
+async def test_excluded_hgi_lwt_calls_on_mqtt_capable_not_unknown(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Excluded HGI (serial primary) LWT calls on_mqtt_capable, not on_unknown_hgi.
+
+    When a serial primary HGI is also publishing on MQTT, the bridge
+    excludes it from the MQTT pool (exclude_hgi_id).  But when its LWT
+    online arrives, it should NOT be treated as an unknown discovery
+    candidate — it's a known, configured HGI handled by the serial
+    transport.  The bridge should call on_mqtt_capable to update
+    _comment (supports both usb and mqtt), not on_unknown_hgi.
+    """
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        accepted_hgi_ids={TEST_HGI_1},
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    discovery = MagicMock()
+    bridge._discovery_callback = discovery
+    bridge._adapter = MagicMock()
+
+    # Exclude HGI 2 (simulating serial primary discovery).
+    bridge.exclude_hgi_id(TEST_HGI_2)
+    assert TEST_HGI_2 not in bridge._configured_hgi_ids
+    assert TEST_HGI_2 in bridge._excluded_hgi_ids
+
+    # LWT online for the excluded HGI.
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_2}"
+    msg.payload = b"online"
+    bridge._handle_status_message(msg)
+
+    # on_mqtt_capable should be called (not on_unknown_hgi).
+    discovery.on_mqtt_capable.assert_called_once()
+    call_args = discovery.on_mqtt_capable.call_args
+    assert str(call_args.args[0]) == TEST_HGI_2
+    assert call_args.kwargs.get("topic") == msg.topic
+
+    # on_unknown_hgi should NOT be called.
+    discovery.on_unknown_hgi.assert_not_called()
+
+    # on_child_online should NOT be called (serial transport handles it).
+    bridge._adapter.on_child_online.assert_not_called()
+
+
 async def test_wait_online_timeout_passed_to_bridge(
     hass: HomeAssistant,
     mock_mqtt_pool: dict[str, Any],

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -1224,3 +1224,650 @@ async def test_lwt_offline_unknown_hgi_no_crash(
     msg.topic = "RAMSES/GATEWAY/18:999999"
     msg.payload = b"offline"
     bridge._handle_status_message(msg)  # should not crash
+
+
+# -- _handle_cmd_message tests ----------------------------------------------
+
+
+async def test_handle_cmd_message_evofw3_response(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_cmd_message processes !V command response."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = json.dumps({"return": 0, "cmd": "!V"}).encode()
+
+    bridge._handle_cmd_message(msg)  # should not crash
+
+
+async def test_handle_cmd_message_ramses_esp_eth(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_cmd_message handles ramses_esp_eth firmware string."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = json.dumps(
+        {"return": "ramses_esp_eth 0.6.6c", "cmd": "!V"}
+    ).encode()
+
+    bridge._handle_cmd_message(msg)  # should not crash
+
+
+async def test_handle_cmd_message_json_decode_error(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_cmd_message handles JSON decode error gracefully."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = b"not json"
+
+    bridge._handle_cmd_message(msg)  # should not crash
+
+
+async def test_handle_cmd_message_no_adapter(
+    hass: HomeAssistant,
+) -> None:
+    """Test _handle_cmd_message returns early when adapter is None."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = b"{}"
+    # Should not crash even though adapter is None
+    bridge._handle_cmd_message(msg)
+
+
+async def test_handle_cmd_message_invalid_hgi_topic(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_cmd_message rejects non-HGI topic."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/32:153289/cmd/result"
+    msg.payload = json.dumps({"return": 0, "cmd": "!V"}).encode()
+
+    bridge._handle_cmd_message(msg)  # should not crash
+
+
+async def test_handle_cmd_message_empty_payload(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_cmd_message handles empty payload."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = b""
+
+    bridge._handle_cmd_message(msg)  # should not crash
+
+
+async def test_handle_cmd_message_int_return_non_v(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_cmd_message with int return for non-!V command."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = json.dumps({"return": 42, "cmd": "!C"}).encode()
+
+    bridge._handle_cmd_message(msg)  # should not crash
+
+
+# -- _handle_broker_status tests --------------------------------------------
+
+
+async def test_handle_broker_status_connected(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_broker_status with connected=True."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    bridge._handle_broker_status(True)
+    # adapter.on_broker_connected should have been called
+    assert bridge._adapter is not None
+
+
+async def test_handle_broker_status_disconnected(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_broker_status with connected=False."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    bridge._handle_broker_status(False)
+    # adapter.on_broker_disconnected should have been called
+    assert bridge._adapter is not None
+
+
+async def test_handle_broker_status_no_adapter(
+    hass: HomeAssistant,
+) -> None:
+    """Test _handle_broker_status returns early when adapter is None."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    # Should not crash
+    bridge._handle_broker_status(True)
+    bridge._handle_broker_status(False)
+
+
+# -- exclude_hgi_id tests ---------------------------------------------------
+
+
+async def test_exclude_hgi_id_removes_from_configured(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test exclude_hgi_id removes HGI from configured list."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    bridge.exclude_hgi_id(TEST_HGI_1)
+    assert TEST_HGI_1 not in bridge._configured_hgi_ids
+    assert TEST_HGI_2 in bridge._configured_hgi_ids
+
+
+async def test_exclude_hgi_id_not_in_list(
+    hass: HomeAssistant,
+) -> None:
+    """Test exclude_hgi_id when HGI is not in configured list."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    # Should not crash
+    bridge.exclude_hgi_id(TEST_HGI_2)
+    assert TEST_HGI_1 in bridge._configured_hgi_ids
+
+
+# -- _is_accepted tests -----------------------------------------------------
+
+
+def test_is_accepted_no_accepted_set(hass: HomeAssistant) -> None:
+    """Test _is_accepted returns True when _accepted_hgi_ids is None."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    assert bridge._is_accepted(TEST_HGI_1) is True
+
+
+def test_is_accepted_in_set(hass: HomeAssistant) -> None:
+    """Test _is_accepted returns True when HGI is in accepted set."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        accepted_hgi_ids={TEST_HGI_1},
+    )
+    assert bridge._is_accepted(TEST_HGI_1) is True
+
+
+def test_is_accepted_not_in_set(hass: HomeAssistant) -> None:
+    """Test _is_accepted returns False when HGI is not in accepted set."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        accepted_hgi_ids={TEST_HGI_2},
+    )
+    assert bridge._is_accepted(TEST_HGI_1) is False
+
+
+# -- _extract_hgi_from_topic edge cases -------------------------------------
+
+
+def test_extract_hgi_from_topic_no_prefix(hass: HomeAssistant) -> None:
+    """Test _extract_hgi_from_topic returns None for wrong prefix."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    assert bridge._extract_hgi_from_topic("OTHER/18:001111", "") is None
+
+
+def test_extract_hgi_from_topic_non_hgi(hass: HomeAssistant) -> None:
+    """Test _extract_hgi_from_topic rejects non-18: device IDs."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    assert (
+        bridge._extract_hgi_from_topic("RAMSES/GATEWAY/32:153289", "") is None
+    )
+
+
+def test_extract_hgi_from_topic_too_short(hass: HomeAssistant) -> None:
+    """Test _extract_hgi_from_topic rejects short IDs."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    assert bridge._extract_hgi_from_topic("RAMSES/GATEWAY/18:123", "") is None
+
+
+def test_extract_hgi_from_topic_with_suffix(hass: HomeAssistant) -> None:
+    """Test _extract_hgi_from_topic strips suffix correctly."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    result = bridge._extract_hgi_from_topic(
+        f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx", "/rx"
+    )
+    assert result == TEST_HGI_1
+
+
+# -- _handle_rx_message edge cases ------------------------------------------
+
+
+async def test_handle_rx_message_json_decode_error(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_rx_message handles JSON decode error."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = b"not json"
+
+    bridge._handle_rx_message(msg)  # should not crash
+
+
+async def test_handle_rx_message_no_adapter(
+    hass: HomeAssistant,
+) -> None:
+    """Test _handle_rx_message returns early when adapter is None."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = (
+        b'{"msg": " I --- 18:001111 32:153289 --:------ 22F1 003 000207"}'
+    )
+    # Should not crash
+    bridge._handle_rx_message(msg)
+
+
+async def test_handle_rx_message_invalid_hgi(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_rx_message rejects non-HGI topic."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/32:153289/rx"
+    msg.payload = b'{"msg": "test"}'
+
+    bridge._handle_rx_message(msg)  # should not crash
+
+
+async def test_handle_rx_message_empty_payload(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """Test _handle_rx_message handles empty payload."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+    await bridge.async_transport_factory(mock_protocol)
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = b""
+
+    bridge._handle_rx_message(msg)  # should not crash
+
+
+# -- async_attach_to_pool tests (hybrid pool) ------------------------------
+
+
+async def test_async_attach_to_pool(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test async_attach_to_pool creates adapter and subscribes."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        wait_online_timeout=0.01,
+    )
+
+    # Mock a PooledTransport
+    mock_pool = MagicMock()
+    mock_pool._protocol = MagicMock()
+    mock_pool._conn_fut = None
+    mock_pool._wait_for_any_connection = AsyncMock()
+
+    with patch(
+        "custom_components.ramses_cc.mqtt_pool_bridge.MqttCallbackPoolAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = MagicMock()
+        mock_adapter_cls.return_value = mock_adapter
+
+        await bridge.async_attach_to_pool(
+            mock_pool, callback_child_start_index=1
+        )
+
+    assert bridge._pool is mock_pool
+    assert bridge._adapter is mock_adapter
+    mock_adapter_cls.assert_called_once()
+
+
+async def test_async_attach_to_pool_mqtt_timeout(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test async_attach_to_pool handles MQTT client timeout."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        wait_online_timeout=0.01,
+    )
+
+    mock_pool = MagicMock()
+    mock_pool._protocol = MagicMock()
+    mock_pool._conn_fut = None
+    mock_pool._wait_for_any_connection = AsyncMock()
+
+    with patch(
+        "custom_components.ramses_cc.mqtt_pool_bridge.MqttCallbackPoolAdapter"
+    ):
+        # Should not crash even if MQTT client setup times out
+        await bridge.async_attach_to_pool(
+            mock_pool, callback_child_start_index=0
+        )
+    assert bridge._adapter is not None
+
+
+# -- Error handling and edge cases ----------------------------------------
+
+
+def test_handle_rx_json_decode_error(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test _handle_rx_message handles JSON decode errors."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    bridge._adapter = MagicMock()
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = b"not valid json"
+
+    bridge._handle_rx_message(msg)
+    # Should not crash, adapter should not be called
+    bridge._adapter.on_rx_packet.assert_not_called()
+
+
+def test_handle_rx_exception(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test _handle_rx_message handles unexpected exceptions."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    # Make adapter raise an exception
+    bridge._adapter = MagicMock()
+    bridge._adapter.on_rx_packet.side_effect = RuntimeError("test error")
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = b'{"frame": "000..." }'
+
+    # Should not crash
+    bridge._handle_rx_message(msg)
+
+
+def test_handle_cmd_json_decode_error(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test _handle_cmd_message handles JSON decode errors."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    msg.payload = b"not valid json"
+
+    bridge._handle_cmd_message(msg)
+    # Should not crash
+
+
+def test_handle_cmd_exception(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test _handle_cmd_message handles unexpected exceptions."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+
+    # Create a msg that will cause an exception during processing
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/cmd/result"
+    # Use a payload that parses as JSON but causes issues downstream
+    msg.payload = b'{"result": "ok"}'
+
+    # Should not crash even with unexpected errors
+    bridge._handle_cmd_message(msg)
+
+
+def test_discovery_callback_on_unknown_hgi(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test that discovery_callback.on_unknown_hgi is called for configured HGIs."""
+    discovery_cb = MagicMock()
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        discovery_callback=discovery_cb,
+        # Don't add to accepted_hgi_ids to avoid !V publish
+    )
+    bridge._adapter = MagicMock()
+
+    # Mock _publish_command to avoid actual MQTT publish
+    bridge._publish_command = AsyncMock()
+
+    # Simulate an LWT online message for a configured HGI
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}"
+    msg.payload = b"online"
+
+    bridge._handle_status_message(msg)
+    # discovery_callback.on_unknown_hgi should be called for configured HGI
+    discovery_cb.on_unknown_hgi.assert_called_once()
+
+
+def test_exclude_hgi_id(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+) -> None:
+    """Test exclude_hgi_id removes HGI from configured and accepted lists."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        accepted_hgi_ids={TEST_HGI_1, TEST_HGI_2},
+    )
+    bridge._pool = MagicMock()
+
+    bridge.exclude_hgi_id(TEST_HGI_1)
+
+    assert TEST_HGI_1 not in bridge._configured_hgi_ids
+    assert TEST_HGI_2 in bridge._configured_hgi_ids
+    assert TEST_HGI_1 not in bridge._accepted_hgi_ids
+    bridge._pool.remove_child.assert_called_once_with(TEST_HGI_1)
+
+
+def test_extract_hgi_from_topic_empty_parts(hass: HomeAssistant) -> None:
+    """Test _extract_hgi_from_topic returns None for empty parts."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    # Topic with no HGI ID after prefix
+    result = bridge._extract_hgi_from_topic(
+        topic=f"{TEST_TOPIC_PREFIX}/",
+        suffix="/rx",
+    )
+    # Should return None for invalid format
+    assert result is None
+
+
+def test_extract_hgi_from_topic_invalid_format(hass: HomeAssistant) -> None:
+    """Test _extract_hgi_from_topic returns None for invalid HGI ID format."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    result = bridge._extract_hgi_from_topic(
+        topic=f"{TEST_TOPIC_PREFIX}/invalid_id/rx",
+        suffix="/rx",
+    )
+    assert result is None
+
+
+def test_extract_hgi_from_topic_not_hgi_device(hass: HomeAssistant) -> None:
+    """Test _extract_hgi_from_topic returns None for non-HGI device IDs."""
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+    )
+    result = bridge._extract_hgi_from_topic(
+        topic=f"{TEST_TOPIC_PREFIX}/01:123456/rx",
+        suffix="/rx",
+    )
+    assert result is None

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -825,7 +825,6 @@ async def test_excluded_hgi_lwt_calls_on_mqtt_capable_not_unknown(
 
     # Exclude HGI 2 (simulating serial primary discovery).
     bridge.exclude_hgi_id(TEST_HGI_2)
-    assert TEST_HGI_2 not in bridge._configured_hgi_ids
     assert TEST_HGI_2 in bridge._excluded_hgi_ids
 
     # LWT online for the excluded HGI.
@@ -1667,7 +1666,7 @@ async def test_exclude_hgi_id_removes_from_configured(
     mock_mqtt_pool: dict[str, Any],
     mock_protocol: MagicMock,
 ) -> None:
-    """Test exclude_hgi_id removes HGI from configured list."""
+    """Test exclude_hgi_id marks HGI as excluded."""
     bridge = RamsesMqttPoolBridge(
         hass,
         TEST_TOPIC_PREFIX,
@@ -1677,8 +1676,8 @@ async def test_exclude_hgi_id_removes_from_configured(
     await bridge.async_transport_factory(mock_protocol)
 
     bridge.exclude_hgi_id(TEST_HGI_1)
-    assert TEST_HGI_1 not in bridge._configured_hgi_ids
-    assert TEST_HGI_2 in bridge._configured_hgi_ids
+    assert TEST_HGI_1 in bridge._excluded_hgi_ids
+    assert TEST_HGI_2 not in bridge._excluded_hgi_ids
 
 
 async def test_exclude_hgi_id_not_in_list(
@@ -1692,7 +1691,7 @@ async def test_exclude_hgi_id_not_in_list(
     )
     # Should not crash
     bridge.exclude_hgi_id(TEST_HGI_2)
-    assert TEST_HGI_1 in bridge._configured_hgi_ids
+    assert TEST_HGI_1 not in bridge._excluded_hgi_ids
 
 
 # -- _is_accepted tests -----------------------------------------------------
@@ -2045,21 +2044,24 @@ def test_exclude_hgi_id(
     hass: HomeAssistant,
     mock_mqtt_pool: dict[str, Any],
 ) -> None:
-    """Test exclude_hgi_id removes HGI from configured and accepted lists."""
+    """Test exclude_hgi_id marks HGI as excluded and offline via adapter."""
     bridge = RamsesMqttPoolBridge(
         hass,
         TEST_TOPIC_PREFIX,
         [TEST_HGI_1, TEST_HGI_2],
         accepted_hgi_ids={TEST_HGI_1, TEST_HGI_2},
     )
-    bridge._pool = MagicMock()
+    bridge._adapter = MagicMock()
 
     bridge.exclude_hgi_id(TEST_HGI_1)
 
-    assert TEST_HGI_1 not in bridge._configured_hgi_ids
-    assert TEST_HGI_2 in bridge._configured_hgi_ids
+    assert TEST_HGI_1 in bridge._excluded_hgi_ids
     assert TEST_HGI_1 not in bridge._accepted_hgi_ids
-    bridge._pool.remove_child.assert_called_once_with(TEST_HGI_1)
+    # The adapter's on_child_offline must be called (not a
+    # nonexistent remove_child on the pool — issue 1119).
+    bridge._adapter.on_child_offline.assert_called_once_with(
+        TEST_HGI_1, definitive=True
+    )
 
 
 def test_extract_hgi_from_topic_empty_parts(hass: HomeAssistant) -> None:
@@ -2141,12 +2143,10 @@ async def test_unexclude_hgi_id_re_includes(
     # Exclude HGI 2 (simulating serial primary discovery).
     bridge.exclude_hgi_id(TEST_HGI_2)
     assert TEST_HGI_2 in bridge._excluded_hgi_ids
-    assert TEST_HGI_2 not in bridge._configured_hgi_ids
 
     # Now unexclude (simulating serial transport disconnect).
     bridge.unexclude_hgi_id(TEST_HGI_2)
     assert TEST_HGI_2 not in bridge._excluded_hgi_ids
-    assert TEST_HGI_2 in bridge._configured_hgi_ids
     assert TEST_HGI_2 in bridge._accepted_hgi_ids  # type: ignore[union-attr]
 
 

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -847,6 +847,48 @@ async def test_excluded_hgi_lwt_calls_on_mqtt_capable_not_unknown(
     bridge._adapter.on_child_online.assert_not_called()
 
 
+async def test_rx_skipped_for_excluded_hgi(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """RX from excluded HGI (serial primary) is skipped, not forwarded.
+
+    When a serial primary HGI is also publishing on MQTT, the bridge
+    excludes it.  RX packets from excluded HGIs should NOT be forwarded
+    to the pool — the serial transport handles them, and forwarding
+    via MQTT would cause duplicate ingestion (even if deduped) and
+    incorrectly mark the excluded MQTT child as connected.
+    """
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1, TEST_HGI_2],
+        accepted_hgi_ids={TEST_HGI_1},
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    bridge._adapter = MagicMock()
+
+    # Exclude HGI 2 (simulating serial primary discovery).
+    bridge.exclude_hgi_id(TEST_HGI_2)
+    assert TEST_HGI_2 in bridge._excluded_hgi_ids
+
+    # RX packet from the excluded HGI.
+    frame = "000  I --- 01:145038 18:000730 --:------ 30C9 003 000F1B"
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_2}/rx"
+    msg.payload = json.dumps({"msg": frame}).encode()
+    bridge._handle_rx_message(msg)
+
+    # on_child_packet should NOT be called (serial transport handles it).
+    bridge._adapter.on_child_packet.assert_not_called()
+    # on_child_online should NOT be called.
+    bridge._adapter.on_child_online.assert_not_called()
+
+
 async def test_wait_online_timeout_passed_to_bridge(
     hass: HomeAssistant,
     mock_mqtt_pool: dict[str, Any],

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -1780,11 +1780,11 @@ def test_handle_cmd_exception(
     bridge._handle_cmd_message(msg)
 
 
-def test_discovery_callback_on_unknown_hgi(
+def test_discovery_callback_on_mqtt_capable(
     hass: HomeAssistant,
     mock_mqtt_pool: dict[str, Any],
 ) -> None:
-    """Test that discovery_callback.on_unknown_hgi is called for configured HGIs."""
+    """Test that discovery_callback.on_mqtt_capable is called for configured HGIs."""
     discovery_cb = MagicMock()
     bridge = RamsesMqttPoolBridge(
         hass,
@@ -1804,8 +1804,10 @@ def test_discovery_callback_on_unknown_hgi(
     msg.payload = b"online"
 
     bridge._handle_status_message(msg)
-    # discovery_callback.on_unknown_hgi should be called for configured HGI
-    discovery_cb.on_unknown_hgi.assert_called_once()
+    # discovery_callback.on_mqtt_capable should be called for configured HGI
+    discovery_cb.on_mqtt_capable.assert_called_once()
+    # on_unknown_hgi should NOT be called for configured HGIs (issue 1208)
+    discovery_cb.on_unknown_hgi.assert_not_called()
 
 
 def test_exclude_hgi_id(

--- a/tests/tests_new/test_mqtt_pool_bridge.py
+++ b/tests/tests_new/test_mqtt_pool_bridge.py
@@ -658,6 +658,45 @@ async def test_ingress_hgi_id_passed_to_adapter(
     assert str(call.kwargs["ingress_hgi_id"]) == TEST_HGI_1
 
 
+async def test_rx_infers_online_when_lwt_missing(
+    hass: HomeAssistant,
+    mock_mqtt_pool: dict[str, Any],
+    mock_protocol: MagicMock,
+) -> None:
+    """RX from a configured HGI without LWT infers online (issue 1185).
+
+    When a configured HGI sends packets but never publishes LWT
+    (or the LWT was missed), the bridge should infer online status
+    from the RX and call on_child_online so the pool child becomes
+    connected and sendable for TX.
+    """
+    bridge = RamsesMqttPoolBridge(
+        hass,
+        TEST_TOPIC_PREFIX,
+        [TEST_HGI_1],
+        accepted_hgi_ids={TEST_HGI_1},
+        wait_online_timeout=0.01,
+    )
+    await bridge._async_attach()
+    await bridge.async_transport_factory(mock_protocol)
+
+    # No LWT online message sent — simulate a packet arriving first.
+    assert TEST_HGI_1 not in bridge._online_hgis
+
+    frame = "000  I --- 01:145038 18:000730 --:------ 30C9 003 000F1B"
+    msg = MagicMock()
+    msg.topic = f"{TEST_TOPIC_PREFIX}/{TEST_HGI_1}/rx"
+    msg.payload = json.dumps({"msg": frame}).encode()
+
+    bridge._adapter = MagicMock()
+    bridge._publish_command = AsyncMock()
+    bridge._handle_rx_message(msg)
+
+    # The HGI should now be in _online_hgis and on_child_online called.
+    assert TEST_HGI_1 in bridge._online_hgis
+    bridge._adapter.on_child_online.assert_called_once_with(TEST_HGI_1)
+
+
 async def test_wait_online_timeout_passed_to_bridge(
     hass: HomeAssistant,
     mock_mqtt_pool: dict[str, Any],

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -2848,7 +2848,14 @@ def test_sync_learned_topology_creates_hgi_schema_entry() -> None:
 
 
 def test_sync_learned_topology_hgi_with_active_and_owner() -> None:
-    """Active HGI should receive _owner trait when root_owner is configured."""
+    """Active HGI should be added as discovery candidate (no _owner).
+
+    All HGIs (including the primary) go through "Review Discovered
+    Devices" as discovery candidates.  The user sets _owner and
+    _preferred_type via the review flow.  The HGI is still in the
+    known_list (devices without _owner are not foreign), so commands
+    work.
+    """
     config: dict[str, Any] = {
         SZ_MAIN_TCS: "01:123456",
         SZ_OWNER: "house",
@@ -2863,7 +2870,8 @@ def test_sync_learned_topology_hgi_with_active_and_owner() -> None:
     }
     result = sync_learned_topology(config, learned, active_hgi_id="18:130236")
     assert result is not None
-    assert result["18:130236"] == {"_class": "HGI", "_owner": "house"}
+    # HGI is added as a discovery candidate (no _owner — pending review).
+    assert result["18:130236"] == {"_class": "HGI"}
 
 
 def test_sync_learned_topology_updates_comment_zone_from_learned() -> None:

--- a/tests/tests_new/test_services.py
+++ b/tests/tests_new/test_services.py
@@ -19,6 +19,8 @@ from pytest_homeassistant_custom_component.common import (  # type: ignore[impor
 )
 
 from custom_components.ramses_cc.const import (
+    CONF_ADVANCED_FEATURES,
+    CONF_PASSIVE_SCAN,
     CONF_RAMSES_RF,
     CONF_SCHEMA,
     DOMAIN,
@@ -1580,6 +1582,7 @@ async def test_setup_schema_merge_failure(hass: HomeAssistant) -> None:
             "packet_log": {},
             "ramses_rf": {},
             CONF_SCHEMA: {},
+            CONF_ADVANCED_FEATURES: {CONF_PASSIVE_SCAN: False},
         },
     )
 

--- a/tests/tests_new/test_store.py
+++ b/tests/tests_new/test_store.py
@@ -333,7 +333,16 @@ def mock_entry() -> MagicMock:
     entry = MagicMock()
     entry.entry_id = "test_entry"
     entry.options = {
-        CONF_SCHEMA: {"18:006402": {"_class": "HGI"}},
+        CONF_SCHEMA: {
+            "18:006402": {
+                "_class": "HGI",
+                "_comment": (
+                    "Supports: usb"
+                    " (don't edit here — adapt with the Pool"
+                    " Management config)"
+                ),
+            }
+        },
         CONF_RAMSES_RF: {},
         "serial_port": "/dev/ttyUSB0",
     }


### PR DESCRIPTION
## Summary

Implements hybrid serial+MQTT pool construction, per-HGI and aggregate pool status entities, MQTT form redesign, and pool exclusion API fixes in ramses_cc.

### Changes

- **Hybrid serial+MQTT pool construction** (issue 1119): `_create_hybrid_pool_transport_constructor` builds a `PooledTransport` with transport-driven serial children and callback-driven MQTT children via the HA-native `RamsesMqttPoolBridge` (no paho inside HA).
- **Un-gate serial pool children in config flow** (issue 1119): serial pool children are no longer gated as "not yet supported" in the config flow. Zigbee remains gated pending Phase 3.
- **socket:// HGI pool coverage**: added test coverage for socket:// HGI pool members, fixed stale serial+MQTT test (issue 1179).
- **ID_COMMAND signature policy for pooled serial children**: serial children in hybrid pools now get `signature_policy=ID_COMMAND` with `startup_grace=8.0s` via `per_child_config_overrides`. ID_COMMAND sends `!I\r` over serial and parses the `# CC:IIIIII` response from evofw3 — no RF TX or loopback needed. Falls back to `configured_hgi_id` or `_PUZZ` signature probe on failure.
- **Reconnect enabled for pooled serial children**: `enable_reconnect=True` is now included in per-child overrides, so USB disconnects trigger automatic reconnect with exponential backoff.
- **Configured HGI identity for primary serial child**: `configured_hgi_id` is passed to the primary serial child when known and not equal to `DEFAULT_HGI_ID`, enabling HGI80 devices that cannot respond to `!I` to become send-ready.
- **MQTT form redesign** (issue 1171): the MQTT pool member form now asks only for an HGI ID and optional topic prefix. It does not collect broker, port, paho, or credentials — HA MQTT is always the broker. Switch-mode validates that the entered HGI ID matches the switching target (`mqtt_hgi_id_mismatch` error on mismatch).
- **Pool exclusion via adapter availability**: replaced the nonexistent `remove_child()` call with `on_child_offline(..., definitive=True)` and `on_child_online(...)` adapter methods, correctly excluding/un-excluding MQTT children without structural pool mutation.
- **Per-HGI and aggregate pool status entities** (issue 1119): added one binary sensor per HGI (connectivity + diagnostic attributes) and an aggregate pool status sensor. Entity creation uses a coordinator listener callback (registered via `async_on_unload`) instead of an unsafe delayed coroutine — no unawaited-coroutine warnings and unload-safe. Unique IDs are scoped to the config entry ID to avoid collisions across multiple integration entries. The aggregate sensor checks `accepted` + `send_ready` (not just connected + online) to reflect actual outbound eligibility.
- **Entry-scoped pool sensor unique IDs**: per-HGI and aggregate sensor unique IDs now include the config entry ID (`{entry_id}_pool_child_{hgi_id}_online`, `{entry_id}_pool_status_online`) to avoid collisions across multiple integration entries.
- **Decimal-only HGI ID validation**: `_HGI_ID_RE` uses `^18:[0-9]{6}$` (decimal-only) to match the canonical `ramses_rf` parser. Hex-accepting regex would allow IDs that fail `DeviceIdT` validation at runtime. Topic extraction also uses decimal-only validation (no hex normalization).
- **Deepcopy for all schema mutations**: all config-flow schema mutations now use `deepcopy` (not `dict()`) so `async_update_entry` detects the changes and triggers a reload.
- **Serial probe narrowed to primary HGI**: `_async_probe_serial_ports` now marks only the identified primary HGI as USB-capable, not all schema HGIs. Other HGIs may be remote MQTT nodes.
- **MQTT→serial primary switch cleanup**: switching primary from MQTT to serial now removes stale `CONF_MQTT_HGI_ID` in addition to `CONF_MQTT_USE_HA`.
- **MqttPoolBridge subscription ordering**: subscriptions are created after the adapter so retained LWT messages are handled immediately. Subscription failure raises `TransportError` instead of silently logging.
- **Unknown HGI RX handling**: RX from an unknown HGI now routes through `on_unknown_hgi` (receive-only discovery), not the configured-HGI path.
- **accepted_hgis plumbing**: `_get_accepted_hgi_ids()` is now passed to `pooled_transport_factory` so the pool can enforce outbound eligibility at construction time.
- **Schema migration via deepcopy**: comment migration now uses `deepcopy(config_schema)` instead of a shallow copy, preventing HA from seeing `old == new` and skipping the save.

### Depends on

- ramses-rf/ramses_rf PR 1208 — provides `per_child_config_overrides` in `pooled_transport_factory` (Gap D), `SignaturePolicy.ID_COMMAND` (Gap E), `configured_hgi_id` (Gap B), HGI80 auto-SKIP (Gap C), evofw3 debug filtering (Gap F), serial reconnect, write-failure eligibility, and stale-child routing exclusion.

**Note:** PR 1183 imports `redact_url` from PR 1208, which is not yet published. CI will fail against the published `ramses-rf` pin until PR 1208 is merged and a new version is published. This is accepted temporarily — the maintainer will handle the manifest pin update.

### Test plan

- [x] `ruff check .` passes
- [x] `mypy --strict` passes (no new errors)
- [x] `pytest tests/` — 1913 passed, 15 skipped
- [x] Pre-commit hooks pass
- [x] Full HA integration testing with mixed USB + MQTT pool (hardware `hass` instance)
- [x] Config flow validation with serial + MQTT hybrid pool
- [x] Per-HGI and aggregate pool status entities verified on hardware
- [x] R123 recipe (non-primary USB-to-MQTT switching) — 21/21 checks passed
- [ ] HGI80 hardware testing (pending physical device)
- [ ] ATmega32U4 `!I` identity discovery validation (pending physical device)
- [ ] nanoCUL `!I` identity discovery validation (pending physical device)