### PR TITLE
Fix deprecated `dr.devices` access

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -484,12 +484,12 @@ class BaseRamsesFlow:
         ports[CONF_MQTT_PATH] = CONF_MQTT_PATH
 
         # If exactly one ramses_esp32c6 Zigbee device is present, show its
-        # friendly name in the selector label. Otherwise show a generic label.
+        # friendly name in the selector label. Otherwise, show a generic label.
         try:
             dev_reg = dr.async_get(self.hass)
             matches = [
                 dev
-                for dev in getattr(dev_reg, "devices", {}).values()
+                for dev in dev_reg.async_get_devices(identifiers=DOMAIN)
                 if "ramses_esp32c6" in (dev.model or "").lower()
             ]
             if len(matches) == 1:
@@ -730,7 +730,7 @@ class BaseRamsesFlow:
             # No submission yet — find matching devices.
             matches = [
                 dev
-                for dev in getattr(dev_reg, "devices", {}).values()
+                for dev in dev_reg.async_get_devices(identifiers=DOMAIN)
                 if "ramses_esp32c6" in (dev.model or "").lower()
             ]
 

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -488,13 +488,16 @@ class BaseRamsesFlow:
         try:
             dev_reg = dr.async_get(self.hass)
             matches = [
-                dev
-                for dev in await dev_reg.async_get_devices(identifiers=DOMAIN)
-                if "ramses_esp32c6" in (dev.model or "").lower()
+                dev_entry
+                for dev_entry in dev_reg.async_get_devices(identifiers=DOMAIN)
+                if "ramses_esp32c6"
+                in (dev_reg.async_get(dev_entry).model or "").lower()
             ]
             if len(matches) == 1:
                 raw_name = (
-                    matches[0].name or matches[0].name_by_user or matches[0].id
+                    dev_reg.async_get(matches[0]).name
+                    or dev_reg.async_get(matches[0]).name_by_user
+                    or dev_reg.async_get(matches[0]).id
                 )
                 display_name = (
                     raw_name.split(" ", 1)[1].strip()
@@ -729,9 +732,10 @@ class BaseRamsesFlow:
 
             # No submission yet — find matching devices.
             matches = [
-                dev
-                for dev in await dev_reg.async_get_devices(identifiers=DOMAIN)
-                if "ramses_esp32c6" in (dev.model or "").lower()
+                dev_entry
+                for dev_entry in dev_reg.async_get_devices(identifiers=DOMAIN)
+                if "ramses_esp32c6"
+                in (dev_reg.async_get(dev_entry).model or "").lower()
             ]
 
             if len(matches) == 0:
@@ -750,7 +754,7 @@ class BaseRamsesFlow:
 
             if len(matches) == 1:
                 candidate = matches[0]
-                ieee = _extract_ieee_from_device(candidate)
+                ieee = _extract_ieee_from_device(dev_reg.async_get(candidate))
 
                 if not ieee:
                     return self.async_show_form(
@@ -771,7 +775,7 @@ class BaseRamsesFlow:
                 )
                 _LOGGER.info(
                     "Auto-constructed Zigbee URL from device %s: %s",
-                    candidate.id,
+                    dev_reg.async_get(candidate).id,
                     zigbee_url,
                 )
                 self.options[SZ_SERIAL_PORT][SZ_PORT_NAME] = zigbee_url
@@ -780,10 +784,12 @@ class BaseRamsesFlow:
             # Multiple matches: present a selector for the user to choose.
             options = [
                 selector.SelectOptionDict(
-                    value=dev.id,
-                    label=dev.name or dev.name_by_user or dev.id,
+                    value=dev_reg.async_get(dev_entry).id,
+                    label=dev_reg.async_get(dev_entry).name
+                    or dev_reg.async_get(dev_entry).name_by_user
+                    or dev_reg.async_get(dev_entry).id,
                 )
-                for dev in matches
+                for dev_entry in matches
             ]
             return self.async_show_form(
                 step_id="zigbee_device",

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -489,7 +489,7 @@ class BaseRamsesFlow:
             dev_reg = dr.async_get(self.hass)
             matches = [
                 dev
-                for dev in dev_reg.async_get_devices(identifiers=DOMAIN)
+                for dev in await dev_reg.async_get_devices(identifiers=DOMAIN)
                 if "ramses_esp32c6" in (dev.model or "").lower()
             ]
             if len(matches) == 1:
@@ -730,7 +730,7 @@ class BaseRamsesFlow:
             # No submission yet — find matching devices.
             matches = [
                 dev
-                for dev in dev_reg.async_get_devices(identifiers=DOMAIN)
+                for dev in await dev_reg.async_get_devices(identifiers=DOMAIN)
                 if "ramses_esp32c6" in (dev.model or "").lower()
             ]
 

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -27,4 +27,4 @@
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest
   # coverage >= ... included in next item
-  pytest_homeassistant_custom_component >= 0.13.359
+  pytest_homeassistant_custom_component >= 0.13.364

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -27,4 +27,4 @@
 # used for testing (incl. HA, pytest*, syrupy, voluptuous, etc.)
 # - pytest
   # coverage >= ... included in next item
-  pytest_homeassistant_custom_component >= 0.13.364
+  pytest_homeassistant_custom_component >= 0.13.359

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -2063,10 +2063,12 @@ async def test_zigbee_no_devices_found(hass: HomeAssistant) -> None:
             return_value={},
         ),
         patch(
-            "custom_components.ramses_cc.config_flow.dr.async_get",
-            return_value=mock_registry,
-        ),
+            "custom_components.ramses_cc.config_flow.dr.async_get"
+        ) as mock_dr,
     ):
