### PR TITLE
fix: poll CH water pressure and DHW flow rate from OTB

### DIFF
--- a/custom_components/ramses_cc/sensor.py
+++ b/custom_components/ramses_cc/sensor.py
@@ -629,6 +629,7 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
         name="CH water pressure",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=UnitOfPressure.BAR,
+        poll_codes=[Code._1300],
     ),
     RamsesSensorEntityDescription(
         key=SZ_DHW_FLOW_RATE,
@@ -636,6 +637,7 @@ SENSOR_DESCRIPTIONS: tuple[RamsesSensorEntityDescription, ...] = (
         ramses_rf_attr=SZ_DHW_FLOW_RATE,
         name="DHW flow rate",
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+        poll_codes=[Code._12F0],
     ),
     RamsesSensorEntityDescription(
         key=SZ_DHW_SETPOINT,

--- a/tests/tests_new/snapshots/test_init.ambr
+++ b/tests/tests_new/snapshots/test_init.ambr
@@ -320,7 +320,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'on',
+      'state': 'unknown',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
@@ -860,7 +860,7 @@
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': 'on',
+      'state': 'unknown',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({


### PR DESCRIPTION
## Summary
- Add `poll_codes` to the CH water pressure (`Code._1300`) and DHW flow rate (`Code._12F0`) sensor descriptions so ramses_cc sends an RQ to the OTB to refresh values periodically, instead of waiting for the OTB's hourly push
- The OTB (OpenTherm Bridge) sends sensor data via `3220` packets on its own schedule (typically once per hour). These two sensors were push-only, so they only updated when the OTB decided to send the data.
- Note: issue 1184 mentions data_id `0x18` as DHW_FLOW_RATE, but per the OpenTherm spec, `0x18` is ROOM_TEMP. DHW_FLOW_RATE is `0x13` (`Code._12F0`) and CH_WATER_PRESSURE is `0x12` (`Code._1300`).

Closes https://github.com/ramses-rf/ramses_cc/issues/1184

#### Test plan
- [ ] Verify CH water pressure sensor updates more frequently than once per hour
- [ ] Verify DHW flow rate sensor updates more frequently than once per hour
- [ ] Verify no errors when OTB is offline (RQ fails gracefully)