### PR TITLE
fix: parse rf_suggests= in review table, allow DIS as bound

### DIFF
--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -3689,10 +3689,21 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                 device_id = entry.device.device_id
                 action = user_input.get(f"mismatch_{device_id}", "skip")
                 if action == "update_class":
-                    # Update _class in schema to match discovery's likely_type
+                    # Update _class in schema to match the suggested class.
+                    # For scan-engine mismatches, likely_type is the
+                    # suggestion.  For ramses_rf contradiction mismatches
+                    # (rf_suggests=), likely_type is still the declared
+                    # class (REM), not the suggestion (CO2) — parse the
+                    # suggestion from the class_mismatch metadata string.
+                    mm = entry.metadata.class_mismatch or ""
+                    suggested_cls = entry.device.likely_type
+                    for key in ("rf_suggests=", "discovery="):
+                        if key in mm:
+                            suggested_cls = mm.split(key)[1].split(",")[0]
+                            break
                     dev_entry = config_schema.get(device_id)
                     if isinstance(dev_entry, dict):
-                        dev_entry[SZ_TR_CLASS] = str(entry.device.likely_type)
+                        dev_entry[SZ_TR_CLASS] = str(suggested_cls)
                         # Apply per-device owner if provided, else root owner
                         per_device_owner = (
                             user_input.get(f"owner_{device_id}", "") or ""
@@ -3706,8 +3717,9 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
                         class_updates.append(device_id)
                         _LOGGER.info(
                             "review_discovered: updated _class for %s to %s "
-                            "(discovery suggestion accepted)",
+                            "(suggestion accepted, was likely_type=%s)",
                             device_id,
+                            suggested_cls,
                             entry.device.likely_type,
                         )
                     # Clear dismissed flag — mismatch resolved by updating

--- a/custom_components/ramses_cc/config_flow.py
+++ b/custom_components/ramses_cc/config_flow.py
@@ -3921,15 +3921,27 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             for entry in mismatched_only:
                 d = entry.device
                 # Parse the mismatch desc: "schema=FAN, discovery=DIS"
+                # or "schema=REM, rf_suggests=CO2" (from
+                # _check_rf_contradictions).
                 mm = entry.metadata.class_mismatch or ""
+                _LOGGER.debug(
+                    "review_discovered: mismatch entry device_id=%s "
+                    "class_mismatch=%r likely_type=%s confidence=%s",
+                    d.device_id,
+                    mm,
+                    d.likely_type,
+                    d.confidence,
+                )
                 schema_cls = (
                     mm.split("schema=")[1].split(",")[0]
                     if "schema=" in mm
                     else "?"
                 )
-                disc_cls = (
-                    mm.split("discovery=")[1] if "discovery=" in mm else "?"
-                )
+                disc_cls = "?"
+                for key in ("discovery=", "rf_suggests="):
+                    if key in mm:
+                        disc_cls = mm.split(key)[1].split(",")[0]
+                        break
                 lines.append(
                     f"| `{d.device_id}` | {schema_cls} | {disc_cls} | "
                     f"{d.confidence} |"
@@ -4152,12 +4164,24 @@ class RamsesOptionsFlowHandler(BaseRamsesFlow, OptionsFlow):
             d = entry.device
             device_id = d.device_id
             mm = entry.metadata.class_mismatch or ""
+            _LOGGER.debug(
+                "review_discovered form: mismatch entry device_id=%s "
+                "class_mismatch=%r likely_type=%s confidence=%s",
+                device_id,
+                mm,
+                d.likely_type,
+                d.confidence,
+            )
             schema_cls = (
                 mm.split("schema=")[1].split(",")[0]
                 if "schema=" in mm
                 else "?"
             )
-            disc_cls = mm.split("discovery=")[1] if "discovery=" in mm else "?"
+            disc_cls = "?"
+            for key in ("discovery=", "rf_suggests="):
+                if key in mm:
+                    disc_cls = mm.split(key)[1].split(",")[0]
+                    break
             field_label = (
                 f"{device_id} | schema _class={schema_cls} → "
                 f"discovery suggests {disc_cls} (conf={d.confidence})"

--- a/custom_components/ramses_cc/coordinator.py
+++ b/custom_components/ramses_cc/coordinator.py
@@ -2178,9 +2178,11 @@ class RamsesCoordinator(DataUpdateCoordinator):
         # Sanitize: ramses_rf's SCH_TRAITS_HEAT does not accept 'bound'
         # (only SCH_TRAITS_HVAC has it).  Remove 'bound' from:
         # - heat-prefix devices without an explicit class (default to heat)
-        # - any device with a heat class (e.g. DIS, CTL, TRV) — even if the
-        #   device ID prefix is non-heat (32: with _class=DIS from R24's
+        # - any device with a heat class (e.g. CTL, TRV, BDR) — even if the
+        #   device ID prefix is non-heat (32: with _class=CTL from R24's
         #   class mismatch test)
+        # Note: DIS, SW2, PIR are HVAC classes (in HVVAC_SLUGS) and DO
+        # accept 'bound'.
         _hvac_slugs = set(str(s) for s in DEV_TYPE_MAP.HVAC_SLUGS)
         _hvac_prefixes = ("32:", "29:", "37:", "63:")
         for _device_id, traits in known_list.items():
@@ -2191,7 +2193,7 @@ class RamsesCoordinator(DataUpdateCoordinator):
                 # Explicit class: keep bound only for HVAC classes
                 if str(cls) in _hvac_slugs:
                     continue  # HVAC class — bound is valid
-                # Heat class (DIS, CTL, TRV, etc.) → remove bound
+                # Heat class (CTL, TRV, BDR, etc.) → remove bound
                 traits.pop("bound", None)
             else:
                 # No explicit class: ramses_rf defaults based on prefix.

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -1721,10 +1721,13 @@ class DiscoveryManager:
         # that check_class_mismatches may have missed (scan engine doesn't
         # re-classify known devices, so likely_type may agree with schema
         # even when ramses_rf's known_list suggests a different class).
+        # Note: _warned_mismatches only controls log-spam prevention for
+        # the WARNING log; the persistent notification must be sent
+        # whenever a mismatch exists, even if already warned.
         rf_flagged = [
             d_id
             for d_id, meta in self._metadata.items()
-            if meta.class_mismatch and d_id not in self._warned_mismatches
+            if meta.class_mismatch
         ]
         if rf_flagged:
             counts["class_mismatch"] += len(rf_flagged)

--- a/custom_components/ramses_cc/discovery.py
+++ b/custom_components/ramses_cc/discovery.py
@@ -858,9 +858,19 @@ class DiscoveryManager:
                     scan_type,
                 )
             else:
-                # Mismatch resolved — clear the flag
+                # Mismatch resolved — clear the flag, but ONLY if the
+                # existing mismatch was set by the scan engine (discovery=),
+                # not by _check_rf_contradictions (rf_suggests=).  The rf
+                # contradiction check runs before check_all_mismatches and
+                # may set a mismatch (e.g. rf_suggests=CO2) that the scan
+                # engine doesn't know about — clearing it here would hide
+                # the rf-suggested class from the review UI.
                 existing_meta = self._metadata.get(device_id)
-                if existing_meta and existing_meta.class_mismatch:
+                if (
+                    existing_meta
+                    and existing_meta.class_mismatch
+                    and "rf_suggests=" not in existing_meta.class_mismatch
+                ):
                     existing_meta.class_mismatch = None
                     self._metadata[device_id] = existing_meta
 

--- a/tests/tests_new/test_coordinator.py
+++ b/tests/tests_new/test_coordinator.py
@@ -3574,6 +3574,39 @@ class TestDeriveKnownListFromSchema:
         assert result["37:168270"]["bound"] == "32:153289"
         assert result["37:168270"]["class"] == "REM"
 
+    def test_dis_class_keeps_bound(self) -> None:
+        """DIS-classed device keeps bound (DIS is an HVAC class).
+
+        DIS was previously treated as a heat class (not in HVVAC_SLUGS),
+        which caused _derive_known_list_from_schema to strip 'bound' from
+        DIS-classed devices.  Now DIS is in HVVAC_SLUGS and keeps bound.
+        """
+        schema = {
+            "main_tcs": "01:145038",
+            "01:145038": {},
+            "37:168270": {
+                "_bound": "32:153289",
+                "_class": "DIS",
+            },
+        }
+        result = RamsesCoordinator._derive_known_list_from_schema(schema)
+        assert result["37:168270"]["bound"] == "32:153289"
+        assert result["37:168270"]["class"] == "DIS"
+
+    def test_sw2_class_keeps_bound(self) -> None:
+        """SW2-classed device keeps bound (SW2 is an HVAC class)."""
+        schema = {
+            "main_tcs": "01:145038",
+            "01:145038": {},
+            "37:168270": {
+                "_bound": "32:153289",
+                "_class": "SW2",
+            },
+        }
+        result = RamsesCoordinator._derive_known_list_from_schema(schema)
+        assert result["37:168270"]["bound"] == "32:153289"
+        assert result["37:168270"]["class"] == "SW2"
+
     def test_scheme_trait_extracted(self) -> None:
         """_scheme on a FAN is extracted into known_list as scheme=<name>."""
         schema = {


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Review table shows ? instead of actual class

The review table and form fields only parsed `"discovery="` from `class_mismatch` descriptions, but `_check_rf_contradictions` uses `"rf_suggests="`. This caused:
- The "Discovery suggests" column to show `?` instead of `CO2` or `DIS`
- The "Update to ?" dropdown option to show `?` instead of the actual class

Now both `"discovery="` and `"rf_suggests="` are parsed.

### 2. DIS is an HVAC class, not a heat class

The bound-sanitize comment incorrectly listed DIS as a heat class. DIS is an HVAC class (now in `HVAC_SLUGS` in ramses_rf — see https://github.com/ramses-rf/ramses_rf/pull/1214), so `bound` is kept for DIS-classed devices.

Added tests for DIS and SW2 keeping their `bound` trait.

#### Test plan
- [x] 1952 ramses_cc tests pass
- [x] ruff and mypy clean
- [x] New tests: `test_dis_class_keeps_bound`, `test_sw2_class_keeps_bound`
- [ ] Depends on https://github.com/ramses-rf/ramses_rf/pull/1214 for DIS/SW2 to be in HVVAC_SLUGS