### PR TITLE
fix: remove THM from zone actuators when zone already has a sensor (issue 1182)

### DIFF
--- a/custom_components/ramses_cc/schemas.py
+++ b/custom_components/ramses_cc/schemas.py
@@ -1782,6 +1782,40 @@ def sync_learned_topology(
                         continue
                     sensor = zone.get(SZ_SENSOR)
                     if sensor:
+                        # Zone already has a sensor — remove any remaining
+                        # sensor-type devices from the actuators list.
+                        # They can't be actuators (ramses_rf rejects THM as
+                        # actuator: "must be ('BdrSwitch', 'TrvActuator',
+                        # 'UfhCircuit')"), and leaving them causes SUPPRESSED
+                        # warnings on every reload (issue 1182).
+                        _sensor_dev_prefixes = ("01:", "22:", "34:")
+                        removed = [
+                            a
+                            for a in actuators
+                            if isinstance(a, str)
+                            and a[:3] in _sensor_dev_prefixes
+                        ]
+                        if removed:
+                            actuators[:] = [
+                                a
+                                for a in actuators
+                                if not (
+                                    isinstance(a, str)
+                                    and a[:3] in _sensor_dev_prefixes
+                                )
+                            ]
+                            changed = True
+                            for a in removed:
+                                _LOGGER.debug(
+                                    "sync_learned_topology: removed %s "
+                                    "from actuators (sensor-type device, "
+                                    "zone already has sensor %s) — "
+                                    "issue 1182",
+                                    a,
+                                    sensor,
+                                )
+                            if not actuators:
+                                zone.pop("actuators", None)
                         continue  # zone already has a sensor
                     # Find first sensor-type device in actuators
                     for act in list(actuators):

--- a/tests/tests_new/test_schemas.py
+++ b/tests/tests_new/test_schemas.py
@@ -3213,6 +3213,54 @@ def test_sync_learned_topology_sanitizes_sensor_in_actuators() -> None:
     assert "04:034720" in zone["actuators"]
 
 
+def test_sync_learned_topology_removes_thm_from_actuators_when_zone_has_sensor() -> (
+    None
+):
+    """Sensor-type devices in actuators are removed when zone already has a sensor.
+
+    ramses_rf's 000C binding packets can place THM/RND devices (22:, 34:) in
+    a zone's actuators list.  When the zone already has a sensor, these
+    devices cannot be actuators (ramses_rf rejects THM as actuator: "must
+    be ('BdrSwitch', 'TrvActuator', 'UfhCircuit')"), and leaving them causes
+    SUPPRESSED warnings on every reload (issue 1182).
+    """
+    config: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:068717",
+        "01:068717": {
+            SZ_ZONES: {
+                "00": {
+                    SZ_SENSOR: "22:072483",
+                    "actuators": ["04:034720", "22:072769", "22:072770"],
+                }
+            }
+        },
+    }
+    learned: dict[str, Any] = {
+        SZ_MAIN_TCS: "01:068717",
+        "01:068717": {
+            SZ_ZONES: {
+                "00": {
+                    SZ_SENSOR: "22:072483",
+                    "actuators": ["04:034720", "22:072769", "22:072770"],
+                    SZ_CLASS: "radiator_valve",
+                }
+            }
+        },
+        SZ_ORPHANS_HEAT: [],
+        SZ_ORPHANS_HVAC: [],
+    }
+    result = sync_learned_topology(config, learned)
+    assert result is not None
+    zone = result["01:068717"][SZ_ZONES]["00"]
+    # Sensor stays
+    assert zone[SZ_SENSOR] == "22:072483"
+    # THMs removed from actuators
+    assert "22:072769" not in zone.get("actuators", [])
+    assert "22:072770" not in zone.get("actuators", [])
+    # TRV stays in actuators
+    assert "04:034720" in zone["actuators"]
+
+
 def test_sync_learned_topology_trv_sensor_rnd_actuator_swapped() -> None:
     """TRV as sensor + RND in actuators → TRV moved to actuators, RND to sensor.
 


### PR DESCRIPTION
## Summary

- ramses_rf's `000C` binding packets can place THM/RND devices (`22:`, `34:`) in a zone's `actuators` list
- When the zone already has a sensor, these devices cannot be actuators — ramses_rf rejects THM with `"must be ('BdrSwitch', 'TrvActuator', 'UfhCircuit')"` and logs a `SUPPRESSED` warning on every reload
- The existing sanitization only moved sensor-type devices from `actuators` to the `sensor` slot when the zone had **no** sensor. When the zone already had a sensor, the THMs stayed in the `actuators` list indefinitely, causing the `SUPPRESSED` warnings reported in issue 1182
- Now sensor-type devices (`01:`, `22:`, `34:`) are also **removed** from the `actuators` list when the zone already has a sensor, leaving only valid actuator types (`04:`, `13:`, etc.) in the list

Fixes https://github.com/ramses-rf/ramses_cc/issues/1182

#### Test plan
- [x] Added regression test `test_sync_learned_topology_removes_thm_from_actuators_when_zone_has_sensor`
- [x] Existing sanitization tests still pass (`test_sync_learned_topology_sanitizes_sensor_in_actuators`, `test_sync_learned_topology_trv_sensor_rnd_actuator_swapped`)
- [x] Full test suite: `1951 passed, 15 skipped`
- [x] `ruff check` + `ruff format` + `mypy` all pass