+        mock_dr.return_value.async_get_devices = AsyncMock(
+            return_value=mock_registry.devices
+        )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
@@ -2096,10 +2098,12 @@ async def test_zigbee_single_device_auto_configure(
             return_value={},
         ),
         patch(
-            "custom_components.ramses_cc.config_flow.dr.async_get",
-            return_value=mock_registry,
-        ),
+            "custom_components.ramses_cc.config_flow.dr.async_get"
+        ) as mock_dr,
     ):
+        mock_dr.return_value.async_get_devices = AsyncMock(
+            return_value=mock_registry.devices
+        )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
@@ -2124,10 +2128,12 @@ async def test_zigbee_single_device_no_ieee(hass: HomeAssistant) -> None:
             return_value={},
         ),
         patch(
-            "custom_components.ramses_cc.config_flow.dr.async_get",
-            return_value=mock_registry,
-        ),
+            "custom_components.ramses_cc.config_flow.dr.async_get"
+        ) as mock_dr,
     ):
+        mock_dr.return_value.async_get_devices = AsyncMock(
+            return_value=mock_registry.devices
+        )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
@@ -2160,10 +2166,12 @@ async def test_zigbee_multiple_devices_shows_selector(
             return_value={},
         ),
         patch(
-            "custom_components.ramses_cc.config_flow.dr.async_get",
-            return_value=mock_registry,
-        ),
+            "custom_components.ramses_cc.config_flow.dr.async_get"
+        ) as mock_dr,
     ):
+        mock_dr.return_value.async_get_devices = AsyncMock(
+            return_value=mock_registry.devices
+        )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
@@ -2197,10 +2205,12 @@ async def test_zigbee_user_selects_device_from_selector(
             return_value={},
         ),
         patch(
-            "custom_components.ramses_cc.config_flow.dr.async_get",
-            return_value=mock_registry,
-        ),
+            "custom_components.ramses_cc.config_flow.dr.async_get"
+        ) as mock_dr,
     ):
+        mock_dr.return_value.async_get_devices = AsyncMock(
+            return_value=mock_registry.devices
+        )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
@@ -2232,10 +2242,12 @@ async def test_zigbee_port_picker_shows_zigbee_option(
             return_value={},
         ),
         patch(
-            "custom_components.ramses_cc.config_flow.dr.async_get",
-            return_value=mock_registry,
-        ),
+            "custom_components.ramses_cc.config_flow.dr.async_get"
+        ) as mock_dr,
     ):
+        mock_dr.return_value.async_get_devices = AsyncMock(
+            return_value=mock_registry.devices
+        )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -2066,8 +2066,8 @@ async def test_zigbee_no_devices_found(hass: HomeAssistant) -> None:
             "custom_components.ramses_cc.config_flow.dr.async_get"
         ) as mock_dr,
     ):
-        mock_dr.return_value.async_get_devices = AsyncMock(
-            return_value=mock_registry.devices
+        mock_dr.return_value.async_get_devices = MagicMock(
+            return_value=mock_registry.devices.keys()
         )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -2101,8 +2101,11 @@ async def test_zigbee_single_device_auto_configure(
             "custom_components.ramses_cc.config_flow.dr.async_get"
         ) as mock_dr,
     ):
-        mock_dr.return_value.async_get_devices = AsyncMock(
-            return_value=mock_registry.devices
+        mock_dr.return_value.async_get_devices = MagicMock(
+            return_value=mock_registry.devices.keys()
+        )
+        mock_dr.return_value.async_get = MagicMock(
+            return_value=mock_registry.devices.get("dev1")
         )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -2131,8 +2134,11 @@ async def test_zigbee_single_device_no_ieee(hass: HomeAssistant) -> None:
             "custom_components.ramses_cc.config_flow.dr.async_get"
         ) as mock_dr,
     ):
-        mock_dr.return_value.async_get_devices = AsyncMock(
-            return_value=mock_registry.devices
+        mock_dr.return_value.async_get_devices = MagicMock(
+            return_value=mock_registry.devices.keys()
+        )
+        mock_dr.return_value.async_get = MagicMock(
+            return_value=mock_registry.devices.get("dev1")
         )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -2169,9 +2175,12 @@ async def test_zigbee_multiple_devices_shows_selector(
             "custom_components.ramses_cc.config_flow.dr.async_get"
         ) as mock_dr,
     ):
-        mock_dr.return_value.async_get_devices = AsyncMock(
-            return_value=mock_registry.devices
+        mock_dr.return_value.async_get_devices = MagicMock(
+            return_value=mock_registry.devices.keys()
         )
+        mock_dr.return_value.async_get = MagicMock(
+            return_value=mock_registry.devices.get("dev1")
+        )  # variable?
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
@@ -2208,8 +2217,11 @@ async def test_zigbee_user_selects_device_from_selector(
             "custom_components.ramses_cc.config_flow.dr.async_get"
         ) as mock_dr,
     ):
-        mock_dr.return_value.async_get_devices = AsyncMock(
-            return_value=mock_registry.devices
+        mock_dr.return_value.async_get_devices = MagicMock(
+            return_value=mock_registry.devices.keys()
+        )
+        mock_dr.return_value.async_get = MagicMock(
+            return_value=mock_registry.devices.get("dev1")
         )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -2245,8 +2257,8 @@ async def test_zigbee_port_picker_shows_zigbee_option(
             "custom_components.ramses_cc.config_flow.dr.async_get"
         ) as mock_dr,
     ):
-        mock_dr.return_value.async_get_devices = AsyncMock(
-            return_value=mock_registry.devices
+        mock_dr.return_value.async_get_devices = MagicMock(
+            return_value=mock_registry.devices.keys()
         )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
@@ -2279,8 +2291,11 @@ async def test_zigbee_single_device_label_in_port_picker(
             "custom_components.ramses_cc.config_flow.dr.async_get"
         ) as mock_dr,
     ):
-        mock_dr.return_value.async_get_devices = AsyncMock(
-            return_value=mock_registry.devices
+        mock_dr.return_value.async_get_devices = MagicMock(
+            return_value=mock_registry.devices.keys()
+        )
+        mock_dr.return_value.async_get = MagicMock(
+            return_value=mock_registry.devices.get("dev1")
         )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}

--- a/tests/tests_new/test_config_flow.py
+++ b/tests/tests_new/test_config_flow.py
@@ -2264,10 +2264,12 @@ async def test_zigbee_single_device_label_in_port_picker(
             return_value={},
         ),
         patch(
-            "custom_components.ramses_cc.config_flow.dr.async_get",
-            return_value=mock_registry,
-        ),
+            "custom_components.ramses_cc.config_flow.dr.async_get"
+        ) as mock_dr,
     ):
+        mock_dr.return_value.async_get_devices = AsyncMock(
+            return_value=mock_registry.devices
+        )
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )


### PR DESCRIPTION
**PR Summary**
This PR fixes #1186
It replaces deprecated methods to fetch devices from the registry, applies the new instructions from dev blog to access protected members.
Mocks the changes in the tests.

- [x] The code follows [HA Architecture Rules](https://developers.home-assistant.io/docs/architecture_components?_highlight=integrations)
- [x] I have reviewed and tested these code changes myself, successfully ran pre-commit hooks and am available to address review comments.
- [x] AI Coding Assistance disclosure: not used/used for 5%
